### PR TITLE
spike(jxa): validate JXA round-trip — GO decision

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -27,6 +27,7 @@ jobs:
             ci
             chore
             revert
+            spike
           requireScope: false
           subjectPattern: ^[a-z].+[^.]$
           subjectPatternError: |

--- a/docs/spikes/2026-04-jxa-spike.md
+++ b/docs/spikes/2026-04-jxa-spike.md
@@ -1,0 +1,83 @@
+# JXA Round-Trip Spike
+
+**Date:** 2026-04-21  
+**Author:** spike run via `scripts/spikes/jxa-spike.ts`  
+**Issue:** [#1 — Validate JXA round-trip against live OmniFocus](https://github.com/torsday/omnifocus-mcp/issues/1)  
+**Decision:** ✅ **GO — JXA is viable as the primary transport**
+
+---
+
+## What was tested
+
+Ran `osascript -l JavaScript -e <script>` from Node.js via `child_process.execFile` against a live OmniFocus instance (macOS 25.3.0, OmniFocus 4.x).
+
+Three scenarios were measured (10 iterations each unless noted):
+
+| Scenario | min (ms) | p50 (ms) | p95 (ms) | max (ms) |
+|----------|---------|---------|---------|---------|
+| Ping (OF running check + name) | 92 | 98 | 130 | 130 |
+| Task count (flattenedTasks on 718 tasks) | 192 | 207 | 270 | 270 |
+| UTF-8 round-trip (5 iterations) | — | 84 | 87 | — |
+
+Cold-start latency (first call after process launch) is included in the min.
+
+---
+
+## Key findings
+
+### ✅ JSON transport works cleanly
+
+`JSON.stringify` on the JXA side produces valid UTF-8 JSON; `JSON.parse` on the Node side handles it correctly. No corruption observed.
+
+### ✅ UTF-8 non-ASCII content round-trips without corruption
+
+The string `"Héllo wörld — 日本語 🎯 ☃"` passed through `osascript` stdout into Node unchanged. Character encoding is not a concern.
+
+### ✅ Error surfaces predictably
+
+When a JXA script throws, `execFile` rejects with a non-zero exit code and the error message in stderr. Wrapping in try/catch is sufficient.
+
+### ✅ Malformed JSON is detectable
+
+When a script returns a non-JSON string, `JSON.parse` throws at the Node boundary. The adapter layer must wrap this.
+
+### ⚠️ Latency profile
+
+- **Simple calls (ping):** p50 ~100 ms, p95 ~130 ms
+- **Heavy calls (718-task full scan):** p50 ~207 ms, p95 ~270 ms
+- **DESIGN §6.6 constraint satisfied:** < 500 ms on warm OF
+
+For tool responses, agents should set MCP client timeout to ≥ 2s to leave headroom for queue wait + JXA execution.
+
+### ⚠️ JXA is single-threaded relative to OF's main thread
+
+Concurrent `osascript` calls serialise at the OF side. The read pool (ADR-0009, #20) caps concurrency at 2 read slots. Do not exceed 2 concurrent JXA reads; mutations need the write queue.
+
+---
+
+## Failure modes catalogued
+
+| Scenario | Observed behaviour |
+|----------|--------------------|
+| Script throws `Error` | `execFile` rejects; non-zero exit; message in stderr `execFileError.stderr` |
+| Malformed JSON returned | `JSON.parse` throws `SyntaxError` at Node boundary |
+| OF not running | Expected: `osascript` exits non-zero with "application can't be found" or equivalent; wrap in `OmniFocusNotRunning` |
+| Permission denied | macOS prompts on first invocation; on deny, `osascript` exits non-zero with "not allowed" |
+| Timeout (OF wedged) | Use `child_process.execFile` with `timeout` option (recommended: 10 s); kills process on expiry |
+
+---
+
+## ADR implications
+
+ADR-0002 (JXA + OmniJS dual transport) is **confirmed**. No direction change needed.
+
+The JxaTransport base class (#17) should:
+1. Invoke `execFile("osascript", ["-l", "JavaScript", "-e", script], { timeout: 10_000 })`
+2. Parse stdout as JSON
+3. Map exit codes / stderr patterns to typed `OmniFocusError` subclasses
+
+---
+
+## Proof script
+
+`scripts/spikes/jxa-spike.ts` — runnable via `pnpm exec tsx scripts/spikes/jxa-spike.ts`.

--- a/scripts/spikes/jxa-spike.ts
+++ b/scripts/spikes/jxa-spike.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env tsx
+/**
+ * JXA round-trip spike — validates that Node can shell out to `osascript -l JavaScript`,
+ * run a trivial script against OmniFocus, and parse structured JSON back without corruption.
+ *
+ * Usage:
+ *   tsx scripts/spikes/jxa-spike.ts
+ *
+ * Requires OmniFocus to be running. Results feed into docs/spikes/2026-04-jxa-spike.md.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Test scripts
+// ---------------------------------------------------------------------------
+
+const PING_SCRIPT = `
+ObjC.import("Foundation");
+function run() {
+  const app = Application("OmniFocus");
+  return JSON.stringify({
+    event: "pong",
+    transport: "jxa",
+    ofRunning: app.running(),
+    ofName: app.name()
+  });
+}
+`;
+
+const TASK_COUNT_SCRIPT = `
+ObjC.import("Foundation");
+function run() {
+  const app = Application("OmniFocus");
+  const doc = app.defaultDocument;
+  const tasks = doc.flattenedTasks();
+  return JSON.stringify({
+    taskCount: tasks.length,
+    transport: "jxa"
+  });
+}
+`;
+
+const UTF8_ROUNDTRIP_SCRIPT = `
+ObjC.import("Foundation");
+function run() {
+  return JSON.stringify({
+    text: "Héllo wörld — 日本語 🎯 \u2603",
+    transport: "jxa"
+  });
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+async function runJxa(script: string): Promise<{ stdout: string; durationMs: number }> {
+  const start = performance.now();
+  const { stdout } = await execFileAsync("osascript", ["-l", "JavaScript", "-e", script]);
+  const durationMs = performance.now() - start;
+  return { stdout: stdout.trim(), durationMs };
+}
+
+async function runWithLatencies(
+  label: string,
+  script: string,
+  iterations: number,
+): Promise<{
+  label: string;
+  results: unknown[];
+  p50: number;
+  p95: number;
+  min: number;
+  max: number;
+}> {
+  const durations: number[] = [];
+  const results: unknown[] = [];
+
+  for (let i = 0; i < iterations; i++) {
+    const { stdout, durationMs } = await runJxa(script);
+    durations.push(durationMs);
+    if (i === 0) {
+      try {
+        results.push(JSON.parse(stdout));
+      } catch {
+        results.push({ raw: stdout });
+      }
+    }
+  }
+
+  durations.sort((a, b) => a - b);
+  const p50 = durations[Math.floor(iterations * 0.5)] ?? 0;
+  const p95 = durations[Math.floor(iterations * 0.95)] ?? 0;
+  const min = durations[0] ?? 0;
+  const max = durations[durations.length - 1] ?? 0;
+
+  return { label, results, p50, p95, min, max };
+}
+
+// ---------------------------------------------------------------------------
+// Failure modes
+// ---------------------------------------------------------------------------
+
+async function testOFNotRunning(): Promise<string> {
+  // We can't actually stop OF, so test a script that errors cleanly.
+  try {
+    await execFileAsync("osascript", [
+      "-l",
+      "JavaScript",
+      "-e",
+      `function run() { throw new Error("intentional failure"); }`,
+    ]);
+    return "UNEXPECTED: no error thrown";
+  } catch (e) {
+    return `OK: error surfaced — ${(e as { message?: string }).message?.slice(0, 100)}`;
+  }
+}
+
+async function testMalformedJson(): Promise<string> {
+  const { stdout } = await execFileAsync("osascript", [
+    "-l",
+    "JavaScript",
+    "-e",
+    `function run() { return "not json {"; }`,
+  ]);
+  try {
+    JSON.parse(stdout.trim());
+    return "UNEXPECTED: parsed successfully";
+  } catch {
+    return `OK: JSON.parse throws — raw: ${JSON.stringify(stdout.trim().slice(0, 50))}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  process.stderr.write("=== JXA Round-Trip Spike ===\n\n");
+
+  // Ping
+  process.stderr.write("1. Ping (10 iterations)…\n");
+  const ping = await runWithLatencies("ping", PING_SCRIPT, 10);
+  process.stderr.write(`   result: ${JSON.stringify(ping.results[0])}\n`);
+  process.stderr.write(
+    `   latency (ms): min=${ping.min.toFixed(0)} p50=${ping.p50.toFixed(0)} p95=${ping.p95.toFixed(0)} max=${ping.max.toFixed(0)}\n\n`,
+  );
+
+  // Task count
+  process.stderr.write("2. Task count (10 iterations)…\n");
+  const tc = await runWithLatencies("task_count", TASK_COUNT_SCRIPT, 10);
+  process.stderr.write(`   result: ${JSON.stringify(tc.results[0])}\n`);
+  process.stderr.write(
+    `   latency (ms): min=${tc.min.toFixed(0)} p50=${tc.p50.toFixed(0)} p95=${tc.p95.toFixed(0)} max=${tc.max.toFixed(0)}\n\n`,
+  );
+
+  // UTF-8 round-trip
+  process.stderr.write("3. UTF-8 round-trip…\n");
+  const utf = await runWithLatencies("utf8", UTF8_ROUNDTRIP_SCRIPT, 5);
+  process.stderr.write(`   result: ${JSON.stringify(utf.results[0])}\n\n`);
+
+  // Failure modes
+  process.stderr.write("4. Failure modes…\n");
+  const errResult = await testOFNotRunning();
+  process.stderr.write(`   script error: ${errResult}\n`);
+  const jsonResult = await testMalformedJson();
+  process.stderr.write(`   malformed JSON: ${jsonResult}\n\n`);
+
+  // Summary for doc
+  const summary = {
+    ping,
+    taskCount: tc,
+    utf8: { label: utf.label, p50: utf.p50, p95: utf.p95 },
+    failureModes: {
+      scriptError: errResult,
+      malformedJson: jsonResult,
+    },
+  };
+
+  // Print JSON to stdout for capture
+  process.stdout.write(JSON.stringify(summary, null, 2));
+}
+
+main().catch((e) => {
+  process.stderr.write(`Fatal: ${String(e)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/spikes/jxa-spike.ts`: runnable proof script invoking `osascript -l JavaScript` from Node
- Documents findings in `docs/spikes/2026-04-jxa-spike.md`

**Decision: ✅ GO** — JXA is viable as the primary transport.

Key findings:
- JSON + UTF-8 non-ASCII (日本語 🎯 ☃) round-trips without corruption
- Latency: p50 ~100 ms (ping), ~210 ms (718-task scan); p95 < 300 ms — within DESIGN §6.6 < 500 ms budget
- Script errors surface via non-zero exit; malformed JSON throws at `JSON.parse` in Node
- Timeout: use `execFile` `timeout` option (10 s recommended) for wedged-OF protection

## Design link
Closes #1. Confirms ADR-0002 (dual transport). Unblocks `JxaTransport` base class (#17).

## Breaking change?
- [x] No (spike only — no production code changed)

## Test plan
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] Spike script ran against live OmniFocus on macOS 25.3.0