### PR TITLE
chore(claude): add settings.json permission allowlist and post-edit biome hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm install)",
+      "Bash(pnpm install *)",
+      "Bash(pnpm build)",
+      "Bash(pnpm dev)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test *)",
+      "Bash(pnpm test:integration)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm format)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm exec *)",
+      "Bash(pnpm biome *)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null); if [[ \"$file\" == *.ts || \"$file\" == *.js ]]; then pnpm biome check --write \"$file\" 2>/dev/null || true; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 .env.local
 .vscode/
 .idea/
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Build outputs (src/ will exist after M0; dist/ is inlined bundle from tsup)
 # For v0.0.1 placeholder, dist/index.js is committed (no src/ yet).


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` (committed) with a narrowly-scoped `pnpm` allowlist so dev commands don't prompt for permission during active sessions
- `PostToolUse` hook auto-runs `pnpm biome check --write` on any edited `.ts` or `.js` file — keeps formatting tight without a manual step
- Adds `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` to `.gitignore` so personal/spike-era patterns stay out of the repo

## Design link
Closes #6.

## Breaking change?
- [x] No

## Test plan
- [x] JSON valid (`python3 -m json.tool .claude/settings.json`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Self-reviewed via review_pr.md
- [x] No new dependencies