### PR TITLE
feat(adapter): introduce JxaTransport script runner and scaffolding (#17)

### DIFF
--- a/src/adapter/jxa/JxaTransport.test.ts
+++ b/src/adapter/jxa/JxaTransport.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for `JxaTransport`.
+ *
+ * Covers the keystone slice this PR ships:
+ * - `syncTrigger` round-trips through the runner with a fake spawner
+ * - Stubbed methods throw the documented `not-yet-wired` ScriptError so
+ *   `TransportRouter` (#19) and tests can detect the partial state
+ * - The constructor's spawner / timeout options reach the runner
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ProjectId, TaskId } from "../../domain/ids.js";
+import { ScriptError } from "../../errors/index.js";
+import { JxaTransport } from "./JxaTransport.js";
+import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
+
+function spawnerReturning(stdout: string): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout,
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    }),
+  );
+}
+
+describe("JxaTransport — syncTrigger (wired)", () => {
+  it("returns the parsed SyncStatus from the underlying script", async () => {
+    const spawner = spawnerReturning('{"lastSyncAt":"2026-04-21T12:00:00.000Z","inFlight":false}');
+    const t = new JxaTransport({ spawner });
+    const status = await t.syncTrigger();
+    expect(status).toEqual({ lastSyncAt: "2026-04-21T12:00:00.000Z", inFlight: false });
+  });
+
+  it("forwards the configured timeout to the spawner", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '{"lastSyncAt":null,"inFlight":false}',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    const t = new JxaTransport({ spawner, timeoutMs: 1234 });
+    await t.syncTrigger();
+    expect(spawner.mock.calls[0]?.[2]).toBe(1234);
+  });
+
+  it("passes scriptName='sync_trigger' for error context", async () => {
+    // We verify the runner was invoked with the correct scriptName tag by
+    // forcing a script error and inspecting the typed error's details.
+    const spawner = vi.fn(
+      async (): Promise<SpawnResult> => ({
+        stdout: "",
+        stderr: "boom",
+        exitCode: 1,
+        timedOut: false,
+      }),
+    );
+    const t = new JxaTransport({ spawner });
+    const err = await t.syncTrigger().catch((e) => e);
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details).toMatchObject({ scriptName: "sync_trigger" });
+  });
+});
+
+describe("JxaTransport — getLastSync (interim)", () => {
+  it("returns a null status until the lifecycle layer (#25) lands", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning("{}") });
+    expect(await t.getLastSync()).toEqual({ lastSyncAt: null, inFlight: false });
+  });
+});
+
+describe("JxaTransport — not-yet-wired stubs", () => {
+  const t = new JxaTransport({ spawner: spawnerReturning("{}") });
+
+  // Sample one method per domain group; the per-method shape is uniform.
+  const cases: Array<readonly [string, () => Promise<unknown>]> = [
+    ["listTasks", () => t.listTasks({})],
+    ["getTask", () => t.getTask("task_000001" as TaskId)],
+    ["createTask", () => t.createTask({ name: "x" })],
+    ["listProjects", () => t.listProjects()],
+    ["getProject", () => t.getProject("proj_000001" as ProjectId)],
+    ["listTags", () => t.listTags()],
+    ["listFolders", () => t.listFolders()],
+  ];
+
+  for (const [method, call] of cases) {
+    it(`${method} throws ScriptError with reason="not-yet-wired"`, async () => {
+      const err = await call().catch((e) => e);
+      expect(err).toBeInstanceOf(ScriptError);
+      expect((err as ScriptError).details).toMatchObject({
+        transport: "jxa",
+        reason: "not-yet-wired",
+        method,
+      });
+    });
+  }
+});

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -1,0 +1,221 @@
+/**
+ * `JxaTransport` — primary `OmniFocusAdapter` implementation.
+ *
+ * Shells to `osascript -l JavaScript` per ADR-0002 / ADR-0005, with each
+ * domain method backed by a JXA script under `src/scripts/jxa/*.js`. The
+ * `runJxaScript` runner handles process lifecycle, timeout, UTF-8, and
+ * typed-error mapping; this class is mostly a thin dispatch layer that
+ * loads the right script and shapes the response into the domain types
+ * defined by `OmniFocusAdapter`.
+ *
+ * **Status (M0 keystone):** This file ships the transport scaffolding plus
+ * one wired method (`syncTrigger`) as proof. Per-domain scripts (tasks,
+ * projects, tags, folders, forecast, search, notes, repetition,
+ * attachments, review) land via follow-up issues so each can carry its
+ * own JXA script + tests + smoke without piling into a single mega-PR.
+ * Stubbed methods throw `ScriptError` with `details.reason: "not-yet-wired"`
+ * so `TransportRouter` (#19) can route around them and tests can detect
+ * the partial-implementation state precisely.
+ *
+ * @see DESIGN.md §6.1, §6.3, §6.4 — adapter seam, layering, script discipline
+ * @see ADR-0002 — JXA + OmniJS dual transport
+ * @see ADR-0005 — scripts as first-class files
+ * @see src/adapter/jxa/scriptRunner.ts
+ */
+
+import type { Folder } from "../../domain/folder.js";
+import type { FolderId, ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import type { Project } from "../../domain/project.js";
+import type { Tag } from "../../domain/tag.js";
+import type { Task } from "../../domain/task.js";
+import { ScriptError } from "../../errors/index.js";
+import syncTriggerScript from "../../scripts/jxa/sync_trigger.js";
+import type {
+  CreateFolderInput,
+  CreateProjectInput,
+  CreateTagInput,
+  CreateTaskInput,
+  OmniFocusAdapter,
+  SyncStatus,
+  TaskFilter,
+  UpdateFolderInput,
+  UpdateProjectInput,
+  UpdateTagInput,
+  UpdateTaskInput,
+} from "../OmniFocusAdapter.js";
+import { type RunScriptOptions, type ScriptSpawner, runJxaScript } from "./scriptRunner.js";
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+export interface JxaTransportOptions {
+  /** Hard timeout for any single JXA invocation. Defaults to 30s. */
+  timeoutMs?: number;
+  /** Inject a fake spawner — used by unit tests; production callers omit. */
+  spawner?: ScriptSpawner;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sentinel thrown by every method whose underlying JXA script hasn't been
+ * wired yet. The `details.reason` value is part of the deliberately-narrow
+ * contract that `TransportRouter` (#19) and unit tests inspect to decide
+ * whether to route to `OmniJsTransport` instead.
+ */
+function notYetWired(method: string): never {
+  throw new ScriptError(`JxaTransport.${method} is not wired yet`, {
+    details: { transport: "jxa", reason: "not-yet-wired", method },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+export class JxaTransport implements OmniFocusAdapter {
+  private readonly runOpts: RunScriptOptions;
+
+  constructor(options: JxaTransportOptions = {}) {
+    this.runOpts = {
+      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+      ...(options.spawner !== undefined ? { spawner: options.spawner } : {}),
+    };
+  }
+
+  // -- Tasks ----------------------------------------------------------------
+
+  async listTasks(_filter: TaskFilter): Promise<Task[]> {
+    return notYetWired("listTasks");
+  }
+  async getTask(_id: TaskId): Promise<Task> {
+    return notYetWired("getTask");
+  }
+  async getTasksMany(_ids: TaskId[]): Promise<(Task | null)[]> {
+    return notYetWired("getTasksMany");
+  }
+  async createTask(_input: CreateTaskInput): Promise<TaskId> {
+    return notYetWired("createTask");
+  }
+  async updateTask(_id: TaskId, _patch: UpdateTaskInput): Promise<void> {
+    return notYetWired("updateTask");
+  }
+  async completeTask(_id: TaskId, _at?: Date): Promise<void> {
+    return notYetWired("completeTask");
+  }
+  async uncompleteTask(_id: TaskId): Promise<void> {
+    return notYetWired("uncompleteTask");
+  }
+  async dropTask(_id: TaskId, _at?: Date): Promise<void> {
+    return notYetWired("dropTask");
+  }
+  async undropTask(_id: TaskId): Promise<void> {
+    return notYetWired("undropTask");
+  }
+  async deleteTask(_id: TaskId): Promise<void> {
+    return notYetWired("deleteTask");
+  }
+  async moveTask(
+    _id: TaskId,
+    _destination: { projectId?: ProjectId; parentId?: TaskId },
+  ): Promise<void> {
+    return notYetWired("moveTask");
+  }
+
+  // -- Projects -------------------------------------------------------------
+
+  async listProjects(_filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<
+    Project[]
+  > {
+    return notYetWired("listProjects");
+  }
+  async getProject(_id: ProjectId): Promise<Project> {
+    return notYetWired("getProject");
+  }
+  async createProject(_input: CreateProjectInput): Promise<ProjectId> {
+    return notYetWired("createProject");
+  }
+  async updateProject(_id: ProjectId, _patch: UpdateProjectInput): Promise<void> {
+    return notYetWired("updateProject");
+  }
+  async completeProject(_id: ProjectId, _at?: Date): Promise<void> {
+    return notYetWired("completeProject");
+  }
+  async dropProject(_id: ProjectId, _at?: Date): Promise<void> {
+    return notYetWired("dropProject");
+  }
+  async moveProject(_id: ProjectId, _destination: { folderId: FolderId | null }): Promise<void> {
+    return notYetWired("moveProject");
+  }
+  async deleteProject(_id: ProjectId): Promise<void> {
+    return notYetWired("deleteProject");
+  }
+  async markProjectReviewed(_id: ProjectId): Promise<void> {
+    return notYetWired("markProjectReviewed");
+  }
+
+  // -- Tags -----------------------------------------------------------------
+
+  async listTags(_filter?: { parentId?: TagId; status?: Tag["status"] }): Promise<Tag[]> {
+    return notYetWired("listTags");
+  }
+  async getTag(_id: TagId): Promise<Tag> {
+    return notYetWired("getTag");
+  }
+  async createTag(_input: CreateTagInput): Promise<TagId> {
+    return notYetWired("createTag");
+  }
+  async updateTag(_id: TagId, _patch: UpdateTagInput): Promise<void> {
+    return notYetWired("updateTag");
+  }
+  async deleteTag(_id: TagId): Promise<void> {
+    return notYetWired("deleteTag");
+  }
+
+  // -- Folders --------------------------------------------------------------
+
+  async listFolders(_filter?: { parentId?: FolderId }): Promise<Folder[]> {
+    return notYetWired("listFolders");
+  }
+  async getFolder(_id: FolderId): Promise<Folder> {
+    return notYetWired("getFolder");
+  }
+  async createFolder(_input: CreateFolderInput): Promise<FolderId> {
+    return notYetWired("createFolder");
+  }
+  async updateFolder(_id: FolderId, _patch: UpdateFolderInput): Promise<void> {
+    return notYetWired("updateFolder");
+  }
+  async deleteFolder(_id: FolderId): Promise<void> {
+    return notYetWired("deleteFolder");
+  }
+
+  // -- Sync (wired) ---------------------------------------------------------
+
+  async syncTrigger(): Promise<SyncStatus> {
+    const result = await runJxaScript<{ lastSyncAt: string | null; inFlight: boolean }>(
+      syncTriggerScript,
+      {},
+      { ...this.runOpts, scriptName: "sync_trigger" },
+    );
+    return result;
+  }
+
+  async getLastSync(): Promise<SyncStatus> {
+    // `getLastSync` is a pure read with no JXA equivalent — OmniFocus does
+    // not expose a "last sync timestamp" property on the document. The real
+    // implementation will surface this from a process-local cache populated
+    // by `syncTrigger`. The lifecycle layer (#25) owns that cache; until
+    // it lands, signal "unknown" rather than a misleading timestamp.
+    return { lastSyncAt: null, inFlight: false };
+  }
+
+  // -- Raw escape hatch (off by default; gated by env at the tool layer) ----
+
+  async runJxaScript(script: string): Promise<unknown> {
+    return runJxaScript(script, {}, { ...this.runOpts, scriptName: "raw" });
+  }
+}

--- a/src/adapter/jxa/scriptRunner.test.ts
+++ b/src/adapter/jxa/scriptRunner.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for `runJxaScript`.
+ *
+ * Every test injects a fake `ScriptSpawner` so no real `osascript` runs.
+ * The runner's job is the protocol: pass the JSON arg through, parse the
+ * stdout, classify stderr signatures into typed errors, time out cleanly.
+ * Real-binary integration goes through the harness in #80.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  OmniFocusError,
+  OmniFocusNotRunning,
+  PermissionDenied,
+  ScriptError,
+  TransportUnavailable,
+} from "../../errors/index.js";
+import { type ScriptSpawner, type SpawnResult, runJxaScript } from "./scriptRunner.js";
+
+function fakeSpawner(result: Partial<SpawnResult>): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+      ...result,
+    }),
+  );
+}
+
+describe("runJxaScript — happy path", () => {
+  it("parses JSON stdout into the typed result", async () => {
+    const spawner = fakeSpawner({ stdout: '{"ok":true,"n":42}' });
+    const out = await runJxaScript<{ ok: boolean; n: number }>("script", {}, { spawner });
+    expect(out).toEqual({ ok: true, n: 42 });
+  });
+
+  it("forwards args as a JSON string in argv[0]", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '"ok"',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    await runJxaScript("script", { name: "buy milk", flagged: true }, { spawner });
+    expect(spawner).toHaveBeenCalledOnce();
+    const [, jsonArg] = spawner.mock.calls[0] ?? [];
+    expect(jsonArg).toBe('{"name":"buy milk","flagged":true}');
+  });
+
+  it("trims surrounding whitespace before parsing", async () => {
+    const spawner = fakeSpawner({ stdout: '\n  {"x":1}\n' });
+    const out = await runJxaScript("script", {}, { spawner });
+    expect(out).toEqual({ x: 1 });
+  });
+
+  it("defaults args to {} when omitted", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '"ok"',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    await runJxaScript("script", undefined, { spawner });
+    expect(spawner.mock.calls[0]?.[1]).toBe("{}");
+  });
+
+  it("forwards the configured timeout to the spawner", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '"ok"',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    await runJxaScript("script", {}, { spawner, timeoutMs: 5000 });
+    expect(spawner.mock.calls[0]?.[2]).toBe(5000);
+  });
+});
+
+describe("runJxaScript — error mapping", () => {
+  it("maps timeout to Timeout with transport context", async () => {
+    const spawner = fakeSpawner({ timedOut: true, exitCode: 1 });
+    await expect(runJxaScript("script", {}, { spawner, timeoutMs: 250 })).rejects.toMatchObject({
+      name: "Timeout",
+      code: "OF_TIMEOUT",
+      details: { transport: "jxa", timeoutMs: 250 },
+    });
+  });
+
+  it("maps spawn ENOENT to TransportUnavailable", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" }) as NodeJS.ErrnoException;
+    const spawner = fakeSpawner({ exitCode: 1, spawnError: enoent });
+    await expect(runJxaScript("script", {}, { spawner })).rejects.toBeInstanceOf(
+      TransportUnavailable,
+    );
+  });
+
+  it("maps 'Application isn't running' stderr to OmniFocusNotRunning", async () => {
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "OmniFocus got an error: Application isn't running.",
+    });
+    await expect(runJxaScript("script", {}, { spawner })).rejects.toBeInstanceOf(
+      OmniFocusNotRunning,
+    );
+  });
+
+  it("maps -1743 (errAEEventNotPermitted) stderr to PermissionDenied", async () => {
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "execution error: Not authorized to send Apple events to OmniFocus. (-1743)",
+    });
+    await expect(runJxaScript("script", {}, { spawner })).rejects.toBeInstanceOf(PermissionDenied);
+  });
+
+  it("maps unclassified non-zero exit to ScriptError carrying stderr", async () => {
+    const spawner = fakeSpawner({ exitCode: 2, stderr: "some other failure mode" });
+    const err = await runJxaScript("script", {}, { spawner, scriptName: "task_list" }).catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details).toMatchObject({
+      transport: "jxa",
+      exitCode: 2,
+      scriptName: "task_list",
+    });
+    expect((err as ScriptError).details?.stderr).toContain("some other failure mode");
+  });
+
+  it("maps malformed stdout JSON to ScriptError with a preview", async () => {
+    const spawner = fakeSpawner({ stdout: "not-json{}" });
+    const err = await runJxaScript("script", {}, { spawner }).catch((e) => e);
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details?.stdoutPreview).toContain("not-json");
+  });
+
+  it("maps empty stdout to ScriptError (script-author bug)", async () => {
+    const spawner = fakeSpawner({ stdout: "   \n" });
+    await expect(runJxaScript("script", {}, { spawner })).rejects.toBeInstanceOf(ScriptError);
+  });
+
+  it("every thrown error is in the typed taxonomy (never raw Error)", async () => {
+    const cases: Array<Partial<SpawnResult>> = [
+      { timedOut: true, exitCode: 1 },
+      { exitCode: 1, stderr: "Application isn't running" },
+      { exitCode: 1, stderr: "Not authorized to send Apple events (-1743)" },
+      { exitCode: 5, stderr: "boom" },
+      { stdout: "garbage" },
+      { stdout: "" },
+    ];
+    for (const c of cases) {
+      const spawner = fakeSpawner(c);
+      const err = await runJxaScript("script", {}, { spawner }).catch((e) => e);
+      expect(err).toBeInstanceOf(OmniFocusError);
+    }
+  });
+});

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -1,0 +1,256 @@
+/**
+ * `runJxaScript` — the keystone of the JXA transport.
+ *
+ * Spawns `osascript -l JavaScript`, pipes a script body via stdin, and
+ * passes a single JSON-stringified argument as `argv[0]` (which JXA scripts
+ * receive in their `function run(argv)` entry point per ADR-0005).
+ *
+ * Responsibilities:
+ *
+ * - **Hard timeout**: kills the child if it runs past the configured limit
+ *   and surfaces a typed `Timeout` error.
+ * - **UTF-8 end-to-end**: forces `LANG=en_US.UTF-8` in the child environment
+ *   so emoji and non-ASCII task names round-trip without mojibake.
+ * - **Typed-error mapping**: well-known stderr signatures (OmniFocus not
+ *   running, automation permission denied, malformed JSON) become specific
+ *   error types from the typed taxonomy (DESIGN §6.7); everything else
+ *   becomes a `ScriptError` with the stderr captured in `details`.
+ * - **Spawner injection**: the underlying `child_process` call is behind a
+ *   `ScriptSpawner` seam so unit tests run in milliseconds without ever
+ *   touching `osascript` — and integration tests exercise the real binary.
+ *
+ * @see DESIGN.md §6.4 — script asset discipline
+ * @see DESIGN.md §6.7 — error taxonomy
+ * @see docs/adr/0005-scripts-as-first-class-files.md
+ */
+
+import { execFile } from "node:child_process";
+import {
+  OmniFocusNotRunning,
+  PermissionDenied,
+  ScriptError,
+  Timeout,
+  TransportUnavailable,
+} from "../../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Spawner seam (injectable for tests)
+// ---------------------------------------------------------------------------
+
+/** Result of a single child-process invocation, normalized for the caller. */
+export interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  /** True if the child was killed because it exceeded the timeout. */
+  timedOut: boolean;
+  /** Set if the child failed to spawn entirely (e.g. binary missing). */
+  spawnError?: NodeJS.ErrnoException;
+}
+
+/**
+ * Spawns the JXA interpreter, pipes `scriptBody` to stdin, passes `jsonArg`
+ * as `argv[0]`, and resolves once the child exits or times out.
+ */
+export type ScriptSpawner = (
+  scriptBody: string,
+  jsonArg: string,
+  timeoutMs: number,
+) => Promise<SpawnResult>;
+
+const MAX_STDOUT_BYTES = 16 * 1024 * 1024; // 16 MiB — comfortably above any sane OF read.
+
+/** Production spawner: real `osascript -l JavaScript` via `child_process.execFile`. */
+export const defaultJxaSpawner: ScriptSpawner = (scriptBody, jsonArg, timeoutMs) =>
+  new Promise<SpawnResult>((resolve) => {
+    const child = execFile(
+      "osascript",
+      ["-l", "JavaScript", "-", jsonArg],
+      {
+        timeout: timeoutMs,
+        maxBuffer: MAX_STDOUT_BYTES,
+        env: { ...process.env, LANG: "en_US.UTF-8" },
+        encoding: "utf8",
+      },
+      (err, stdout, stderr) => {
+        // `encoding: "utf8"` above means `stdout` / `stderr` are strings.
+        const stdoutStr = stdout;
+        const stderrStr = stderr;
+        // `err.killed === true` plus a SIGTERM signal is execFile's timeout signal.
+        const timedOut = err !== null && err.killed === true;
+        // ENOENT = binary not on PATH; surface it as a spawn failure.
+        const spawnError =
+          err && (err as NodeJS.ErrnoException).code === "ENOENT"
+            ? (err as NodeJS.ErrnoException)
+            : undefined;
+        resolve({
+          stdout: stdoutStr,
+          stderr: stderrStr,
+          exitCode: err === null ? 0 : ((err as { code?: number }).code ?? 1),
+          timedOut,
+          ...(spawnError !== undefined ? { spawnError } : {}),
+        });
+      },
+    );
+    // Pipe the script body in via stdin so we never write a temp file and never
+    // pass user content on argv (where the shell could see it).
+    if (child.stdin !== null) {
+      child.stdin.end(scriptBody, "utf8");
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface RunScriptOptions {
+  /** Override the default 30s timeout (`OMNIFOCUS_JXA_TIMEOUT_MS`). */
+  timeoutMs?: number;
+  /** Inject a fake spawner — used by unit tests; production callers omit. */
+  spawner?: ScriptSpawner;
+  /** Optional script name for error context (`details.scriptName`). */
+  scriptName?: string;
+}
+
+/**
+ * Run a JXA script and return its parsed JSON output.
+ *
+ * The script is expected to define `function run(argv) { ... }` and return a
+ * JSON-encoded string from that function. Anything else is a `ScriptError`.
+ */
+export async function runJxaScript<T = unknown>(
+  scriptBody: string,
+  args: unknown = {},
+  options: RunScriptOptions = {},
+): Promise<T> {
+  const spawner = options.spawner ?? defaultJxaSpawner;
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const jsonArg = JSON.stringify(args ?? {});
+  const scriptName = options.scriptName;
+
+  const result = await spawner(scriptBody, jsonArg, timeoutMs);
+
+  // 1. Spawn failure (binary missing) — the transport itself is unavailable.
+  if (result.spawnError !== undefined) {
+    throw new TransportUnavailable("Failed to spawn osascript", {
+      cause: result.spawnError,
+      details: {
+        transport: "jxa",
+        reason: result.spawnError.code ?? "spawn-failed",
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // 2. Hard timeout.
+  if (result.timedOut) {
+    const suffix = scriptName !== undefined ? ` (script: ${scriptName})` : "";
+    throw new Timeout(`JXA script exceeded ${timeoutMs}ms timeout${suffix}`, {
+      details: {
+        transport: "jxa",
+        timeoutMs,
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // 3. Non-zero exit — classify by stderr signature, fall back to ScriptError.
+  if (result.exitCode !== 0) {
+    const typed = classifyJxaStderr(result.stderr, scriptName);
+    if (typed !== null) throw typed;
+    const tag = scriptName !== undefined ? ` [${scriptName}]` : "";
+    throw new ScriptError(`JXA script failed (exit ${result.exitCode})${tag}`, {
+      details: {
+        transport: "jxa",
+        exitCode: result.exitCode,
+        stderr: truncate(result.stderr, 1024),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // 4. Empty stdout is a script-author bug — every JXA script must return
+  //    a JSON-stringified value as its `run()` return.
+  const trimmed = result.stdout.trim();
+  if (trimmed === "") {
+    throw new ScriptError(
+      "JXA script returned empty stdout — `run()` must return a JSON-encoded string",
+      {
+        details: {
+          transport: "jxa",
+          ...(scriptName !== undefined ? { scriptName } : {}),
+        },
+      },
+    );
+  }
+
+  // 5. Parse the JSON. A malformed payload is the script author's problem,
+  //    not a transient issue — surface it as a ScriptError.
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch (cause) {
+    throw new ScriptError("JXA script returned malformed JSON", {
+      cause,
+      details: {
+        transport: "jxa",
+        stdoutPreview: truncate(trimmed, 200),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map well-known JXA / osascript stderr signatures to typed errors. Returns
+ * `null` if no specific signature matches — the caller should fall back to
+ * a generic `ScriptError`.
+ *
+ * The signatures here are the patterns we've actually seen in the wild;
+ * we deliberately stay conservative — better to report a precise
+ * `ScriptError` than to mis-classify and trigger the wrong remediation.
+ */
+function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
+  // `Application can't be found` → app isn't installed or isn't named OmniFocus.
+  // `OmniFocus got an error: Application isn't running.` → user quit the app.
+  if (
+    /Application can't be found/i.test(stderr) ||
+    /Application isn['’]t running/i.test(stderr) ||
+    /OmniFocus(?:.*)not running/i.test(stderr)
+  ) {
+    return new OmniFocusNotRunning({
+      details: {
+        transport: "jxa",
+        stderr: truncate(stderr, 512),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // -1743 = errAEEventNotPermitted (TCC denial).
+  // "is not allowed assistive access" / "Not authorized to send Apple events" → same.
+  if (
+    /-1743\b/.test(stderr) ||
+    /not authori[sz]ed to send Apple events/i.test(stderr) ||
+    /errAEEventNotPermitted/i.test(stderr) ||
+    /not allowed assistive access/i.test(stderr)
+  ) {
+    return new PermissionDenied({
+      details: {
+        transport: "jxa",
+        stderr: truncate(stderr, 512),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  return null;
+}
+
+/** Cap a string to `n` chars so it never balloons an error payload. */
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}

--- a/src/scripts/jxa/sync_trigger.d.ts
+++ b/src/scripts/jxa/sync_trigger.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Type shim for `sync_trigger.js`.
+ *
+ * The tsup `scriptInlinerPlugin` rewrites this import at build time so the
+ * default export is the raw script source as a UTF-8 string. This `.d.ts`
+ * teaches TypeScript the same shape so `JxaTransport` can `import` it
+ * without a missing-module error.
+ *
+ * Each JXA script gets its own sibling `.d.ts` file rather than a wildcard
+ * declaration so the import surface is greppable and explicit.
+ *
+ * @see src/scripts/scriptLoader.ts
+ */
+
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/sync_trigger.js
+++ b/src/scripts/jxa/sync_trigger.js
@@ -1,0 +1,23 @@
+/**
+ * JXA: trigger Omni Sync.
+ *
+ * `Application("OmniFocus").defaultDocument.synchronize()` kicks off a sync
+ * with the configured Omni Sync server. The call returns immediately — it
+ * does not wait for the sync to complete — so we report the kickoff time
+ * as `lastSyncAt` and `inFlight: false` for the round-trip.
+ *
+ * `runJxaScript` sees this script's `run(argv)` return value as a JSON
+ * string, parses it, and surfaces the parsed object to the adapter.
+ *
+ * @see src/adapter/jxa/scriptRunner.ts
+ * @see src/adapter/OmniFocusAdapter.ts — `syncTrigger()` contract
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(_argv) {
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+  ofApp.defaultDocument.synchronize();
+  const lastSyncAt = new Date().toISOString();
+  return JSON.stringify({ lastSyncAt: lastSyncAt, inFlight: false });
+}


### PR DESCRIPTION
## Summary
- Lands the JXA script runner — typed-error mapping (Timeout, OmniFocusNotRunning, PermissionDenied, TransportUnavailable, ScriptError), hard timeout, UTF-8 environment, JSON-arg-via-stdin protocol per ADR-0005. Spawner is injected, so unit tests run in milliseconds.
- Lands `JxaTransport` implementing `OmniFocusAdapter`. `syncTrigger()` is wired end-to-end through `src/scripts/jxa/sync_trigger.js` as proof; remaining methods throw `ScriptError { reason: "not-yet-wired" }` so `TransportRouter` (#19) and tests can detect the partial-implementation state precisely.
- Per-domain JXA scripts (tasks, projects, tags, folders, forecast, search, notes, repetition, attachments, review) will land via follow-up issues — this PR is the keystone slice that unblocks #18/#19/#25.

## Test plan
- [x] 24 new unit tests: 13 cover the runner protocol (happy path, JSON-arg forwarding, every error class), 11 cover the transport scaffolding (wired sync_trigger, not-yet-wired stubs, getLastSync interim, scriptName plumbing)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (biome + custom)
- [x] `pnpm test` — 262/262 passing

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)