### PR TITLE
feat(domain): Task + Project zod schemas matching domain-reference.md

### DIFF
--- a/src/domain/ids.ts
+++ b/src/domain/ids.ts
@@ -29,11 +29,11 @@ import { z } from "zod";
 // Branded types
 // ---------------------------------------------------------------------------
 
-declare const TaskIdBrand: unique symbol;
-declare const ProjectIdBrand: unique symbol;
-declare const TagIdBrand: unique symbol;
-declare const FolderIdBrand: unique symbol;
-declare const AttachmentIdBrand: unique symbol;
+export const TaskIdBrand: unique symbol = Symbol("TaskId");
+export const ProjectIdBrand: unique symbol = Symbol("ProjectId");
+export const TagIdBrand: unique symbol = Symbol("TagId");
+export const FolderIdBrand: unique symbol = Symbol("FolderId");
+export const AttachmentIdBrand: unique symbol = Symbol("AttachmentId");
 
 export type TaskId = string & { readonly [TaskIdBrand]: "TaskId" };
 export type ProjectId = string & { readonly [ProjectIdBrand]: "ProjectId" };

--- a/src/domain/project.test.ts
+++ b/src/domain/project.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { ProjectSchema } from "./project.js";
+
+const BASE_PROJECT = {
+  id: "pAbCdEfGhIj",
+  name: "Q2 Budget Review",
+  note: null,
+  noteHtml: null,
+  folderId: null,
+  tagIds: [],
+  status: "active",
+  completionCriterion: "parallel",
+  deferDate: null,
+  dueDate: null,
+  estimatedMinutes: null,
+  flagged: false,
+  reviewIntervalDays: 7,
+  nextReviewDate: "2026-04-28T09:00:00-05:00",
+  lastReviewDate: "2026-04-21T09:00:00-05:00",
+  completed: false,
+  completedAt: null,
+  dropped: false,
+  droppedAt: null,
+  taskCount: 5,
+  completedTaskCount: 2,
+  createdAt: "2026-01-01T10:00:00Z",
+  modifiedAt: "2026-04-19T15:23:04-05:00",
+};
+
+describe("ProjectSchema", () => {
+  it("round-trips a representative project", () => {
+    const result = ProjectSchema.parse(BASE_PROJECT);
+    expect(result.id).toBe("pAbCdEfGhIj");
+    expect(result.status).toBe("active");
+    expect(result.completionCriterion).toBe("parallel");
+    expect(result.taskCount).toBe(5);
+  });
+
+  it("accepts all status values", () => {
+    for (const status of ["active", "on-hold", "done", "dropped"] as const) {
+      const result = ProjectSchema.parse({ ...BASE_PROJECT, status });
+      expect(result.status).toBe(status);
+    }
+  });
+
+  it("accepts all completionCriterion values", () => {
+    for (const cc of ["parallel", "sequential", "singleActions"] as const) {
+      const result = ProjectSchema.parse({ ...BASE_PROJECT, completionCriterion: cc });
+      expect(result.completionCriterion).toBe(cc);
+    }
+  });
+
+  it("accepts a folderId", () => {
+    const result = ProjectSchema.parse({ ...BASE_PROJECT, folderId: "fXyZaBcDeF" });
+    expect(result.folderId).toBe("fXyZaBcDeF");
+  });
+
+  it("accepts tagIds", () => {
+    const result = ProjectSchema.parse({ ...BASE_PROJECT, tagIds: ["tWorK"] });
+    expect(result.tagIds).toEqual(["tWorK"]);
+  });
+
+  it("rejects a bare local date (no offset)", () => {
+    expect(() =>
+      ProjectSchema.parse({ ...BASE_PROJECT, dueDate: "2026-05-01T12:00:00" }),
+    ).toThrow();
+  });
+
+  it("rejects an invalid projectId shape (too short)", () => {
+    expect(() => ProjectSchema.parse({ ...BASE_PROJECT, id: "ab" })).toThrow();
+  });
+
+  it("rejects an invalid status", () => {
+    expect(() => ProjectSchema.parse({ ...BASE_PROJECT, status: "archived" })).toThrow();
+  });
+
+  it("accepts null for all nullable review dates", () => {
+    const result = ProjectSchema.parse({
+      ...BASE_PROJECT,
+      reviewIntervalDays: null,
+      nextReviewDate: null,
+      lastReviewDate: null,
+    });
+    expect(result.reviewIntervalDays).toBeNull();
+  });
+
+  it("accepts a completed project with timestamp", () => {
+    const result = ProjectSchema.parse({
+      ...BASE_PROJECT,
+      status: "done",
+      completed: true,
+      completedAt: "2026-04-20T10:00:00Z",
+    });
+    expect(result.completedAt).toBe("2026-04-20T10:00:00Z");
+  });
+});

