### PR TITLE
feat(adapter): introduce OmniFocusAdapter interface and InMemoryAdapter (#16)

### DIFF
--- a/src/adapter/OmniFocusAdapter.ts
+++ b/src/adapter/OmniFocusAdapter.ts
@@ -1,0 +1,227 @@
+/**
+ * `OmniFocusAdapter` is the **sacred seam** between the service layer and
+ * OmniFocus itself (DESIGN §6.1, §6.3). Services never see `osascript`, never
+ * see URL schemes — they consume only this interface.
+ *
+ * Three concrete implementations satisfy this contract:
+ * - `JxaTransport` (#17) — primary, calls `osascript -l JavaScript`
+ * - `OmniJsTransport` (#18) — fallback for surfaces JXA can't reach (custom
+ *   perspectives, plug-ins) — invoked via `Application("OmniFocus").evaluateJavascript(...)` (ADR-0002 amendment)
+ * - `InMemoryAdapter` — unit-test double; behavior asserted by the contract
+ *   harness (#30) so substitutability is enforced
+ *
+ * `TransportRouter` (#19) is itself an `OmniFocusAdapter` that delegates
+ * per-method to the right underlying transport.
+ *
+ * ## Contract
+ *
+ * - Inputs are validated at the boundary; bad input throws `ValidationError`
+ * - Unknown IDs throw `NotFound`
+ * - Reads do not mutate; writes are serialized by the calling layer
+ *   (concurrency policy lives in DESIGN §6.6, not in implementations)
+ * - Dates are `IsoDateString` (ISO-8601 with offset, ADR-0007)
+ * - IDs are branded opaque types (ADR-0008)
+ * - Errors thrown are members of the typed taxonomy (DESIGN §6.7) — generic
+ *   `Error` is forbidden and lint-checked
+ *
+ * @see DESIGN.md §6.1 — layering
+ * @see DESIGN.md §6.3 — adapter sketch (this file is the canonical version)
+ * @see DESIGN.md §19 — InMemoryAdapter scope (what's NOT modeled in-memory)
+ * @see ADR-0002 — JXA + OmniJS dual transport
+ */
+
+import type { Folder } from "../domain/folder.js";
+import type { FolderId, ProjectId, TagId, TaskId } from "../domain/ids.js";
+import type { Project } from "../domain/project.js";
+import type { Tag } from "../domain/tag.js";
+import type { RepetitionRule, Task } from "../domain/task.js";
+
+// ---------------------------------------------------------------------------
+// Filter / input types
+// ---------------------------------------------------------------------------
+
+/**
+ * Filters apply on the adapter side; concrete implementations may push them
+ * down to the underlying transport (JXA where-clauses, OmniJS predicates, in-
+ * memory predicate functions). Semantics are identical across implementations.
+ */
+export interface TaskFilter {
+  projectId?: ProjectId;
+  tagId?: TagId;
+  parentId?: TaskId;
+  flagged?: boolean;
+  available?: boolean;
+  blocked?: boolean;
+  completed?: boolean;
+  /** ISO-8601-with-offset string; matches tasks completed on or after */
+  completedSince?: string;
+  /** ISO-8601-with-offset string; matches tasks due strictly before */
+  dueBefore?: string;
+  /** ISO-8601-with-offset string; matches tasks due strictly after */
+  dueAfter?: string;
+  /** ISO-8601-with-offset string; matches tasks deferred strictly before */
+  deferredBefore?: string;
+  /** ISO-8601-with-offset string; matches tasks deferred strictly after */
+  deferredAfter?: string;
+}
+
+export interface CreateTaskInput {
+  name: string;
+  /**
+   * Where the task lives. Exactly one of `projectId` or `parentId` may be set.
+   * If neither is provided, the task lands in the inbox.
+   */
+  projectId?: ProjectId;
+  parentId?: TaskId;
+  note?: string;
+  noteHtml?: string;
+  flagged?: boolean;
+  deferDate?: string;
+  dueDate?: string;
+  estimatedMinutes?: number;
+  tagIds?: TagId[];
+  sequential?: boolean;
+  completedByChildren?: boolean;
+}
+
+export interface UpdateTaskInput {
+  name?: string;
+  note?: string | null;
+  noteHtml?: string | null;
+  flagged?: boolean;
+  deferDate?: string | null;
+  dueDate?: string | null;
+  estimatedMinutes?: number | null;
+  tagIds?: TagId[];
+  sequential?: boolean;
+  completedByChildren?: boolean;
+  repetition?: RepetitionRule | null;
+}
+
+export interface CreateProjectInput {
+  name: string;
+  folderId?: FolderId;
+  note?: string;
+  noteHtml?: string;
+  status?: "active" | "on-hold";
+  completionCriterion?: "parallel" | "sequential" | "singleActions";
+  deferDate?: string;
+  dueDate?: string;
+  estimatedMinutes?: number;
+  flagged?: boolean;
+  tagIds?: TagId[];
+  reviewIntervalDays?: number;
+}
+
+export interface UpdateProjectInput {
+  name?: string;
+  note?: string | null;
+  noteHtml?: string | null;
+  status?: "active" | "on-hold";
+  completionCriterion?: "parallel" | "sequential" | "singleActions";
+  deferDate?: string | null;
+  dueDate?: string | null;
+  estimatedMinutes?: number | null;
+  flagged?: boolean;
+  tagIds?: TagId[];
+  reviewIntervalDays?: number | null;
+}
+
+export interface CreateTagInput {
+  name: string;
+  parentId?: TagId;
+  status?: "active" | "on-hold";
+  allowsNextAction?: boolean;
+}
+
+export interface UpdateTagInput {
+  name?: string;
+  parentId?: TagId | null;
+  status?: "active" | "on-hold" | "dropped";
+  allowsNextAction?: boolean;
+}
+
+export interface CreateFolderInput {
+  name: string;
+  parentId?: FolderId;
+}
+
+export interface UpdateFolderInput {
+  name?: string;
+  parentId?: FolderId | null;
+}
+
+export interface SyncStatus {
+  /** ISO-8601-with-offset of the last successful sync; `null` if never synced */
+  lastSyncAt: string | null;
+  /** Whether a sync is currently in flight */
+  inFlight: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Every method returns `Promise<...>` even when the underlying call is
+ * synchronous (e.g. InMemoryAdapter). Async-by-default keeps services
+ * implementation-agnostic.
+ */
+export interface OmniFocusAdapter {
+  // -- Tasks -----------------------------------------------------------------
+
+  listTasks(filter: TaskFilter): Promise<Task[]>;
+  getTask(id: TaskId): Promise<Task>;
+  /** Bulk fetch by ID list — returns tasks in input order. Missing IDs surface in `meta.warnings` at the service layer; the adapter signals them by returning `null` for those positions. */
+  getTasksMany(ids: TaskId[]): Promise<(Task | null)[]>;
+  createTask(input: CreateTaskInput): Promise<TaskId>;
+  updateTask(id: TaskId, patch: UpdateTaskInput): Promise<void>;
+  completeTask(id: TaskId, at?: Date): Promise<void>;
+  uncompleteTask(id: TaskId): Promise<void>;
+  dropTask(id: TaskId, at?: Date): Promise<void>;
+  undropTask(id: TaskId): Promise<void>;
+  /** Hard delete — irreversible; distinct from drop. */
+  deleteTask(id: TaskId): Promise<void>;
+  moveTask(id: TaskId, destination: { projectId?: ProjectId; parentId?: TaskId }): Promise<void>;
+
+  // -- Projects --------------------------------------------------------------
+
+  listProjects(filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<Project[]>;
+  getProject(id: ProjectId): Promise<Project>;
+  createProject(input: CreateProjectInput): Promise<ProjectId>;
+  updateProject(id: ProjectId, patch: UpdateProjectInput): Promise<void>;
+  completeProject(id: ProjectId, at?: Date): Promise<void>;
+  dropProject(id: ProjectId, at?: Date): Promise<void>;
+  moveProject(id: ProjectId, destination: { folderId: FolderId | null }): Promise<void>;
+  /** Hard delete — irreversible; distinct from drop. */
+  deleteProject(id: ProjectId): Promise<void>;
+  /** Mark a project as reviewed (sets `lastReviewDate` to now and advances `nextReviewDate`). */
+  markProjectReviewed(id: ProjectId): Promise<void>;
+
+  // -- Tags ------------------------------------------------------------------
+
+  listTags(filter?: { parentId?: TagId; status?: Tag["status"] }): Promise<Tag[]>;
+  getTag(id: TagId): Promise<Tag>;
+  createTag(input: CreateTagInput): Promise<TagId>;
+  updateTag(id: TagId, patch: UpdateTagInput): Promise<void>;
+  deleteTag(id: TagId): Promise<void>;
+
+  // -- Folders ---------------------------------------------------------------
+
+  listFolders(filter?: { parentId?: FolderId }): Promise<Folder[]>;
+  getFolder(id: FolderId): Promise<Folder>;
+  createFolder(input: CreateFolderInput): Promise<FolderId>;
+  updateFolder(id: FolderId, patch: UpdateFolderInput): Promise<void>;
+  deleteFolder(id: FolderId): Promise<void>;
+
+  // -- Sync ------------------------------------------------------------------
+
+  /** Trigger a sync with Omni Sync; resolves once initiated (does not wait for completion). */
+  syncTrigger(): Promise<SyncStatus>;
+  getLastSync(): Promise<SyncStatus>;
+
+  // -- Raw escape hatches (only wired when OMNIFOCUS_ALLOW_RAW_SCRIPT=1) -----
+
+  runJxaScript?(script: string): Promise<unknown>;
+  runOmniJsScript?(script: string): Promise<unknown>;
+}

--- a/src/adapter/inMemory/InMemoryAdapter.test.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Unit tests for `InMemoryAdapter`.
+ *
+ * Goldilocks coverage: round-trip behavior, filter semantics, derived-count
+ * maintenance, and the typed error contract. The full cross-implementation
+ * substitutability harness lands in #30; these tests cover the in-memory
+ * double in isolation so it is trustworthy as a stand-in for OmniFocus in
+ * service-layer unit tests.
+ */
+
+import { describe, expect, it } from "vitest";
+import { NotFound, ValidationError } from "../../errors/index.js";
+import { InMemoryAdapter } from "./InMemoryAdapter.js";
+
+const FIXED_NOW = new Date("2026-04-21T12:00:00.000Z");
+
+function makeAdapter(now: Date = FIXED_NOW): InMemoryAdapter {
+  return new InMemoryAdapter({ now: () => now });
+}
+
+describe("InMemoryAdapter — Tasks", () => {
+  it("creates an inbox task and returns it via getTask", async () => {
+    const a = makeAdapter();
+    const id = await a.createTask({ name: "buy milk" });
+    const task = await a.getTask(id);
+    expect(task.id).toBe(id);
+    expect(task.name).toBe("buy milk");
+    expect(task.projectId).toBeNull();
+    expect(task.parentId).toBeNull();
+    expect(task.completed).toBe(false);
+    expect(task.createdAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  it("rejects an empty name with ValidationError", async () => {
+    const a = makeAdapter();
+    await expect(a.createTask({ name: "  " })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects projectId + parentId both set", async () => {
+    const a = makeAdapter();
+    const projectId = await a.createProject({ name: "p" });
+    const parentId = await a.createTask({ name: "parent" });
+    await expect(a.createTask({ name: "child", projectId, parentId })).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+  });
+
+  it("rejects unknown projectId with NotFound", async () => {
+    const a = makeAdapter();
+    const projectId = await a.createProject({ name: "p" });
+    await a.deleteProject(projectId);
+    await expect(a.createTask({ name: "x", projectId })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("getTask throws NotFound for unknown id", async () => {
+    const a = makeAdapter();
+    const id = await a.createTask({ name: "tmp" });
+    await a.deleteTask(id);
+    await expect(a.getTask(id)).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("getTasksMany preserves input order, returning null for missing ids", async () => {
+    const a = makeAdapter();
+    const a1 = await a.createTask({ name: "one" });
+    const a2 = await a.createTask({ name: "two" });
+    await a.deleteTask(a2);
+    const out = await a.getTasksMany([a2, a1]);
+    expect(out[0]).toBeNull();
+    expect(out[1]?.id).toBe(a1);
+  });
+
+  it("updateTask applies a partial patch and bumps modifiedAt via injected clock", async () => {
+    const t1 = new Date("2026-04-21T12:00:00.000Z");
+    const t2 = new Date("2026-04-22T08:00:00.000Z");
+    let now = t1;
+    const a = new InMemoryAdapter({ now: () => now });
+    const id = await a.createTask({ name: "draft" });
+    now = t2;
+    await a.updateTask(id, { name: "final", flagged: true });
+    const task = await a.getTask(id);
+    expect(task.name).toBe("final");
+    expect(task.flagged).toBe(true);
+    expect(task.modifiedAt).toBe(t2.toISOString());
+  });
+
+  it("completeTask flips completed=true and tracks completedTaskCount on the project", async () => {
+    const a = makeAdapter();
+    const projectId = await a.createProject({ name: "p" });
+    const id = await a.createTask({ name: "t", projectId });
+    await a.completeTask(id);
+    const task = await a.getTask(id);
+    const project = await a.getProject(projectId);
+    expect(task.completed).toBe(true);
+    expect(task.completedAt).toBe(FIXED_NOW.toISOString());
+    expect(project.taskCount).toBe(1);
+    expect(project.completedTaskCount).toBe(1);
+  });
+
+  it("uncompleteTask is idempotent on already-uncompleted tasks", async () => {
+    const a = makeAdapter();
+    const id = await a.createTask({ name: "t" });
+    await expect(a.uncompleteTask(id)).resolves.toBeUndefined();
+  });
+
+  it("dropTask + undropTask round-trip", async () => {
+    const a = makeAdapter();
+    const id = await a.createTask({ name: "t" });
+    await a.dropTask(id);
+    expect((await a.getTask(id)).dropped).toBe(true);
+    await a.undropTask(id);
+    expect((await a.getTask(id)).dropped).toBe(false);
+  });
+
+  it("moveTask updates projectId and rebalances counts", async () => {
+    const a = makeAdapter();
+    const p1 = await a.createProject({ name: "from" });
+    const p2 = await a.createProject({ name: "to" });
+    const id = await a.createTask({ name: "t", projectId: p1 });
+    await a.moveTask(id, { projectId: p2 });
+    expect((await a.getTask(id)).projectId).toBe(p2);
+    expect((await a.getProject(p1)).taskCount).toBe(0);
+    expect((await a.getProject(p2)).taskCount).toBe(1);
+  });
+
+  it("moveTask rejects projectId + parentId both set", async () => {
+    const a = makeAdapter();
+    const projectId = await a.createProject({ name: "p" });
+    const parentId = await a.createTask({ name: "parent" });
+    const id = await a.createTask({ name: "child" });
+    await expect(a.moveTask(id, { projectId, parentId })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("deleteTask decrements counts including completedTaskCount", async () => {
+    const a = makeAdapter();
+    const projectId = await a.createProject({ name: "p" });
+    const id = await a.createTask({ name: "t", projectId });
+    await a.completeTask(id);
+    await a.deleteTask(id);
+    const project = await a.getProject(projectId);
+    expect(project.taskCount).toBe(0);
+    expect(project.completedTaskCount).toBe(0);
+  });
+});
+
+describe("InMemoryAdapter — listTasks filters", () => {
+  it("filters by projectId, flagged, and completed", async () => {
+    const a = makeAdapter();
+    const p = await a.createProject({ name: "p" });
+    const t1 = await a.createTask({ name: "flag", projectId: p, flagged: true });
+    const t2 = await a.createTask({ name: "plain", projectId: p });
+    await a.completeTask(t2);
+
+    const flagged = await a.listTasks({ flagged: true });
+    expect(flagged.map((t) => t.id)).toEqual([t1]);
+
+    const completed = await a.listTasks({ completed: true });
+    expect(completed.map((t) => t.id)).toEqual([t2]);
+
+    const inProject = await a.listTasks({ projectId: p });
+    expect(inProject).toHaveLength(2);
+  });
+
+  it("filters by tagId", async () => {
+    const a = makeAdapter();
+    const tag = await a.createTag({ name: "next" });
+    const tagged = await a.createTask({ name: "x", tagIds: [tag] });
+    await a.createTask({ name: "y" });
+    const out = await a.listTasks({ tagId: tag });
+    expect(out.map((t) => t.id)).toEqual([tagged]);
+  });
+
+  it("filters by dueBefore / dueAfter date bounds", async () => {
+    const a = makeAdapter();
+    const early = await a.createTask({ name: "e", dueDate: "2026-01-01T00:00:00Z" });
+    const late = await a.createTask({ name: "l", dueDate: "2026-12-01T00:00:00Z" });
+    await a.createTask({ name: "n" }); // no due date
+
+    const before = await a.listTasks({ dueBefore: "2026-06-01T00:00:00Z" });
+    expect(before.map((t) => t.id)).toEqual([early]);
+
+    const after = await a.listTasks({ dueAfter: "2026-06-01T00:00:00Z" });
+    expect(after.map((t) => t.id)).toEqual([late]);
+  });
+
+  it("filters by completedSince inclusively", async () => {
+    const t0 = new Date("2026-04-21T12:00:00.000Z");
+    const t1 = new Date("2026-04-21T13:00:00.000Z");
+    let now = t0;
+    const a = new InMemoryAdapter({ now: () => now });
+    const id = await a.createTask({ name: "x" });
+    now = t1;
+    await a.completeTask(id);
+    const out = await a.listTasks({ completedSince: t1.toISOString() });
+    expect(out.map((t) => t.id)).toEqual([id]);
+    const none = await a.listTasks({ completedSince: "2027-01-01T00:00:00Z" });
+    expect(none).toEqual([]);
+  });
+});
+
+describe("InMemoryAdapter — Projects", () => {
+  it("creates a project and lists by status", async () => {
+    const a = makeAdapter();
+    const p1 = await a.createProject({ name: "active1" });
+    const p2 = await a.createProject({ name: "hold", status: "on-hold" });
+    const active = await a.listProjects({ status: "active" });
+    const onHold = await a.listProjects({ status: "on-hold" });
+    expect(active.map((p) => p.id)).toEqual([p1]);
+    expect(onHold.map((p) => p.id)).toEqual([p2]);
+  });
+
+  it("rejects creation with unknown folderId", async () => {
+    const a = makeAdapter();
+    const folderId = await a.createFolder({ name: "f" });
+    await a.deleteFolder(folderId);
+    await expect(a.createProject({ name: "p", folderId })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("moveProject rebalances folder.projectCount", async () => {
+    const a = makeAdapter();
+    const f1 = await a.createFolder({ name: "f1" });
+    const f2 = await a.createFolder({ name: "f2" });
+    const p = await a.createProject({ name: "p", folderId: f1 });
+    await a.moveProject(p, { folderId: f2 });
+    expect((await a.getFolder(f1)).projectCount).toBe(0);
+    expect((await a.getFolder(f2)).projectCount).toBe(1);
+  });
+
+  it("deleteProject orphans its tasks (projectId becomes null)", async () => {
+    const a = makeAdapter();
+    const p = await a.createProject({ name: "p" });
+    const t = await a.createTask({ name: "t", projectId: p });
+    await a.deleteProject(p);
+    expect((await a.getTask(t)).projectId).toBeNull();
+  });
+
+  it("markProjectReviewed advances nextReviewDate by reviewIntervalDays", async () => {
+    const a = makeAdapter();
+    const p = await a.createProject({ name: "p", reviewIntervalDays: 7 });
+    await a.markProjectReviewed(p);
+    const proj = await a.getProject(p);
+    expect(proj.lastReviewDate).toBe(FIXED_NOW.toISOString());
+    expect(proj.nextReviewDate).toBe("2026-04-28T12:00:00.000Z");
+  });
+
+  it("completeProject flips status to done", async () => {
+    const a = makeAdapter();
+    const p = await a.createProject({ name: "p" });
+    await a.completeProject(p);
+    const proj = await a.getProject(p);
+    expect(proj.status).toBe("done");
+    expect(proj.completed).toBe(true);
+  });
+});
+
+describe("InMemoryAdapter — Tags", () => {
+  it("creates, updates, and deletes a tag", async () => {
+    const a = makeAdapter();
+    const id = await a.createTag({ name: "errand" });
+    expect((await a.getTag(id)).name).toBe("errand");
+    await a.updateTag(id, { name: "errands", status: "on-hold" });
+    const t = await a.getTag(id);
+    expect(t.name).toBe("errands");
+    expect(t.status).toBe("on-hold");
+    await a.deleteTag(id);
+    await expect(a.getTag(id)).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("deleteTag strips the tag from any task carrying it", async () => {
+    const a = makeAdapter();
+    const tag = await a.createTag({ name: "x" });
+    const task = await a.createTask({ name: "t", tagIds: [tag] });
+    await a.deleteTag(tag);
+    expect((await a.getTask(task)).tagIds).toEqual([]);
+  });
+
+  it("createTask rejects unknown tagId with NotFound", async () => {
+    const a = makeAdapter();
+    const tag = await a.createTag({ name: "x" });
+    await a.deleteTag(tag);
+    await expect(a.createTask({ name: "t", tagIds: [tag] })).rejects.toBeInstanceOf(NotFound);
+  });
+});
+
+describe("InMemoryAdapter — Folders", () => {
+  it("createFolder maintains parent.subfolderCount", async () => {
+    const a = makeAdapter();
+    const parent = await a.createFolder({ name: "p" });
+    await a.createFolder({ name: "c", parentId: parent });
+    expect((await a.getFolder(parent)).subfolderCount).toBe(1);
+  });
+
+  it("deleteFolder refuses non-empty folder", async () => {
+    const a = makeAdapter();
+    const f = await a.createFolder({ name: "f" });
+    await a.createProject({ name: "p", folderId: f });
+    await expect(a.deleteFolder(f)).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("updateFolder reparenting rebalances subfolderCount on both sides", async () => {
+    const a = makeAdapter();
+    const p1 = await a.createFolder({ name: "p1" });
+    const p2 = await a.createFolder({ name: "p2" });
+    const child = await a.createFolder({ name: "c", parentId: p1 });
+    await a.updateFolder(child, { parentId: p2 });
+    expect((await a.getFolder(p1)).subfolderCount).toBe(0);
+    expect((await a.getFolder(p2)).subfolderCount).toBe(1);
+  });
+});
+
+describe("InMemoryAdapter — Sync", () => {
+  it("syncTrigger sets lastSyncAt to the current clock", async () => {
+    const a = makeAdapter();
+    expect((await a.getLastSync()).lastSyncAt).toBeNull();
+    const status = await a.syncTrigger();
+    expect(status.lastSyncAt).toBe(FIXED_NOW.toISOString());
+    expect(status.inFlight).toBe(false);
+    expect((await a.getLastSync()).lastSyncAt).toBe(FIXED_NOW.toISOString());
+  });
+});

--- a/src/adapter/inMemory/InMemoryAdapter.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.ts
@@ -1,0 +1,705 @@
+/**
+ * `InMemoryAdapter` — minimal test double for `OmniFocusAdapter`.
+ *
+ * **Scope (DESIGN §19):** CRUD on tasks/projects/tags/folders, filter
+ * application with the same semantics as JXA, and the basic error conditions
+ * (`NotFound` on unknown IDs, `ValidationError` on bad input).
+ *
+ * **Out of scope by design** — exercised only in the integration tier
+ * against real OmniFocus:
+ * - `available` / `blocked` derivation (full task-graph reachability)
+ * - cascade effects of recurring-task completion (next-occurrence spawn)
+ * - perspective evaluation
+ * - sync mechanics, attachments, TaskPaper/OPML round-trips
+ *
+ * Methods that fall outside the in-memory scope (`syncTrigger`, etc.) return
+ * sensible no-op results so services can be tested end-to-end without
+ * pretending the simulator is OmniFocus. Callers that depend on real OF
+ * semantics for those surfaces must use the integration tier.
+ *
+ * Determinism: ID generation is a monotonic counter prefixed by kind; date
+ * generation flows through an injectable `now()` clock. Tests can pin both.
+ *
+ * @see DESIGN.md §6.3, §6.6, §19
+ * @see src/adapter/OmniFocusAdapter.ts — interface this satisfies
+ */
+
+import type { Folder } from "../../domain/folder.js";
+import {
+  type FolderId,
+  FolderId as FolderIdCtor,
+  type ProjectId,
+  ProjectId as ProjectIdCtor,
+  type TagId,
+  TagId as TagIdCtor,
+  type TaskId,
+  TaskId as TaskIdCtor,
+} from "../../domain/ids.js";
+import type { Project } from "../../domain/project.js";
+import type { Tag } from "../../domain/tag.js";
+import type { Task } from "../../domain/task.js";
+import { NotFound, ValidationError } from "../../errors/index.js";
+import type {
+  CreateFolderInput,
+  CreateProjectInput,
+  CreateTagInput,
+  CreateTaskInput,
+  OmniFocusAdapter,
+  SyncStatus,
+  TaskFilter,
+  UpdateFolderInput,
+  UpdateProjectInput,
+  UpdateTagInput,
+  UpdateTaskInput,
+} from "../OmniFocusAdapter.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export interface InMemoryAdapterOptions {
+  /** Override for the system clock. Returns ISO-8601-with-offset on each call. */
+  now?: () => Date;
+  /** Seed for the ID counter. Defaults to 0. */
+  idSeed?: number;
+}
+
+function isoOf(d: Date): string {
+  // toISOString returns Zulu form ("2026-04-21T17:30:00.000Z") which is a valid
+  // ISO-8601 with offset (Z == +00:00). The domain dates module accepts this.
+  return d.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export class InMemoryAdapter implements OmniFocusAdapter {
+  private readonly now: () => Date;
+  private idCounter: number;
+
+  private readonly tasks = new Map<TaskId, Task>();
+  private readonly projects = new Map<ProjectId, Project>();
+  private readonly tags = new Map<TagId, Tag>();
+  private readonly folders = new Map<FolderId, Folder>();
+
+  private lastSyncAt: string | null = null;
+
+  constructor(options: InMemoryAdapterOptions = {}) {
+    this.now = options.now ?? (() => new Date());
+    this.idCounter = options.idSeed ?? 0;
+  }
+
+  // -- ID generation --------------------------------------------------------
+
+  private nextId<B extends string>(prefix: string, ctor: { of(s: string): B }): B {
+    this.idCounter += 1;
+    // Pad to keep IDs sortable; pattern still matches ^[A-Za-z0-9_-]{3,64}$.
+    return ctor.of(`${prefix}_${this.idCounter.toString().padStart(6, "0")}`);
+  }
+
+  // -- Tasks ----------------------------------------------------------------
+
+  async listTasks(filter: TaskFilter): Promise<Task[]> {
+    return Array.from(this.tasks.values()).filter((t) => this.matchesTask(t, filter));
+  }
+
+  async getTask(id: TaskId): Promise<Task> {
+    const task = this.tasks.get(id);
+    if (task === undefined) {
+      throw new NotFound(`Task not found: ${id}`, { details: { resource: "task", id } });
+    }
+    return task;
+  }
+
+  async getTasksMany(ids: TaskId[]): Promise<(Task | null)[]> {
+    return ids.map((id) => this.tasks.get(id) ?? null);
+  }
+
+  async createTask(input: CreateTaskInput): Promise<TaskId> {
+    if (input.name.trim() === "") {
+      throw new ValidationError("Task name must be non-empty", {
+        details: { field: "name" },
+      });
+    }
+    if (input.projectId !== undefined && input.parentId !== undefined) {
+      throw new ValidationError("createTask: provide projectId OR parentId, not both", {
+        details: { field: "projectId|parentId" },
+      });
+    }
+    if (input.projectId !== undefined && !this.projects.has(input.projectId)) {
+      throw new NotFound(`Project not found: ${input.projectId}`, {
+        details: { resource: "project", id: input.projectId },
+      });
+    }
+    if (input.parentId !== undefined && !this.tasks.has(input.parentId)) {
+      throw new NotFound(`Parent task not found: ${input.parentId}`, {
+        details: { resource: "task", id: input.parentId },
+      });
+    }
+    for (const tagId of input.tagIds ?? []) {
+      if (!this.tags.has(tagId)) {
+        throw new NotFound(`Tag not found: ${tagId}`, {
+          details: { resource: "tag", id: tagId },
+        });
+      }
+    }
+
+    const id = this.nextId("task", TaskIdCtor);
+    const now = isoOf(this.now()) as Task["createdAt"];
+    const task: Task = {
+      id,
+      name: input.name,
+      note: input.note ?? null,
+      noteHtml: input.noteHtml ?? null,
+      projectId: input.projectId ?? null,
+      parentId: input.parentId ?? null,
+      tagIds: [...(input.tagIds ?? [])],
+      deferDate: (input.deferDate ?? null) as Task["deferDate"],
+      dueDate: (input.dueDate ?? null) as Task["dueDate"],
+      estimatedMinutes: input.estimatedMinutes ?? null,
+      flagged: input.flagged ?? false,
+      completed: false,
+      completedAt: null,
+      dropped: false,
+      droppedAt: null,
+      // Availability/blocked derivation is integration-only (DESIGN §19); the
+      // in-memory double assumes a freshly-created task is available + unblocked.
+      available: true,
+      blocked: false,
+      sequential: input.sequential ?? false,
+      completedByChildren: input.completedByChildren ?? false,
+      repetition: null,
+      createdAt: now,
+      modifiedAt: now,
+    };
+    this.tasks.set(id, task);
+    this.bumpProjectTaskCount(task.projectId, +1);
+    return id;
+  }
+
+  async updateTask(id: TaskId, patch: UpdateTaskInput): Promise<void> {
+    const task = await this.getTask(id);
+    if (patch.name !== undefined && patch.name.trim() === "") {
+      throw new ValidationError("Task name must be non-empty", { details: { field: "name" } });
+    }
+    if (patch.tagIds !== undefined) {
+      for (const tagId of patch.tagIds) {
+        if (!this.tags.has(tagId)) {
+          throw new NotFound(`Tag not found: ${tagId}`, {
+            details: { resource: "tag", id: tagId },
+          });
+        }
+      }
+    }
+    const updated: Task = {
+      ...task,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+      ...(patch.note !== undefined ? { note: patch.note } : {}),
+      ...(patch.noteHtml !== undefined ? { noteHtml: patch.noteHtml } : {}),
+      ...(patch.flagged !== undefined ? { flagged: patch.flagged } : {}),
+      ...(patch.deferDate !== undefined ? { deferDate: patch.deferDate as Task["deferDate"] } : {}),
+      ...(patch.dueDate !== undefined ? { dueDate: patch.dueDate as Task["dueDate"] } : {}),
+      ...(patch.estimatedMinutes !== undefined ? { estimatedMinutes: patch.estimatedMinutes } : {}),
+      ...(patch.tagIds !== undefined ? { tagIds: [...patch.tagIds] } : {}),
+      ...(patch.sequential !== undefined ? { sequential: patch.sequential } : {}),
+      ...(patch.completedByChildren !== undefined
+        ? { completedByChildren: patch.completedByChildren }
+        : {}),
+      ...(patch.repetition !== undefined ? { repetition: patch.repetition } : {}),
+      modifiedAt: isoOf(this.now()) as Task["modifiedAt"],
+    };
+    this.tasks.set(id, updated);
+  }
+
+  async completeTask(id: TaskId, at?: Date): Promise<void> {
+    const task = await this.getTask(id);
+    const completedAt = isoOf(at ?? this.now()) as Task["completedAt"];
+    this.tasks.set(id, {
+      ...task,
+      completed: true,
+      completedAt,
+      modifiedAt: completedAt as unknown as Task["modifiedAt"],
+    });
+    this.bumpProjectCompletedCount(task.projectId, +1);
+  }
+
+  async uncompleteTask(id: TaskId): Promise<void> {
+    const task = await this.getTask(id);
+    if (!task.completed) return;
+    this.tasks.set(id, {
+      ...task,
+      completed: false,
+      completedAt: null,
+      modifiedAt: isoOf(this.now()) as Task["modifiedAt"],
+    });
+    this.bumpProjectCompletedCount(task.projectId, -1);
+  }
+
+  async dropTask(id: TaskId, at?: Date): Promise<void> {
+    const task = await this.getTask(id);
+    const droppedAt = isoOf(at ?? this.now()) as Task["droppedAt"];
+    this.tasks.set(id, {
+      ...task,
+      dropped: true,
+      droppedAt,
+      modifiedAt: droppedAt as unknown as Task["modifiedAt"],
+    });
+  }
+
+  async undropTask(id: TaskId): Promise<void> {
+    const task = await this.getTask(id);
+    if (!task.dropped) return;
+    this.tasks.set(id, {
+      ...task,
+      dropped: false,
+      droppedAt: null,
+      modifiedAt: isoOf(this.now()) as Task["modifiedAt"],
+    });
+  }
+
+  async deleteTask(id: TaskId): Promise<void> {
+    const task = await this.getTask(id);
+    this.tasks.delete(id);
+    this.bumpProjectTaskCount(task.projectId, -1);
+    if (task.completed) this.bumpProjectCompletedCount(task.projectId, -1);
+  }
+
+  async moveTask(
+    id: TaskId,
+    destination: { projectId?: ProjectId; parentId?: TaskId },
+  ): Promise<void> {
+    const task = await this.getTask(id);
+    if (destination.projectId !== undefined && destination.parentId !== undefined) {
+      throw new ValidationError("moveTask: provide projectId OR parentId, not both", {
+        details: { field: "projectId|parentId" },
+      });
+    }
+    if (destination.projectId !== undefined && !this.projects.has(destination.projectId)) {
+      throw new NotFound(`Project not found: ${destination.projectId}`, {
+        details: { resource: "project", id: destination.projectId },
+      });
+    }
+    if (destination.parentId !== undefined && !this.tasks.has(destination.parentId)) {
+      throw new NotFound(`Parent task not found: ${destination.parentId}`, {
+        details: { resource: "task", id: destination.parentId },
+      });
+    }
+    this.bumpProjectTaskCount(task.projectId, -1);
+    if (task.completed) this.bumpProjectCompletedCount(task.projectId, -1);
+
+    const newProjectId = destination.projectId ?? null;
+    this.tasks.set(id, {
+      ...task,
+      projectId: newProjectId,
+      parentId: destination.parentId ?? null,
+      modifiedAt: isoOf(this.now()) as Task["modifiedAt"],
+    });
+    this.bumpProjectTaskCount(newProjectId, +1);
+    if (task.completed) this.bumpProjectCompletedCount(newProjectId, +1);
+  }
+
+  // -- Projects -------------------------------------------------------------
+
+  async listProjects(
+    filter: { folderId?: FolderId; status?: Project["status"] } = {},
+  ): Promise<Project[]> {
+    return Array.from(this.projects.values()).filter((p) => {
+      if (filter.folderId !== undefined && p.folderId !== filter.folderId) return false;
+      if (filter.status !== undefined && p.status !== filter.status) return false;
+      return true;
+    });
+  }
+
+  async getProject(id: ProjectId): Promise<Project> {
+    const project = this.projects.get(id);
+    if (project === undefined) {
+      throw new NotFound(`Project not found: ${id}`, { details: { resource: "project", id } });
+    }
+    return project;
+  }
+
+  async createProject(input: CreateProjectInput): Promise<ProjectId> {
+    if (input.name.trim() === "") {
+      throw new ValidationError("Project name must be non-empty", {
+        details: { field: "name" },
+      });
+    }
+    if (input.folderId !== undefined && !this.folders.has(input.folderId)) {
+      throw new NotFound(`Folder not found: ${input.folderId}`, {
+        details: { resource: "folder", id: input.folderId },
+      });
+    }
+
+    const id = this.nextId("proj", ProjectIdCtor);
+    const now = isoOf(this.now()) as Project["createdAt"];
+    const project: Project = {
+      id,
+      name: input.name,
+      note: input.note ?? null,
+      noteHtml: input.noteHtml ?? null,
+      folderId: input.folderId ?? null,
+      tagIds: [...(input.tagIds ?? [])],
+      status: input.status ?? "active",
+      completionCriterion: input.completionCriterion ?? "parallel",
+      deferDate: (input.deferDate ?? null) as Project["deferDate"],
+      dueDate: (input.dueDate ?? null) as Project["dueDate"],
+      estimatedMinutes: input.estimatedMinutes ?? null,
+      flagged: input.flagged ?? false,
+      reviewIntervalDays: input.reviewIntervalDays ?? null,
+      nextReviewDate: null,
+      lastReviewDate: null,
+      completed: false,
+      completedAt: null,
+      dropped: false,
+      droppedAt: null,
+      taskCount: 0,
+      completedTaskCount: 0,
+      createdAt: now,
+      modifiedAt: now,
+    };
+    this.projects.set(id, project);
+    this.bumpFolderProjectCount(project.folderId, +1);
+    return id;
+  }
+
+  async updateProject(id: ProjectId, patch: UpdateProjectInput): Promise<void> {
+    const project = await this.getProject(id);
+    if (patch.name !== undefined && patch.name.trim() === "") {
+      throw new ValidationError("Project name must be non-empty", { details: { field: "name" } });
+    }
+    const updated: Project = {
+      ...project,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+      ...(patch.note !== undefined ? { note: patch.note } : {}),
+      ...(patch.noteHtml !== undefined ? { noteHtml: patch.noteHtml } : {}),
+      ...(patch.status !== undefined ? { status: patch.status } : {}),
+      ...(patch.completionCriterion !== undefined
+        ? { completionCriterion: patch.completionCriterion }
+        : {}),
+      ...(patch.deferDate !== undefined
+        ? { deferDate: patch.deferDate as Project["deferDate"] }
+        : {}),
+      ...(patch.dueDate !== undefined ? { dueDate: patch.dueDate as Project["dueDate"] } : {}),
+      ...(patch.estimatedMinutes !== undefined ? { estimatedMinutes: patch.estimatedMinutes } : {}),
+      ...(patch.flagged !== undefined ? { flagged: patch.flagged } : {}),
+      ...(patch.tagIds !== undefined ? { tagIds: [...patch.tagIds] } : {}),
+      ...(patch.reviewIntervalDays !== undefined
+        ? { reviewIntervalDays: patch.reviewIntervalDays }
+        : {}),
+      modifiedAt: isoOf(this.now()) as Project["modifiedAt"],
+    };
+    this.projects.set(id, updated);
+  }
+
+  async completeProject(id: ProjectId, at?: Date): Promise<void> {
+    const project = await this.getProject(id);
+    const completedAt = isoOf(at ?? this.now()) as Project["completedAt"];
+    this.projects.set(id, {
+      ...project,
+      status: "done",
+      completed: true,
+      completedAt,
+      modifiedAt: completedAt as unknown as Project["modifiedAt"],
+    });
+  }
+
+  async dropProject(id: ProjectId, at?: Date): Promise<void> {
+    const project = await this.getProject(id);
+    const droppedAt = isoOf(at ?? this.now()) as Project["droppedAt"];
+    this.projects.set(id, {
+      ...project,
+      status: "dropped",
+      dropped: true,
+      droppedAt,
+      modifiedAt: droppedAt as unknown as Project["modifiedAt"],
+    });
+  }
+
+  async moveProject(id: ProjectId, destination: { folderId: FolderId | null }): Promise<void> {
+    const project = await this.getProject(id);
+    if (destination.folderId !== null && !this.folders.has(destination.folderId)) {
+      throw new NotFound(`Folder not found: ${destination.folderId}`, {
+        details: { resource: "folder", id: destination.folderId },
+      });
+    }
+    this.bumpFolderProjectCount(project.folderId, -1);
+    this.projects.set(id, {
+      ...project,
+      folderId: destination.folderId,
+      modifiedAt: isoOf(this.now()) as Project["modifiedAt"],
+    });
+    this.bumpFolderProjectCount(destination.folderId, +1);
+  }
+
+  async deleteProject(id: ProjectId): Promise<void> {
+    const project = await this.getProject(id);
+    // Cascade: orphaned tasks become inbox tasks (matches OF behavior loosely;
+    // real OF prompts the user). Out-of-scope details fall to the integration tier.
+    for (const [taskId, task] of this.tasks) {
+      if (task.projectId === id) {
+        this.tasks.set(taskId, { ...task, projectId: null });
+      }
+    }
+    this.projects.delete(id);
+    this.bumpFolderProjectCount(project.folderId, -1);
+  }
+
+  async markProjectReviewed(id: ProjectId): Promise<void> {
+    const project = await this.getProject(id);
+    const now = this.now();
+    const lastReviewDate = isoOf(now) as Project["lastReviewDate"];
+    let nextReviewDate: Project["nextReviewDate"] = null;
+    if (project.reviewIntervalDays !== null) {
+      const next = new Date(now);
+      next.setUTCDate(next.getUTCDate() + project.reviewIntervalDays);
+      nextReviewDate = isoOf(next) as Project["nextReviewDate"];
+    }
+    this.projects.set(id, {
+      ...project,
+      lastReviewDate,
+      nextReviewDate,
+      modifiedAt: lastReviewDate as unknown as Project["modifiedAt"],
+    });
+  }
+
+  // -- Tags -----------------------------------------------------------------
+
+  async listTags(filter: { parentId?: TagId; status?: Tag["status"] } = {}): Promise<Tag[]> {
+    return Array.from(this.tags.values()).filter((t) => {
+      if (filter.parentId !== undefined && t.parentId !== filter.parentId) return false;
+      if (filter.status !== undefined && t.status !== filter.status) return false;
+      return true;
+    });
+  }
+
+  async getTag(id: TagId): Promise<Tag> {
+    const tag = this.tags.get(id);
+    if (tag === undefined) {
+      throw new NotFound(`Tag not found: ${id}`, { details: { resource: "tag", id } });
+    }
+    return tag;
+  }
+
+  async createTag(input: CreateTagInput): Promise<TagId> {
+    if (input.name.trim() === "") {
+      throw new ValidationError("Tag name must be non-empty", { details: { field: "name" } });
+    }
+    if (input.parentId !== undefined && !this.tags.has(input.parentId)) {
+      throw new NotFound(`Parent tag not found: ${input.parentId}`, {
+        details: { resource: "tag", id: input.parentId },
+      });
+    }
+
+    const id = this.nextId("tag", TagIdCtor);
+    const now = isoOf(this.now()) as Tag["createdAt"];
+    const tag: Tag = {
+      id,
+      name: input.name,
+      parentId: input.parentId ?? null,
+      status: input.status ?? "active",
+      location: null,
+      allowsNextAction: input.allowsNextAction ?? true,
+      taskCount: 0,
+      createdAt: now,
+      modifiedAt: now,
+    };
+    this.tags.set(id, tag);
+    return id;
+  }
+
+  async updateTag(id: TagId, patch: UpdateTagInput): Promise<void> {
+    const tag = await this.getTag(id);
+    if (patch.name !== undefined && patch.name.trim() === "") {
+      throw new ValidationError("Tag name must be non-empty", { details: { field: "name" } });
+    }
+    if (patch.parentId !== undefined && patch.parentId !== null && !this.tags.has(patch.parentId)) {
+      throw new NotFound(`Parent tag not found: ${patch.parentId}`, {
+        details: { resource: "tag", id: patch.parentId },
+      });
+    }
+    this.tags.set(id, {
+      ...tag,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+      ...(patch.parentId !== undefined ? { parentId: patch.parentId } : {}),
+      ...(patch.status !== undefined ? { status: patch.status } : {}),
+      ...(patch.allowsNextAction !== undefined ? { allowsNextAction: patch.allowsNextAction } : {}),
+      modifiedAt: isoOf(this.now()) as Tag["modifiedAt"],
+    });
+  }
+
+  async deleteTag(id: TagId): Promise<void> {
+    await this.getTag(id);
+    // Drop the tag from any task carrying it.
+    for (const [taskId, task] of this.tasks) {
+      if (task.tagIds.includes(id)) {
+        this.tasks.set(taskId, {
+          ...task,
+          tagIds: task.tagIds.filter((t) => t !== id),
+        });
+      }
+    }
+    this.tags.delete(id);
+  }
+
+  // -- Folders --------------------------------------------------------------
+
+  async listFolders(filter: { parentId?: FolderId } = {}): Promise<Folder[]> {
+    return Array.from(this.folders.values()).filter((f) => {
+      if (filter.parentId !== undefined && f.parentId !== filter.parentId) return false;
+      return true;
+    });
+  }
+
+  async getFolder(id: FolderId): Promise<Folder> {
+    const folder = this.folders.get(id);
+    if (folder === undefined) {
+      throw new NotFound(`Folder not found: ${id}`, { details: { resource: "folder", id } });
+    }
+    return folder;
+  }
+
+  async createFolder(input: CreateFolderInput): Promise<FolderId> {
+    if (input.name.trim() === "") {
+      throw new ValidationError("Folder name must be non-empty", {
+        details: { field: "name" },
+      });
+    }
+    if (input.parentId !== undefined && !this.folders.has(input.parentId)) {
+      throw new NotFound(`Parent folder not found: ${input.parentId}`, {
+        details: { resource: "folder", id: input.parentId },
+      });
+    }
+
+    const id = this.nextId("fold", FolderIdCtor);
+    const now = isoOf(this.now()) as Folder["createdAt"];
+    const folder: Folder = {
+      id,
+      name: input.name,
+      parentId: input.parentId ?? null,
+      projectCount: 0,
+      subfolderCount: 0,
+      createdAt: now,
+      modifiedAt: now,
+    };
+    this.folders.set(id, folder);
+    if (folder.parentId !== null) this.bumpFolderSubfolderCount(folder.parentId, +1);
+    return id;
+  }
+
+  async updateFolder(id: FolderId, patch: UpdateFolderInput): Promise<void> {
+    const folder = await this.getFolder(id);
+    if (patch.name !== undefined && patch.name.trim() === "") {
+      throw new ValidationError("Folder name must be non-empty", { details: { field: "name" } });
+    }
+    if (
+      patch.parentId !== undefined &&
+      patch.parentId !== null &&
+      !this.folders.has(patch.parentId)
+    ) {
+      throw new NotFound(`Parent folder not found: ${patch.parentId}`, {
+        details: { resource: "folder", id: patch.parentId },
+      });
+    }
+    if (patch.parentId !== undefined && patch.parentId !== folder.parentId) {
+      if (folder.parentId !== null) this.bumpFolderSubfolderCount(folder.parentId, -1);
+      if (patch.parentId !== null) this.bumpFolderSubfolderCount(patch.parentId, +1);
+    }
+    this.folders.set(id, {
+      ...folder,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+      ...(patch.parentId !== undefined ? { parentId: patch.parentId } : {}),
+      modifiedAt: isoOf(this.now()) as Folder["modifiedAt"],
+    });
+  }
+
+  async deleteFolder(id: FolderId): Promise<void> {
+    const folder = await this.getFolder(id);
+    if (folder.projectCount > 0 || folder.subfolderCount > 0) {
+      throw new ValidationError(
+        `Folder is not empty (projects=${folder.projectCount}, subfolders=${folder.subfolderCount})`,
+        { details: { resource: "folder", id } },
+      );
+    }
+    this.folders.delete(id);
+    if (folder.parentId !== null) this.bumpFolderSubfolderCount(folder.parentId, -1);
+  }
+
+  // -- Sync (no-op stubs; integration tier owns real semantics) ------------
+
+  async syncTrigger(): Promise<SyncStatus> {
+    this.lastSyncAt = isoOf(this.now());
+    return { lastSyncAt: this.lastSyncAt, inFlight: false };
+  }
+
+  async getLastSync(): Promise<SyncStatus> {
+    return { lastSyncAt: this.lastSyncAt, inFlight: false };
+  }
+
+  // -- Internal helpers -----------------------------------------------------
+
+  private matchesTask(task: Task, filter: TaskFilter): boolean {
+    if (filter.projectId !== undefined && task.projectId !== filter.projectId) return false;
+    if (filter.parentId !== undefined && task.parentId !== filter.parentId) return false;
+    if (filter.tagId !== undefined && !task.tagIds.includes(filter.tagId)) return false;
+    if (filter.flagged !== undefined && task.flagged !== filter.flagged) return false;
+    if (filter.completed !== undefined && task.completed !== filter.completed) return false;
+    if (filter.available !== undefined && task.available !== filter.available) return false;
+    if (filter.blocked !== undefined && task.blocked !== filter.blocked) return false;
+    if (filter.completedSince !== undefined) {
+      if (task.completedAt === null || task.completedAt < filter.completedSince) return false;
+    }
+    if (filter.dueBefore !== undefined) {
+      if (task.dueDate === null || task.dueDate >= filter.dueBefore) return false;
+    }
+    if (filter.dueAfter !== undefined) {
+      if (task.dueDate === null || task.dueDate <= filter.dueAfter) return false;
+    }
+    if (filter.deferredBefore !== undefined) {
+      if (task.deferDate === null || task.deferDate >= filter.deferredBefore) return false;
+    }
+    if (filter.deferredAfter !== undefined) {
+      if (task.deferDate === null || task.deferDate <= filter.deferredAfter) return false;
+    }
+    return true;
+  }
+
+  private bumpProjectTaskCount(projectId: ProjectId | null, delta: number): void {
+    if (projectId === null) return;
+    const project = this.projects.get(projectId);
+    if (project === undefined) return;
+    this.projects.set(projectId, {
+      ...project,
+      taskCount: Math.max(0, project.taskCount + delta),
+    });
+  }
+
+  private bumpProjectCompletedCount(projectId: ProjectId | null, delta: number): void {
+    if (projectId === null) return;
+    const project = this.projects.get(projectId);
+    if (project === undefined) return;
+    this.projects.set(projectId, {
+      ...project,
+      completedTaskCount: Math.max(0, project.completedTaskCount + delta),
+    });
+  }
+
+  private bumpFolderProjectCount(folderId: FolderId | null, delta: number): void {
+    if (folderId === null) return;
+    const folder = this.folders.get(folderId);
+    if (folder === undefined) return;
+    this.folders.set(folderId, {
+      ...folder,
+      projectCount: Math.max(0, folder.projectCount + delta),
+    });
+  }
+
+  private bumpFolderSubfolderCount(folderId: FolderId, delta: number): void {
+    const folder = this.folders.get(folderId);
+    if (folder === undefined) return;
+    this.folders.set(folderId, {
+      ...folder,
+      subfolderCount: Math.max(0, folder.subfolderCount + delta),
+    });
+  }
+}

--- a/src/domain/folder.ts
+++ b/src/domain/folder.ts
@@ -1,0 +1,44 @@
+/**
+ * Zod schemas and TypeScript types for the Folder domain object.
+ *
+ * Matches the canonical schema in `docs/domain-reference.md` exactly.
+ * Dates are ISO-8601 with offset per ADR-0007; IDs are branded per ADR-0008.
+ *
+ * This M0 introduction is intentionally minimal — `Folder` CRUD ships in M2
+ * (#54). The shape here exists so the adapter interface (#16) and the
+ * InMemoryAdapter can be typed precisely from the start.
+ *
+ * @see docs/domain-reference.md — canonical field definitions
+ */
+
+import { z } from "zod";
+import { type IsoDateString, isoDateString } from "./dates.js";
+import { type FolderId, FolderId as FolderIdCtor } from "./ids.js";
+
+// ---------------------------------------------------------------------------
+// Folder
+// ---------------------------------------------------------------------------
+
+export interface Folder {
+  id: FolderId;
+  name: string;
+  parentId: FolderId | null;
+  projectCount: number;
+  subfolderCount: number;
+  createdAt: IsoDateString;
+  modifiedAt: IsoDateString;
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const FolderSchema: z.ZodType<Folder, z.ZodTypeDef, unknown> = z.object({
+  id: FolderIdCtor.schema,
+  name: z.string(),
+  parentId: FolderIdCtor.schema.nullable(),
+  projectCount: z.number().int().min(0),
+  subfolderCount: z.number().int().min(0),
+  createdAt: isoDateString(),
+  modifiedAt: isoDateString(),
+}) as z.ZodType<Folder, z.ZodTypeDef, unknown>;

--- a/src/domain/tag.ts
+++ b/src/domain/tag.ts
@@ -1,0 +1,72 @@
+/**
+ * Zod schemas and TypeScript types for the Tag domain object.
+ *
+ * Matches the canonical schema in `docs/domain-reference.md` exactly.
+ * Dates are ISO-8601 with offset per ADR-0007; IDs are branded per ADR-0008.
+ *
+ * This M0 introduction is intentionally minimal — `Tag` CRUD ships in M2 (#49,
+ * #50). The shape here exists so the adapter interface (#16) and InMemoryAdapter
+ * can be typed precisely from the start.
+ *
+ * @see docs/domain-reference.md — canonical field definitions
+ */
+
+import { z } from "zod";
+import { type IsoDateString, isoDateString } from "./dates.js";
+import { type TagId, TagId as TagIdCtor } from "./ids.js";
+
+// ---------------------------------------------------------------------------
+// Tag
+// ---------------------------------------------------------------------------
+
+export interface TagLocation {
+  name: string | null;
+  latitude: number;
+  longitude: number;
+  radiusMeters: number;
+  trigger: "entering" | "leaving" | "both";
+}
+
+export interface Tag {
+  id: TagId;
+  name: string;
+  parentId: TagId | null;
+
+  status: "active" | "on-hold" | "dropped";
+
+  location: TagLocation | null;
+  allowsNextAction: boolean;
+
+  taskCount: number;
+
+  createdAt: IsoDateString;
+  modifiedAt: IsoDateString;
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const TagLocationSchema: z.ZodType<TagLocation, z.ZodTypeDef, unknown> = z.object({
+  name: z.string().nullable(),
+  latitude: z.number(),
+  longitude: z.number(),
+  radiusMeters: z.number().min(0),
+  trigger: z.enum(["entering", "leaving", "both"]),
+}) as z.ZodType<TagLocation, z.ZodTypeDef, unknown>;
+
+export const TagSchema: z.ZodType<Tag, z.ZodTypeDef, unknown> = z.object({
+  id: TagIdCtor.schema,
+  name: z.string(),
+  parentId: TagIdCtor.schema.nullable(),
+
+  status: z.enum(["active", "on-hold", "dropped"]),
+
+  location: TagLocationSchema.nullable(),
+  allowsNextAction: z.boolean(),
+
+  taskCount: z.number().int().min(0),
+
+  createdAt: isoDateString(),
+  modifiedAt: isoDateString(),
+}) as z.ZodType<Tag, z.ZodTypeDef, unknown>;


### PR DESCRIPTION
## Summary
- Defines `OmniFocusAdapter` — the sacred seam between services and OmniFocus (DESIGN §6.1, §6.3). Every concrete transport (JxaTransport #17, OmniJsTransport #18, TransportRouter #19) and the in-memory test double implement this contract.
- Ships `InMemoryAdapter` per DESIGN §19 scope: CRUD + filter for tasks/projects/tags/folders, with injectable clock and monotonic IDs for deterministic tests. Out of scope (availability derivation, recurring cascade, perspectives, real sync) is documented and deferred to the integration tier.
- Adds minimal `Tag`/`Folder` domain shapes so the adapter can be typed precisely from M0; full CRUD lands in M2 (#49, #50, #54).

## Test plan
- [x] 30 new unit tests cover CRUD round-trips, filter semantics (projectId, tagId, flagged, completed, dueBefore/After, completedSince), derived-count maintenance (project.taskCount, completedTaskCount; folder.projectCount, subfolderCount), and typed errors (`NotFound`, `ValidationError`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (biome + custom)
- [x] `pnpm test` — 222/222 passing

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)