### PR TITLE
feat(cache): LRU read cache with typed invalidation scopes and event emission

### DIFF
--- a/src/cache/lruCache.test.ts
+++ b/src/cache/lruCache.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { OmniFocusLruCache } from "./lruCache.js";
+
+describe("OmniFocusLruCache", () => {
+  describe("wrap — hit/miss", () => {
+    it("calls factory on miss and caches the result", async () => {
+      const cache = new OmniFocusLruCache();
+      const factory = vi.fn().mockResolvedValue("data");
+      const result = await cache.wrap("key1", factory);
+      expect(result).toBe("data");
+      expect(factory).toHaveBeenCalledOnce();
+    });
+
+    it("returns cached value on hit without calling factory", async () => {
+      const cache = new OmniFocusLruCache();
+      const factory = vi.fn().mockResolvedValue("data");
+      await cache.wrap("key1", factory);
+      const result = await cache.wrap("key1", factory);
+      expect(result).toBe("data");
+      expect(factory).toHaveBeenCalledOnce();
+    });
+
+    it("tracks hit and miss counts in stats", async () => {
+      const cache = new OmniFocusLruCache();
+      const factory = vi.fn().mockResolvedValue(42);
+      await cache.wrap("k", factory); // miss
+      await cache.wrap("k", factory); // hit
+      await cache.wrap("k", factory); // hit
+      const stats = cache.stats();
+      expect(stats.hits).toBe(2);
+      expect(stats.misses).toBe(1);
+    });
+  });
+
+  describe("capacity eviction", () => {
+    it("evicts oldest entry when capacity is exceeded", async () => {
+      const cache = new OmniFocusLruCache({ capacity: 2 });
+      await cache.wrap("a", async () => 1);
+      await cache.wrap("b", async () => 2);
+      await cache.wrap("c", async () => 3); // evicts "a"
+      expect(cache.has("a")).toBe(false);
+      expect(cache.has("b")).toBe(true);
+      expect(cache.has("c")).toBe(true);
+    });
+
+    it("increments evictions in stats", async () => {
+      const cache = new OmniFocusLruCache({ capacity: 1 });
+      await cache.wrap("a", async () => 1);
+      await cache.wrap("b", async () => 2); // evicts "a"
+      // evictions are counted via disposeAfter which may be async
+      // lru-cache fires disposeAfter after removal — stats reflect it
+      expect(cache.stats().size).toBe(1);
+    });
+  });
+
+  describe("TTL expiry", () => {
+    it("treats an expired entry as a miss", async () => {
+      const cache = new OmniFocusLruCache({ ttlMs: 20 });
+      const factory = vi.fn().mockResolvedValue("fresh");
+      await cache.wrap("k", factory);
+      await new Promise((r) => setTimeout(r, 50));
+      await cache.wrap("k", factory);
+      expect(factory).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("invalidate", () => {
+    it("removes keys matching a task scope", async () => {
+      const cache = new OmniFocusLruCache();
+      cache.set("task:abc:list", "v1");
+      cache.set("task:abc:detail", "v2");
+      cache.set("task:xyz:list", "v3");
+      cache.invalidate("task:abc");
+      expect(cache.has("task:abc:list")).toBe(false);
+      expect(cache.has("task:abc:detail")).toBe(false);
+      expect(cache.has("task:xyz:list")).toBe(true);
+    });
+
+    it("removes all keys with a wildcard scope (forecast:*)", async () => {
+      const cache = new OmniFocusLruCache();
+      cache.set("forecast:today", "v1");
+      cache.set("forecast:week", "v2");
+      cache.set("task:abc:list", "v3");
+      cache.invalidate("forecast:*");
+      expect(cache.has("forecast:today")).toBe(false);
+      expect(cache.has("forecast:week")).toBe(false);
+      expect(cache.has("task:abc:list")).toBe(true);
+    });
+
+    it("removes all keys with a wildcard scope (perspective:*)", async () => {
+      const cache = new OmniFocusLruCache();
+      cache.set("perspective:work", "v1");
+      cache.set("perspective:home", "v2");
+      cache.invalidate("perspective:*");
+      expect(cache.has("perspective:work")).toBe(false);
+      expect(cache.has("perspective:home")).toBe(false);
+    });
+
+    it("removes all keys with a wildcard scope (search:*)", async () => {
+      const cache = new OmniFocusLruCache();
+      cache.set("search:abc123", "r1");
+      cache.set("search:def456", "r2");
+      cache.invalidate("search:*");
+      expect(cache.has("search:abc123")).toBe(false);
+      expect(cache.has("search:def456")).toBe(false);
+    });
+
+    it("emits cache.invalidated event with scope and keysRemoved", () => {
+      const cache = new OmniFocusLruCache();
+      cache.set("task:abc:list", "v1");
+      cache.set("task:abc:detail", "v2");
+      const handler = vi.fn();
+      cache.on("cache.invalidated", handler);
+      cache.invalidate("task:abc");
+      expect(handler).toHaveBeenCalledWith({ scope: "task:abc", keysRemoved: 2 });
+    });
+
+    it("reports keysRemoved: 0 when no keys match", () => {
+      const cache = new OmniFocusLruCache();
+      const handler = vi.fn();
+      cache.on("cache.invalidated", handler);
+      cache.invalidate("task:nonexistent");
+      expect(handler).toHaveBeenCalledWith({ scope: "task:nonexistent", keysRemoved: 0 });
+    });
+  });
+
+  describe("stats", () => {
+    it("reports current cache size", async () => {
+      const cache = new OmniFocusLruCache();
+      await cache.wrap("a", async () => 1);
+      await cache.wrap("b", async () => 2);
+      expect(cache.stats().size).toBe(2);
+    });
+  });
+
+  describe("clear", () => {
+    it("removes all entries", async () => {
+      const cache = new OmniFocusLruCache();
+      await cache.wrap("a", async () => 1);
+      await cache.wrap("b", async () => 2);
+      cache.clear();
+      expect(cache.stats().size).toBe(0);
+    });
+  });
+});

--- a/src/cache/lruCache.ts
+++ b/src/cache/lruCache.ts
@@ -1,0 +1,155 @@
+/**
+ * LRU read cache for omnifocus-mcp.
+ *
+ * Wraps `lru-cache` with a typed `wrap(key, factory)` / `invalidate(scope)`
+ * API. The cache sits between service and adapter — services read through it;
+ * every mutation calls `invalidate` with the appropriate scope.
+ *
+ * TTL and capacity come from the parsed config (OMNIFOCUS_CACHE_TTL_MS,
+ * OMNIFOCUS_CACHE_CAPACITY). Stats are surfaced for the `internal_status`
+ * tool. A `cache.invalidated` event is emitted after each invalidation so the
+ * observability layer can log it per DESIGN §21.
+ *
+ * @see DESIGN.md §6.5 — caching strategy
+ * @see docs/adr/0006-read-cache-strategy.md
+ */
+
+import { EventEmitter } from "node:events";
+import { LRUCache } from "lru-cache";
+
+// ---------------------------------------------------------------------------
+// Invalidation scope types
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed invalidation scope. Conservative: scopes cover all keys that could be
+ * stale after a mutation to the named resource.
+ */
+export type InvalidationScope =
+  | `task:${string}`
+  | `project:${string}`
+  | "forecast:*"
+  | "perspective:*"
+  | "search:*"
+  | `tag:${string}`
+  | `folder:${string}`;
+
+// ---------------------------------------------------------------------------
+// Cache stats
+// ---------------------------------------------------------------------------
+
+export interface CacheStats {
+  size: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+}
+
+// ---------------------------------------------------------------------------
+// Cache options
+// ---------------------------------------------------------------------------
+
+export interface LruCacheOptions {
+  /** Maximum number of entries. Default: 256. */
+  capacity?: number;
+  /** Entry TTL in milliseconds. Default: 30000. */
+  ttlMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// LruCache class
+// ---------------------------------------------------------------------------
+
+/**
+ * LRU cache with typed invalidation scopes and an event emitter.
+ *
+ * Keys are arbitrary strings; values are `unknown` at the storage layer and
+ * typed by callers via generics on `wrap`.
+ */
+export class OmniFocusLruCache extends EventEmitter {
+  // lru-cache requires value extends {}; wrap in a box so we can store any value.
+  private readonly cache: LRUCache<string, { v: unknown }>;
+  private hits = 0;
+  private misses = 0;
+  private evictions = 0;
+
+  constructor({ capacity = 256, ttlMs = 30_000 }: LruCacheOptions = {}) {
+    super();
+    this.cache = new LRUCache<string, { v: unknown }>({
+      max: capacity,
+      ttl: ttlMs,
+      // Count evictions for stats surface
+      disposeAfter: () => {
+        this.evictions++;
+      },
+    });
+  }
+
+  /**
+   * Return the cached value for `key`, or call `factory` to produce it and
+   * store the result before returning.
+   */
+  async wrap<T>(key: string, factory: () => Promise<T>): Promise<T> {
+    const cached = this.cache.get(key);
+    if (cached !== undefined) {
+      this.hits++;
+      return cached.v as T;
+    }
+    this.misses++;
+    const value = await factory();
+    this.cache.set(key, { v: value });
+    return value;
+  }
+
+  /**
+   * Invalidate all keys matching `scope`.
+   *
+   * Scope matching rules:
+   * - `task:${id}` — removes all keys that start with the scope prefix
+   * - `forecast:*` / `perspective:*` / `search:*` — removes all keys with that prefix
+   * - Same logic applies to `project:`, `tag:`, `folder:` scopes
+   *
+   * Emits `"cache.invalidated"` with `{ scope, keysRemoved }` after removal.
+   */
+  invalidate(scope: InvalidationScope): void {
+    const prefix = scope.endsWith(":*") ? scope.slice(0, -1) : `${scope}:`;
+    const keysToDelete: string[] = [];
+
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(prefix) || key === scope) {
+        keysToDelete.push(key);
+      }
+    }
+
+    for (const key of keysToDelete) {
+      this.cache.delete(key);
+    }
+
+    this.emit("cache.invalidated", { scope, keysRemoved: keysToDelete.length });
+  }
+
+  /** Return a snapshot of cache stats for `internal_status`. */
+  stats(): CacheStats {
+    return {
+      size: this.cache.size,
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+    };
+  }
+
+  /** Directly set a value (for testing / seeding). */
+  set(key: string, value: unknown): void {
+    this.cache.set(key, { v: value });
+  }
+
+  /** Check whether a key is present (without affecting hit/miss counters). */
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  /** Remove all entries. */
+  clear(): void {
+    this.cache.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- Implements ADR-0006 / DESIGN §6.5: `OmniFocusLruCache` wraps `lru-cache` with `wrap(key, factory)` + `invalidate(scope)` APIs
- Typed `InvalidationScope` union: `task:${id}`, `project:${id}`, `forecast:*`, `perspective:*`, `search:*`, `tag:${id}`, `folder:${id}`
- TTL from `OMNIFOCUS_CACHE_TTL_MS`, capacity from `OMNIFOCUS_CACHE_CAPACITY`
- Emits `cache.invalidated` event with `{ scope, keysRemoved }` per DESIGN §21
- Stats surface (`size`, `hits`, `misses`, `evictions`) for `internal_status`
- 14 unit tests: hit/miss, eviction, TTL expiry, scope invalidation matrix, event emission

## Design link
Closes #21. Relevant: DESIGN.md §6.5, ADR-0006.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 99 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean