### PR TITLE
feat(observability): per-tool circuit breaker with closed/open/half-open state machine

### DIFF
--- a/src/server/circuitBreaker.test.ts
+++ b/src/server/circuitBreaker.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for CircuitBreaker and CircuitBreakerRegistry.
+ *
+ * Uses an injected clock (`now` option) so every timing assertion is
+ * deterministic — no real timers, no `setTimeout`, no flakiness.
+ *
+ * @see src/server/circuitBreaker.ts
+ * @see DESIGN.md §6.10 — circuit breaker specification
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { CircuitOpen } from "../errors/index.js";
+import { CircuitBreaker, CircuitBreakerRegistry } from "./circuitBreaker.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Controllable fake clock. */
+function makeClock(initial = 0) {
+  let t = initial;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+/** A breaker with tight thresholds for fast tests. */
+function makeBreaker(clock = makeClock(), overrides: { failureThreshold?: number } = {}) {
+  return new CircuitBreaker("test_tool", {
+    failureThreshold: overrides.failureThreshold ?? 3,
+    windowMs: 60_000,
+    openDurationMs: 60_000,
+    now: clock.now,
+  });
+}
+
+const ok = () => Promise.resolve("ok");
+const fail = () => Promise.reject(new Error("boom"));
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe("CircuitBreaker — initial state", () => {
+  it("starts in CLOSED state", () => {
+    expect(makeBreaker().state).toBe("closed");
+  });
+
+  it("passes through successful calls unchanged", async () => {
+    const b = makeBreaker();
+    const result = await b.call(ok);
+    expect(result).toBe("ok");
+    expect(b.state).toBe("closed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure counting
+// ---------------------------------------------------------------------------
+
+describe("CircuitBreaker — failure counting", () => {
+  it("stays CLOSED below the failure threshold", async () => {
+    const b = makeBreaker();
+    await expect(b.call(fail)).rejects.toThrow("boom");
+    await expect(b.call(fail)).rejects.toThrow("boom");
+    expect(b.state).toBe("closed"); // 2 failures, threshold is 3
+  });
+
+  it("opens after hitting the failure threshold", async () => {
+    const b = makeBreaker();
+    await expect(b.call(fail)).rejects.toThrow();
+    await expect(b.call(fail)).rejects.toThrow();
+    await expect(b.call(fail)).rejects.toThrow();
+    expect(b.state).toBe("open");
+  });
+
+  it("success resets the failure count", async () => {
+    const b = makeBreaker();
+    await expect(b.call(fail)).rejects.toThrow();
+    await expect(b.call(fail)).rejects.toThrow();
+    await b.call(ok); // resets failures
+    await expect(b.call(fail)).rejects.toThrow();
+    await expect(b.call(fail)).rejects.toThrow();
+    expect(b.state).toBe("closed"); // only 2 failures since last success
+  });
+
+  it("prunes failures outside the rolling window", async () => {
+    const clock = makeClock();
+    const b = makeBreaker(clock);
+    await expect(b.call(fail)).rejects.toThrow(); // t=0
+    await expect(b.call(fail)).rejects.toThrow(); // t=0
+    clock.advance(61_000); // past windowMs
+    await expect(b.call(fail)).rejects.toThrow(); // t=61000 — old failures pruned
+    await expect(b.call(fail)).rejects.toThrow(); // t=61000 — 2nd fresh failure
+    expect(b.state).toBe("closed"); // only 2 in-window failures
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPEN state — fast-fail
+// ---------------------------------------------------------------------------
+
+describe("CircuitBreaker — OPEN state", () => {
+  async function openBreaker() {
+    const clock = makeClock();
+    const b = makeBreaker(clock);
+    for (let i = 0; i < 3; i++) await expect(b.call(fail)).rejects.toThrow();
+    return { b, clock };
+  }
+
+  it("throws CircuitOpen without calling fn", async () => {
+    const { b } = await openBreaker();
+    const fn = vi.fn(ok);
+    await expect(b.call(fn)).rejects.toBeInstanceOf(CircuitOpen);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("CircuitOpen has code OF_CIRCUIT_OPEN", async () => {
+    const { b } = await openBreaker();
+    try {
+      await b.call(ok);
+    } catch (e) {
+      expect(e).toBeInstanceOf(CircuitOpen);
+      expect((e as CircuitOpen).code).toBe("OF_CIRCUIT_OPEN");
+    }
+  });
+
+  it("includes retryAfterMs in details", async () => {
+    const { b } = await openBreaker();
+    try {
+      await b.call(ok);
+    } catch (e) {
+      const err = e as CircuitOpen;
+      expect(typeof err.details?.retryAfterMs).toBe("number");
+      expect((err.details?.retryAfterMs as number) ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  it("stays OPEN before openDurationMs elapses", async () => {
+    const { b, clock } = await openBreaker();
+    clock.advance(59_999);
+    expect(b.state).toBe("open");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HALF_OPEN state — probe logic
+// ---------------------------------------------------------------------------
+
+describe("CircuitBreaker — HALF_OPEN state", () => {
+  async function halfOpenBreaker() {
+    const clock = makeClock();
+    const b = makeBreaker(clock);
+    for (let i = 0; i < 3; i++) await expect(b.call(fail)).rejects.toThrow();
+    clock.advance(60_000); // openDurationMs elapsed → half-open
+    return { b, clock };
+  }
+
+  it("transitions to HALF_OPEN after openDurationMs", async () => {
+    const { b } = await halfOpenBreaker();
+    expect(b.state).toBe("half_open");
+  });
+
+  it("closes on successful probe", async () => {
+    const { b } = await halfOpenBreaker();
+    await b.call(ok);
+    expect(b.state).toBe("closed");
+  });
+
+  it("re-opens on failed probe", async () => {
+    const { b } = await halfOpenBreaker();
+    await expect(b.call(fail)).rejects.toThrow();
+    expect(b.state).toBe("open");
+  });
+
+  it("fast-fails concurrent callers while probe is in flight", async () => {
+    const { b } = await halfOpenBreaker();
+    // Start a slow probe that hasn't resolved yet
+    let resolveProbe!: () => void;
+    const slowProbe = new Promise<string>((resolve) => {
+      resolveProbe = () => resolve("ok");
+    });
+    const probeCall = b.call(() => slowProbe);
+    // Second caller should fast-fail
+    await expect(b.call(ok)).rejects.toBeInstanceOf(CircuitOpen);
+    resolveProbe();
+    await probeCall;
+    expect(b.state).toBe("closed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CircuitBreakerRegistry
+// ---------------------------------------------------------------------------
+
+describe("CircuitBreakerRegistry", () => {
+  it("returns a CircuitBreaker for a given tool name", () => {
+    const reg = new CircuitBreakerRegistry();
+    const b = reg.get("task_list");
+    expect(b).toBeInstanceOf(CircuitBreaker);
+  });
+
+  it("returns the same instance on repeated calls", () => {
+    const reg = new CircuitBreakerRegistry();
+    expect(reg.get("task_list")).toBe(reg.get("task_list"));
+  });
+
+  it("returns distinct instances for different tool names", () => {
+    const reg = new CircuitBreakerRegistry();
+    expect(reg.get("task_list")).not.toBe(reg.get("project_list"));
+  });
+
+  it("tracks the number of registered breakers", () => {
+    const reg = new CircuitBreakerRegistry();
+    reg.get("a");
+    reg.get("b");
+    expect(reg.size).toBe(2);
+  });
+
+  it("clear() removes all breakers", () => {
+    const reg = new CircuitBreakerRegistry();
+    reg.get("a");
+    reg.clear();
+    expect(reg.size).toBe(0);
+  });
+
+  it("propagates default options to created breakers", async () => {
+    const clock = makeClock();
+    const reg = new CircuitBreakerRegistry({ failureThreshold: 1, now: clock.now });
+    const b = reg.get("fast_fail");
+    await expect(b.call(fail)).rejects.toThrow();
+    expect(b.state).toBe("open"); // threshold 1 → open after single failure
+  });
+});

--- a/src/server/circuitBreaker.ts
+++ b/src/server/circuitBreaker.ts
@@ -1,0 +1,265 @@
+/**
+ * Per-tool circuit breaker for omnifocus-mcp.
+ *
+ * Implements a standard closed → open → half-open state machine per
+ * DESIGN §6.10 and `agent_systems.md` (fail-fast, actionable errors):
+ *
+ *   CLOSED   — normal operation; failures are counted within a rolling window.
+ *   OPEN     — fast-fails with `CircuitOpen`; entered after threshold failures.
+ *   HALF_OPEN — allows a single probe call; success → CLOSED, failure → OPEN.
+ *
+ * Default thresholds (overridable via constructor options for testing):
+ *   - failureThreshold: 3 consecutive failures within windowMs (60 s)
+ *   - openDurationMs: 60 s before transitioning to HALF_OPEN
+ *
+ * Observability: `circuit.opened` and `circuit.closed` log events are emitted
+ * on every state transition per DESIGN §21.
+ *
+ * Usage:
+ *   const breaker = registry.get("task_list");
+ *   await breaker.call(() => transport.taskList(params));
+ *
+ * @see DESIGN.md §6.10 — circuit breaker specification
+ * @see src/errors/index.ts — CircuitOpen error class
+ */
+
+import { CircuitOpen } from "../errors/index.js";
+import { logger } from "../logging/logger.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The three states of the circuit breaker state machine. */
+export type CircuitState = "closed" | "open" | "half_open";
+
+/** Constructor options — all optional; defaults match DESIGN §6.10. */
+export interface CircuitBreakerOptions {
+  /** Number of consecutive failures that open the circuit. Default: 3. */
+  failureThreshold?: number;
+  /** Rolling window (ms) in which failures are counted. Default: 60 000. */
+  windowMs?: number;
+  /** Time (ms) the circuit stays open before moving to half-open. Default: 60 000. */
+  openDurationMs?: number;
+  /** Injected clock for testing. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+// ---------------------------------------------------------------------------
+// CircuitBreaker
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-tool circuit breaker.
+ *
+ * Thread-safety note: Node.js is single-threaded; no locks are needed.
+ * Concurrent async calls that both fail in the same tick both count toward
+ * the failure threshold — this is the desired behaviour (fail fast).
+ */
+export class CircuitBreaker {
+  private readonly _tool: string;
+  private readonly _failureThreshold: number;
+  private readonly _windowMs: number;
+  private readonly _openDurationMs: number;
+  private readonly _now: () => number;
+
+  private _state: CircuitState = "closed";
+  /** Timestamps (ms) of failures within the current window. */
+  private _failures: number[] = [];
+  /** Timestamp when the circuit opened; used to compute half-open transition. */
+  private _openedAt: number | null = null;
+  /** True when a half-open probe is already in flight. */
+  private _probeInFlight = false;
+
+  constructor(tool: string, options: CircuitBreakerOptions = {}) {
+    this._tool = tool;
+    this._failureThreshold = options.failureThreshold ?? 3;
+    this._windowMs = options.windowMs ?? 60_000;
+    this._openDurationMs = options.openDurationMs ?? 60_000;
+    this._now = options.now ?? (() => Date.now());
+  }
+
+  /** Current state of the breaker. */
+  get state(): CircuitState {
+    this._maybeTransitionToHalfOpen();
+    return this._state;
+  }
+
+  /**
+   * Execute `fn` through the circuit breaker.
+   *
+   * - CLOSED: always calls `fn`; records success or failure.
+   * - OPEN: throws `CircuitOpen` immediately without calling `fn`.
+   * - HALF_OPEN: allows exactly one probe; if probe succeeds → CLOSED,
+   *   if probe fails → OPEN again.
+   *
+   * @throws {CircuitOpen} when the circuit is open and no probe slot is available.
+   */
+  async call<T>(fn: () => Promise<T>): Promise<T> {
+    this._maybeTransitionToHalfOpen();
+
+    if (this._state === "open") {
+      const retryAfterMs = this._retryAfterMs();
+      throw new CircuitOpen(`Circuit for tool "${this._tool}" is open after repeated failures.`, {
+        details: { tool: this._tool, retryAfterMs },
+      });
+    }
+
+    if (this._state === "half_open") {
+      if (this._probeInFlight) {
+        // Only one probe at a time; other callers fast-fail.
+        throw new CircuitOpen(
+          `Circuit for tool "${this._tool}" is half-open; probe already in flight.`,
+          { details: { tool: this._tool, retryAfterMs: 0 } },
+        );
+      }
+      this._probeInFlight = true;
+    }
+
+    try {
+      const result = await fn();
+      this._onSuccess();
+      return result;
+    } catch (err) {
+      this._onFailure();
+      throw err;
+    } finally {
+      if (this._state === "half_open") {
+        this._probeInFlight = false;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — state transitions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Check whether enough time has elapsed to move from OPEN → HALF_OPEN.
+   * Called lazily before any state read or call.
+   */
+  private _maybeTransitionToHalfOpen(): void {
+    if (this._state === "open" && this._openedAt !== null) {
+      const elapsed = this._now() - this._openedAt;
+      if (elapsed >= this._openDurationMs) {
+        this._state = "half_open";
+        this._probeInFlight = false;
+        logger.info(
+          { event: "circuit.half_open", tool: this._tool, elapsed },
+          "circuit moved to half-open; probe allowed",
+        );
+      }
+    }
+  }
+
+  private _onSuccess(): void {
+    if (this._state === "half_open") {
+      this._close("probe succeeded");
+    } else {
+      // Success resets the failure window in CLOSED state.
+      this._failures = [];
+    }
+  }
+
+  private _onFailure(): void {
+    const now = this._now();
+
+    if (this._state === "half_open") {
+      // Probe failed — re-open immediately.
+      this._open(now, "probe failed");
+      return;
+    }
+
+    // Prune failures outside the rolling window.
+    this._failures = this._failures.filter((t) => now - t < this._windowMs);
+    this._failures.push(now);
+
+    if (this._failures.length >= this._failureThreshold) {
+      this._open(now, `${this._failures.length} failures within ${this._windowMs}ms`);
+    }
+  }
+
+  private _open(now: number, reason: string): void {
+    this._state = "open";
+    this._openedAt = now;
+    this._probeInFlight = false;
+    logger.warn(
+      {
+        event: "circuit.opened",
+        tool: this._tool,
+        reason,
+        openDurationMs: this._openDurationMs,
+      },
+      "circuit opened — fast-failing calls",
+    );
+  }
+
+  private _close(reason: string): void {
+    this._state = "closed";
+    this._openedAt = null;
+    this._failures = [];
+    this._probeInFlight = false;
+    logger.info(
+      { event: "circuit.closed", tool: this._tool, reason },
+      "circuit closed — resuming normal operation",
+    );
+  }
+
+  /** Remaining ms before the open circuit will half-open. */
+  private _retryAfterMs(): number {
+    if (this._openedAt === null) return this._openDurationMs;
+    const elapsed = this._now() - this._openedAt;
+    return Math.max(0, this._openDurationMs - elapsed);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CircuitBreakerRegistry
+// ---------------------------------------------------------------------------
+
+/**
+ * Registry that vends per-tool `CircuitBreaker` instances.
+ *
+ * Each tool name gets exactly one breaker (created lazily on first access).
+ * Tool handlers call `registry.get(toolName).call(() => ...)`.
+ */
+export class CircuitBreakerRegistry {
+  private readonly _breakers = new Map<string, CircuitBreaker>();
+  private readonly _defaults: CircuitBreakerOptions;
+
+  constructor(defaults: CircuitBreakerOptions = {}) {
+    this._defaults = defaults;
+  }
+
+  /**
+   * Return the breaker for `toolName`, creating one if it does not exist.
+   */
+  get(toolName: string): CircuitBreaker {
+    let breaker = this._breakers.get(toolName);
+    if (!breaker) {
+      breaker = new CircuitBreaker(toolName, this._defaults);
+      this._breakers.set(toolName, breaker);
+    }
+    return breaker;
+  }
+
+  /** Reset all breakers — useful in tests. */
+  clear(): void {
+    this._breakers.clear();
+  }
+
+  /** Number of registered breakers. */
+  get size(): number {
+    return this._breakers.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module singleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Module-level registry singleton.
+ * Tool handlers import this and call `circuitBreakerRegistry.get(toolName)`.
+ */
+export const circuitBreakerRegistry = new CircuitBreakerRegistry();


### PR DESCRIPTION
## Summary
- Adds `CircuitBreaker` + `CircuitBreakerRegistry` (`src/server/circuitBreaker.ts`)
- Full closed/open/half-open state machine: 3 failures in 60s → open; 60s later → half-open; single probe success → closed
- Concurrent callers during half-open probe fast-fail with `CircuitOpen` (only one probe slot)
- Emits `circuit.opened`, `circuit.closed`, `circuit.half_open` log events (DESIGN §21)
- Registry singleton (`circuitBreakerRegistry`) for tool handlers to import; per-tool instances created lazily
- All thresholds injectable via constructor — fake clock in tests, no `setTimeout`, deterministic

## Design link
Closes #23. See DESIGN.md §6.10.

## Breaking change?
- [x] No

## Test plan
- [x] 20 unit tests covering full state machine (initial, failure counting, window pruning, OPEN fast-fail, HALF_OPEN probe logic, registry)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (65 files, no violations)
- [x] All 332 tests passing
- [x] Self-reviewed
- [x] No new dependencies