### PR TITLE
feat(errors): typed error hierarchy (#8)

### DIFF
--- a/src/errors/index.test.ts
+++ b/src/errors/index.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  CircuitOpen,
+  FeatureRequiresOfVersion,
+  FeatureRequiresPro,
+  NotFound,
+  OmniFocusError,
+  OmniFocusNotRunning,
+  PermissionDenied,
+  QueueFull,
+  RateLimited,
+  ScriptError,
+  ServerShuttingDown,
+  Timeout,
+  TransportUnavailable,
+  ValidationError,
+  isOmniFocusError,
+} from "./index.js";
+
+describe("OmniFocusError", () => {
+  it("we expose the code, message, and class name", () => {
+    const err = new OmniFocusNotRunning();
+    expect(err.code).toBe("OF_NOT_RUNNING");
+    expect(err.message).toBe("OmniFocus is not running.");
+    expect(err.name).toBe("OmniFocusNotRunning");
+  });
+
+  it("we surface a default suggestion that tells the agent the next step", () => {
+    expect(new OmniFocusNotRunning().suggestion).toBe("Launch OmniFocus and retry.");
+    expect(new PermissionDenied().suggestion).toContain("System Settings");
+  });
+
+  it("we let the caller override suggestion and details without losing the code", () => {
+    const err = new NotFound("Project not found", {
+      suggestion: "Check project_list output.",
+      details: { resource: "project", id: "pXYZ" },
+    });
+    expect(err.code).toBe("OF_NOT_FOUND");
+    expect(err.suggestion).toBe("Check project_list output.");
+    expect(err.details).toEqual({ resource: "project", id: "pXYZ" });
+  });
+
+  it("we chain underlying causes via Error.cause", () => {
+    const root = new Error("osascript exited 1");
+    const err = new ScriptError("Script failed", { cause: root });
+    expect(err.cause).toBe(root);
+  });
+
+  it("we omit suggestion and details from toJSON when not set", () => {
+    // Force an instance without the defaults by using the base constructor.
+    const err = new OmniFocusError("OF_VALIDATION", "raw");
+    expect(err.toJSON()).toEqual({
+      name: "OmniFocusError",
+      code: "OF_VALIDATION",
+      message: "raw",
+    });
+  });
+
+  it("we serialize to the envelope shape with suggestion and details", () => {
+    const err = new ValidationError("Bad input", {
+      details: { failures: [{ index: 2, field: "due", reason: "bare local time" }] },
+    });
+    const json = err.toJSON();
+    expect(json.code).toBe("OF_VALIDATION");
+    expect(json.message).toBe("Bad input");
+    expect(json.suggestion).toBeDefined();
+    expect(json.details).toBeDefined();
+    expect(json.details?.failures).toHaveLength(1);
+  });
+});
+
+describe("instanceof discrimination", () => {
+  it("we narrow with isOmniFocusError on caught unknowns", () => {
+    let caught: unknown;
+    try {
+      throw new RateLimited("slow down");
+    } catch (e) {
+      caught = e;
+    }
+    expect(isOmniFocusError(caught)).toBe(true);
+    if (isOmniFocusError(caught)) {
+      // Inside the guard, TypeScript knows it's an OmniFocusError.
+      expect(caught.code).toBe("OF_RATE_LIMITED");
+    }
+  });
+
+  it("we reject non-error values from isOmniFocusError", () => {
+    expect(isOmniFocusError(null)).toBe(false);
+    expect(isOmniFocusError(undefined)).toBe(false);
+    expect(isOmniFocusError("string")).toBe(false);
+    expect(isOmniFocusError({ code: "OF_NOT_FOUND" })).toBe(false);
+    expect(isOmniFocusError(new Error("plain"))).toBe(false);
+  });
+
+  it("we preserve instanceof across all subclasses", () => {
+    const cases: { instance: OmniFocusError; ctor: new (...args: never[]) => OmniFocusError }[] = [
+      { instance: new OmniFocusNotRunning(), ctor: OmniFocusNotRunning },
+      { instance: new PermissionDenied(), ctor: PermissionDenied },
+      { instance: new FeatureRequiresPro("Pro needed"), ctor: FeatureRequiresPro },
+      { instance: new FeatureRequiresOfVersion("OF 4 needed"), ctor: FeatureRequiresOfVersion },
+      { instance: new ValidationError("bad"), ctor: ValidationError },
+      { instance: new NotFound("missing"), ctor: NotFound },
+      { instance: new Timeout("slow"), ctor: Timeout },
+      { instance: new RateLimited("limited"), ctor: RateLimited },
+      { instance: new QueueFull("full"), ctor: QueueFull },
+      { instance: new CircuitOpen("open"), ctor: CircuitOpen },
+      { instance: new TransportUnavailable("offline"), ctor: TransportUnavailable },
+      { instance: new ScriptError("script bad"), ctor: ScriptError },
+      { instance: new ServerShuttingDown(), ctor: ServerShuttingDown },
+    ];
+
+    for (const { instance, ctor } of cases) {
+      expect(instance).toBeInstanceOf(OmniFocusError);
+      expect(instance).toBeInstanceOf(Error);
+      expect(instance).toBeInstanceOf(ctor);
+      expect(instance.name).toBe(ctor.name);
+    }
+  });
+});
+
+describe("error code coverage — every documented code has a class", () => {
+  it("we have a concrete class for each code in DESIGN §6.7", () => {
+    const expectedCodes = new Set([
+      "OF_NOT_RUNNING",
+      "OF_PERMISSION_DENIED",
+      "OF_FEATURE_REQUIRES_PRO",
+      "OF_FEATURE_REQUIRES_VERSION",
+      "OF_VALIDATION",
+      "OF_NOT_FOUND",
+      "OF_TIMEOUT",
+      "OF_RATE_LIMITED",
+      "OF_QUEUE_FULL",
+      "OF_CIRCUIT_OPEN",
+      "OF_TRANSPORT_UNAVAILABLE",
+      "OF_SCRIPT_ERROR",
+      "OF_SHUTTING_DOWN",
+    ]);
+
+    const actualCodes = new Set([
+      new OmniFocusNotRunning().code,
+      new PermissionDenied().code,
+      new FeatureRequiresPro("").code,
+      new FeatureRequiresOfVersion("").code,
+      new ValidationError("").code,
+      new NotFound("").code,
+      new Timeout("").code,
+      new RateLimited("").code,
+      new QueueFull("").code,
+      new CircuitOpen("").code,
+      new TransportUnavailable("").code,
+      new ScriptError("").code,
+      new ServerShuttingDown().code,
+    ]);
+
+    expect(actualCodes).toEqual(expectedCodes);
+    expect(actualCodes.size).toBe(13);
+  });
+});

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,258 @@
+/**
+ * Typed error hierarchy for omnifocus-mcp.
+ *
+ * Every throw in the server is one of these classes; generic `Error` is
+ * forbidden by lint rule (issue #5). Classes are grouped by remediation
+ * class so an agent reading an error knows, at a glance, whether to retry,
+ * wait, fix input, or stop and ask the user — see DESIGN §6.7.
+ *
+ * The `code` field is part of the public stability contract (ADR-0011);
+ * removing or renaming a code is a breaking change. New codes are additive.
+ *
+ * @see DESIGN.md §6.7 — error taxonomy
+ * @see DESIGN.md §12 — response envelope
+ * @see docs/adr/0013-tool-response-envelope.md — error envelope shape
+ */
+
+// ---------------------------------------------------------------------------
+// Public contract — error codes
+// ---------------------------------------------------------------------------
+
+/** Stable identifier surfaced to clients in `error.code`. Public contract. */
+export type ErrorCode =
+  // Environment — retry pointless; user action required
+  | "OF_NOT_RUNNING"
+  | "OF_PERMISSION_DENIED"
+  | "OF_FEATURE_REQUIRES_PRO"
+  | "OF_FEATURE_REQUIRES_VERSION"
+  // Input — agent should fix the input before retrying
+  | "OF_VALIDATION"
+  | "OF_NOT_FOUND"
+  // Transient — agent may retry after waiting
+  | "OF_TIMEOUT"
+  | "OF_RATE_LIMITED"
+  | "OF_QUEUE_FULL"
+  | "OF_CIRCUIT_OPEN"
+  // Infrastructure — usually transient but not the agent's to fix
+  | "OF_TRANSPORT_UNAVAILABLE"
+  | "OF_SCRIPT_ERROR"
+  // Lifecycle — stop and reconnect
+  | "OF_SHUTTING_DOWN";
+
+/** Constructor options shared by every concrete error. */
+export interface ErrorOptions {
+  /** Human-readable next step for the agent or operator. Overrides class default. */
+  suggestion?: string;
+  /** Per-error-code structured payload (e.g. `{ resource, id }` for NotFound). */
+  details?: Record<string, unknown>;
+  /** Underlying cause for chaining; surfaced via `Error.cause`. */
+  cause?: unknown;
+}
+
+/** Wire shape produced by `toJSON()` and consumed by the response envelope. */
+export interface SerializedError {
+  name: string;
+  code: ErrorCode;
+  message: string;
+  suggestion?: string;
+  details?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Base class
+// ---------------------------------------------------------------------------
+
+/**
+ * Base for every error this server throws. Carries a stable `code`, an
+ * optional `suggestion` for the agent's next action, and structured
+ * `details` for the per-code payload.
+ *
+ * Always thrown via a concrete subclass — do not instantiate directly.
+ */
+export class OmniFocusError extends Error {
+  public readonly code: ErrorCode;
+  public readonly suggestion?: string;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(code: ErrorCode, message: string, options: ErrorOptions = {}) {
+    super(message, options.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = new.target.name;
+    this.code = code;
+    if (options.suggestion !== undefined) this.suggestion = options.suggestion;
+    if (options.details !== undefined) this.details = options.details;
+  }
+
+  /** Wire serialization for the response envelope. */
+  public toJSON(): SerializedError {
+    const out: SerializedError = {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+    };
+    if (this.suggestion !== undefined) out.suggestion = this.suggestion;
+    if (this.details !== undefined) out.details = this.details;
+    return out;
+  }
+}
+
+/** Type guard for narrowing unknown caught values. */
+export function isOmniFocusError(value: unknown): value is OmniFocusError {
+  return value instanceof OmniFocusError;
+}
+
+// ---------------------------------------------------------------------------
+// Environment — retry is pointless; user action required
+// ---------------------------------------------------------------------------
+
+/** Thrown when OmniFocus is not running and we need it to be. */
+export class OmniFocusNotRunning extends OmniFocusError {
+  constructor(options: ErrorOptions = {}) {
+    super("OF_NOT_RUNNING", "OmniFocus is not running.", {
+      suggestion: "Launch OmniFocus and retry.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when macOS Automation permission for OmniFocus has been denied. */
+export class PermissionDenied extends OmniFocusError {
+  constructor(options: ErrorOptions = {}) {
+    super("OF_PERMISSION_DENIED", "Automation permission for OmniFocus is denied.", {
+      suggestion:
+        "Open System Settings → Privacy & Security → Automation; grant this terminal or client access to OmniFocus.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when a feature requires OmniFocus Pro but Standard is installed. */
+export class FeatureRequiresPro extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_FEATURE_REQUIRES_PRO", message, {
+      suggestion: "This feature requires OmniFocus Pro. Upgrade or use a different tool.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when a feature requires a newer OmniFocus version than the one running. */
+export class FeatureRequiresOfVersion extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_FEATURE_REQUIRES_VERSION", message, {
+      suggestion:
+        "This feature requires a newer OmniFocus version. Update OmniFocus or use a different tool.",
+      ...options,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input — agent should fix the input before retrying
+// ---------------------------------------------------------------------------
+
+/** Thrown when input fails validation (zod, schema constraint, business rule). */
+export class ValidationError extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_VALIDATION", message, {
+      suggestion: "Fix the input and retry. See `details` for field-level reasons.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when a referenced OmniFocus resource cannot be found. */
+export class NotFound extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_NOT_FOUND", message, {
+      suggestion:
+        "Confirm the ID with the corresponding `*_list` tool. Use OmniFocus persistent IDs, not names.",
+      ...options,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transient — agent may retry after waiting
+// ---------------------------------------------------------------------------
+
+/** Thrown when an OmniFocus call exceeded its hard timeout. */
+export class Timeout extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_TIMEOUT", message, {
+      suggestion: "Retry once. If repeated, OmniFocus may be wedged — relaunch it.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when the per-tool rate limit window has been exceeded. */
+export class RateLimited extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_RATE_LIMITED", message, {
+      suggestion:
+        "Wait before retrying. The default window is 60 seconds. See `details.retryAfterMs`.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when the write queue's soft cap is exceeded. */
+export class QueueFull extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_QUEUE_FULL", message, {
+      suggestion: "The write queue is saturated. Wait for in-flight writes to drain, then retry.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when a tool's circuit breaker is open after consecutive failures. */
+export class CircuitOpen extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_CIRCUIT_OPEN", message, {
+      suggestion:
+        "This tool failed repeatedly and is rejecting calls fast. Investigate, then wait for the circuit to half-open (default 60 seconds).",
+      ...options,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Infrastructure — usually transient but not the agent's to fix
+// ---------------------------------------------------------------------------
+
+/** Thrown when neither JXA nor OmniJS transport can serve the request. */
+export class TransportUnavailable extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_TRANSPORT_UNAVAILABLE", message, {
+      suggestion:
+        "The required transport is unreachable. Verify OmniFocus is running and responsive.",
+      ...options,
+    });
+  }
+}
+
+/** Thrown when the underlying JXA or OmniJS script raised an error. */
+export class ScriptError extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_SCRIPT_ERROR", message, {
+      suggestion:
+        "The OmniFocus script failed. Inspect `details.transport` and `details.reason` for context.",
+      ...options,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle — stop and reconnect
+// ---------------------------------------------------------------------------
+
+/** Thrown when the server has begun shutting down and rejects new work. */
+export class ServerShuttingDown extends OmniFocusError {
+  constructor(options: ErrorOptions = {}) {
+    super("OF_SHUTTING_DOWN", "Server is shutting down; not accepting new requests.", {
+      suggestion: "Reconnect to a fresh server instance.",
+      ...options,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- 13-class error taxonomy from DESIGN §6.7, grouped by remediation class
- Default `suggestion` per class so agents know the next step without prose parsing
- `toJSON()` matches the response envelope shape from ADR-0013
- 10 unit tests covering surfacing, overrides, instanceof, and code coverage

## Design link

Implements DESIGN.md §6.7. Public contract per ADR-0011 and ADR-0013.

Closes #8.

## Breaking change?

- [x] No — additive; this is the first time these classes ship

## Test plan

- [x] Unit tests cover happy + edge + error
- [x] No stdout output during server run (these are throw classes; not exercised)
- [x] Response envelope + typed error used; toJSON tested
- [x] All public classes have docblocks per coding.md
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green locally

## Conventions checklist

- [x] Follows `coding.md` (typed errors, docblocks, Goldilocks tests)
- [x] Conventional Commits (`feat(errors):`)
- [x] No new dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)