### PR TITLE
feat(envelope): structured warnings — meta.warnings as Warning[] with stable codes

### DIFF
--- a/src/envelope/index.test.ts
+++ b/src/envelope/index.test.ts
@@ -6,10 +6,16 @@ import {
   type ToolEnvelope,
   type ToolError,
   type ToolSuccess,
+  type Warning,
   err,
   isError,
   isSuccess,
   ok,
+  warnDeprecatedField,
+  warnDryRun,
+  warnIdsNotFound,
+  warnResultTruncated,
+  warnSyncPending,
 } from "./index.js";
 
 const baseMeta: ResponseMeta = {
@@ -39,13 +45,12 @@ describe("ok()", () => {
     expect("pagination" in envelope).toBe(false);
   });
 
-  it("we propagate meta.warnings into the envelope verbatim", () => {
-    const metaWithWarnings: ResponseMeta = {
-      ...baseMeta,
-      warnings: ["rate limit approaching"],
-    };
+  it("we propagate meta.warnings (Warning[]) into the envelope verbatim", () => {
+    const warning: Warning = warnSyncPending();
+    const metaWithWarnings: ResponseMeta = { ...baseMeta, warnings: [warning] };
     const envelope = ok({ done: true }, metaWithWarnings);
-    expect(envelope.meta.warnings).toEqual(["rate limit approaching"]);
+    expect(envelope.meta.warnings).toHaveLength(1);
+    expect(envelope.meta.warnings?.[0].code).toBe("WARN_SYNC_PENDING");
   });
 });
 
@@ -138,6 +143,7 @@ describe("envelope shape — snapshot locks", () => {
           },
           "message": "Task not found",
           "name": "NotFound",
+          "remediationClass": "input",
           "suggestion": "Confirm the ID with the corresponding \`*_list\` tool. Use OmniFocus persistent IDs, not names.",
         },
         "meta": {
@@ -170,6 +176,44 @@ describe("isSuccess / isError type guards", () => {
     if (isError(envelope)) {
       expect(envelope.error.code).toBe("OF_VALIDATION");
     }
+  });
+});
+
+describe("Warning builders", () => {
+  it("warnIdsNotFound includes missing IDs in details", () => {
+    const w = warnIdsNotFound(["id1", "id2"]);
+    expect(w.code).toBe("WARN_IDS_NOT_FOUND");
+    expect(w.details?.missing).toEqual(["id1", "id2"]);
+    expect(w.suggestion).toBeDefined();
+  });
+
+  it("warnResultTruncated includes limit in details", () => {
+    const w = warnResultTruncated(500);
+    expect(w.code).toBe("WARN_RESULT_TRUNCATED");
+    expect(w.details?.limit).toBe(500);
+    expect(w.suggestion).toBeDefined();
+  });
+
+  it("warnSyncPending has no details", () => {
+    const w = warnSyncPending();
+    expect(w.code).toBe("WARN_SYNC_PENDING");
+    expect(w.details).toBeUndefined();
+    expect(w.suggestion).toBeDefined();
+  });
+
+  it("warnDeprecatedField includes field and replacement in details", () => {
+    const w = warnDeprecatedField("oldField", "newField");
+    expect(w.code).toBe("WARN_DEPRECATED_FIELD");
+    expect(w.details?.field).toBe("oldField");
+    expect(w.details?.replacement).toBe("newField");
+    expect(w.suggestion).toContain("newField");
+  });
+
+  it("warnDryRun has no details", () => {
+    const w = warnDryRun();
+    expect(w.code).toBe("WARN_DRY_RUN");
+    expect(w.details).toBeUndefined();
+    expect(w.suggestion).toBeDefined();
   });
 });
 

--- a/src/envelope/index.ts
+++ b/src/envelope/index.ts
@@ -19,6 +19,104 @@
 import type { OmniFocusError, SerializedError } from "../errors/index.js";
 
 // ---------------------------------------------------------------------------
