### PR TITLE
ci: add bundle-size budget check (< 500 KB) to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,13 @@ jobs:
       - run: pnpm test
 
       - run: pnpm build
+
+      - name: Bundle-size budget (< 500 KB)
+        run: |
+          SIZE=$(wc -c < dist/index.js)
+          BUDGET=512000
+          echo "dist/index.js: ${SIZE} bytes (budget: ${BUDGET} bytes)"
+          if [ "$SIZE" -gt "$BUDGET" ]; then
+            echo "ERROR: bundle exceeds 500 KB budget (${SIZE} > ${BUDGET})"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a bundle-size budget step to `ci.yml` after `pnpm build`
- Measures `dist/index.js` byte count; fails CI if > 512 000 bytes (~500 KB)
- Current bundle: ~5.6 KB — well within budget
- Runs in both Node 20 and Node 22 matrix jobs

## Design link
Closes #83. See DESIGN.md §20.

## Breaking change?
- [x] No

## Test plan
- [x] CI runs green on this PR (budget check passes at current bundle size)
- [x] Step is self-documenting — prints current size vs budget on every run