### PR TITLE
feat(server): stdout-write guard throwing on stray non-MCP writes

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -37,7 +37,9 @@ export type ErrorCode =
   | "OF_TRANSPORT_UNAVAILABLE"
   | "OF_SCRIPT_ERROR"
   // Lifecycle — stop and reconnect
-  | "OF_SHUTTING_DOWN";
+  | "OF_SHUTTING_DOWN"
+  // Protocol guard — stray write to stdout (MCP transport channel)
+  | "OF_STRAY_STDOUT";
 
 /** Constructor options shared by every concrete error. */
 export interface ErrorOptions {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -18,6 +18,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { parseConfig, redactConfig } from "../config/env.js";
 import { logger } from "../logging/logger.js";
+import { installStdoutGuard } from "./stdoutGuard.js";
 
 const PACKAGE_VERSION = "0.0.1";
 const SERVER_NAME = "omnifocus-mcp";
@@ -41,6 +42,10 @@ export function createMcpServer(): McpServer {
  * is running.
  */
 export async function startServer(): Promise<void> {
+  // Guard stdout before anything else — a stray write before connect would
+  // corrupt the MCP framing.
+  installStdoutGuard();
+
   const config = parseConfig();
 
   // Apply validated log level before the first structured log event.

--- a/src/server/stdoutGuard.test.ts
+++ b/src/server/stdoutGuard.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { installStdoutGuard, isAllowedStackTrace, uninstallStdoutGuard } from "./stdoutGuard.js";
+
+afterEach(() => {
+  uninstallStdoutGuard();
+});
+
+describe("isAllowedStackTrace", () => {
+  it("allows the MCP SDK path", () => {
+    expect(
+      isAllowedStackTrace(
+        "at Object.<anonymous> (node_modules/@modelcontextprotocol/sdk/dist/server/stdio.js:12:5)",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows the alternative SDK path form", () => {
+    expect(
+      isAllowedStackTrace("at StdioTransport.send (@modelcontextprotocol/sdk/server.js:99)"),
+    ).toBe(true);
+  });
+
+  it("rejects our own code path", () => {
+    expect(isAllowedStackTrace("at Object.<anonymous> (src/services/taskService.ts:42)")).toBe(
+      false,
+    );
+  });
+
+  it("rejects an empty stack", () => {
+    expect(isAllowedStackTrace("")).toBe(false);
+  });
+});
+
+describe("installStdoutGuard", () => {
+  it("throws when application code calls process.stdout.write", () => {
+    installStdoutGuard();
+    expect(() => process.stdout.write("hello\n")).toThrow(/Stray stdout write detected/);
+  });
+
+  it("error message includes the attempted content", () => {
+    installStdoutGuard();
+    let message = "";
+    try {
+      process.stdout.write("secret diagnostic");
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain("secret diagnostic");
+  });
+
+  it("is idempotent — installing twice has no effect", () => {
+    installStdoutGuard();
+    const wrappedOnce = process.stdout.write;
+    installStdoutGuard();
+    expect(process.stdout.write).toBe(wrappedOnce);
+  });
+
+  it("uninstallStdoutGuard restores original write", () => {
+    const before = process.stdout.write;
+    installStdoutGuard();
+    expect(process.stdout.write).not.toBe(before);
+    uninstallStdoutGuard();
+    expect(process.stdout.write).toBe(before);
+  });
+
+  it("uninstall is a no-op when guard is not installed", () => {
+    expect(() => uninstallStdoutGuard()).not.toThrow();
+  });
+});

--- a/src/server/stdoutGuard.ts
+++ b/src/server/stdoutGuard.ts
@@ -1,0 +1,94 @@
+/**
+ * Stdout-write guard for omnifocus-mcp (DESIGN §17, §18).
+ *
+ * The MCP server uses stdio as its transport: every byte written to stdout
+ * is part of the protocol framing. A stray `console.log` or accidental
+ * `process.stdout.write` corrupts the protocol and is nearly impossible to
+ * debug from the client side.
+ *
+ * `installStdoutGuard()` wraps `process.stdout.write` with an assertion.
+ * Calls that originate inside the MCP SDK transport module are permitted
+ * (identified via stack-trace whitelist); all others throw immediately so
+ * the bug surfaces at the write site rather than silently at the client.
+ *
+ * Call once during server startup, before `server.connect(transport)`.
+ *
+ * @see DESIGN.md §17 — lifecycle
+ * @see DESIGN.md §18 — security posture
+ */
+
+import { OmniFocusError } from "../errors/index.js";
+
+/** Stack-trace substrings that identify MCP-SDK-originated stdout writes. */
+const ALLOWED_STACK_SUBSTRINGS = [
+  "@modelcontextprotocol/sdk",
+  "node_modules/@modelcontextprotocol",
+];
+
+/** True if the provided stack trace originates from an allowed module. */
+export function isAllowedStackTrace(stack: string): boolean {
+  return ALLOWED_STACK_SUBSTRINGS.some((s) => stack.includes(s));
+}
+
+let originalWrite: typeof process.stdout.write | null = null;
+let guardInstalled = false;
+
+/**
+ * Install the stdout-write guard.
+ *
+ * Replaces `process.stdout.write` with a wrapper that throws for any call
+ * not originating from the MCP SDK. Safe to call multiple times — installs
+ * only once.
+ */
+export function installStdoutGuard(): void {
+  if (guardInstalled) return;
+
+  originalWrite = process.stdout.write;
+  guardInstalled = true;
+
+  const saved = originalWrite;
+
+  process.stdout.write = function guardedWrite(
+    chunk: Uint8Array | string,
+    encodingOrCallback?: BufferEncoding | ((err?: Error | null) => void),
+    callback?: (err?: Error | null) => void,
+  ): boolean {
+    const stack = new Error().stack ?? "";
+    if (isAllowedStackTrace(stack)) {
+      if (typeof encodingOrCallback === "function") {
+        return (
+          saved as (chunk: Uint8Array | string, cb: (err?: Error | null) => void) => boolean
+        ).call(process.stdout, chunk, encodingOrCallback);
+      }
+      return (
+        saved as (
+          chunk: Uint8Array | string,
+          encoding?: BufferEncoding,
+          cb?: (err?: Error | null) => void,
+        ) => boolean
+      ).call(process.stdout, chunk, encodingOrCallback as BufferEncoding, callback);
+    }
+
+    const excerpt = typeof chunk === "string" ? chunk.slice(0, 120) : `<${chunk.byteLength} bytes>`;
+
+    throw new OmniFocusError(
+      "OF_STRAY_STDOUT",
+      `Stray stdout write detected — stdout is reserved for MCP transport. Use process.stderr / logger for diagnostics. Attempted: ${JSON.stringify(excerpt)}`,
+      {
+        suggestion:
+          "Replace console.log / process.stdout.write with process.stderr.write or logger.",
+      },
+    );
+  } as typeof process.stdout.write;
+}
+
+/**
+ * Remove the guard and restore the original `process.stdout.write`.
+ * Intended for test teardown only.
+ */
+export function uninstallStdoutGuard(): void {
+  if (!guardInstalled || !originalWrite) return;
+  process.stdout.write = originalWrite;
+  originalWrite = null;
+  guardInstalled = false;
+}


### PR DESCRIPTION
## Summary
- `src/server/stdoutGuard.ts`: `installStdoutGuard()` wraps `process.stdout.write` with an assertion that throws `OmniFocusError("OF_STRAY_STDOUT")` for any write not originating from the MCP SDK
- Stack-trace whitelist allows `@modelcontextprotocol/sdk` writes through; all others are blocked at the call site
- `uninstallStdoutGuard()` restores original for test teardown; idempotent install
- Wired into `startServer()` before `server.connect(transport)`
- Added `OF_STRAY_STDOUT` to `ErrorCode` union in `src/errors/index.ts`
- 9 unit tests: allow/block, idempotency, reference restore, empty stack, no-op uninstall

## Design link
Closes #11. See DESIGN.md §17 (lifecycle) and §18 (security posture).

## Breaking change?
- [x] No

## Test plan
- [x] 177 unit tests passing (`pnpm test`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] No new dependencies