### PR TITLE
feat(adapter): introduce TransportRouter with auditable routing table

### DIFF
--- a/src/adapter/router.test.ts
+++ b/src/adapter/router.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for `TransportRouter`.
+ *
+ * The router is pure dispatch — its job is to delegate each method to the
+ * transport named in `ROUTING_TABLE`. Tests assert two things:
+ *
+ * 1. **Routing**: every method on `OmniFocusAdapter` reaches the transport
+ *    chosen by the table, and only that one. The stub transports record
+ *    calls so we can confirm exactly one delegation per invocation.
+ * 2. **Table integrity**: the table covers every adapter method (no holes
+ *    when new methods land), and the exposed `routingTable` getter is the
+ *    same frozen object — so the envelope layer can index it safely.
+ *
+ * Contract substitutability against `InMemoryAdapter` lives in the harness
+ * shipped by #30; this file is the unit-level guarantee that delegation
+ * works at all.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { FolderId, ProjectId, TagId, TaskId } from "../domain/ids.js";
+import type { OmniFocusAdapter } from "./OmniFocusAdapter.js";
+import { type AdapterMethod, ROUTING_TABLE, TransportRouter, transportFor } from "./router.js";
+
+// ---------------------------------------------------------------------------
+// Stub transports — every method records its receiver and returns a sentinel
+// ---------------------------------------------------------------------------
+
+type Receiver = "jxa" | "omnijs";
+
+function makeStub(name: Receiver): OmniFocusAdapter & { calls: string[] } {
+  const calls: string[] = [];
+  const record =
+    (method: string) =>
+    async (..._args: unknown[]): Promise<never> => {
+      calls.push(`${name}:${method}`);
+      // Return a sentinel that's still type-safe across the various return
+      // shapes — `unknown` widens to whatever the caller asked for.
+      return name as never;
+    };
+  return {
+    calls,
+    listTasks: record("listTasks"),
+    getTask: record("getTask"),
+    getTasksMany: record("getTasksMany"),
+    createTask: record("createTask"),
+    updateTask: record("updateTask"),
+    completeTask: record("completeTask"),
+    uncompleteTask: record("uncompleteTask"),
+    dropTask: record("dropTask"),
+    undropTask: record("undropTask"),
+    deleteTask: record("deleteTask"),
+    moveTask: record("moveTask"),
+    listProjects: record("listProjects"),
+    getProject: record("getProject"),
+    createProject: record("createProject"),
+    updateProject: record("updateProject"),
+    completeProject: record("completeProject"),
+    dropProject: record("dropProject"),
+    moveProject: record("moveProject"),
+    deleteProject: record("deleteProject"),
+    markProjectReviewed: record("markProjectReviewed"),
+    listTags: record("listTags"),
+    getTag: record("getTag"),
+    createTag: record("createTag"),
+    updateTag: record("updateTag"),
+    deleteTag: record("deleteTag"),
+    listFolders: record("listFolders"),
+    getFolder: record("getFolder"),
+    createFolder: record("createFolder"),
+    updateFolder: record("updateFolder"),
+    deleteFolder: record("deleteFolder"),
+    syncTrigger: record("syncTrigger"),
+    getLastSync: record("getLastSync"),
+    runJxaScript: record("runJxaScript"),
+    runOmniJsScript: record("runOmniJsScript"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// One sample call per method, with arguments that satisfy each signature
+// ---------------------------------------------------------------------------
+
+const T_ID = "task_000001" as TaskId;
+const P_ID = "proj_000001" as ProjectId;
+const TAG_ID = "tag_000001" as TagId;
+const F_ID = "folder_000001" as FolderId;
+
+function callsByMethod(r: TransportRouter): Record<AdapterMethod, () => Promise<unknown>> {
+  return {
+    listTasks: () => r.listTasks({}),
+    getTask: () => r.getTask(T_ID),
+    getTasksMany: () => r.getTasksMany([T_ID]),
+    createTask: () => r.createTask({ name: "x" }),
+    updateTask: () => r.updateTask(T_ID, { name: "y" }),
+    completeTask: () => r.completeTask(T_ID),
+    uncompleteTask: () => r.uncompleteTask(T_ID),
+    dropTask: () => r.dropTask(T_ID),
+    undropTask: () => r.undropTask(T_ID),
+    deleteTask: () => r.deleteTask(T_ID),
+    moveTask: () => r.moveTask(T_ID, { projectId: P_ID }),
+    listProjects: () => r.listProjects(),
+    getProject: () => r.getProject(P_ID),
+    createProject: () => r.createProject({ name: "p" }),
+    updateProject: () => r.updateProject(P_ID, { name: "q" }),
+    completeProject: () => r.completeProject(P_ID),
+    dropProject: () => r.dropProject(P_ID),
+    moveProject: () => r.moveProject(P_ID, { folderId: null }),
+    deleteProject: () => r.deleteProject(P_ID),
+    markProjectReviewed: () => r.markProjectReviewed(P_ID),
+    listTags: () => r.listTags(),
+    getTag: () => r.getTag(TAG_ID),
+    createTag: () => r.createTag({ name: "t" }),
+    updateTag: () => r.updateTag(TAG_ID, { name: "u" }),
+    deleteTag: () => r.deleteTag(TAG_ID),
+    listFolders: () => r.listFolders(),
+    getFolder: () => r.getFolder(F_ID),
+    createFolder: () => r.createFolder({ name: "f" }),
+    updateFolder: () => r.updateFolder(F_ID, { name: "g" }),
+    deleteFolder: () => r.deleteFolder(F_ID),
+    syncTrigger: () => r.syncTrigger(),
+    getLastSync: () => r.getLastSync(),
+    runJxaScript: () => r.runJxaScript("noop"),
+    runOmniJsScript: () => r.runOmniJsScript("noop"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TransportRouter — routing", () => {
+  it("dispatches each method to the transport named in the table", async () => {
+    const jxa = makeStub("jxa");
+    const omnijs = makeStub("omnijs");
+    const router = new TransportRouter({ jxa, omnijs });
+    const calls = callsByMethod(router);
+
+    for (const [method, invoke] of Object.entries(calls) as Array<
+      [AdapterMethod, () => Promise<unknown>]
+    >) {
+      await invoke();
+      const expected = ROUTING_TABLE[method];
+      const sink = expected === "jxa" ? jxa : omnijs;
+      expect(sink.calls.at(-1)).toBe(`${expected}:${method}`);
+    }
+  });
+
+  it("never delegates to the other transport", async () => {
+    const jxa = makeStub("jxa");
+    const omnijs = makeStub("omnijs");
+    const router = new TransportRouter({ jxa, omnijs });
+    const calls = callsByMethod(router);
+
+    for (const [method, invoke] of Object.entries(calls) as Array<
+      [AdapterMethod, () => Promise<unknown>]
+    >) {
+      const expected = ROUTING_TABLE[method];
+      const wrongSink = expected === "jxa" ? omnijs : jxa;
+      const before = wrongSink.calls.length;
+      await invoke();
+      expect(wrongSink.calls.length).toBe(before);
+    }
+  });
+
+  it("forwards arguments unchanged to the chosen transport", async () => {
+    const jxa = {
+      ...makeStub("jxa"),
+      moveTask: vi.fn(async (_id: TaskId, _dest: unknown): Promise<void> => undefined),
+    };
+    const omnijs = makeStub("omnijs");
+    const router = new TransportRouter({ jxa, omnijs });
+    const dest = { projectId: P_ID };
+    await router.moveTask(T_ID, dest);
+    expect(jxa.moveTask).toHaveBeenCalledWith(T_ID, dest);
+  });
+});
+
+describe("TransportRouter — table integrity", () => {
+  it("ROUTING_TABLE only assigns 'jxa' or 'omnijs'", () => {
+    for (const transport of Object.values(ROUTING_TABLE)) {
+      expect(transport === "jxa" || transport === "omnijs").toBe(true);
+    }
+  });
+
+  it("ROUTING_TABLE is frozen so callers cannot mutate the policy at runtime", () => {
+    expect(Object.isFrozen(ROUTING_TABLE)).toBe(true);
+  });
+
+  it("transportFor() returns the table entry for a method", () => {
+    expect(transportFor("listTasks")).toBe("jxa");
+    expect(transportFor("runOmniJsScript")).toBe("omnijs");
+  });
+
+  it("router.routingTable getter returns the exported table (same identity)", () => {
+    const router = new TransportRouter({ jxa: makeStub("jxa"), omnijs: makeStub("omnijs") });
+    expect(router.routingTable).toBe(ROUTING_TABLE);
+  });
+
+  it("current policy: only runOmniJsScript routes to omnijs", () => {
+    const omniJsRoutes = (Object.entries(ROUTING_TABLE) as Array<[AdapterMethod, string]>)
+      .filter(([, t]) => t === "omnijs")
+      .map(([m]) => m);
+    expect(omniJsRoutes).toEqual(["runOmniJsScript"]);
+  });
+});
+
+describe("TransportRouter — raw-script edge cases", () => {
+  it("rejects with TypeError if the dispatched transport is missing the raw method", async () => {
+    // Build the stub without the optional `runJxaScript` property so the type
+    // system reflects what a transport that opts out of the escape hatch
+    // looks like in production.
+    const { runJxaScript: _omit, ...jxaMissingRaw } = makeStub("jxa");
+    const router = new TransportRouter({ jxa: jxaMissingRaw, omnijs: makeStub("omnijs") });
+    await expect(router.runJxaScript("noop")).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("propagates the underlying transport's rejection", async () => {
+    const omnijs: OmniFocusAdapter = {
+      ...makeStub("omnijs"),
+      runOmniJsScript: async () => {
+        throw new Error("kaboom");
+      },
+    };
+    const router = new TransportRouter({ jxa: makeStub("jxa"), omnijs });
+    await expect(router.runOmniJsScript("noop")).rejects.toThrow("kaboom");
+  });
+});

--- a/src/adapter/router.ts
+++ b/src/adapter/router.ts
@@ -1,0 +1,328 @@
+/**
+ * `TransportRouter` — the facade every service layer talks to.
+ *
+ * The router is itself an `OmniFocusAdapter`, so services are blind to which
+ * underlying transport serves each call (DESIGN §6.1 — the adapter seam).
+ * It holds references to a `JxaTransport` and an `OmniJsTransport`, and
+ * dispatches per-method according to a single literal **routing table**.
+ *
+ * ## Why a routing table?
+ *
+ * The choice of transport per method is a load-bearing policy decision
+ * (ADR-0002 — JXA is the default; OmniJS for surfaces JXA cannot reach,
+ * e.g. custom perspectives and plug-in invocation). Keeping that policy in
+ * one auditable literal means:
+ *
+ * - Any reviewer can answer "which transport handles X?" by reading one file.
+ * - Moving a method between transports is a one-line change with zero
+ *   knock-on effects in service code.
+ * - The envelope layer (ADR-0013 / DESIGN §13) can stamp
+ *   `meta.transport` by indexing into the exported {@link ROUTING_TABLE}
+ *   rather than instrumenting every call site.
+ *
+ * The current table routes everything to JXA except the OmniJS raw escape
+ * hatch. Per-method OmniJS surfaces (custom perspectives #55, plugin
+ * invocation #74) will add new rows as those methods land on the adapter
+ * interface.
+ *
+ * ## Lifecycle & concurrency
+ *
+ * The router does not itself introduce concurrency controls; those live in
+ * #20 (read pool / write queue / OmniJS queue) and compose _above_ the
+ * router. The router also does not gate on OF version or running-state —
+ * that is the lifecycle layer's job (#25). Keeping the router pure dispatch
+ * makes it substitutable by `InMemoryAdapter` for service tests.
+ *
+ * @see DESIGN.md §6.1, §6.3 — layering, adapter seam
+ * @see docs/adr/0002-omnifocus-transport-dual.md
+ * @see docs/adr/0009-concurrency-pool-and-queue.md
+ * @see docs/adr/0013-tool-response-envelope.md
+ */
+
+import type { Folder } from "../domain/folder.js";
+import type { FolderId, ProjectId, TagId, TaskId } from "../domain/ids.js";
+import type { Project } from "../domain/project.js";
+import type { Tag } from "../domain/tag.js";
+import type { Task } from "../domain/task.js";
+import type {
+  CreateFolderInput,
+  CreateProjectInput,
+  CreateTagInput,
+  CreateTaskInput,
+  OmniFocusAdapter,
+  SyncStatus,
+  TaskFilter,
+  UpdateFolderInput,
+  UpdateProjectInput,
+  UpdateTagInput,
+  UpdateTaskInput,
+} from "./OmniFocusAdapter.js";
+import type { JxaTransport } from "./jxa/JxaTransport.js";
+import type { OmniJsTransport } from "./omnijs/OmniJsTransport.js";
+
+// ---------------------------------------------------------------------------
+// Routing table
+// ---------------------------------------------------------------------------
+
+/** Names of every method on `OmniFocusAdapter`, including the optional raw escape hatches. */
+export type AdapterMethod = keyof OmniFocusAdapter;
+
+/** The two concrete transports the router can dispatch to. */
+export type TransportName = "jxa" | "omnijs";
+
+/**
+ * The single source of truth for per-method transport selection.
+ *
+ * Read this once to know the entire policy. Moving a method between
+ * transports is a one-line edit here; no call-site changes required.
+ *
+ * Current policy:
+ *
+ * - **JXA** — every data/sync/raw-JXA method. JXA is the primary transport
+ *   per ADR-0002 and reaches the full OmniFocus scripting surface that the
+ *   M1 services need.
+ * - **OmniJS** — only the `runOmniJsScript` raw escape hatch today. As
+ *   OmniJS-only methods land on the adapter interface (custom perspectives
+ *   #55, plugin invocation #74), their rows switch to `"omnijs"`.
+ */
+export const ROUTING_TABLE: Readonly<Record<AdapterMethod, TransportName>> = Object.freeze({
+  // -- Tasks ----------------------------------------------------------------
+  listTasks: "jxa",
+  getTask: "jxa",
+  getTasksMany: "jxa",
+  createTask: "jxa",
+  updateTask: "jxa",
+  completeTask: "jxa",
+  uncompleteTask: "jxa",
+  dropTask: "jxa",
+  undropTask: "jxa",
+  deleteTask: "jxa",
+  moveTask: "jxa",
+
+  // -- Projects -------------------------------------------------------------
+  listProjects: "jxa",
+  getProject: "jxa",
+  createProject: "jxa",
+  updateProject: "jxa",
+  completeProject: "jxa",
+  dropProject: "jxa",
+  moveProject: "jxa",
+  deleteProject: "jxa",
+  markProjectReviewed: "jxa",
+
+  // -- Tags -----------------------------------------------------------------
+  listTags: "jxa",
+  getTag: "jxa",
+  createTag: "jxa",
+  updateTag: "jxa",
+  deleteTag: "jxa",
+
+  // -- Folders --------------------------------------------------------------
+  listFolders: "jxa",
+  getFolder: "jxa",
+  createFolder: "jxa",
+  updateFolder: "jxa",
+  deleteFolder: "jxa",
+
+  // -- Sync -----------------------------------------------------------------
+  syncTrigger: "jxa",
+  getLastSync: "jxa",
+
+  // -- Raw escape hatches ---------------------------------------------------
+  runJxaScript: "jxa",
+  runOmniJsScript: "omnijs",
+});
+
+/**
+ * Return the transport name assigned to a given adapter method.
+ *
+ * The envelope layer uses this to stamp `meta.transport` without
+ * instrumenting every dispatch site.
+ */
+export function transportFor(method: AdapterMethod): TransportName {
+  return ROUTING_TABLE[method];
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+export interface TransportRouterOptions {
+  jxa: OmniFocusAdapter;
+  omnijs: OmniFocusAdapter;
+}
+
+/**
+ * Dispatches `OmniFocusAdapter` calls to the transport chosen by
+ * {@link ROUTING_TABLE}. The injected transports are typed as
+ * `OmniFocusAdapter` (not the concrete classes) so tests can swap in stubs
+ * and the contract harness (#30) can exercise the router without spawning
+ * real `osascript` processes.
+ */
+export class TransportRouter implements OmniFocusAdapter {
+  private readonly jxa: OmniFocusAdapter;
+  private readonly omnijs: OmniFocusAdapter;
+
+  constructor(options: TransportRouterOptions) {
+    this.jxa = options.jxa;
+    this.omnijs = options.omnijs;
+  }
+
+  /** Expose the routing policy so callers can audit or reflect over it. */
+  get routingTable(): Readonly<Record<AdapterMethod, TransportName>> {
+    return ROUTING_TABLE;
+  }
+
+  /**
+   * Factory that wires in real `JxaTransport` / `OmniJsTransport` instances.
+   * Prefer this in production; tests use the plain constructor with stubs.
+   */
+  static fromTransports(jxa: JxaTransport, omnijs: OmniJsTransport): TransportRouter {
+    return new TransportRouter({ jxa, omnijs });
+  }
+
+  /** Internal dispatch helper. Narrows the method lookup to one place. */
+  private pick(method: AdapterMethod): OmniFocusAdapter {
+    return ROUTING_TABLE[method] === "jxa" ? this.jxa : this.omnijs;
+  }
+
+  // -- Tasks ----------------------------------------------------------------
+
+  listTasks(filter: TaskFilter): Promise<Task[]> {
+    return this.pick("listTasks").listTasks(filter);
+  }
+  getTask(id: TaskId): Promise<Task> {
+    return this.pick("getTask").getTask(id);
+  }
+  getTasksMany(ids: TaskId[]): Promise<(Task | null)[]> {
+    return this.pick("getTasksMany").getTasksMany(ids);
+  }
+  createTask(input: CreateTaskInput): Promise<TaskId> {
+    return this.pick("createTask").createTask(input);
+  }
+  updateTask(id: TaskId, patch: UpdateTaskInput): Promise<void> {
+    return this.pick("updateTask").updateTask(id, patch);
+  }
+  completeTask(id: TaskId, at?: Date): Promise<void> {
+    return this.pick("completeTask").completeTask(id, at);
+  }
+  uncompleteTask(id: TaskId): Promise<void> {
+    return this.pick("uncompleteTask").uncompleteTask(id);
+  }
+  dropTask(id: TaskId, at?: Date): Promise<void> {
+    return this.pick("dropTask").dropTask(id, at);
+  }
+  undropTask(id: TaskId): Promise<void> {
+    return this.pick("undropTask").undropTask(id);
+  }
+  deleteTask(id: TaskId): Promise<void> {
+    return this.pick("deleteTask").deleteTask(id);
+  }
+  moveTask(id: TaskId, destination: { projectId?: ProjectId; parentId?: TaskId }): Promise<void> {
+    return this.pick("moveTask").moveTask(id, destination);
+  }
+
+  // -- Projects -------------------------------------------------------------
+
+  listProjects(filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<Project[]> {
+    return this.pick("listProjects").listProjects(filter);
+  }
+  getProject(id: ProjectId): Promise<Project> {
+    return this.pick("getProject").getProject(id);
+  }
+  createProject(input: CreateProjectInput): Promise<ProjectId> {
+    return this.pick("createProject").createProject(input);
+  }
+  updateProject(id: ProjectId, patch: UpdateProjectInput): Promise<void> {
+    return this.pick("updateProject").updateProject(id, patch);
+  }
+  completeProject(id: ProjectId, at?: Date): Promise<void> {
+    return this.pick("completeProject").completeProject(id, at);
+  }
+  dropProject(id: ProjectId, at?: Date): Promise<void> {
+    return this.pick("dropProject").dropProject(id, at);
+  }
+  moveProject(id: ProjectId, destination: { folderId: FolderId | null }): Promise<void> {
+    return this.pick("moveProject").moveProject(id, destination);
+  }
+  deleteProject(id: ProjectId): Promise<void> {
+    return this.pick("deleteProject").deleteProject(id);
+  }
+  markProjectReviewed(id: ProjectId): Promise<void> {
+    return this.pick("markProjectReviewed").markProjectReviewed(id);
+  }
+
+  // -- Tags -----------------------------------------------------------------
+
+  listTags(filter?: { parentId?: TagId; status?: Tag["status"] }): Promise<Tag[]> {
+    return this.pick("listTags").listTags(filter);
+  }
+  getTag(id: TagId): Promise<Tag> {
+    return this.pick("getTag").getTag(id);
+  }
+  createTag(input: CreateTagInput): Promise<TagId> {
+    return this.pick("createTag").createTag(input);
+  }
+  updateTag(id: TagId, patch: UpdateTagInput): Promise<void> {
+    return this.pick("updateTag").updateTag(id, patch);
+  }
+  deleteTag(id: TagId): Promise<void> {
+    return this.pick("deleteTag").deleteTag(id);
+  }
+
+  // -- Folders --------------------------------------------------------------
+
+  listFolders(filter?: { parentId?: FolderId }): Promise<Folder[]> {
+    return this.pick("listFolders").listFolders(filter);
+  }
+  getFolder(id: FolderId): Promise<Folder> {
+    return this.pick("getFolder").getFolder(id);
+  }
+  createFolder(input: CreateFolderInput): Promise<FolderId> {
+    return this.pick("createFolder").createFolder(input);
+  }
+  updateFolder(id: FolderId, patch: UpdateFolderInput): Promise<void> {
+    return this.pick("updateFolder").updateFolder(id, patch);
+  }
+  deleteFolder(id: FolderId): Promise<void> {
+    return this.pick("deleteFolder").deleteFolder(id);
+  }
+
+  // -- Sync -----------------------------------------------------------------
+
+  syncTrigger(): Promise<SyncStatus> {
+    return this.pick("syncTrigger").syncTrigger();
+  }
+  getLastSync(): Promise<SyncStatus> {
+    return this.pick("getLastSync").getLastSync();
+  }
+
+  // -- Raw escape hatches ---------------------------------------------------
+  //
+  // The raw-script methods are optional on `OmniFocusAdapter` (they only
+  // exist to satisfy the env-gated `run_*_script` tools). The router always
+  // exposes them — if the chosen transport doesn't implement the method we
+  // throw a `TypeError` at the boundary so the misconfiguration is loud.
+
+  runJxaScript(script: string): Promise<unknown> {
+    const target = this.pick("runJxaScript");
+    if (typeof target.runJxaScript !== "function") {
+      return Promise.reject(
+        new TypeError("Router dispatched runJxaScript to a transport that does not implement it"),
+      );
+    }
+    return target.runJxaScript(script);
+  }
+
+  runOmniJsScript(script: string): Promise<unknown> {
+    const target = this.pick("runOmniJsScript");
+    if (typeof target.runOmniJsScript !== "function") {
+      return Promise.reject(
+        new TypeError(
+          "Router dispatched runOmniJsScript to a transport that does not implement it",
+        ),
+      );
+    }
+    return target.runOmniJsScript(script);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/adapter/router.ts` exporting `TransportRouter implements OmniFocusAdapter` plus a single frozen `ROUTING_TABLE` literal mapping every adapter method to `"jxa" | "omnijs"`. The router is pure dispatch — it holds references to a JXA transport and an OmniJS transport (typed as the interface, not the concrete classes, so stubs and `InMemoryAdapter` substitute cleanly) and delegates each method via the table.
- Exports `transportFor(method)` so the envelope layer (ADR-0013) can stamp `meta.transport` by indexing into the table without instrumenting every dispatch site.
- Current policy: every data/sync method routes to JXA; only the `runOmniJsScript` raw escape hatch routes to OmniJS. Per-method OmniJS surfaces (custom perspectives #55, plugin invocation #74) add new rows when those methods land on the adapter interface.
- 10 new unit tests cover routing, no-cross-talk to the wrong transport, argument forwarding, table integrity (frozen, complete coverage, only valid transport names), the `routingTable` getter identity, and the TypeError fallback when a transport opts out of an optional raw method.

## Design link

Closes #19. Sits above the now-shipped `JxaTransport` (#17) and `OmniJsTransport` (#18); concurrency primitives (#20) and the lifecycle gate (#25) compose above the router rather than inside it, keeping it pure dispatch and substitutable by `InMemoryAdapter` for service tests (full contract verification lands with #30).

- DESIGN §6.1, §6.3 — layering, adapter seam
- ADR-0002 — JXA + OmniJS dual transport
- ADR-0009 — concurrency wraps above the router
- ADR-0013 — `meta.transport` envelope stamp

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (biome + custom rules)
- [x] `pnpm test` — 299 / 299 green (10 new)
- [x] `pnpm build` — green
- [x] Self-reviewed via review_pr.md
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)