--- a/src/domain/project.ts
+++ b/src/domain/project.ts
@@ -1,0 +1,100 @@
+/**
+ * Zod schemas and TypeScript types for the Project domain object.
+ *
+ * Matches the canonical schema in `docs/domain-reference.md` exactly.
+ * Dates are ISO-8601 with offset per ADR-0007; IDs are branded per ADR-0008.
+ *
+ * The explicit interface (Project) is the source of truth for the TypeScript
+ * type; the zod schema is annotated as `z.ZodType<Project>` to avoid TS4023
+ * "cannot be named" errors caused by unique-symbol brands inside deeply-
+ * inferred zod generics.
+ *
+ * @see docs/domain-reference.md — canonical field definitions
+ * @see DESIGN.md §13 — ID strategy
+ * @see DESIGN.md §14 — date handling
+ */
+
+import { z } from "zod";
+import { type IsoDateString, isoDateString } from "./dates.js";
+import {
+  type FolderId,
+  FolderId as FolderIdCtor,
+  type ProjectId,
+  ProjectId as ProjectIdCtor,
+  type TagId,
+  TagId as TagIdCtor,
+} from "./ids.js";
+
+// ---------------------------------------------------------------------------
+// Project
+// ---------------------------------------------------------------------------
+
+export interface Project {
+  id: ProjectId;
+  name: string;
+  note: string | null;
+  noteHtml: string | null;
+
+  folderId: FolderId | null;
+  tagIds: TagId[];
+
+  status: "active" | "on-hold" | "done" | "dropped";
+  completionCriterion: "parallel" | "sequential" | "singleActions";
+
+  deferDate: IsoDateString | null;
+  dueDate: IsoDateString | null;
+  estimatedMinutes: number | null;
+  flagged: boolean;
+
+  reviewIntervalDays: number | null;
+  nextReviewDate: IsoDateString | null;
+  lastReviewDate: IsoDateString | null;
+
+  completed: boolean;
+  completedAt: IsoDateString | null;
+  dropped: boolean;
+  droppedAt: IsoDateString | null;
+
+  taskCount: number;
+  completedTaskCount: number;
+
+  createdAt: IsoDateString;
+  modifiedAt: IsoDateString;
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const ProjectSchema: z.ZodType<Project, z.ZodTypeDef, unknown> = z.object({
+  id: ProjectIdCtor.schema,
+  name: z.string(),
+  note: z.string().nullable(),
+  noteHtml: z.string().nullable(),
+
+  folderId: FolderIdCtor.schema.nullable(),
+  tagIds: z.array(TagIdCtor.schema),
+
+  status: z.enum(["active", "on-hold", "done", "dropped"]),
+  completionCriterion: z.enum(["parallel", "sequential", "singleActions"]),
+
+  deferDate: isoDateString().nullable(),
+  dueDate: isoDateString().nullable(),
+  estimatedMinutes: z.number().int().min(1).nullable(),
+  flagged: z.boolean(),
+
+  reviewIntervalDays: z.number().int().min(1).nullable(),
+  nextReviewDate: isoDateString().nullable(),
+  lastReviewDate: isoDateString().nullable(),
+
+  completed: z.boolean(),
+  completedAt: isoDateString().nullable(),
+  dropped: z.boolean(),
+  droppedAt: isoDateString().nullable(),
+
+  taskCount: z.number().int().min(0),
+  completedTaskCount: z.number().int().min(0),
+
+  createdAt: isoDateString(),
+  modifiedAt: isoDateString(),
+}) as z.ZodType<Project, z.ZodTypeDef, unknown>;

--- a/src/domain/task.test.ts
+++ b/src/domain/task.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { RepetitionRuleSchema, TaskSchema } from "./task.js";
+
+const BASE_TASK = {
+  id: "gHqVKr3xAWo",
+  name: "Review Q2 budget",
+  note: null,
+  noteHtml: null,
+  projectId: "pAbCdEfGhIj",
+  parentId: null,
+  tagIds: ["tWorK"],
+  deferDate: null,
+  dueDate: "2026-05-01T17:00:00-05:00",
+  estimatedMinutes: 45,
+  flagged: true,
+  completed: false,
+  completedAt: null,
+  dropped: false,
+  droppedAt: null,
+  available: true,
+  blocked: false,
+  sequential: false,
+  completedByChildren: false,
+  repetition: null,
+  createdAt: "2026-04-19T15:23:04-05:00",
+  modifiedAt: "2026-04-19T15:23:04-05:00",
+};
+
+describe("TaskSchema", () => {
+  it("round-trips a representative task", () => {
+    const result = TaskSchema.parse(BASE_TASK);
+    expect(result.id).toBe("gHqVKr3xAWo");
+    expect(result.tagIds).toEqual(["tWorK"]);
+    expect(result.dueDate).toBe("2026-05-01T17:00:00-05:00");
+  });
+
+  it("accepts an inbox task (null projectId)", () => {
+    const result = TaskSchema.parse({ ...BASE_TASK, projectId: null });
+    expect(result.projectId).toBeNull();
+  });
+
+  it("accepts empty tagIds array", () => {
+    const result = TaskSchema.parse({ ...BASE_TASK, tagIds: [] });
+    expect(result.tagIds).toHaveLength(0);
+  });
+
+  it("rejects a bare local date (no offset)", () => {
+    expect(() => TaskSchema.parse({ ...BASE_TASK, dueDate: "2026-05-01T17:00:00" })).toThrow();
+  });
+
+  it("rejects a naked string where projectId is expected", () => {
+    expect(() => TaskSchema.parse({ ...BASE_TASK, projectId: "ab" })).toThrow();
+  });
+
+  it("rejects a naked string where a tagId is expected", () => {
+    expect(() => TaskSchema.parse({ ...BASE_TASK, tagIds: ["ab"] })).toThrow();
+  });
+
+  it("accepts null for all nullable date fields", () => {
+    const result = TaskSchema.parse({
+      ...BASE_TASK,
+      deferDate: null,
+      dueDate: null,
+      completedAt: null,
+      droppedAt: null,
+    });
+    expect(result.deferDate).toBeNull();
+  });
+
+  it("accepts a task with a repetition rule", () => {
+    const result = TaskSchema.parse({
+      ...BASE_TASK,
+      repetition: { method: "fixed", unit: "weeks", steps: 1 },
+    });
+    expect(result.repetition?.method).toBe("fixed");
+  });
+});
+
+describe("RepetitionRuleSchema", () => {
+  it("accepts fixed/weeks/1", () => {
+    const r = RepetitionRuleSchema.parse({ method: "fixed", unit: "weeks", steps: 1 });
+    expect(r.unit).toBe("weeks");
+  });
+
+  it("accepts weekdays with unit=weeks", () => {
+    const r = RepetitionRuleSchema.parse({
+      method: "start-again",
+      unit: "weeks",
+      steps: 1,
+      weekdays: ["monday", "wednesday"],
+    });
+    expect(r.weekdays).toEqual(["monday", "wednesday"]);
+  });
+
+  it("rejects weekdays when unit is not weeks", () => {
+    expect(() =>
+      RepetitionRuleSchema.parse({
+        method: "fixed",
+        unit: "days",
+        steps: 1,
+        weekdays: ["monday"],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts monthlyAnchor with day", () => {
+    const r = RepetitionRuleSchema.parse({
+      method: "due-again",
+      unit: "months",
+      steps: 1,
+      monthlyAnchor: { day: 15 },
+    });
+    expect(r.monthlyAnchor).toEqual({ day: 15 });
+  });
+
+  it("accepts monthlyAnchor with weekday+position", () => {
+    const r = RepetitionRuleSchema.parse({
+      method: "fixed",
+      unit: "months",
+      steps: 3,
+      monthlyAnchor: { weekday: "friday", position: "last" },
+    });
+    expect(r.monthlyAnchor).toEqual({ weekday: "friday", position: "last" });
+  });
+
+  it("rejects monthlyAnchor when unit is not months", () => {
+    expect(() =>
+      RepetitionRuleSchema.parse({
+        method: "fixed",
+        unit: "weeks",
+        steps: 1,
+        monthlyAnchor: { day: 15 },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects both weekdays and monthlyAnchor set simultaneously", () => {
+    expect(() =>
+      RepetitionRuleSchema.parse({
+        method: "fixed",
+        unit: "weeks",
+        steps: 1,
+        weekdays: ["monday"],
+        monthlyAnchor: { day: 1 },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects steps < 1", () => {
+    expect(() => RepetitionRuleSchema.parse({ method: "fixed", unit: "days", steps: 0 })).toThrow();
+  });
+});

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -1,0 +1,161 @@
+/**
+ * Zod schemas and TypeScript types for the Task domain object.
+ *
+ * Matches the canonical schema in `docs/domain-reference.md` exactly.
+ * Dates are ISO-8601 with offset per ADR-0007; IDs are branded per ADR-0008.
+ *
+ * The explicit interfaces (Task, RepetitionRule) are the source of truth for
+ * the TypeScript types; the zod schemas are annotated as `z.ZodType<T>` to
+ * avoid TS4023 "cannot be named" errors caused by unique-symbol brands inside
+ * deeply-inferred zod generics.
+ *
+ * @see docs/domain-reference.md — canonical field definitions
+ * @see DESIGN.md §13 — ID strategy
+ * @see DESIGN.md §14 — date handling
+ */
+
+import { z } from "zod";
+import { type IsoDateString, isoDateString } from "./dates.js";
+import {
+  type ProjectId,
+  ProjectId as ProjectIdCtor,
+  type TagId,
+  TagId as TagIdCtor,
+  type TaskId,
+  TaskId as TaskIdCtor,
+} from "./ids.js";
+
+// ---------------------------------------------------------------------------
+// RepetitionRule
+// ---------------------------------------------------------------------------
+
+export type Weekday =
+  | "sunday"
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday";
+
+export type MonthlyAnchor =
+  | { day: number }
+  | { weekday: Weekday; position: 1 | 2 | 3 | 4 | "last" };
+
+export interface RepetitionRule {
+  method: "fixed" | "start-again" | "due-again";
+  unit: "minutes" | "hours" | "days" | "weeks" | "months" | "years";
+  steps: number;
+  weekdays?: Weekday[];
+  monthlyAnchor?: MonthlyAnchor;
+}
+
+// ---------------------------------------------------------------------------
+// Task
+// ---------------------------------------------------------------------------
+
+export interface Task {
+  id: TaskId;
+  name: string;
+
+  note: string | null;
+  noteHtml: string | null;
+
+  projectId: ProjectId | null;
+  parentId: TaskId | null;
+  tagIds: TagId[];
+
+  deferDate: IsoDateString | null;
+  dueDate: IsoDateString | null;
+  estimatedMinutes: number | null;
+
+  flagged: boolean;
+  completed: boolean;
+  completedAt: IsoDateString | null;
+  dropped: boolean;
+  droppedAt: IsoDateString | null;
+  available: boolean;
+  blocked: boolean;
+
+  sequential: boolean;
+  completedByChildren: boolean;
+
+  repetition: RepetitionRule | null;
+
+  createdAt: IsoDateString;
+  modifiedAt: IsoDateString;
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const weekdaySchema = z.enum([
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+]);
+
+const monthlyAnchorSchema = z.union([
+  z.object({ day: z.number().int().min(1).max(31) }),
+  z.object({
+    weekday: weekdaySchema,
+    position: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal("last")]),
+  }),
+]);
+
+export const RepetitionRuleSchema: z.ZodType<RepetitionRule, z.ZodTypeDef, unknown> = z
+  .object({
+    method: z.enum(["fixed", "start-again", "due-again"]),
+    unit: z.enum(["minutes", "hours", "days", "weeks", "months", "years"]),
+    steps: z.number().int().min(1),
+    weekdays: z.array(weekdaySchema).optional(),
+    monthlyAnchor: monthlyAnchorSchema.optional(),
+  })
+  .refine((r) => r.weekdays === undefined || r.unit === "weeks", {
+    message: "weekdays is only valid when unit is 'weeks'",
+    path: ["weekdays"],
+  })
+  .refine((r) => r.monthlyAnchor === undefined || r.unit === "months", {
+    message: "monthlyAnchor is only valid when unit is 'months'",
+    path: ["monthlyAnchor"],
+  })
+  .refine((r) => !(r.weekdays !== undefined && r.monthlyAnchor !== undefined), {
+    message: "Only one of weekdays or monthlyAnchor may be set",
+  }) as z.ZodType<RepetitionRule, z.ZodTypeDef, unknown>;
+
+export const TaskSchema: z.ZodType<Task, z.ZodTypeDef, unknown> = z.object({
+  id: TaskIdCtor.schema,
+  name: z.string(),
+
+  note: z.string().nullable(),
+  noteHtml: z.string().nullable(),
+
+  projectId: ProjectIdCtor.schema.nullable(),
+  parentId: TaskIdCtor.schema.nullable(),
+  tagIds: z.array(TagIdCtor.schema),
+
+  deferDate: isoDateString().nullable(),
+  dueDate: isoDateString().nullable(),
+  estimatedMinutes: z.number().int().min(1).nullable(),
+
+  flagged: z.boolean(),
+  completed: z.boolean(),
+  completedAt: isoDateString().nullable(),
+  dropped: z.boolean(),
+  droppedAt: isoDateString().nullable(),
+  available: z.boolean(),
+  blocked: z.boolean(),
+
+  sequential: z.boolean(),
+  completedByChildren: z.boolean(),
+
+  repetition: RepetitionRuleSchema.nullable(),
+
+  createdAt: isoDateString(),
+  modifiedAt: isoDateString(),
+}) as z.ZodType<Task, z.ZodTypeDef, unknown>;


### PR DESCRIPTION
## Summary
- Adds `TaskSchema`, `ProjectSchema`, `RepetitionRuleSchema` (+ types) covering all fields in `docs/domain-reference.md`
- Branded IDs (TaskId, ProjectId, TagId, FolderId) and `isoDateString()` dates flow through correctly
- Annotated as `z.ZodType<T, ZodTypeDef, unknown>` to prevent TS4023 from unique-symbol brands in zod generics
- Exports brand symbols from `ids.ts` as concrete consts (was `declare const`; needed for declaration visibility)
- 26 unit tests: round-trips, nullable fields, bad date/ID/enum rejection, RepetitionRule constraint validation

## Design link
Closes #34. See DESIGN.md §13 (IDs) and §14 (dates); docs/domain-reference.md (canonical schemas).

## Breaking change?
- [x] No

## Test plan
- [x] 151 unit tests passing (`pnpm test`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (biome + lint-custom)
- [x] Self-reviewed via review_pr.md checklist
- [x] No new dependencies