### PR TITLE
feat(pagination): cursor codec for base64url cursor-based pagination

### DIFF
--- a/src/pagination/cursor.test.ts
+++ b/src/pagination/cursor.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "../errors/index.js";
+import {
+  type CursorPayload,
+  decodeCursor,
+  encodeCursor,
+  hashFilter,
+  isAfterCursor,
+} from "./cursor.js";
+
+describe("hashFilter", () => {
+  it("produces a 64-char hex string", () => {
+    const h = hashFilter({ available: true });
+    expect(h).toHaveLength(64);
+    expect(h).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("is deterministic for the same input", () => {
+    const a = hashFilter({ available: true, limit: 50 });
+    const b = hashFilter({ available: true, limit: 50 });
+    expect(a).toBe(b);
+  });
+
+  it("is stable regardless of key order", () => {
+    const a = hashFilter({ available: true, limit: 50 });
+    const b = hashFilter({ limit: 50, available: true });
+    expect(a).toBe(b);
+  });
+
+  it("differs for different filters", () => {
+    const a = hashFilter({ available: true });
+    const b = hashFilter({ available: false });
+    expect(a).not.toBe(b);
+  });
+
+  it("ignores undefined values", () => {
+    const a = hashFilter({ available: true });
+    const b = hashFilter({ available: true, projectId: undefined });
+    expect(a).toBe(b);
+  });
+});
+
+describe("encodeCursor / decodeCursor round-trip", () => {
+  const payload: CursorPayload = {
+    lastId: "gHqVKr3xAWo",
+    lastCreatedAt: "2026-04-19T15:23:04-05:00",
+    filterHash: hashFilter({ available: true }),
+  };
+
+  it("round-trips a cursor payload", () => {
+    const cursor = encodeCursor(payload);
+    const decoded = decodeCursor(cursor, payload.filterHash);
+    expect(decoded).toEqual(payload);
+  });
+
+  it("produces a base64url string (no +, /, or =)", () => {
+    const cursor = encodeCursor(payload);
+    expect(cursor).not.toContain("+");
+    expect(cursor).not.toContain("/");
+    expect(cursor).not.toContain("=");
+  });
+
+  it("throws ValidationError on tampered (non-base64url) input", () => {
+    expect(() => decodeCursor("not!!valid@#", payload.filterHash)).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError when filterHash mismatches", () => {
+    const cursor = encodeCursor(payload);
+    const differentHash = hashFilter({ completed: true });
+    expect(() => decodeCursor(cursor, differentHash)).toThrow(ValidationError);
+  });
+
+  it("includes filterHash mismatch details in the error", () => {
+    const cursor = encodeCursor(payload);
+    const differentHash = hashFilter({ completed: true });
+    let err: ValidationError | undefined;
+    try {
+      decodeCursor(cursor, differentHash);
+    } catch (e) {
+      err = e as ValidationError;
+    }
+    expect(err?.details).toMatchObject({
+      cursorFilterHash: payload.filterHash,
+      currentFilterHash: differentHash,
+    });
+  });
+
+  it("throws ValidationError on missing required fields", () => {
+    const bad = Buffer.from(JSON.stringify({ lastId: "abc" })).toString("base64url");
+    expect(() => decodeCursor(bad, payload.filterHash)).toThrow(ValidationError);
+  });
+
+  it("throws ValidationError on non-JSON payload", () => {
+    const bad = Buffer.from("not json").toString("base64url");
+    expect(() => decodeCursor(bad, payload.filterHash)).toThrow(ValidationError);
+  });
+});
+
+describe("isAfterCursor", () => {
+  const cursor: CursorPayload = {
+    lastId: "gHqVKr3xAWo",
+    lastCreatedAt: "2026-04-19T15:23:04-05:00",
+    filterHash: "irrelevant",
+  };
+
+  it("returns true when createdAt is strictly after cursor", () => {
+    expect(isAfterCursor({ id: "anyId", createdAt: "2026-04-20T00:00:00Z" }, cursor)).toBe(true);
+  });
+
+  it("returns true when createdAt is equal and id is lexicographically greater", () => {
+    expect(
+      isAfterCursor({ id: "zZZZZZZZZZZ", createdAt: "2026-04-19T15:23:04-05:00" }, cursor),
+    ).toBe(true);
+  });
+
+  it("returns false when createdAt is equal and id is equal", () => {
+    expect(
+      isAfterCursor({ id: "gHqVKr3xAWo", createdAt: "2026-04-19T15:23:04-05:00" }, cursor),
+    ).toBe(false);
+  });
+
+  it("returns false when createdAt is before cursor", () => {
+    expect(isAfterCursor({ id: "zZZZZZZZZZZ", createdAt: "2026-04-18T00:00:00Z" }, cursor)).toBe(
+      false,
+    );
+  });
+
+  it("returns false when createdAt is equal and id is lexicographically less", () => {
+    expect(isAfterCursor({ id: "aaaaaaaaa", createdAt: "2026-04-19T15:23:04-05:00" }, cursor)).toBe(
+      false,
+    );
+  });
+});

--- a/src/pagination/cursor.ts
+++ b/src/pagination/cursor.ts
@@ -1,0 +1,120 @@
+/**
+ * Cursor codec for cursor-based pagination (DESIGN §15).
+ *
+ * Cursors are opaque to clients and base64url-encoded internally.
+ * Each cursor encodes `{ lastId, lastCreatedAt, filterHash }`:
+ *
+ * - `lastId` — the OF persistent ID of the last item returned
+ * - `lastCreatedAt` — ISO-8601 timestamp of that item (with offset)
+ * - `filterHash` — SHA-256 (hex) of the serialized filter object; a mismatch
+ *   means the client changed filters mid-page and gets a ValidationError
+ *
+ * Sort order: `createdAt ASC, id ASC` — stable under concurrent inserts.
+ *
+ * @see DESIGN.md §15 — pagination strategy
+ */
+
+import { createHash } from "node:crypto";
+import { ValidationError } from "../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CursorPayload {
+  lastId: string;
+  lastCreatedAt: string;
+  filterHash: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Compute a stable SHA-256 hex digest of an arbitrary filter object. */
+export function hashFilter(filter: Record<string, unknown>): string {
+  const stable = JSON.stringify(
+    Object.fromEntries(
+      Object.entries(filter)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b)),
+    ),
+  );
+  return createHash("sha256").update(stable).digest("hex");
+}
+
+/** Encode a cursor payload to a base64url string. */
+export function encodeCursor(payload: CursorPayload): string {
+  const json = JSON.stringify(payload);
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+/**
+ * Decode a cursor string and validate it against the current filter.
+ *
+ * @throws ValidationError if the cursor is malformed or the filterHash does
+ *   not match `currentFilterHash`.
+ */
+export function decodeCursor(cursor: string, currentFilterHash: string): CursorPayload {
+  let json: string;
+  try {
+    json = Buffer.from(cursor, "base64url").toString("utf8");
+  } catch {
+    throw new ValidationError("Cursor is not valid base64url.", {
+      suggestion: "Pass the cursor value exactly as returned by the previous response.",
+    });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    throw new ValidationError("Cursor payload is not valid JSON.", {
+      suggestion: "Pass the cursor value exactly as returned by the previous response.",
+    });
+  }
+
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    typeof (payload as Record<string, unknown>).lastId !== "string" ||
+    typeof (payload as Record<string, unknown>).lastCreatedAt !== "string" ||
+    typeof (payload as Record<string, unknown>).filterHash !== "string"
+  ) {
+    throw new ValidationError("Cursor payload is missing required fields.", {
+      suggestion: "Pass the cursor value exactly as returned by the previous response.",
+    });
+  }
+
+  const p = payload as CursorPayload;
+
+  if (p.filterHash !== currentFilterHash) {
+    throw new ValidationError(
+      "Cursor filter hash does not match the current query filters. Start a fresh query.",
+      {
+        suggestion:
+          "Call the list tool without a cursor to begin a new page sequence with the updated filters.",
+        details: { cursorFilterHash: p.filterHash, currentFilterHash },
+      },
+    );
+  }
+
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Sort predicate
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if `item` should appear after the cursor in a
+ * `(createdAt ASC, id ASC)` sort — i.e., the item is on the next page.
+ */
+export function isAfterCursor(
+  item: { id: string; createdAt: string },
+  cursor: CursorPayload,
+): boolean {
+  if (item.createdAt > cursor.lastCreatedAt) return true;
+  if (item.createdAt === cursor.lastCreatedAt) return item.id > cursor.lastId;
+  return false;
+}


### PR DESCRIPTION
## Summary
- Adds `src/pagination/cursor.ts`: `encodeCursor`, `decodeCursor`, `hashFilter`, `isAfterCursor`
- Cursors are base64url-encoded `{lastId, lastCreatedAt, filterHash}` (DESIGN §15)
- `filterHash` = SHA-256 of sorted filter JSON — stable across runs, mismatch → `ValidationError`
- `isAfterCursor()` implements `(createdAt ASC, id ASC)` sort for JXA pagination scripts
- 17 unit tests: round-trips, tamper detection, missing fields, hash mismatch with details, sort edge cases

## Design link
Closes #35. See DESIGN.md §15 (pagination strategy).

## Breaking change?
- [x] No

## Test plan
- [x] 168 unit tests passing (`pnpm test`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] No new dependencies