### PR TITLE
feat(lifecycle): implement graceful shutdown controller

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -5,8 +5,8 @@
  * API from @modelcontextprotocol/sdk. No tools are registered here — they
  * arrive from per-noun registrations in M1+.
  *
- * Signal handlers for SIGINT/SIGTERM initiate graceful shutdown (#26). Until
- * that issue lands, we do a best-effort close and exit.
+ * Signal handlers for SIGINT/SIGTERM delegate to `shutdownController` (#26),
+ * which drains in-flight calls, flushes logs, and exits 0.
  *
  * Cold-start target: < 500ms on a warm macOS (DESIGN §17).
  *
@@ -18,6 +18,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { parseConfig, redactConfig } from "../config/env.js";
 import { logger } from "../logging/logger.js";
+import { shutdownController } from "./shutdown.js";
 import { installStdoutGuard } from "./stdoutGuard.js";
 
 const PACKAGE_VERSION = "0.0.1";
@@ -40,6 +41,8 @@ export function createMcpServer(): McpServer {
  * Boot the MCP server over stdio, parse config, wire signal handlers,
  * and emit the `server.started` event. Never returns while the server
  * is running.
+ *
+ * Unhandled exceptions log at `fatal` and exit 1 (DESIGN §17).
  */
 export async function startServer(): Promise<void> {
   // Guard stdout before anything else — a stray write before connect would
@@ -54,15 +57,26 @@ export async function startServer(): Promise<void> {
   const server = createMcpServer();
   const transport = new StdioServerTransport();
 
-  // Graceful shutdown — full implementation lands in #26.
-  const shutdown = async (reason: string) => {
-    logger.info({ event: "server.shutdown", reason, graceMs: 0 }, "shutting down");
-    await server.close();
-    process.exit(0);
-  };
+  // Graceful shutdown — delegate to shutdownController so tool handlers can
+  // call assertNotShuttingDown() and in-flight queues drain cleanly.
+  process.on("SIGINT", () => {
+    void shutdownController.initiate("SIGINT");
+  });
+  process.on("SIGTERM", () => {
+    void shutdownController.initiate("SIGTERM");
+  });
 
-  process.on("SIGINT", () => void shutdown("SIGINT"));
-  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  // Unhandled rejection / exception: log fatal and exit 1 (DESIGN §17).
+  process.on("unhandledRejection", (reason) => {
+    logger.fatal({ event: "server.unhandled_rejection", reason }, "unhandled rejection");
+    logger.flush();
+    process.exit(1);
+  });
+  process.on("uncaughtException", (err) => {
+    logger.fatal({ event: "server.uncaught_exception", err }, "uncaught exception");
+    logger.flush();
+    process.exit(1);
+  });
 
   await server.connect(transport);
 

--- a/src/server/shutdown.test.ts
+++ b/src/server/shutdown.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for ShutdownController.
+ *
+ * All tests use an injectable `exitFn` so they never call `process.exit`.
+ * The module singleton is NOT used; each test creates a fresh instance.
+ *
+ * @see src/server/shutdown.ts
+ * @see DESIGN.md §17 — lifecycle
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { ServerShuttingDown } from "../errors/index.js";
+import { ShutdownController } from "./shutdown.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeController() {
+  return new ShutdownController();
+}
+
+/** A DrainableQueue stub whose pending count can be controlled in tests. */
+function makeQueue(name: string, initialPending = 0) {
+  let pending = initialPending;
+  return {
+    name,
+    pendingCount: () => pending,
+    setPending: (n: number) => {
+      pending = n;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isShuttingDown
+// ---------------------------------------------------------------------------
+
+describe("ShutdownController.isShuttingDown", () => {
+  it("is false before initiate()", () => {
+    const ctrl = makeController();
+    expect(ctrl.isShuttingDown).toBe(false);
+  });
+
+  it("is true immediately after initiate() resolves", async () => {
+    const ctrl = makeController();
+    const exitFn = vi.fn();
+    await ctrl.initiate("test", exitFn);
+    expect(ctrl.isShuttingDown).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertNotShuttingDown
+// ---------------------------------------------------------------------------
+
+describe("ShutdownController.assertNotShuttingDown", () => {
+  it("does not throw before initiate()", () => {
+    const ctrl = makeController();
+    expect(() => ctrl.assertNotShuttingDown()).not.toThrow();
+  });
+
+  it("throws ServerShuttingDown after initiate()", async () => {
+    const ctrl = makeController();
+    await ctrl.initiate("test", vi.fn());
+    expect(() => ctrl.assertNotShuttingDown()).toThrow(ServerShuttingDown);
+  });
+
+  it("throws an error with the expected code", async () => {
+    const ctrl = makeController();
+    await ctrl.initiate("test", vi.fn());
+    try {
+      ctrl.assertNotShuttingDown();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ServerShuttingDown);
+      expect((e as ServerShuttingDown).code).toBe("OF_SHUTTING_DOWN");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initiate — basic lifecycle
+// ---------------------------------------------------------------------------
+
+describe("ShutdownController.initiate", () => {
+  it("calls exitFn(0) on clean shutdown", async () => {
+    const ctrl = makeController();
+    const exitFn = vi.fn();
+    await ctrl.initiate("SIGINT", exitFn);
+    expect(exitFn).toHaveBeenCalledOnce();
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it("is idempotent — calling initiate twice only exits once", async () => {
+    const ctrl = makeController();
+    const exitFn = vi.fn();
+    await ctrl.initiate("SIGTERM", exitFn);
+    await ctrl.initiate("SIGTERM", exitFn); // second call should no-op
+    expect(exitFn).toHaveBeenCalledOnce();
+  });
+
+  it("accepts any reason string", async () => {
+    const ctrl = makeController();
+    const exitFn = vi.fn();
+    await ctrl.initiate("custom-reason", exitFn);
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerQueue + draining
+// ---------------------------------------------------------------------------
+
+describe("ShutdownController.registerQueue", () => {
+  it("resolves immediately when no queues are registered", async () => {
+    const ctrl = makeController();
+    const exitFn = vi.fn();
+    const start = Date.now();
+    await ctrl.initiate("test", exitFn);
+    expect(Date.now() - start).toBeLessThan(500);
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it("resolves immediately when all registered queues start at 0", async () => {
+    const ctrl = makeController();
+    ctrl.registerQueue(makeQueue("read-pool", 0));
+    ctrl.registerQueue(makeQueue("write-queue", 0));
+    const exitFn = vi.fn();
+    await ctrl.initiate("test", exitFn);
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it("drains a queue that becomes idle before timeout", async () => {
+    const ctrl = new ShutdownController({ readGraceMs: 300, writeGraceMs: 300 });
+    const queue = makeQueue("read-pool", 1);
+    ctrl.registerQueue(queue);
+
+    const exitFn = vi.fn();
+    // Drain the queue after 50ms — well within the 300ms grace window.
+    setTimeout(() => queue.setPending(0), 50);
+    await ctrl.initiate("test", exitFn);
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it("still exits if a queue never drains (timeout path)", async () => {
+    const ctrl = new ShutdownController({ readGraceMs: 60, writeGraceMs: 60 });
+    // Queue that never drains
+    ctrl.registerQueue(makeQueue("stuck-queue", 5));
+    const exitFn = vi.fn();
+    await ctrl.initiate("test", exitFn);
+    expect(exitFn).toHaveBeenCalledWith(0); // exits despite the stuck queue
+  }, 1_000);
+
+  it("does not register the same queue object twice", () => {
+    const ctrl = makeController();
+    const queue = makeQueue("dedup-queue", 0);
+    ctrl.registerQueue(queue);
+    ctrl.registerQueue(queue); // should be a no-op
+    // No assertion needed beyond "doesn't throw"; coverage verifies the branch.
+  });
+});

--- a/src/server/shutdown.ts
+++ b/src/server/shutdown.ts
@@ -1,0 +1,195 @@
+/**
+ * Graceful shutdown controller for omnifocus-mcp.
+ *
+ * Implements the DESIGN §17 shutdown sequence:
+ *   1. Set `isShuttingDown = true` — tool handlers call `assertNotShuttingDown()`
+ *      at entry and receive `ServerShuttingDown` for new calls.
+ *   2. Drain in-flight reads (READ_GRACE_MS, default 5 s).
+ *   3. Drain in-flight writes (WRITE_GRACE_MS, default 10 s).
+ *   4. Flush the pino logger.
+ *   5. Emit `server.shutdown` log event and exit 0.
+ *
+ * In-flight tracking is pluggable: M1 transport layers register a
+ * `DrainableQueue` via `registerQueue()`. Until then, drain resolves
+ * immediately because there are no queued calls.
+ *
+ * Usage:
+ *   import { shutdownController } from './shutdown.js';
+ *   shutdownController.assertNotShuttingDown();  // in every tool handler
+ *   shutdownController.registerQueue(readPool);  // in JxaTransport
+ *
+ * @see DESIGN.md §17 — lifecycle and shutdown sequence
+ */
+
+import { ServerShuttingDown } from "../errors/index.js";
+import { logger } from "../logging/logger.js";
+
+// ---------------------------------------------------------------------------
+// Grace-period defaults
+// ---------------------------------------------------------------------------
+
+/** Default ms to wait for in-flight reads to finish. */
+export const DEFAULT_READ_GRACE_MS = 5_000;
+
+/** Default ms to wait for in-flight writes to finish. */
+export const DEFAULT_WRITE_GRACE_MS = 10_000;
+
+/** Poll interval when checking whether queues have drained. */
+const DRAIN_POLL_MS = 50;
+
+// ---------------------------------------------------------------------------
+// DrainableQueue interface — implemented by M1 transport queues
+// ---------------------------------------------------------------------------
+
+/**
+ * A named in-flight counter that the shutdown controller drains before exit.
+ * M1 transport classes implement this interface and register with
+ * `shutdownController.registerQueue()`.
+ */
+export interface DrainableQueue {
+  /** Human-readable name used in shutdown log events. */
+  readonly name: string;
+  /** Number of requests currently in flight. */
+  pendingCount(): number;
+}
+
+// ---------------------------------------------------------------------------
+// ShutdownController
+// ---------------------------------------------------------------------------
+
+/** Constructor options for ShutdownController. */
+export interface ShutdownControllerOptions {
+  /** Override the read-drain grace window (ms). Defaults to env var or 5 s. */
+  readGraceMs?: number;
+  /** Override the write-drain grace window (ms). Defaults to env var or 10 s. */
+  writeGraceMs?: number;
+}
+
+/**
+ * Controls the server's shutdown lifecycle.
+ *
+ * Exposes:
+ * - `isShuttingDown` — read by the MCP bootstrap; checked by tool handlers
+ * - `assertNotShuttingDown()` — throws `ServerShuttingDown` when set
+ * - `registerQueue(q)` — registers a drainable transport queue
+ * - `initiate(reason)` — starts the full drain + exit sequence
+ */
+export class ShutdownController {
+  private _shuttingDown = false;
+  private readonly _queues: DrainableQueue[] = [];
+  private readonly _readGraceMs: number;
+  private readonly _writeGraceMs: number;
+
+  constructor(options: ShutdownControllerOptions = {}) {
+    this._readGraceMs =
+      options.readGraceMs ?? Number(process.env.OMNIFOCUS_READ_GRACE_MS ?? DEFAULT_READ_GRACE_MS);
+    this._writeGraceMs =
+      options.writeGraceMs ??
+      Number(process.env.OMNIFOCUS_WRITE_GRACE_MS ?? DEFAULT_WRITE_GRACE_MS);
+  }
+
+  /** True once `initiate()` has been called. Monotonically false→true. */
+  get isShuttingDown(): boolean {
+    return this._shuttingDown;
+  }
+
+  /**
+   * Throw `ServerShuttingDown` if shutdown has started.
+   * Call this at the entry of every tool handler.
+   */
+  assertNotShuttingDown(): void {
+    if (this._shuttingDown) {
+      throw new ServerShuttingDown();
+    }
+  }
+
+  /**
+   * Register a drainable queue so the shutdown sequence waits for it.
+   * Idempotent — registering the same object twice is a no-op.
+   */
+  registerQueue(queue: DrainableQueue): void {
+    if (!this._queues.includes(queue)) {
+      this._queues.push(queue);
+    }
+  }
+
+  /**
+   * Begin the graceful shutdown sequence. Idempotent — subsequent calls
+   * return immediately without re-running the sequence.
+   *
+   * Sequence:
+   *   1. Set `isShuttingDown = true`
+   *   2. Drain all registered queues within their grace window
+   *   3. Flush pino logger
+   *   4. `process.exit(0)`
+   *
+   * @param reason  Human-readable trigger source (e.g. "SIGINT", "SIGTERM").
+   * @param exitFn  Injectable exit function; defaults to `process.exit`. Use
+   *                in tests to avoid actually exiting the test process.
+   */
+  async initiate(reason: string, exitFn: (code: number) => void = process.exit): Promise<void> {
+    if (this._shuttingDown) return;
+    this._shuttingDown = true;
+
+    logger.info(
+      {
+        event: "server.shutdown",
+        reason,
+        readGraceMs: this._readGraceMs,
+        writeGraceMs: this._writeGraceMs,
+      },
+      "graceful shutdown initiated",
+    );
+
+    // Drain all queues within a combined grace window.
+    // In M0 there are no queues; this resolves immediately.
+    const totalGraceMs = this._readGraceMs + this._writeGraceMs;
+    await this._drainAll(totalGraceMs);
+
+    // Flush the pino logger — pino uses a synchronous write to stderr, so
+    // `flush()` ensures the last log line is written before exit.
+    logger.flush();
+
+    exitFn(0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Poll until all registered queues report zero pending calls, or until
+   * `timeoutMs` elapses. Logs a warning for any queue that did not drain.
+   */
+  private async _drainAll(timeoutMs: number): Promise<void> {
+    if (this._queues.length === 0) return;
+
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const pending = this._queues.filter((q) => q.pendingCount() > 0);
+      if (pending.length === 0) return;
+
+      await new Promise<void>((resolve) => setTimeout(resolve, DRAIN_POLL_MS));
+    }
+
+    // Timeout — log which queues are still active and proceed to exit anyway.
+    const stillPending = this._queues.filter((q) => q.pendingCount() > 0);
+    for (const q of stillPending) {
+      logger.warn(
+        { event: "server.shutdown.drain_timeout", queue: q.name, pending: q.pendingCount() },
+        "queue did not drain within grace window; forcing shutdown",
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module singleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Module-level singleton shutdown controller.
+ * Import and use this in `mcpServer.ts` and all tool handlers.
+ */
+export const shutdownController = new ShutdownController();


### PR DESCRIPTION
## Summary
- Adds `ShutdownController` (`src/server/shutdown.ts`) implementing the DESIGN §17 shutdown sequence
- `assertNotShuttingDown()` for tool handlers — throws `ServerShuttingDown` (code `OF_SHUTTING_DOWN`, remediation `lifecycle`) at any call received after shutdown starts
- `DrainableQueue` interface for M1 transport layers to register; drain loop polls with configurable grace windows (5s reads + 10s writes default)
- Wires SIGINT/SIGTERM signal handlers in `mcpServer.ts`; adds `unhandledRejection`/`uncaughtException` → `fatal` log + exit 1
- Grace windows injectable in constructor so tests run in <300ms without touching env vars

## Design link
Closes #26. See DESIGN.md §17 — lifecycle and shutdown sequence.

## Breaking change?
- [x] No

## Test plan
- [x] 13 unit tests — flag lifecycle, idempotency, drain success, drain timeout, queue dedup; all use injectable `exitFn` (never calls `process.exit`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (63 files, no violations)
- [x] All 312 tests passing
- [x] Self-reviewed
- [x] No new dependencies