### PR TITLE
feat(config): env-var config loader with zod validation and startup failure

### DIFF
--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,0 +1,166 @@
+import { homedir } from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import { type Config, parseConfig, redactConfig } from "./env.js";
+
+describe("parseConfig", () => {
+  describe("defaults", () => {
+    it("returns defaults when no env vars are set", () => {
+      const config = parseConfig({});
+      expect(config).toEqual<Config>({
+        OMNIFOCUS_LOG_LEVEL: "info",
+        OMNIFOCUS_INTEGRATION: false,
+        OMNIFOCUS_E2E: false,
+        OMNIFOCUS_ALLOW_RAW_SCRIPT: false,
+        OMNIFOCUS_CACHE_TTL_MS: 30000,
+        OMNIFOCUS_CACHE_CAPACITY: 256,
+        OMNIFOCUS_READ_POOL_SIZE: 2,
+        OMNIFOCUS_WRITE_QUEUE_CAP: 50,
+        OMNIFOCUS_JXA_TIMEOUT_MS: 30000,
+        OMNIFOCUS_OMNIJS_TIMEOUT_MS: 45000,
+        OMNIFOCUS_ATTACHMENT_PATHS: [homedir()],
+        OMNIFOCUS_MAX_ATTACHMENT_MB: 100,
+        OMNIFOCUS_TOOL_RATE_LIMIT: { limit: 120, windowSeconds: 60 },
+      });
+    });
+  });
+
+  describe("boolean flags", () => {
+    it('treats "1" as true', () => {
+      const config = parseConfig({
+        OMNIFOCUS_INTEGRATION: "1",
+        OMNIFOCUS_E2E: "1",
+        OMNIFOCUS_ALLOW_RAW_SCRIPT: "1",
+      });
+      expect(config.OMNIFOCUS_INTEGRATION).toBe(true);
+      expect(config.OMNIFOCUS_E2E).toBe(true);
+      expect(config.OMNIFOCUS_ALLOW_RAW_SCRIPT).toBe(true);
+    });
+
+    it('treats any non-"1" value as false', () => {
+      const config = parseConfig({
+        OMNIFOCUS_INTEGRATION: "true",
+        OMNIFOCUS_E2E: "yes",
+        OMNIFOCUS_ALLOW_RAW_SCRIPT: "0",
+      });
+      expect(config.OMNIFOCUS_INTEGRATION).toBe(false);
+      expect(config.OMNIFOCUS_E2E).toBe(false);
+      expect(config.OMNIFOCUS_ALLOW_RAW_SCRIPT).toBe(false);
+    });
+  });
+
+  describe("numeric fields", () => {
+    it("parses valid numeric strings", () => {
+      const config = parseConfig({
+        OMNIFOCUS_CACHE_TTL_MS: "60000",
+        OMNIFOCUS_READ_POOL_SIZE: "3",
+      });
+      expect(config.OMNIFOCUS_CACHE_TTL_MS).toBe(60000);
+      expect(config.OMNIFOCUS_READ_POOL_SIZE).toBe(3);
+    });
+
+    it("fails on non-numeric values", () => {
+      const onError = vi.fn((_msg: string) => {
+        throw new Error("config-error");
+      });
+      expect(() => parseConfig({ OMNIFOCUS_CACHE_TTL_MS: "fast" }, onError as never)).toThrow(
+        "config-error",
+      );
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining("OMNIFOCUS_CACHE_TTL_MS"));
+    });
+
+    it("fails on zero or negative values", () => {
+      const onError = vi.fn((_msg: string) => {
+        throw new Error("config-error");
+      });
+      expect(() => parseConfig({ OMNIFOCUS_CACHE_TTL_MS: "0" }, onError as never)).toThrow(
+        "config-error",
+      );
+    });
+  });
+
+  describe("OMNIFOCUS_LOG_LEVEL", () => {
+    it("accepts valid levels", () => {
+      for (const level of ["trace", "debug", "info", "warn", "error"] as const) {
+        const config = parseConfig({ OMNIFOCUS_LOG_LEVEL: level });
+        expect(config.OMNIFOCUS_LOG_LEVEL).toBe(level);
+      }
+    });
+
+    it("fails on invalid log level", () => {
+      const onError = vi.fn((_msg: string) => {
+        throw new Error("config-error");
+      });
+      expect(() => parseConfig({ OMNIFOCUS_LOG_LEVEL: "verbose" }, onError as never)).toThrow(
+        "config-error",
+      );
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining("OMNIFOCUS_LOG_LEVEL"));
+    });
+  });
+
+  describe("OMNIFOCUS_ATTACHMENT_PATHS", () => {
+    it("splits colon-separated paths", () => {
+      const config = parseConfig({
+        OMNIFOCUS_ATTACHMENT_PATHS: "/tmp/a:/tmp/b",
+      });
+      expect(config.OMNIFOCUS_ATTACHMENT_PATHS).toEqual(["/tmp/a", "/tmp/b"]);
+    });
+
+    it("filters empty segments", () => {
+      const config = parseConfig({ OMNIFOCUS_ATTACHMENT_PATHS: "/tmp/a:" });
+      expect(config.OMNIFOCUS_ATTACHMENT_PATHS).toEqual(["/tmp/a"]);
+    });
+  });
+
+  describe("OMNIFOCUS_TOOL_RATE_LIMIT", () => {
+    it("parses N/SECONDS format", () => {
+      const config = parseConfig({ OMNIFOCUS_TOOL_RATE_LIMIT: "200/120" });
+      expect(config.OMNIFOCUS_TOOL_RATE_LIMIT).toEqual({
+        limit: 200,
+        windowSeconds: 120,
+      });
+    });
+
+    it("fails on invalid format", () => {
+      const onError = vi.fn((_msg: string) => {
+        throw new Error("config-error");
+      });
+      expect(() => parseConfig({ OMNIFOCUS_TOOL_RATE_LIMIT: "120rpm" }, onError as never)).toThrow(
+        "config-error",
+      );
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining("OMNIFOCUS_TOOL_RATE_LIMIT"));
+    });
+  });
+
+  describe("startup failure", () => {
+    it("calls onError with a message referencing DESIGN §22", () => {
+      const onError = vi.fn((_msg: string) => {
+        throw new Error("config-error");
+      });
+      expect(() => parseConfig({ OMNIFOCUS_LOG_LEVEL: "bad" }, onError as never)).toThrow(
+        "config-error",
+      );
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining("DESIGN §22"));
+    });
+  });
+});
+
+describe("redactConfig", () => {
+  it("hashes attachment paths", () => {
+    const config = parseConfig({
+      OMNIFOCUS_ATTACHMENT_PATHS: "/Users/alice/Documents",
+    });
+    const redacted = redactConfig(config);
+    const paths = redacted.OMNIFOCUS_ATTACHMENT_PATHS as string[];
+    expect(paths).toHaveLength(1);
+    // Hash is 12-char hex, not the literal path
+    expect(paths[0]).toMatch(/^[0-9a-f]{12}$/);
+    expect(paths[0]).not.toContain("alice");
+  });
+
+  it("passes through non-path values unchanged", () => {
+    const config = parseConfig({ OMNIFOCUS_CACHE_TTL_MS: "60000" });
+    const redacted = redactConfig(config);
+    expect(redacted.OMNIFOCUS_CACHE_TTL_MS).toBe(60000);
+    expect(redacted.OMNIFOCUS_LOG_LEVEL).toBe("info");
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,141 @@
+/**
+ * Environment-variable configuration for omnifocus-mcp.
+ *
+ * All env vars are parsed and validated once at startup. Invalid values exit
+ * the process immediately with a readable message on stderr rather than
+ * failing at first tool call — see DESIGN §22.
+ *
+ * Path-shaped values (`OMNIFOCUS_ATTACHMENT_PATHS`) are logged as hashes to
+ * avoid leaking directory structure in operator logs — see DESIGN §17.
+ *
+ * @see DESIGN.md §22 — configuration & environment
+ */
+
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Rate-limit schema — parses "N/SECONDS" format
+// ---------------------------------------------------------------------------
+
+const rateLimitSchema = z
+  .string()
+  .regex(/^\d+\/\d+$/, 'must be "N/SECONDS" format, e.g. "120/60"')
+  .transform((s) => {
+    const [limit, windowSeconds] = s.split("/").map(Number);
+    return { limit: limit as number, windowSeconds: windowSeconds as number };
+  });
+
+// ---------------------------------------------------------------------------
+// Full config schema
+// ---------------------------------------------------------------------------
+
+const envSchema = z.object({
+  OMNIFOCUS_LOG_LEVEL: z.enum(["trace", "debug", "info", "warn", "error"]).default("info"),
+  OMNIFOCUS_INTEGRATION: z
+    .string()
+    .transform((v) => v === "1")
+    .default(""),
+  OMNIFOCUS_E2E: z
+    .string()
+    .transform((v) => v === "1")
+    .default(""),
+  OMNIFOCUS_ALLOW_RAW_SCRIPT: z
+    .string()
+    .transform((v) => v === "1")
+    .default(""),
+  OMNIFOCUS_CACHE_TTL_MS: z.coerce.number().int().positive().default(30000),
+  OMNIFOCUS_CACHE_CAPACITY: z.coerce.number().int().positive().default(256),
+  OMNIFOCUS_READ_POOL_SIZE: z.coerce.number().int().min(1).max(8).default(2),
+  OMNIFOCUS_WRITE_QUEUE_CAP: z.coerce.number().int().positive().default(50),
+  OMNIFOCUS_JXA_TIMEOUT_MS: z.coerce.number().int().positive().default(30000),
+  OMNIFOCUS_OMNIJS_TIMEOUT_MS: z.coerce.number().int().positive().default(45000),
+  OMNIFOCUS_ATTACHMENT_PATHS: z
+    .string()
+    .default(homedir())
+    .transform((v) => v.split(":").filter(Boolean)),
+  OMNIFOCUS_MAX_ATTACHMENT_MB: z.coerce.number().int().positive().default(100),
+  OMNIFOCUS_TOOL_RATE_LIMIT: rateLimitSchema.default("120/60"),
+});
+
+// ---------------------------------------------------------------------------
+// Exported config type
+// ---------------------------------------------------------------------------
+
+export type Config = z.output<typeof envSchema>;
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate all OMNIFOCUS_* env vars from `processEnv`.
+ *
+ * On validation failure, writes a human-readable message to `stderr` and
+ * exits the process with code 1. Caller may override both for testing.
+ */
+export function parseConfig(
+  processEnv: NodeJS.ProcessEnv = process.env,
+  onError: (message: string) => never = (msg) => {
+    process.stderr.write(`[omnifocus-mcp] Config error: ${msg}\n`);
+    process.exit(1);
+  },
+): Config {
+  const result = envSchema.safeParse({
+    OMNIFOCUS_LOG_LEVEL: processEnv.OMNIFOCUS_LOG_LEVEL,
+    OMNIFOCUS_INTEGRATION: processEnv.OMNIFOCUS_INTEGRATION,
+    OMNIFOCUS_E2E: processEnv.OMNIFOCUS_E2E,
+    OMNIFOCUS_ALLOW_RAW_SCRIPT: processEnv.OMNIFOCUS_ALLOW_RAW_SCRIPT,
+    OMNIFOCUS_CACHE_TTL_MS: processEnv.OMNIFOCUS_CACHE_TTL_MS,
+    OMNIFOCUS_CACHE_CAPACITY: processEnv.OMNIFOCUS_CACHE_CAPACITY,
+    OMNIFOCUS_READ_POOL_SIZE: processEnv.OMNIFOCUS_READ_POOL_SIZE,
+    OMNIFOCUS_WRITE_QUEUE_CAP: processEnv.OMNIFOCUS_WRITE_QUEUE_CAP,
+    OMNIFOCUS_JXA_TIMEOUT_MS: processEnv.OMNIFOCUS_JXA_TIMEOUT_MS,
+    OMNIFOCUS_OMNIJS_TIMEOUT_MS: processEnv.OMNIFOCUS_OMNIJS_TIMEOUT_MS,
+    OMNIFOCUS_ATTACHMENT_PATHS: processEnv.OMNIFOCUS_ATTACHMENT_PATHS,
+    OMNIFOCUS_MAX_ATTACHMENT_MB: processEnv.OMNIFOCUS_MAX_ATTACHMENT_MB,
+    OMNIFOCUS_TOOL_RATE_LIMIT: processEnv.OMNIFOCUS_TOOL_RATE_LIMIT,
+  });
+
+  if (!result.success) {
+    const lines = result.error.errors.map((e) => `  ${e.path.join(".")}: ${e.message}`);
+    return onError(
+      `Invalid environment configuration:\n${lines.join("\n")}\nSee DESIGN §22 for allowed values.`,
+    );
+  }
+
+  return result.data;
+}
+
+// ---------------------------------------------------------------------------
+// Redacted summary for the server.started event log
+// ---------------------------------------------------------------------------
+
+/** Hash a string value for safe inclusion in logs. */
+function hashValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+/**
+ * Return a redacted view of the config safe to emit in structured logs.
+ * Path-shaped values are replaced with a short hash.
+ */
+export function redactConfig(config: Config): Record<string, unknown> {
+  return {
+    OMNIFOCUS_LOG_LEVEL: config.OMNIFOCUS_LOG_LEVEL,
+    OMNIFOCUS_INTEGRATION: config.OMNIFOCUS_INTEGRATION,
+    OMNIFOCUS_E2E: config.OMNIFOCUS_E2E,
+    OMNIFOCUS_ALLOW_RAW_SCRIPT: config.OMNIFOCUS_ALLOW_RAW_SCRIPT,
+    OMNIFOCUS_CACHE_TTL_MS: config.OMNIFOCUS_CACHE_TTL_MS,
+    OMNIFOCUS_CACHE_CAPACITY: config.OMNIFOCUS_CACHE_CAPACITY,
+    OMNIFOCUS_READ_POOL_SIZE: config.OMNIFOCUS_READ_POOL_SIZE,
+    OMNIFOCUS_WRITE_QUEUE_CAP: config.OMNIFOCUS_WRITE_QUEUE_CAP,
+    OMNIFOCUS_JXA_TIMEOUT_MS: config.OMNIFOCUS_JXA_TIMEOUT_MS,
+    OMNIFOCUS_OMNIJS_TIMEOUT_MS: config.OMNIFOCUS_OMNIJS_TIMEOUT_MS,
+    // Path-shaped — hash each entry to avoid leaking directory structure
+    OMNIFOCUS_ATTACHMENT_PATHS: config.OMNIFOCUS_ATTACHMENT_PATHS.map(hashValue),
+    OMNIFOCUS_MAX_ATTACHMENT_MB: config.OMNIFOCUS_MAX_ATTACHMENT_MB,
+    OMNIFOCUS_TOOL_RATE_LIMIT: config.OMNIFOCUS_TOOL_RATE_LIMIT,
+  };
+}


### PR DESCRIPTION
## Summary
- Implements DESIGN §22: validates all 13 `OMNIFOCUS_*` env vars with zod at startup
- Invalid config exits 1 immediately with a field-level error message referencing DESIGN §22
- `OMNIFOCUS_TOOL_RATE_LIMIT` uses bespoke `N/SECONDS` parser
- `redactConfig()` hashes path-shaped values (`OMNIFOCUS_ATTACHMENT_PATHS`) for safe `server.started` log events per DESIGN §17
- 15 unit tests: defaults, boolean flags, numeric validation, log level enum, colon-separated paths, rate-limit format, startup failure messaging

## Design link
Closes #12. Relevant: DESIGN.md §22 (configuration) and §17 (observability / log redaction).

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 66 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Self-reviewed via review_pr.md
- [x] No new dependencies