### PR TITLE
feat(logging): ULID correlation-ID context via AsyncLocalStorage

### DIFF
--- a/src/logging/correlation.test.ts
+++ b/src/logging/correlation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { generateCorrelationId, getCorrelationId, withCorrelationId } from "./correlation.js";
+
+describe("withCorrelationId", () => {
+  it("propagates a generated ULID to getCorrelationId inside the scope", () => {
+    let id: string | undefined;
+    withCorrelationId(() => {
+      id = getCorrelationId();
+    });
+    expect(id).toBeDefined();
+    expect(id).toMatch(/^[0-9A-Z]{26}$/);
+  });
+
+  it("reuses an incoming ID when provided", () => {
+    const incoming = "01JBZK1234567890ABCDEFGHIJ";
+    let id: string | undefined;
+    withCorrelationId(() => {
+      id = getCorrelationId();
+    }, incoming);
+    expect(id).toBe(incoming);
+  });
+
+  it("generates a new ULID when incoming is empty string", () => {
+    let id: string | undefined;
+    withCorrelationId(() => {
+      id = getCorrelationId();
+    }, "");
+    expect(id).toBeDefined();
+    expect(id).not.toBe("");
+  });
+
+  it("generates a new ULID when incoming is whitespace only", () => {
+    let id: string | undefined;
+    withCorrelationId(() => {
+      id = getCorrelationId();
+    }, "   ");
+    expect(id).toBeDefined();
+    expect(id?.trim().length).toBeGreaterThan(0);
+    expect(id).not.toBe("   ");
+  });
+
+  it("isolates IDs across concurrent scopes", async () => {
+    const ids: string[] = [];
+    await Promise.all([
+      new Promise<void>((resolve) =>
+        withCorrelationId(() => {
+          // Yield to let other scope run
+          setTimeout(() => {
+            ids.push(getCorrelationId() ?? "");
+            resolve();
+          }, 0);
+        }, "ID-A"),
+      ),
+      new Promise<void>((resolve) =>
+        withCorrelationId(() => {
+          setTimeout(() => {
+            ids.push(getCorrelationId() ?? "");
+            resolve();
+          }, 0);
+        }, "ID-B"),
+      ),
+    ]);
+    expect(ids).toContain("ID-A");
+    expect(ids).toContain("ID-B");
+    expect(ids).toHaveLength(2);
+  });
+
+  it("returns undefined outside a scope", () => {
+    expect(getCorrelationId()).toBeUndefined();
+  });
+
+  it("returns the value produced by fn", () => {
+    const result = withCorrelationId(() => 42);
+    expect(result).toBe(42);
+  });
+});
+
+describe("generateCorrelationId", () => {
+  it("returns a ULID-shaped string", () => {
+    const id = generateCorrelationId();
+    expect(id).toMatch(/^[0-9A-Z]{26}$/);
+  });
+
+  it("returns unique values on each call", () => {
+    const a = generateCorrelationId();
+    const b = generateCorrelationId();
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/logging/correlation.ts
+++ b/src/logging/correlation.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-request correlation-ID context for omnifocus-mcp.
+ *
+ * Each MCP tool call runs inside a `withCorrelationId` scope. Code anywhere
+ * in the call stack can read the current ID via `getCorrelationId()` without
+ * threading it through every function argument.
+ *
+ * IDs are ULIDs — lexicographically sortable, collision-resistant, and
+ * easy to grep in logs. If the MCP client supplies its own correlation ID
+ * (via request meta), we reuse it so client and server logs align.
+ *
+ * @see DESIGN.md §21 — observability contract (correlation)
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { ulid } from "ulid";
+
+const storage = new AsyncLocalStorage<string>();
+
+/**
+ * Run `fn` in a new correlation-ID scope.
+ *
+ * If `incomingId` is provided (non-empty string), it is reused; otherwise a
+ * fresh ULID is generated. The ID is available inside `fn` via
+ * `getCorrelationId()`.
+ */
+export function withCorrelationId<T>(fn: () => T, incomingId?: string): T {
+  const id = incomingId?.trim() ? incomingId.trim() : ulid();
+  return storage.run(id, fn);
+}
+
+/**
+ * Return the current correlation ID, or `undefined` if called outside a
+ * `withCorrelationId` scope.
+ */
+export function getCorrelationId(): string | undefined {
+  return storage.getStore();
+}
+
+/** Generate a fresh ULID (exposed for callers that need one without a scope). */
+export function generateCorrelationId(): string {
+  return ulid();
+}


### PR DESCRIPTION
## Summary
- Implements DESIGN §21 per-request correlation: `withCorrelationId()` scopes a ULID via `AsyncLocalStorage`
- Reuses incoming client-supplied IDs when provided; generates a fresh ULID otherwise
- `getCorrelationId()` readable anywhere in the call stack without arg threading
- 9 unit tests: propagation, incoming ID reuse, empty/whitespace fallback, concurrent isolation, out-of-scope undefined

## Design link
Closes #10. Relevant: DESIGN.md §21 (observability — correlation).

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 85 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] No new dependencies (ulid was already in package.json)