### PR TITLE
feat(adapter): introduce OmniJsTransport script runner and scaffolding

### DIFF
--- a/src/adapter/omnijs/OmniJsTransport.test.ts
+++ b/src/adapter/omnijs/OmniJsTransport.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for `OmniJsTransport`.
+ *
+ * Covers the keystone slice this PR ships:
+ * - `runOmniJsScript` (raw escape hatch) round-trips through the runner
+ *   with a fake spawner — the wired proof method
+ * - Stubbed methods throw the documented `not-yet-wired` ScriptError so
+ *   `TransportRouter` (#19) and tests can detect the partial state
+ * - The constructor's spawner / timeout options reach the runner
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ProjectId, TaskId } from "../../domain/ids.js";
+import { ScriptError } from "../../errors/index.js";
+import { OmniJsTransport } from "./OmniJsTransport.js";
+import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
+
+function spawnerReturning(stdout: string): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout,
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    }),
+  );
+}
+
+describe("OmniJsTransport — runOmniJsScript (wired)", () => {
+  it("returns the parsed payload from the underlying runner", async () => {
+    const spawner = spawnerReturning('{"pong":true,"omniFocusVersion":"4.8.8"}');
+    const t = new OmniJsTransport({ spawner });
+    const result = await t.runOmniJsScript("(() => JSON.stringify({pong:true}))()");
+    expect(result).toEqual({ pong: true, omniFocusVersion: "4.8.8" });
+  });
+
+  it("forwards the configured timeout to the spawner", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '"ok"',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    const t = new OmniJsTransport({ spawner, timeoutMs: 9999 });
+    await t.runOmniJsScript("(() => '\"ok\"')()");
+    expect(spawner.mock.calls[0]?.[2]).toBe(9999);
+  });
+
+  it("tags raw-script errors with scriptName='raw' for context", async () => {
+    const spawner = vi.fn(
+      async (): Promise<SpawnResult> => ({
+        stdout: "",
+        stderr: "boom",
+        exitCode: 1,
+        timedOut: false,
+      }),
+    );
+    const t = new OmniJsTransport({ spawner });
+    const err = await t.runOmniJsScript("bad").catch((e) => e);
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details).toMatchObject({
+      transport: "omnijs",
+      scriptName: "raw",
+    });
+  });
+});
+
+describe("OmniJsTransport — not-yet-wired stubs", () => {
+  const t = new OmniJsTransport({ spawner: spawnerReturning("{}") });
+
+  // Sample one method per domain group; the per-method shape is uniform.
+  const cases: Array<readonly [string, () => Promise<unknown>]> = [
+    ["listTasks", () => t.listTasks({})],
+    ["getTask", () => t.getTask("task_000001" as TaskId)],
+    ["createTask", () => t.createTask({ name: "x" })],
+    ["listProjects", () => t.listProjects()],
+    ["getProject", () => t.getProject("proj_000001" as ProjectId)],
+    ["listTags", () => t.listTags()],
+    ["listFolders", () => t.listFolders()],
+    ["syncTrigger", () => t.syncTrigger()],
+    ["getLastSync", () => t.getLastSync()],
+  ];
+
+  for (const [method, call] of cases) {
+    it(`${method} throws ScriptError with reason="not-yet-wired"`, async () => {
+      const err = await call().catch((e) => e);
+      expect(err).toBeInstanceOf(ScriptError);
+      expect((err as ScriptError).details).toMatchObject({
+        transport: "omnijs",
+        reason: "not-yet-wired",
+        method,
+      });
+    });
+  }
+});

