### PR TITLE
ci: baseline GitHub workflows — CI, board sync, PR title, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    groups:
+      dev-deps:
+        dependency-type: development
+        update-types: [minor, patch]
+      prod-deps:
+        dependency-type: production
+        update-types: [minor, patch]
+    commit-message:
+      prefix: chore(deps)
+    labels:
+      - "type: chore"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: chore(ci)
+    labels:
+      - "type: chore"

--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -1,0 +1,119 @@
+# Board-state sync for the user-owned Projects v2 board `torsday/projects/4`.
+#
+# Requires a repo secret `PROJECT_TOKEN` — a fine-grained PAT with:
+#   - User permission "Projects: Read and write"
+#   - Repository permission "Issues: Read and write"
+# GITHUB_TOKEN can't write to user-owned projects; the PAT is required.
+#
+# Field/option IDs are hardcoded for project 4. If the project is recreated,
+# re-query:
+#   gh api graphql -f query='query { user(login:"torsday") { projectV2(number:4) {
+#     id field(name:"Status") { ... on ProjectV2SingleSelectField { id options { id name } } } } } }'
+# and update the env block below.
+
+name: Board sync
+
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+  issues:
+    types: [closed, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+env:
+  GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+  PROJECT_ID: PVT_kwHOAARNgc4BVGvQ
+  STATUS_FIELD: PVTSSF_lAHOAARNgc4BVGvQzhQkx-E
+  OPT_IN_PROGRESS: "381a1e62"
+  OPT_IN_REVIEW: "04079029"
+  OPT_DONE: c2f7c066
+
+jobs:
+  pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if no token
+        if: env.GH_TOKEN == ''
+        run: |
+          echo "::warning::PROJECT_TOKEN not set — skipping board sync. Add a PAT with Projects read/write to enable."
+          exit 0
+
+      - name: Extract linked issue numbers from PR body
+        id: linked
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          nums=$(printf '%s' "$PR_BODY" \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u \
+            | tr '\n' ' ')
+          echo "nums=$nums" >> "$GITHUB_OUTPUT"
+          echo "Linked issues: ${nums:-<none>}"
+
+      - name: PR opened → flip linked issues to In Review
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          NUMS: ${{ steps.linked.outputs.nums }}
+        run: |
+          for n in $NUMS; do
+            item=$(gh api graphql \
+              -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
+              -F o="$OWNER" -F r="$REPO" -F n="$n" \
+              --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id==\"$PROJECT_ID\") | .id" || true)
+            [ -z "$item" ] && { echo "#$n not on project — skip"; continue; }
+            gh api graphql -f query="mutation{updateProjectV2ItemFieldValue(input:{projectId:\"$PROJECT_ID\",itemId:\"$item\",fieldId:\"$STATUS_FIELD\",value:{singleSelectOptionId:\"$OPT_IN_REVIEW\"}}){projectV2Item{id}}}" >/dev/null
+            echo "#$n → In Review"
+          done
+
+      - name: PR merged → flip linked issues to Done + strip label
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          NUMS: ${{ steps.linked.outputs.nums }}
+        run: |
+          for n in $NUMS; do
+            item=$(gh api graphql \
+              -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
+              -F o="$OWNER" -F r="$REPO" -F n="$n" \
+              --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id==\"$PROJECT_ID\") | .id" || true)
+            if [ -n "$item" ]; then
+              gh api graphql -f query="mutation{updateProjectV2ItemFieldValue(input:{projectId:\"$PROJECT_ID\",itemId:\"$item\",fieldId:\"$STATUS_FIELD\",value:{singleSelectOptionId:\"$OPT_DONE\"}}){projectV2Item{id}}}" >/dev/null
+              echo "#$n → Done"
+            fi
+            gh issue edit "$n" --remove-label "status: in-progress" 2>/dev/null || true
+          done
+
+  issue-closed:
+    if: github.event_name == 'issues' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if no token
+        if: env.GH_TOKEN == ''
+        run: |
+          echo "::warning::PROJECT_TOKEN not set — skipping board sync."
+          exit 0
+
+      - name: Flip closed issue to Done + strip label
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          N: ${{ github.event.issue.number }}
+        run: |
+          item=$(gh api graphql \
+            -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
+            -F o="$OWNER" -F r="$REPO" -F n="$N" \
+            --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id==\"$PROJECT_ID\") | .id" || true)
+          if [ -n "$item" ]; then
+            gh api graphql -f query="mutation{updateProjectV2ItemFieldValue(input:{projectId:\"$PROJECT_ID\",itemId:\"$item\",fieldId:\"$STATUS_FIELD\",value:{singleSelectOptionId:\"$OPT_DONE\"}}){projectV2Item{id}}}" >/dev/null
+            echo "#$N → Done"
+          fi
+          gh issue edit "$N" --remove-label "status: in-progress" 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ concurrency:
 jobs:
   build:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    name: build (Node ${{ matrix.node-version }})
     steps:
       - uses: actions/checkout@v4
 
@@ -19,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+
+      - run: pnpm lint
+
+      - run: pnpm test
+
+      - run: pnpm build

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^[a-z].+[^.]$
+          subjectPatternError: |
+            PR title subject must start lowercase and not end with a period.
+            Got: "{subject}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`: runs on `macos-latest` × Node 20/22 matrix — typecheck, lint, test, build
- Adds `.github/workflows/pr-title.yml`: enforces Conventional Commits PR title format
- Adds `.github/workflows/board-sync.yml`: syncs closed issues/merged PRs to project board
- Adds `.github/dependabot.yml`: weekly npm dependency updates
- Node 20/22 matrix added in latest commit to satisfy issue #7 AC

## Design link
Closes #7. See DESIGN.md §20 (CI/CD).

## Breaking change?
- [x] No

## Test plan
- [x] CI pipeline runs green on this PR itself
- [x] Both Node 20 and Node 22 jobs must pass