+// Public contract — Warning
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable machine-readable warning codes. Agents switch on `code` to decide
+ * whether to act — the same pattern used for error `remediationClass`.
+ *
+ * **Additive only.** New codes are minor-version additions; removing a code
+ * is a breaking change per ADR-0011.
+ *
+ * | Code                   | Emitted when                                         | `details` shape                   |
+ * |------------------------|------------------------------------------------------|-----------------------------------|
+ * | `WARN_IDS_NOT_FOUND`   | Bulk request had unmatched IDs                       | `{ missing: string[] }`           |
+ * | `WARN_RESULT_TRUNCATED`| Response hit a hard size/count ceiling               | `{ limit: number }`               |
+ * | `WARN_SYNC_PENDING`    | Mutation saved locally; OF hasn't synced             | —                                 |
+ * | `WARN_DEPRECATED_FIELD`| Caller used a deprecated input field                 | `{ field: string, replacement: string }` |
+ * | `WARN_DRY_RUN`         | Response is hypothetical; no write occurred          | —                                 |
+ */
+export type WarningCode =
+  | "WARN_IDS_NOT_FOUND"
+  | "WARN_RESULT_TRUNCATED"
+  | "WARN_SYNC_PENDING"
+  | "WARN_DEPRECATED_FIELD"
+  | "WARN_DRY_RUN";
+
+/**
+ * Structured non-fatal issue that the agent should see inline.
+ *
+ * Replaces the previous `string[]` shape so agents can act programmatically
+ * on warnings rather than parsing English. Mirrors the error hierarchy
+ * convention: stable `code`, optional `suggestion`, optional `details`.
+ *
+ * @see DESIGN.md §34 — agent ergonomics
+ */
+export interface Warning {
+  /** Stable machine-readable code — agents switch on this. */
+  code: WarningCode;
+  /** English description of the condition. */
+  message: string;
+  /** Recommended agent action — same convention as `error.suggestion`. */
+  suggestion?: string;
+  /** Per-code structured payload (e.g. `{ missing: string[] }` for WARN_IDS_NOT_FOUND). */
+  details?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Warning builder helpers
+// ---------------------------------------------------------------------------
+
+/** Build a `WARN_IDS_NOT_FOUND` warning for bulk-fetch tools. */
+export function warnIdsNotFound(missing: string[]): Warning {
+  return {
+    code: "WARN_IDS_NOT_FOUND",
+    message: `${missing.length} requested ID(s) were not found and have been omitted.`,
+    suggestion: "Verify the IDs are correct and that the items have not been deleted.",
+    details: { missing },
+  };
+}
+
+/** Build a `WARN_RESULT_TRUNCATED` warning when a hard ceiling is hit. */
+export function warnResultTruncated(limit: number): Warning {
+  return {
+    code: "WARN_RESULT_TRUNCATED",
+    message: `Results were truncated at the hard ceiling of ${limit} items.`,
+    suggestion: "Use cursor pagination or add filters to narrow the result set.",
+    details: { limit },
+  };
+}
+
+/** Build a `WARN_SYNC_PENDING` warning on mutation responses. */
+export function warnSyncPending(): Warning {
+  return {
+    code: "WARN_SYNC_PENDING",
+    message: "Changes have been saved locally but OmniFocus has not yet synced to Omni Sync.",
+    suggestion: "Call sync_trigger if you need to confirm propagation to other devices.",
+  };
+}
+
+/** Build a `WARN_DEPRECATED_FIELD` warning when a deprecated field is detected. */
+export function warnDeprecatedField(field: string, replacement: string): Warning {
+  return {
+    code: "WARN_DEPRECATED_FIELD",
+    message: `Input field "${field}" is deprecated and will be removed in a future version.`,
+    suggestion: `Use "${replacement}" instead.`,
+    details: { field, replacement },
+  };
+}
+
+/** Build a `WARN_DRY_RUN` warning on hypothetical responses. */
+export function warnDryRun(): Warning {
+  return {
+    code: "WARN_DRY_RUN",
+    message: "This response is hypothetical — no write was performed (dry_run: true).",
+    suggestion: "Remove dry_run or set it to false to commit the change.",
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Public contract — envelope types
 // ---------------------------------------------------------------------------
 
@@ -47,8 +145,11 @@ export interface ResponseMeta {
    * `sync_trigger` rather than relying on documentation alone.
    */
   syncPending?: boolean;
-  /** Non-fatal issues the agent should see inline (e.g. zod refinement warnings). */
-  warnings?: string[];
+  /**
+   * Structured non-fatal issues the agent should see inline.
+   * Each entry has a stable `code` agents can switch on — see `Warning`.
+   */
+  warnings?: Warning[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace `meta.warnings?: string[]` with `meta.warnings?: Warning[]` — a typed interface with a stable `WarningCode` that agents can switch on
- Add five builder helpers: `warnIdsNotFound`, `warnResultTruncated`, `warnSyncPending`, `warnDeprecatedField`, `warnDryRun`
- Extend test coverage: 5 new Warning-builder tests + updated existing string-based test

## Design link
Closes #147. See `docs/adr/0013-tool-response-envelope.md` for the envelope contract.

## Breaking change?
- [x] Yes — `meta.warnings` type changes from `string[]` to `Warning[]`. No callers exist yet (service layer is pre-M1), so the blast radius is zero.

## Test plan
- [x] 18 envelope tests pass (all green)
- [x] Full 366-test suite passes
- [x] `pnpm lint` — no violations
- [x] Self-reviewed