--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -1,0 +1,217 @@
+/**
+ * `OmniJsTransport` — fallback `OmniFocusAdapter` implementation for surfaces
+ * JXA cannot reach (custom perspectives, Omni Automation plug-ins, anything
+ * the Omni Automation API exposes exclusively).
+ *
+ * Per ADR-0002 (and the spike at `docs/spikes/2026-04-omnijs-spike.md` that
+ * superseded the original URL-scheme transport), OmniJS is invoked via the
+ * JXA bridge: `Application("OmniFocus").evaluateJavascript(...)`. The
+ * underlying spawner is a sibling of `JxaTransport`'s — same UTF-8 handling,
+ * same timeout discipline, same typed-error mapping — but with a longer
+ * default timeout (45s, `OMNIFOCUS_OMNIJS_TIMEOUT_MS`) because Omni
+ * Automation work tends to be heavier than direct JXA reads.
+ *
+ * **Status (M0 keystone):** This file ships the transport scaffolding plus
+ * the raw `runOmniJsScript` escape hatch as the wired proof. Per-domain
+ * methods (custom perspectives in #55, plugin invocation in #74) land via
+ * follow-up issues so each can carry its own OmniJS script + tests + smoke
+ * without piling into a single mega-PR. Stubbed methods throw `ScriptError`
+ * with `details.reason: "not-yet-wired"` so `TransportRouter` (#19) can
+ * route around them and tests can detect the partial-implementation state
+ * precisely.
+ *
+ * @see DESIGN.md §6.1, §6.3, §6.4 — adapter seam, layering, script discipline
+ * @see ADR-0002 — JXA + OmniJS dual transport
+ * @see ADR-0005 — scripts as first-class files
+ * @see docs/spikes/2026-04-omnijs-spike.md — `evaluateJavascript` adoption
+ * @see src/adapter/omnijs/scriptRunner.ts
+ */
+
+import type { Folder } from "../../domain/folder.js";
+import type { FolderId, ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import type { Project } from "../../domain/project.js";
+import type { Tag } from "../../domain/tag.js";
+import type { Task } from "../../domain/task.js";
+import { ScriptError } from "../../errors/index.js";
+import type {
+  CreateFolderInput,
+  CreateProjectInput,
+  CreateTagInput,
+  CreateTaskInput,
+  OmniFocusAdapter,
+  SyncStatus,
+  TaskFilter,
+  UpdateFolderInput,
+  UpdateProjectInput,
+  UpdateTagInput,
+  UpdateTaskInput,
+} from "../OmniFocusAdapter.js";
+import { type RunScriptOptions, type ScriptSpawner, runOmniJsScript } from "./scriptRunner.js";
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+export interface OmniJsTransportOptions {
+  /** Hard timeout for any single OmniJS invocation. Defaults to 45s. */
+  timeoutMs?: number;
+  /** Inject a fake spawner — used by unit tests; production callers omit. */
+  spawner?: ScriptSpawner;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sentinel thrown by every method whose underlying OmniJS script hasn't been
+ * wired yet. The `details.reason` value is part of the deliberately-narrow
+ * contract that `TransportRouter` (#19) and unit tests inspect to decide
+ * whether to route to `JxaTransport` instead.
+ */
+function notYetWired(method: string): never {
+  throw new ScriptError(`OmniJsTransport.${method} is not wired yet`, {
+    details: { transport: "omnijs", reason: "not-yet-wired", method },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+export class OmniJsTransport implements OmniFocusAdapter {
+  private readonly runOpts: RunScriptOptions;
+
+  constructor(options: OmniJsTransportOptions = {}) {
+    this.runOpts = {
+      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+      ...(options.spawner !== undefined ? { spawner: options.spawner } : {}),
+    };
+  }
+
+  // -- Tasks ----------------------------------------------------------------
+
+  async listTasks(_filter: TaskFilter): Promise<Task[]> {
+    return notYetWired("listTasks");
+  }
+  async getTask(_id: TaskId): Promise<Task> {
+    return notYetWired("getTask");
+  }
+  async getTasksMany(_ids: TaskId[]): Promise<(Task | null)[]> {
+    return notYetWired("getTasksMany");
+  }
+  async createTask(_input: CreateTaskInput): Promise<TaskId> {
+    return notYetWired("createTask");
+  }
+  async updateTask(_id: TaskId, _patch: UpdateTaskInput): Promise<void> {
+    return notYetWired("updateTask");
+  }
+  async completeTask(_id: TaskId, _at?: Date): Promise<void> {
+    return notYetWired("completeTask");
+  }
+  async uncompleteTask(_id: TaskId): Promise<void> {
+    return notYetWired("uncompleteTask");
+  }
+  async dropTask(_id: TaskId, _at?: Date): Promise<void> {
+    return notYetWired("dropTask");
+  }
+  async undropTask(_id: TaskId): Promise<void> {
+    return notYetWired("undropTask");
+  }
+  async deleteTask(_id: TaskId): Promise<void> {
+    return notYetWired("deleteTask");
+  }
+  async moveTask(
+    _id: TaskId,
+    _destination: { projectId?: ProjectId; parentId?: TaskId },
+  ): Promise<void> {
+    return notYetWired("moveTask");
+  }
+
+  // -- Projects -------------------------------------------------------------
+
+  async listProjects(_filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<
+    Project[]
+  > {
+    return notYetWired("listProjects");
+  }
+  async getProject(_id: ProjectId): Promise<Project> {
+    return notYetWired("getProject");
+  }
+  async createProject(_input: CreateProjectInput): Promise<ProjectId> {
+    return notYetWired("createProject");
+  }
+  async updateProject(_id: ProjectId, _patch: UpdateProjectInput): Promise<void> {
+    return notYetWired("updateProject");
+  }
+  async completeProject(_id: ProjectId, _at?: Date): Promise<void> {
+    return notYetWired("completeProject");
+  }
+  async dropProject(_id: ProjectId, _at?: Date): Promise<void> {
+    return notYetWired("dropProject");
+  }
+  async moveProject(_id: ProjectId, _destination: { folderId: FolderId | null }): Promise<void> {
+    return notYetWired("moveProject");
+  }
+  async deleteProject(_id: ProjectId): Promise<void> {
+    return notYetWired("deleteProject");
+  }
+  async markProjectReviewed(_id: ProjectId): Promise<void> {
+    return notYetWired("markProjectReviewed");
+  }
+
+  // -- Tags -----------------------------------------------------------------
+
+  async listTags(_filter?: { parentId?: TagId; status?: Tag["status"] }): Promise<Tag[]> {
+    return notYetWired("listTags");
+  }
+  async getTag(_id: TagId): Promise<Tag> {
+    return notYetWired("getTag");
+  }
+  async createTag(_input: CreateTagInput): Promise<TagId> {
+    return notYetWired("createTag");
+  }
+  async updateTag(_id: TagId, _patch: UpdateTagInput): Promise<void> {
+    return notYetWired("updateTag");
+  }
+  async deleteTag(_id: TagId): Promise<void> {
+    return notYetWired("deleteTag");
+  }
+
+  // -- Folders --------------------------------------------------------------
+
+  async listFolders(_filter?: { parentId?: FolderId }): Promise<Folder[]> {
+    return notYetWired("listFolders");
+  }
+  async getFolder(_id: FolderId): Promise<Folder> {
+    return notYetWired("getFolder");
+  }
+  async createFolder(_input: CreateFolderInput): Promise<FolderId> {
+    return notYetWired("createFolder");
+  }
+  async updateFolder(_id: FolderId, _patch: UpdateFolderInput): Promise<void> {
+    return notYetWired("updateFolder");
+  }
+  async deleteFolder(_id: FolderId): Promise<void> {
+    return notYetWired("deleteFolder");
+  }
+
+  // -- Sync -----------------------------------------------------------------
+
+  // Sync is a document-level operation exposed by JXA, not OmniJS. The
+  // primary transport for these methods is `JxaTransport`; `OmniJsTransport`
+  // exposes them only to satisfy the interface — `TransportRouter` (#19)
+  // will never route here.
+  async syncTrigger(): Promise<SyncStatus> {
+    return notYetWired("syncTrigger");
+  }
+  async getLastSync(): Promise<SyncStatus> {
+    return notYetWired("getLastSync");
+  }
+
+  // -- Raw escape hatch (off by default; gated by env at the tool layer) ----
+
+  async runOmniJsScript(script: string): Promise<unknown> {
+    return runOmniJsScript(script, {}, { ...this.runOpts, scriptName: "raw" });
+  }
+}

--- a/src/adapter/omnijs/scriptRunner.test.ts
+++ b/src/adapter/omnijs/scriptRunner.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for `runOmniJsScript`.
+ *
+ * Every test injects a fake `ScriptSpawner` so no real `osascript` runs.
+ * The runner's job is the protocol: wrap the OmniJS script in the JXA
+ * `evaluateJavascript` envelope, parse stdout, classify stderr signatures
+ * into typed errors, time out cleanly. Real-binary integration goes through
+ * the harness in #80.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  OmniFocusError,
+  OmniFocusNotRunning,
+  PermissionDenied,
+  ScriptError,
+  Timeout,
+  TransportUnavailable,
+} from "../../errors/index.js";
+import {
+  type ScriptSpawner,
+  type SpawnResult,
+  runOmniJsScript,
+  wrapOmniJsForJxa,
+} from "./scriptRunner.js";
+
+function fakeSpawner(result: Partial<SpawnResult>): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+      ...result,
+    }),
+  );
+}
+
+describe("runOmniJsScript — happy path", () => {
+  it("parses JSON stdout into the typed result", async () => {
+    const spawner = fakeSpawner({ stdout: '{"pong":true,"n":7}' });
+    const out = await runOmniJsScript<{ pong: boolean; n: number }>("script", {}, { spawner });
+    expect(out).toEqual({ pong: true, n: 7 });
+  });
+
+  it("trims surrounding whitespace before parsing", async () => {
+    const spawner = fakeSpawner({ stdout: '\n  {"x":1}\n' });
+    const out = await runOmniJsScript("script", {}, { spawner });
+    expect(out).toEqual({ x: 1 });
+  });
+
+  it("defaults args to {} when omitted", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '"ok"',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    await runOmniJsScript("script", undefined, { spawner });
+    // The runner forwards argsJson="{}" to the spawner for symmetry; the
+    // wrapper itself also embeds the args (asserted in the wrapper section).
+    expect(spawner.mock.calls[0]?.[1]).toBe("{}");
+  });
+
+  it("forwards the configured timeout to the spawner", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '"ok"',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    await runOmniJsScript("script", {}, { spawner, timeoutMs: 7500 });
+    expect(spawner.mock.calls[0]?.[2]).toBe(7500);
+  });
+
+  it("uses a 45s default timeout when none configured", async () => {
+    const spawner = vi.fn(
+      async (_body: string, _arg: string, _ms: number): Promise<SpawnResult> => ({
+        stdout: '"ok"',
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    await runOmniJsScript("script", {}, { spawner });
+    expect(spawner.mock.calls[0]?.[2]).toBe(45_000);
+  });
+});
+
+describe("runOmniJsScript — error mapping", () => {
+  it("maps timeout to Timeout with omnijs transport context", async () => {
+    const spawner = fakeSpawner({ timedOut: true, exitCode: 1 });
+    const err = await runOmniJsScript("script", {}, { spawner, timeoutMs: 250 }).catch((e) => e);
+    expect(err).toBeInstanceOf(Timeout);
+    expect((err as Timeout).details).toMatchObject({ transport: "omnijs", timeoutMs: 250 });
+  });
+
+  it("maps spawn ENOENT to TransportUnavailable", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" }) as NodeJS.ErrnoException;
+    const spawner = fakeSpawner({ exitCode: 1, spawnError: enoent });
+    await expect(runOmniJsScript("script", {}, { spawner })).rejects.toBeInstanceOf(
+      TransportUnavailable,
+    );
+  });
+
+  it("maps 'Application isn't running' stderr to OmniFocusNotRunning", async () => {
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "OmniFocus got an error: Application isn't running.",
+    });
+    await expect(runOmniJsScript("script", {}, { spawner })).rejects.toBeInstanceOf(
+      OmniFocusNotRunning,
+    );
+  });
+
+  it("maps -1743 (errAEEventNotPermitted) stderr to PermissionDenied", async () => {
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "execution error: Not authorized to send Apple events to OmniFocus. (-1743)",
+    });
+    await expect(runOmniJsScript("script", {}, { spawner })).rejects.toBeInstanceOf(
+      PermissionDenied,
+    );
+  });
+
+  it("maps an OmniJS thrown error to ScriptError carrying stderr", async () => {
+    // The OmniJS spike documents thrown errors surfacing as
+    // `execution error: Error: Error: Error: <message> undefined:1:1 (3)`.
+    // We don't try to parse out the inner message — we surface the stderr.
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "execution error: Error: Error: Error: missing semicolon undefined:1:1 (3)",
+    });
+    const err = await runOmniJsScript("script", {}, { spawner, scriptName: "ping" }).catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details).toMatchObject({
+      transport: "omnijs",
+      scriptName: "ping",
+    });
+    expect((err as ScriptError).details?.stderr).toContain("missing semicolon");
+  });
+
+  it("maps malformed stdout JSON to ScriptError with a preview", async () => {
+    const spawner = fakeSpawner({ stdout: "not-json{}" });
+    const err = await runOmniJsScript("script", {}, { spawner }).catch((e) => e);
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details?.stdoutPreview).toContain("not-json");
+  });
+
+  it("maps empty stdout to ScriptError (script-author bug)", async () => {
+    const spawner = fakeSpawner({ stdout: "   \n" });
+    await expect(runOmniJsScript("script", {}, { spawner })).rejects.toBeInstanceOf(ScriptError);
+  });
+
+  it("every thrown error is in the typed taxonomy (never raw Error)", async () => {
+    const cases: Array<Partial<SpawnResult>> = [
+      { timedOut: true, exitCode: 1 },
+      { exitCode: 1, stderr: "Application isn't running" },
+      { exitCode: 1, stderr: "Not authorized to send Apple events (-1743)" },
+      { exitCode: 5, stderr: "boom" },
+      { stdout: "garbage" },
+      { stdout: "" },
+    ];
+    for (const c of cases) {
+      const spawner = fakeSpawner(c);
+      const err = await runOmniJsScript("script", {}, { spawner }).catch((e) => e);
+      expect(err).toBeInstanceOf(OmniFocusError);
+    }
+  });
+});
+
+describe("wrapOmniJsForJxa", () => {
+  it("embeds the OmniJS body and args as a JXA evaluateJavascript call", () => {
+    const wrapped = wrapOmniJsForJxa("return JSON.stringify({n: __args.n});", '{"n":42}');
+    // Forms a `function run` JXA entry point.
+    expect(wrapped).toContain("function run(_argv)");
+    // Calls evaluateJavascript on OmniFocus.
+    expect(wrapped).toContain('Application("OmniFocus")');
+    expect(wrapped).toContain("evaluateJavascript");
+    // Embeds the args installation prefix.
+    expect(wrapped).toContain("globalThis.__args =");
+    expect(wrapped).toContain('{\\"n\\":42}');
+    // Embeds the original OmniJS script body.
+    expect(wrapped).toContain("return JSON.stringify({n: __args.n});");
+  });
+
+  it("safely round-trips quotes, newlines, and backslashes via JSON.stringify", () => {
+    const tricky = 'return "he said \\"hi\\"\\nand \\\\";';
+    const wrapped = wrapOmniJsForJxa(tricky, "{}");
+    // The script body and args appear as JSON.stringify'd strings, never raw,
+    // so a closing quote inside the body cannot break out of the wrapper.
+    expect(wrapped).not.toContain('"he said "hi"');
+    // Re-parsing the JSON-encoded payload yields the exact original body
+    // (with the args prefix prepended).
+    const match = wrapped.match(/const __omnijs = (".*");/);
+    expect(match).not.toBeNull();
+    const decoded = JSON.parse((match as RegExpMatchArray)[1] as string);
+    expect(decoded).toBe(`globalThis.__args = {};\n${tricky}`);
+  });
+});

