### PR TITLE
feat(envelope): response envelope helpers ok() / err() (#15)

### DIFF
--- a/src/envelope/index.test.ts
+++ b/src/envelope/index.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { NotFound, OmniFocusError, ValidationError } from "../errors/index.js";
+import {
+  type Pagination,
+  type ResponseMeta,
+  type ToolEnvelope,
+  type ToolError,
+  type ToolSuccess,
+  err,
+  isError,
+  isSuccess,
+  ok,
+} from "./index.js";
+
+const baseMeta: ResponseMeta = {
+  correlationId: "01JBZK7PDR6XSYVMWT5YYVH8VQ",
+  durationMs: 142,
+  cacheHit: false,
+  transport: "jxa",
+  ofVersion: "4.5.2",
+};
+
+describe("ok()", () => {
+  it("we wrap data in the standard success envelope", () => {
+    const envelope = ok({ tasks: [{ id: "tA", name: "Write" }] }, baseMeta);
+    expect(envelope.data).toEqual({ tasks: [{ id: "tA", name: "Write" }] });
+    expect(envelope.meta).toBe(baseMeta);
+    expect(envelope.pagination).toBeUndefined();
+  });
+
+  it("we include pagination when caller provides it", () => {
+    const pagination: Pagination = { cursor: "abc", hasMore: true, total: 237 };
+    const envelope = ok({ tasks: [] }, baseMeta, pagination);
+    expect(envelope.pagination).toBe(pagination);
+  });
+
+  it("we omit pagination when not provided — envelope stays minimal", () => {
+    const envelope = ok({ id: "p1" }, baseMeta);
+    expect("pagination" in envelope).toBe(false);
+  });
+
+  it("we propagate meta.warnings into the envelope verbatim", () => {
+    const metaWithWarnings: ResponseMeta = {
+      ...baseMeta,
+      warnings: ["rate limit approaching"],
+    };
+    const envelope = ok({ done: true }, metaWithWarnings);
+    expect(envelope.meta.warnings).toEqual(["rate limit approaching"]);
+  });
+});
+
+describe("err()", () => {
+  it("we serialize the OmniFocusError via toJSON into the error envelope", () => {
+    const error = new NotFound("Project not found", {
+      details: { resource: "project", id: "pMissing" },
+    });
+    const envelope = err(error, baseMeta);
+
+    expect(envelope.error.code).toBe("OF_NOT_FOUND");
+    expect(envelope.error.name).toBe("NotFound");
+    expect(envelope.error.message).toBe("Project not found");
+    expect(envelope.error.details).toEqual({ resource: "project", id: "pMissing" });
+    expect(envelope.meta).toBe(baseMeta);
+  });
+
+  it("we preserve the default suggestion from the class", () => {
+    const envelope = err(new ValidationError("Bad input"), baseMeta);
+    expect(envelope.error.suggestion).toContain("Fix the input");
+  });
+
+  it("we accept the base OmniFocusError class, not just subclasses", () => {
+    const generic = new OmniFocusError("OF_SCRIPT_ERROR", "raw");
+    const envelope = err(generic, baseMeta);
+    expect(envelope.error.code).toBe("OF_SCRIPT_ERROR");
+    expect(envelope.error.name).toBe("OmniFocusError");
+    // No suggestion when the base class is used directly.
+    expect(envelope.error.suggestion).toBeUndefined();
+  });
+});
+
+describe("envelope shape — snapshot locks", () => {
+  it("success snapshot matches the ADR-0013 contract", () => {
+    const envelope = ok(
+      { tasks: [{ id: "t1", name: "example" }] },
+      {
+        correlationId: "01JBZK_SUCCESS",
+        durationMs: 87,
+        cacheHit: true,
+        transport: "cache",
+        ofVersion: "4.5.2",
+      },
+      { cursor: null, hasMore: false, total: 1 },
+    );
+    expect(envelope).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "tasks": [
+            {
+              "id": "t1",
+              "name": "example",
+            },
+          ],
+        },
+        "meta": {
+          "cacheHit": true,
+          "correlationId": "01JBZK_SUCCESS",
+          "durationMs": 87,
+          "ofVersion": "4.5.2",
+          "transport": "cache",
+        },
+        "pagination": {
+          "cursor": null,
+          "hasMore": false,
+          "total": 1,
+        },
+      }
+    `);
+  });
+
+  it("error snapshot matches the ADR-0013 contract", () => {
+    const envelope = err(
+      new NotFound("Task not found", { details: { resource: "task", id: "tXYZ" } }),
+      {
+        correlationId: "01JBZK_ERROR",
+        durationMs: 12,
+        cacheHit: false,
+        transport: "jxa",
+        ofVersion: "4.5.2",
+      },
+    );
+    expect(envelope).toMatchInlineSnapshot(`
+      {
+        "error": {
+          "code": "OF_NOT_FOUND",
+          "details": {
+            "id": "tXYZ",
+            "resource": "task",
+          },
+          "message": "Task not found",
+          "name": "NotFound",
+          "suggestion": "Confirm the ID with the corresponding \`*_list\` tool. Use OmniFocus persistent IDs, not names.",
+        },
+        "meta": {
+          "cacheHit": false,
+          "correlationId": "01JBZK_ERROR",
+          "durationMs": 12,
+          "ofVersion": "4.5.2",
+          "transport": "jxa",
+        },
+      }
+    `);
+  });
+});
+
+describe("isSuccess / isError type guards", () => {
+  it("we narrow a ToolEnvelope to ToolSuccess inside isSuccess", () => {
+    const envelope: ToolEnvelope<{ n: number }> = ok({ n: 1 }, baseMeta);
+    expect(isSuccess(envelope)).toBe(true);
+    expect(isError(envelope)).toBe(false);
+    if (isSuccess(envelope)) {
+      // Compile-time narrowing — data is accessible without error guard.
+      expect(envelope.data.n).toBe(1);
+    }
+  });
+
+  it("we narrow a ToolEnvelope to ToolError inside isError", () => {
+    const envelope: ToolEnvelope<{ n: number }> = err(new ValidationError("bad"), baseMeta);
+    expect(isError(envelope)).toBe(true);
+    expect(isSuccess(envelope)).toBe(false);
+    if (isError(envelope)) {
+      expect(envelope.error.code).toBe("OF_VALIDATION");
+    }
+  });
+});
+
+describe("TypeScript surface", () => {
+  it("ok() preserves the data type parameter through the envelope", () => {
+    type Payload = { tasks: { id: string; name: string }[] };
+    const envelope = ok<Payload>({ tasks: [] }, baseMeta);
+    expectTypeOf(envelope).toMatchTypeOf<ToolSuccess<Payload>>();
+    expectTypeOf(envelope.data.tasks).toEqualTypeOf<{ id: string; name: string }[]>();
+  });
+
+  it("err() return type is structurally ToolError", () => {
+    const envelope = err(new NotFound("x"), baseMeta);
+    expectTypeOf(envelope).toMatchTypeOf<ToolError>();
+  });
+});

--- a/src/envelope/index.ts
+++ b/src/envelope/index.ts
@@ -1,0 +1,117 @@
+/**
+ * Response envelope helpers for MCP tool returns.
+ *
+ * Every tool in this MCP returns a uniform JSON envelope — success as
+ * `{ data, meta, pagination? }`, failure as `{ error, meta }`. The helpers
+ * here are the only sanctioned way to produce those shapes; a lint rule
+ * (issue #78) forbids raw `return { data: ... }` outside these helpers.
+ *
+ * `ResponseMeta` is required on every response. The handler harness (lands
+ * with issue #27) supplies correlationId, durationMs, transport, cacheHit,
+ * and ofVersion from request-scoped context. Service methods never construct
+ * meta themselves — they return domain payloads and let the harness wrap.
+ *
+ * @see DESIGN.md §12 — tool response envelope
+ * @see DESIGN.md §15 — pagination shape
+ * @see docs/adr/0013-tool-response-envelope.md — public contract for this shape
+ */
+
+import type { OmniFocusError, SerializedError } from "../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Public contract — envelope types
+// ---------------------------------------------------------------------------
+
+/** Which layer produced the response. Useful for debugging and cache analysis. */
+export type Transport = "jxa" | "omnijs" | "cache" | "memory";
+
+/**
+ * Metadata carried on every response — success or error. Populated by the
+ * handler harness from per-request context. Every field here is part of the
+ * public stability contract (ADR-0011).
+ */
+export interface ResponseMeta {
+  /** ULID per MCP request. Echoed to logs for cross-event correlation. */
+  correlationId: string;
+  /** Wall-clock milliseconds from tool entry to envelope construction. */
+  durationMs: number;
+  /** True if this response was served without calling OmniFocus (cache hit or in-memory adapter). */
+  cacheHit: boolean;
+  /** The adapter path that produced this response. */
+  transport: Transport;
+  /** The OmniFocus version the adapter observed, e.g. `"4.5.2"`. `"unknown"` on cold path. */
+  ofVersion: string;
+  /** Non-fatal issues the agent should see inline (e.g. zod refinement warnings). */
+  warnings?: string[];
+}
+
+/**
+ * Pagination block present on list-shaped tools. `cursor: null` means
+ * "no more results." `total` is omitted when computing it would double
+ * the cost of the read.
+ */
+export interface Pagination {
+  cursor: string | null;
+  hasMore: boolean;
+  total?: number;
+}
+
+/** Success envelope — the shape every non-list tool returns on success. */
+export interface ToolSuccess<T> {
+  data: T;
+  meta: ResponseMeta;
+  pagination?: Pagination;
+}
+
+/** Failure envelope — the shape every tool returns on error. */
+export interface ToolError {
+  error: SerializedError;
+  meta: ResponseMeta;
+}
+
+/** Either success or failure. Discriminated by presence of `data` vs `error`. */
+export type ToolEnvelope<T> = ToolSuccess<T> | ToolError;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a success payload in the standard envelope.
+ *
+ * @param data — tool-specific payload (e.g. `{ tasks: Task[] }` for list tools)
+ * @param meta — request-scoped metadata from the handler harness
+ * @param pagination — optional pagination block for list-shaped responses
+ * @returns a `ToolSuccess<T>` matching the ADR-0013 contract
+ */
+export function ok<T>(data: T, meta: ResponseMeta, pagination?: Pagination): ToolSuccess<T> {
+  const envelope: ToolSuccess<T> = { data, meta };
+  if (pagination !== undefined) envelope.pagination = pagination;
+  return envelope;
+}
+
+/**
+ * Wrap a typed error in the standard envelope. The caller is responsible
+ * for catching at the handler boundary and calling `err()` to produce the
+ * wire shape — see agent_systems.md "actionable errors" principle.
+ *
+ * @param error — any `OmniFocusError` subclass; serialized via its `toJSON()`
+ * @param meta — request-scoped metadata; same shape as success meta
+ * @returns a `ToolError` matching the ADR-0013 contract
+ */
+export function err(error: OmniFocusError, meta: ResponseMeta): ToolError {
+  return {
+    error: error.toJSON(),
+    meta,
+  };
+}
+
+/** Narrowing guard for consumers that see `ToolEnvelope<T>` and need to branch. */
+export function isSuccess<T>(envelope: ToolEnvelope<T>): envelope is ToolSuccess<T> {
+  return "data" in envelope;
+}
+
+/** Complement of `isSuccess` for symmetry. */
+export function isError<T>(envelope: ToolEnvelope<T>): envelope is ToolError {
+  return "error" in envelope;
+}


### PR DESCRIPTION
## Summary

- `ok(data, meta, pagination?)` and `err(error, meta)` build the ADR-0013 envelope
- `ResponseMeta`, `Pagination`, `ToolSuccess<T>`, `ToolError`, `ToolEnvelope<T>` types — public stability contract
- `isSuccess`/`isError` discriminated-union guards
- 13 tests including inline snapshots of both envelope shapes

## Design link

Closes #15. Implements DESIGN §12 and the decision in ADR-0013. Directly consumes the typed error hierarchy from #8 (merged in #95).

## Breaking change?

- [x] No — additive; first time these helpers ship

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green locally (23 tests, <10ms)
- [x] Inline snapshots lock the envelope shape — any accidental drift fails CI
- [x] No stdout output (no runtime surface yet)
- [x] Tool description / agent_systems "rich response, actionable error" principles respected via toJSON integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)