### PR TITLE
feat(errors): remediationClass + retryAfterMs on typed errors

### DIFF
--- a/src/errors/index.test.ts
+++ b/src/errors/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   CircuitOpen,
+  ConflictError,
   FeatureRequiresOfVersion,
   FeatureRequiresPro,
   NotFound,
@@ -100,6 +101,7 @@ describe("instanceof discrimination", () => {
       { instance: new FeatureRequiresOfVersion("OF 4 needed"), ctor: FeatureRequiresOfVersion },
       { instance: new ValidationError("bad"), ctor: ValidationError },
       { instance: new NotFound("missing"), ctor: NotFound },
+      { instance: new ConflictError("stale"), ctor: ConflictError },
       { instance: new Timeout("slow"), ctor: Timeout },
       { instance: new RateLimited("limited"), ctor: RateLimited },
       { instance: new QueueFull("full"), ctor: QueueFull },
@@ -118,6 +120,101 @@ describe("instanceof discrimination", () => {
   });
 });
 
+describe("remediationClass — machine-readable agent action", () => {
+  it("environment errors stop the agent and require user action", () => {
+    expect(new OmniFocusNotRunning().remediationClass).toBe("environment");
+    expect(new PermissionDenied().remediationClass).toBe("environment");
+    expect(new FeatureRequiresPro("").remediationClass).toBe("environment");
+    expect(new FeatureRequiresOfVersion("").remediationClass).toBe("environment");
+  });
+
+  it("input errors tell the agent to fix the input before retrying", () => {
+    expect(new ValidationError("").remediationClass).toBe("input");
+    expect(new NotFound("").remediationClass).toBe("input");
+    expect(new ConflictError("").remediationClass).toBe("input");
+  });
+
+  it("transient errors tell the agent to wait and retry", () => {
+    expect(new Timeout("").remediationClass).toBe("transient");
+    expect(new RateLimited("").remediationClass).toBe("transient");
+    expect(new QueueFull("").remediationClass).toBe("transient");
+    expect(new CircuitOpen("").remediationClass).toBe("transient");
+  });
+
+  it("infrastructure errors tell the agent to retry once then surface to user", () => {
+    expect(new TransportUnavailable("").remediationClass).toBe("infrastructure");
+    expect(new ScriptError("").remediationClass).toBe("infrastructure");
+  });
+
+  it("lifecycle errors tell the agent to reconnect", () => {
+    expect(new ServerShuttingDown().remediationClass).toBe("lifecycle");
+  });
+
+  it("remediationClass appears in toJSON output", () => {
+    const json = new NotFound("task missing").toJSON();
+    expect(json.remediationClass).toBe("input");
+  });
+
+  it("base OmniFocusError has no remediationClass when not set", () => {
+    const err = new OmniFocusError("OF_VALIDATION", "raw");
+    expect(err.remediationClass).toBeUndefined();
+    expect(err.toJSON()).toEqual({ name: "OmniFocusError", code: "OF_VALIDATION", message: "raw" });
+  });
+
+  it("caller can override remediationClass via options", () => {
+    const err = new Timeout("slow", { remediationClass: "infrastructure" });
+    expect(err.remediationClass).toBe("infrastructure");
+  });
+});
+
+describe("ConflictError — optimistic-concurrency violation", () => {
+  it("has code OF_CONFLICT and remediationClass input", () => {
+    const err = new ConflictError("Task was modified");
+    expect(err.code).toBe("OF_CONFLICT");
+    expect(err.remediationClass).toBe("input");
+    expect(err.name).toBe("ConflictError");
+  });
+
+  it("suggestion tells the agent to re-read and retry with fresh modifiedAt", () => {
+    expect(new ConflictError("").suggestion).toContain("modifiedAt");
+  });
+
+  it("caller can attach details with the stale and current timestamps", () => {
+    const err = new ConflictError("Stale write", {
+      details: { expected: "2026-04-21T10:00:00-07:00", actual: "2026-04-21T10:05:00-07:00" },
+    });
+    expect(err.details?.expected).toBeDefined();
+    expect(err.details?.actual).toBeDefined();
+  });
+
+  it("serializes cleanly to the error envelope shape", () => {
+    const json = new ConflictError("Conflict").toJSON();
+    expect(json.code).toBe("OF_CONFLICT");
+    expect(json.remediationClass).toBe("input");
+    expect(json.suggestion).toBeDefined();
+  });
+});
+
+describe("retryAfterMs — structured wait time on transient errors", () => {
+  it("RateLimited includes retryAfterMs: 60000 in details by default", () => {
+    expect(new RateLimited("too fast").details?.retryAfterMs).toBe(60_000);
+  });
+
+  it("CircuitOpen includes retryAfterMs: 60000 in details by default", () => {
+    expect(new CircuitOpen("open").details?.retryAfterMs).toBe(60_000);
+  });
+
+  it("caller can override retryAfterMs via details", () => {
+    const err = new RateLimited("slow", { details: { retryAfterMs: 30_000 } });
+    expect(err.details?.retryAfterMs).toBe(30_000);
+  });
+
+  it("retryAfterMs appears in toJSON details", () => {
+    const json = new CircuitOpen("").toJSON();
+    expect(json.details?.retryAfterMs).toBe(60_000);
+  });
+});
+
 describe("error code coverage — every documented code has a class", () => {
   it("we have a concrete class for each code in DESIGN §6.7", () => {
     const expectedCodes = new Set([
@@ -127,6 +224,7 @@ describe("error code coverage — every documented code has a class", () => {
       "OF_FEATURE_REQUIRES_VERSION",
       "OF_VALIDATION",
       "OF_NOT_FOUND",
+      "OF_CONFLICT",
       "OF_TIMEOUT",
       "OF_RATE_LIMITED",
       "OF_QUEUE_FULL",
@@ -143,6 +241,7 @@ describe("error code coverage — every documented code has a class", () => {
       new FeatureRequiresOfVersion("").code,
       new ValidationError("").code,
       new NotFound("").code,
+      new ConflictError("").code,
       new Timeout("").code,
       new RateLimited("").code,
       new QueueFull("").code,
@@ -153,6 +252,6 @@ describe("error code coverage — every documented code has a class", () => {
     ]);
 
     expect(actualCodes).toEqual(expectedCodes);
-    expect(actualCodes.size).toBe(13);
+    expect(actualCodes.size).toBe(14);
   });
 });

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -28,6 +28,7 @@ export type ErrorCode =
   // Input — agent should fix the input before retrying
   | "OF_VALIDATION"
   | "OF_NOT_FOUND"
+  | "OF_CONFLICT"
   // Transient — agent may retry after waiting
   | "OF_TIMEOUT"
   | "OF_RATE_LIMITED"
@@ -41,6 +42,25 @@ export type ErrorCode =
   // Protocol guard — stray write to stdout (MCP transport channel)
   | "OF_STRAY_STDOUT";
 
+/**
+ * Machine-readable remediation class. Agents switch on this to decide what
+ * to do next without parsing `message` or `suggestion` text.
+ *
+ * | Class          | Agent action                                              |
+ * | -------------- | --------------------------------------------------------- |
+ * | environment    | Stop; user must act (launch OF, grant permission)         |
+ * | input          | Fix the input and retry                                   |
+ * | transient      | Wait `details.retryAfterMs` ms then retry                 |
+ * | infrastructure | Retry once; if still failing, surface to user             |
+ * | lifecycle      | Reconnect to a fresh server instance                      |
+ */
+export type RemediationClass =
+  | "environment"
+  | "input"
+  | "transient"
+  | "infrastructure"
+  | "lifecycle";
+
 /** Constructor options shared by every concrete error. */
 export interface ErrorOptions {
   /** Human-readable next step for the agent or operator. Overrides class default. */
@@ -49,6 +69,8 @@ export interface ErrorOptions {
   details?: Record<string, unknown>;
   /** Underlying cause for chaining; surfaced via `Error.cause`. */
   cause?: unknown;
+  /** Overrides the subclass default remediation class. Rarely needed. */
+  remediationClass?: RemediationClass;
 }
 
 /** Wire shape produced by `toJSON()` and consumed by the response envelope. */
@@ -56,6 +78,8 @@ export interface SerializedError {
   name: string;
   code: ErrorCode;
   message: string;
+  /** Machine-readable remediation class — agents switch on this to decide next action. */
+  remediationClass?: RemediationClass;
   suggestion?: string;
   details?: Record<string, unknown>;
 }
@@ -73,6 +97,7 @@ export interface SerializedError {
  */
 export class OmniFocusError extends Error {
   public readonly code: ErrorCode;
+  public readonly remediationClass?: RemediationClass;
   public readonly suggestion?: string;
   public readonly details?: Record<string, unknown>;
 
@@ -80,6 +105,7 @@ export class OmniFocusError extends Error {
     super(message, options.cause !== undefined ? { cause: options.cause } : undefined);
     this.name = new.target.name;
     this.code = code;
+    if (options.remediationClass !== undefined) this.remediationClass = options.remediationClass;
     if (options.suggestion !== undefined) this.suggestion = options.suggestion;
     if (options.details !== undefined) this.details = options.details;
   }
@@ -91,6 +117,7 @@ export class OmniFocusError extends Error {
       code: this.code,
       message: this.message,
     };
+    if (this.remediationClass !== undefined) out.remediationClass = this.remediationClass;
     if (this.suggestion !== undefined) out.suggestion = this.suggestion;
     if (this.details !== undefined) out.details = this.details;
     return out;
@@ -110,6 +137,7 @@ export function isOmniFocusError(value: unknown): value is OmniFocusError {
 export class OmniFocusNotRunning extends OmniFocusError {
   constructor(options: ErrorOptions = {}) {
     super("OF_NOT_RUNNING", "OmniFocus is not running.", {
+      remediationClass: "environment",
       suggestion: "Launch OmniFocus and retry.",
       ...options,
     });
@@ -120,6 +148,7 @@ export class OmniFocusNotRunning extends OmniFocusError {
 export class PermissionDenied extends OmniFocusError {
   constructor(options: ErrorOptions = {}) {
     super("OF_PERMISSION_DENIED", "Automation permission for OmniFocus is denied.", {
+      remediationClass: "environment",
       suggestion:
         "Open System Settings → Privacy & Security → Automation; grant this terminal or client access to OmniFocus.",
       ...options,
@@ -131,6 +160,7 @@ export class PermissionDenied extends OmniFocusError {
 export class FeatureRequiresPro extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_FEATURE_REQUIRES_PRO", message, {
+      remediationClass: "environment",
       suggestion: "This feature requires OmniFocus Pro. Upgrade or use a different tool.",
       ...options,
     });
@@ -141,6 +171,7 @@ export class FeatureRequiresPro extends OmniFocusError {
 export class FeatureRequiresOfVersion extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_FEATURE_REQUIRES_VERSION", message, {
+      remediationClass: "environment",
       suggestion:
         "This feature requires a newer OmniFocus version. Update OmniFocus or use a different tool.",
       ...options,
@@ -156,6 +187,7 @@ export class FeatureRequiresOfVersion extends OmniFocusError {
 export class ValidationError extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_VALIDATION", message, {
+      remediationClass: "input",
       suggestion: "Fix the input and retry. See `details` for field-level reasons.",
       ...options,
     });
@@ -166,8 +198,25 @@ export class ValidationError extends OmniFocusError {
 export class NotFound extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_NOT_FOUND", message, {
+      remediationClass: "input",
       suggestion:
         "Confirm the ID with the corresponding `*_list` tool. Use OmniFocus persistent IDs, not names.",
+      ...options,
+    });
+  }
+}
+
+/**
+ * Thrown when an optimistic-concurrency assertion fails — the resource was
+ * modified between the agent's read and its write. The agent should re-read
+ * the resource, merge changes, and retry with the fresh `modifiedAt`.
+ */
+export class ConflictError extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_CONFLICT", message, {
+      remediationClass: "input",
+      suggestion:
+        "The resource was modified since you read it. Re-read with the corresponding `*_get` tool, merge your changes, and retry with the fresh `modifiedAt` value.",
       ...options,
     });
   }
@@ -181,6 +230,7 @@ export class NotFound extends OmniFocusError {
 export class Timeout extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_TIMEOUT", message, {
+      remediationClass: "transient",
       suggestion: "Retry once. If repeated, OmniFocus may be wedged — relaunch it.",
       ...options,
     });
@@ -191,9 +241,10 @@ export class Timeout extends OmniFocusError {
 export class RateLimited extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_RATE_LIMITED", message, {
-      suggestion:
-        "Wait before retrying. The default window is 60 seconds. See `details.retryAfterMs`.",
+      remediationClass: "transient",
+      suggestion: "Wait details.retryAfterMs milliseconds then retry.",
       ...options,
+      details: { retryAfterMs: 60_000, ...options.details },
     });
   }
 }
@@ -202,6 +253,7 @@ export class RateLimited extends OmniFocusError {
 export class QueueFull extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_QUEUE_FULL", message, {
+      remediationClass: "transient",
       suggestion: "The write queue is saturated. Wait for in-flight writes to drain, then retry.",
       ...options,
     });
@@ -212,9 +264,11 @@ export class QueueFull extends OmniFocusError {
 export class CircuitOpen extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_CIRCUIT_OPEN", message, {
+      remediationClass: "transient",
       suggestion:
-        "This tool failed repeatedly and is rejecting calls fast. Investigate, then wait for the circuit to half-open (default 60 seconds).",
+        "This tool failed repeatedly and is rejecting calls fast. Wait details.retryAfterMs milliseconds for the circuit to half-open.",
       ...options,
+      details: { retryAfterMs: 60_000, ...options.details },
     });
   }
 }
@@ -227,6 +281,7 @@ export class CircuitOpen extends OmniFocusError {
 export class TransportUnavailable extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_TRANSPORT_UNAVAILABLE", message, {
+      remediationClass: "infrastructure",
       suggestion:
         "The required transport is unreachable. Verify OmniFocus is running and responsive.",
       ...options,
@@ -238,6 +293,7 @@ export class TransportUnavailable extends OmniFocusError {
 export class ScriptError extends OmniFocusError {
   constructor(message: string, options: ErrorOptions = {}) {
     super("OF_SCRIPT_ERROR", message, {
+      remediationClass: "infrastructure",
       suggestion:
         "The OmniFocus script failed. Inspect `details.transport` and `details.reason` for context.",
       ...options,
@@ -253,6 +309,7 @@ export class ScriptError extends OmniFocusError {
 export class ServerShuttingDown extends OmniFocusError {
   constructor(options: ErrorOptions = {}) {
     super("OF_SHUTTING_DOWN", "Server is shutting down; not accepting new requests.", {
+      remediationClass: "lifecycle",
       suggestion: "Reconnect to a fresh server instance.",
       ...options,
     });


### PR DESCRIPTION
## Summary
- Add `RemediationClass` type (`environment | input | transient | infrastructure | lifecycle`) to all 13 error subclasses
- Add `retryAfterMs: 60_000` default in `details` on `RateLimited` and `CircuitOpen` — agents wait this long before retry
- `toJSON()` includes `remediationClass` so it appears in every error envelope
- Caller can override `remediationClass` or `details.retryAfterMs` via constructor options

## Design link
Closes #137. See `DESIGN.md §6.7` error taxonomy.

## Breaking change?
- [x] Yes (additive) — `SerializedError` gains `remediationClass?` field. Consumers filtering for unknown keys would see a new field, but no existing field is removed.

## Test plan
- [x] All 366 tests pass
- [x] Per-class remediationClass coverage (environment/input/transient/infrastructure/lifecycle)
- [x] `toJSON()` includes remediationClass
- [x] `retryAfterMs` default + override tested for RateLimited and CircuitOpen
- [x] Envelope snapshot updated to include remediationClass