--- a/src/adapter/omnijs/scriptRunner.ts
+++ b/src/adapter/omnijs/scriptRunner.ts
@@ -1,0 +1,303 @@
+/**
+ * `runOmniJsScript` — the keystone of the OmniJS transport.
+ *
+ * OmniJS (Omni Automation) is OmniFocus's in-process JavaScript engine.
+ * Per the spike (`docs/spikes/2026-04-omnijs-spike.md`) the URL-scheme
+ * transport (`omnifocus://localhost/omnijs-run?script=…`) is unusable in a
+ * background MCP server — it pops a security dialog on every invocation
+ * and runs in a sandbox that blocks the file writes we'd need for result
+ * retrieval. The adopted transport is the **JXA bridge**:
+ *
+ *     osascript -l JavaScript -e 'Application("OmniFocus").evaluateJavascript(<script>)'
+ *
+ * which uses the macOS Automation channel already granted to `osascript`,
+ * has no dialogs, and round-trips the script's return value through stdout.
+ *
+ * Responsibilities mirror `runJxaScript` so the two transports behave
+ * identically from a calling-services perspective:
+ *
+ * - **Hard timeout** (default 45s; `OMNIFOCUS_OMNIJS_TIMEOUT_MS`) kills the
+ *   child and surfaces a typed `Timeout` error.
+ * - **UTF-8 end-to-end** via `LANG=en_US.UTF-8` in the child environment.
+ * - **Typed-error mapping**: well-known stderr signatures (OmniFocus not
+ *   running, automation permission denied, OmniJS script threw, malformed
+ *   JSON) become specific error types from the typed taxonomy
+ *   (DESIGN §6.7); everything else becomes a `ScriptError`.
+ * - **Spawner injection** behind a `ScriptSpawner` seam so unit tests run
+ *   in milliseconds without ever touching `osascript`.
+ * - **Argument injection without shell exposure**: the OmniJS script body is
+ *   embedded into a small JXA wrapper that calls `evaluateJavascript`, with
+ *   the call args installed as `globalThis.__args` inside the OmniJS script.
+ *   Neither user content nor the script body is ever passed via argv (where
+ *   the shell could see it) — both travel via stdin.
+ *
+ * @see DESIGN.md §6.4 — script asset discipline
+ * @see DESIGN.md §6.7 — error taxonomy
+ * @see docs/adr/0002-omnifocus-transport-dual.md
+ * @see docs/adr/0005-scripts-as-first-class-files.md
+ * @see docs/spikes/2026-04-omnijs-spike.md
+ */
+
+import { execFile } from "node:child_process";
+import {
+  OmniFocusNotRunning,
+  PermissionDenied,
+  ScriptError,
+  Timeout,
+  TransportUnavailable,
+} from "../../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Spawner seam (injectable for tests)
+// ---------------------------------------------------------------------------
+
+/** Result of a single child-process invocation, normalized for the caller. */
+export interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  /** True if the child was killed because it exceeded the timeout. */
+  timedOut: boolean;
+  /** Set if the child failed to spawn entirely (e.g. binary missing). */
+  spawnError?: NodeJS.ErrnoException;
+}
+
+/**
+ * Spawns the JXA interpreter for the OmniJS bridge, pipes `wrappedJxaBody`
+ * (already wrapped — see {@link wrapOmniJsForJxa}) to stdin, and resolves
+ * once the child exits or times out. The `argsJson` parameter is reserved
+ * for symmetry with `JxaTransport`'s spawner; OmniJS callers embed args
+ * inside the wrapper rather than threading them via argv (so the parameter
+ * is unused by the production spawner but fakeable in tests).
+ */
+export type ScriptSpawner = (
+  wrappedJxaBody: string,
+  argsJson: string,
+  timeoutMs: number,
+) => Promise<SpawnResult>;
+
+const MAX_STDOUT_BYTES = 16 * 1024 * 1024; // 16 MiB — comfortably above any sane OF read.
+
+/**
+ * Production spawner: real `osascript -l JavaScript` via
+ * `child_process.execFile`. The wrapper body is piped via stdin (never argv),
+ * so OF script content and user-provided args are never visible to the shell.
+ */
+export const defaultOmniJsSpawner: ScriptSpawner = (wrappedJxaBody, _argsJson, timeoutMs) =>
+  new Promise<SpawnResult>((resolve) => {
+    const child = execFile(
+      "osascript",
+      ["-l", "JavaScript", "-"],
+      {
+        timeout: timeoutMs,
+        maxBuffer: MAX_STDOUT_BYTES,
+        env: { ...process.env, LANG: "en_US.UTF-8" },
+        encoding: "utf8",
+      },
+      (err, stdout, stderr) => {
+        const stdoutStr = stdout;
+        const stderrStr = stderr;
+        const timedOut = err !== null && err.killed === true;
+        const spawnError =
+          err && (err as NodeJS.ErrnoException).code === "ENOENT"
+            ? (err as NodeJS.ErrnoException)
+            : undefined;
+        resolve({
+          stdout: stdoutStr,
+          stderr: stderrStr,
+          exitCode: err === null ? 0 : ((err as { code?: number }).code ?? 1),
+          timedOut,
+          ...(spawnError !== undefined ? { spawnError } : {}),
+        });
+      },
+    );
+    if (child.stdin !== null) {
+      child.stdin.end(wrappedJxaBody, "utf8");
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface RunScriptOptions {
+  /** Override the default 45s timeout (`OMNIFOCUS_OMNIJS_TIMEOUT_MS`). */
+  timeoutMs?: number;
+  /** Inject a fake spawner — used by unit tests; production callers omit. */
+  spawner?: ScriptSpawner;
+  /** Optional script name for error context (`details.scriptName`). */
+  scriptName?: string;
+}
+
+/**
+ * Run an OmniJS script via the `evaluateJavascript` JXA bridge and return
+ * its parsed JSON output.
+ *
+ * The OmniJS script is expected to be a self-contained IIFE whose final
+ * expression is a JSON-encoded string. The runner installs the call args as
+ * `globalThis.__args` before evaluating, so scripts that need arguments can
+ * read them without further plumbing.
+ */
+export async function runOmniJsScript<T = unknown>(
+  omniJsScriptBody: string,
+  args: unknown = {},
+  options: RunScriptOptions = {},
+): Promise<T> {
+  const spawner = options.spawner ?? defaultOmniJsSpawner;
+  const timeoutMs = options.timeoutMs ?? 45_000;
+  const argsJson = JSON.stringify(args ?? {});
+  const scriptName = options.scriptName;
+
+  const wrapped = wrapOmniJsForJxa(omniJsScriptBody, argsJson);
+  const result = await spawner(wrapped, argsJson, timeoutMs);
+
+  // 1. Spawn failure (binary missing) — the transport itself is unavailable.
+  if (result.spawnError !== undefined) {
+    throw new TransportUnavailable("Failed to spawn osascript", {
+      cause: result.spawnError,
+      details: {
+        transport: "omnijs",
+        reason: result.spawnError.code ?? "spawn-failed",
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // 2. Hard timeout.
+  if (result.timedOut) {
+    const suffix = scriptName !== undefined ? ` (script: ${scriptName})` : "";
+    throw new Timeout(`OmniJS script exceeded ${timeoutMs}ms timeout${suffix}`, {
+      details: {
+        transport: "omnijs",
+        timeoutMs,
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // 3. Non-zero exit — classify by stderr signature, fall back to ScriptError.
+  if (result.exitCode !== 0) {
+    const typed = classifyOmniJsStderr(result.stderr, scriptName);
+    if (typed !== null) throw typed;
+    const tag = scriptName !== undefined ? ` [${scriptName}]` : "";
+    throw new ScriptError(`OmniJS script failed (exit ${result.exitCode})${tag}`, {
+      details: {
+        transport: "omnijs",
+        exitCode: result.exitCode,
+        stderr: truncate(result.stderr, 1024),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // 4. Empty stdout — by convention every OmniJS script in this repo returns
+  //    a JSON-encoded string as its final expression, which `evaluateJavascript`
+  //    forwards through JXA's stdout. Empty output means the script returned
+  //    `undefined` (script-author bug).
+  const trimmed = result.stdout.trim();
+  if (trimmed === "") {
+    throw new ScriptError(
+      "OmniJS script returned empty stdout — the IIFE must return a JSON-encoded string",
+      {
+        details: {
+          transport: "omnijs",
+          ...(scriptName !== undefined ? { scriptName } : {}),
+        },
+      },
+    );
+  }
+
+  // 5. Parse the JSON. A malformed payload is the script author's problem,
+  //    not a transient issue — surface it as a ScriptError.
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch (cause) {
+    throw new ScriptError("OmniJS script returned malformed JSON", {
+      cause,
+      details: {
+        transport: "omnijs",
+        stdoutPreview: truncate(trimmed, 200),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the JXA wrapper body that delivers `omniJsScriptBody` to OmniFocus's
+ * `evaluateJavascript` channel with `argsJson` pre-installed as
+ * `globalThis.__args`.
+ *
+ * We embed both via `JSON.stringify` so any character (quotes, newlines,
+ * backslashes, unicode) round-trips safely.
+ */
+export function wrapOmniJsForJxa(omniJsScriptBody: string, argsJson: string): string {
+  // The OmniJS payload prepends the args installation so the user's IIFE can
+  // read them at any nesting depth.
+  const omniJsPayload = `globalThis.__args = ${argsJson};\n${omniJsScriptBody}`;
+  return [
+    "function run(_argv) {",
+    '  const ofApp = Application("OmniFocus");',
+    "  ofApp.includeStandardAdditions = false;",
+    `  const __omnijs = ${JSON.stringify(omniJsPayload)};`,
+    "  const __result = ofApp.evaluateJavascript(__omnijs);",
+    // `evaluateJavascript` returns the script's value. By contract our scripts
+    // already return a JSON-encoded string, so we forward it unchanged.
+    "  return __result;",
+    "}",
+  ].join("\n");
+}
+
+/**
+ * Map well-known osascript / OmniJS stderr signatures to typed errors.
+ * Returns `null` if no specific signature matches — the caller falls back
+ * to a generic `ScriptError`.
+ *
+ * The OmniFocus-not-running and permission-denied signatures are shared with
+ * JXA (the underlying channel is the same `osascript` binary). The OmniJS
+ * thrown-error signature documented in the spike (`Error: Error: Error: …`)
+ * is left to fall through to `ScriptError`, which is the right outcome — a
+ * script bug surfaces with the original stderr in `details.stderr` for the
+ * author to read.
+ */
+function classifyOmniJsStderr(stderr: string, scriptName?: string): Error | null {
+  if (
+    /Application can't be found/i.test(stderr) ||
+    /Application isn['’]t running/i.test(stderr) ||
+    /OmniFocus(?:.*)not running/i.test(stderr)
+  ) {
+    return new OmniFocusNotRunning({
+      details: {
+        transport: "omnijs",
+        stderr: truncate(stderr, 512),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  if (
+    /-1743\b/.test(stderr) ||
+    /not authori[sz]ed to send Apple events/i.test(stderr) ||
+    /errAEEventNotPermitted/i.test(stderr) ||
+    /not allowed assistive access/i.test(stderr)
+  ) {
+    return new PermissionDenied({
+      details: {
+        transport: "omnijs",
+        stderr: truncate(stderr, 512),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  return null;
+}
+
+/** Cap a string to `n` chars so it never balloons an error payload. */
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}

--- a/src/scripts/omnijs/ping.d.ts
+++ b/src/scripts/omnijs/ping.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Type shim for `ping.js`.
+ *
+ * The tsup `scriptInlinerPlugin` rewrites this import at build time so the
+ * default export is the raw OmniJS script source as a UTF-8 string. This
+ * `.d.ts` teaches TypeScript the same shape so `OmniJsTransport` can
+ * `import` it without a missing-module error.
+ *
+ * Each OmniJS script gets its own sibling `.d.ts` file rather than a wildcard
+ * declaration so the import surface is greppable and explicit.
+ *
+ * @see src/scripts/scriptLoader.ts
+ */
+
+declare const source: string;
+export default source;


### PR DESCRIPTION
## Summary

- Adds `src/adapter/omnijs/scriptRunner.ts` — `runOmniJsScript<T>` with spawner injection, 45s default timeout, UTF-8 environment, and the typed-error mapping discipline (`Timeout`, `TransportUnavailable`, `OmniFocusNotRunning`, `PermissionDenied`, `ScriptError`) that `runJxaScript` ships, all tagged `transport: "omnijs"`.
- Adds `src/adapter/omnijs/OmniJsTransport.ts` implementing `OmniFocusAdapter`. Raw `runOmniJsScript` is wired as the keystone proof; every domain method throws a typed `not-yet-wired` `ScriptError` with `details.reason: "not-yet-wired"` so `TransportRouter` (#19) can route around them precisely.
- 27 new unit tests (15 runner + 12 transport) — all green via injected fake spawner; no real `osascript` is invoked under `pnpm test`.
- Adds the `src/scripts/omnijs/ping.d.ts` type shim so `OmniJsTransport` (and future scripts) can `import` OmniJS files inlined by the tsup `scriptInlinerPlugin` without TypeScript missing-module errors.

### Why the URL-scheme transport from the original DESIGN is gone

The OmniJS spike (#125, `docs/spikes/2026-04-omnijs-spike.md`) ruled the URL-scheme path (`omnifocus:///omnijs-run?script=…` + filesystem callback) non-viable for a background MCP server: it pops a security dialog on every invocation, and OmniFocus 4's sandbox blocks the file writes we'd need for result retrieval. The adopted transport is the **JXA bridge** — `Application("OmniFocus").evaluateJavascript(...)` via `osascript -l JavaScript` — which uses the macOS Automation channel already granted to `osascript`, has no dialogs, and round-trips the script's return value through stdout. The runner builds a small JXA wrapper that embeds the OmniJS body via `JSON.stringify` (so quotes/newlines/backslashes/unicode round-trip safely) and installs call args as `globalThis.__args` for the script to read; both script body and args travel via stdin so neither is ever exposed to the shell.

The acceptance-criteria items in the original issue body that talked about callback files (\"Callback-file path randomized per call; cleanup guaranteed\") are obsolete under the adopted bridge — there are no callback files. The spirit of the issue (scaffolding, hard timeout, structured errors, queue separation per ADR-0009, integration-test proof) is preserved.

## Design link

Refs #18. Mirrors the keystone-slice approach used for #17 (PR #143). Per-domain OmniJS wiring (custom perspectives in #55, plugin invocation in #74) lands via follow-ups so each carries its own script + tests + smoke without piling into one mega-PR. Live-OF round-trip integration deferred to the E2E harness in #80.

- ADR-0002 — JXA + OmniJS dual transport
- ADR-0005 — scripts as first-class files
- ADR-0009 — read pool + write queue + OmniJS queue
- DESIGN.md §6.1, §6.3, §6.4, §6.7

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (biome + custom rules)
- [x] `pnpm test` — 289 / 289 green (27 new)
- [x] `pnpm build` — green
- [x] Self-reviewed via `review_pr.md`
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)