### PR TITLE
docs(clients): client config snippets for Claude Desktop, Claude Code, and generic stdio

### DIFF
--- a/docs/clients/claude-code.md
+++ b/docs/clients/claude-code.md
@@ -1,0 +1,127 @@
+# Claude Code — omnifocus-mcp setup
+
+Adds omnifocus-mcp as a local MCP server in Claude Code (the CLI).
+
+## Prerequisites
+
+- macOS 13 (Ventura) or later
+- OmniFocus 3.15+ or OmniFocus 4.x
+- Node.js 20 LTS or 22 LTS (`node --version`)
+- Claude Code installed (`claude --version`)
+
+## One-time install
+
+```bash
+npm install -g @torsday/omnifocus-mcp
+```
+
+Verify the binary is available:
+
+```bash
+omnifocus-mcp --version
+```
+
+## Register the server
+
+Run once to add the server to Claude Code's MCP configuration:
+
+```bash
+claude mcp add omnifocus omnifocus-mcp
+```
+
+To verify it was registered:
+
+```bash
+claude mcp list
+```
+
+You should see `omnifocus` in the output.
+
+## Start a session
+
+```bash
+claude
+```
+
+The `omnifocus` server starts automatically. In the session, type:
+
+> Use the internal_status tool and tell me what it returns.
+
+A healthy response looks like:
+
+```json
+{
+  "data": {
+    "status": "ok",
+    "ofVersion": "4.5.2",
+    "transport": "jxa"
+  },
+  "meta": { ... }
+}
+```
+
+## macOS Automation permission
+
+The first `osascript` call triggers a macOS Automation permission prompt:
+
+> **"Terminal" would like to control "OmniFocus"**
+
+Click **OK**. If you accidentally denied it, re-grant it in:
+
+**System Settings → Privacy & Security → Automation → Terminal → OmniFocus** ✓
+
+## Optional environment variables
+
+Pass environment variables with `-e` flags:
+
+```bash
+claude mcp add omnifocus omnifocus-mcp \
+  -e OMNIFOCUS_LOG_LEVEL=debug \
+  -e OMNIFOCUS_CACHE_TTL_MS=60000
+```
+
+Or edit the generated config (`~/.claude.json` or project `.claude/mcp.json`) directly:
+
+```json
+{
+  "mcpServers": {
+    "omnifocus": {
+      "command": "omnifocus-mcp",
+      "args": [],
+      "env": {
+        "OMNIFOCUS_LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OMNIFOCUS_LOG_LEVEL` | `info` | Log verbosity: `trace` / `debug` / `info` / `warn` / `error` |
+| `OMNIFOCUS_CACHE_TTL_MS` | `30000` | Read-cache TTL in milliseconds |
+| `OMNIFOCUS_READ_GRACE_MS` | `5000` | Grace window for in-flight reads on shutdown |
+| `OMNIFOCUS_WRITE_GRACE_MS` | `10000` | Grace window for in-flight writes on shutdown |
+| `OMNIFOCUS_ALLOW_RAW_SCRIPT` | — | Set to `1` to enable `run_jxa_script` / `run_omnijs_script` escape hatches |
+
+## Remove the server
+
+```bash
+claude mcp remove omnifocus
+```
+
+## Troubleshooting
+
+**`OF_NOT_RUNNING` error**
+- Launch OmniFocus before starting a session that uses the server.
+
+**`OF_PERMISSION_DENIED` error**
+- Re-grant the Automation permission (see above).
+
+**Check server status inside a session**
+
+```
+/mcp
+```
+
+Claude Code shows all registered MCP servers and their connection state.

--- a/docs/clients/claude-desktop.md
+++ b/docs/clients/claude-desktop.md
@@ -1,0 +1,99 @@
+# Claude Desktop — omnifocus-mcp setup
+
+Adds omnifocus-mcp as a local MCP server in Claude Desktop.
+
+## Prerequisites
+
+- macOS 13 (Ventura) or later
+- OmniFocus 3.15+ or OmniFocus 4.x
+- Node.js 20 LTS or 22 LTS (`node --version`)
+- Claude Desktop (latest)
+
+## One-time install
+
+```bash
+npm install -g @torsday/omnifocus-mcp
+```
+
+Verify the binary is available:
+
+```bash
+omnifocus-mcp --version
+```
+
+## Configuration
+
+Open (or create) `~/Library/Application Support/Claude/claude_desktop_config.json` and add the `omnifocus-mcp` entry to `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "omnifocus": {
+      "command": "omnifocus-mcp",
+      "args": [],
+      "env": {
+        "OMNIFOCUS_LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+If Claude Desktop is already running, **quit and relaunch** it. The server starts automatically when Claude opens.
+
+## Verify it works
+
+In a new Claude conversation, type:
+
+> Use the internal_status tool and tell me what it returns.
+
+A healthy response looks like:
+
+```json
+{
+  "data": {
+    "status": "ok",
+    "ofVersion": "4.5.2",
+    "transport": "jxa"
+  },
+  "meta": { ... }
+}
+```
+
+## macOS Automation permission
+
+The first `osascript` call triggers a macOS Automation permission prompt:
+
+> **"Terminal" would like to control "OmniFocus"**
+
+Click **OK**. If you accidentally denied it, re-grant it in:
+
+**System Settings → Privacy & Security → Automation → Terminal → OmniFocus** ✓
+
+## Optional environment variables
+
+Add any of these to the `env` block in `claude_desktop_config.json`:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OMNIFOCUS_LOG_LEVEL` | `info` | Log verbosity: `trace` / `debug` / `info` / `warn` / `error` |
+| `OMNIFOCUS_CACHE_TTL_MS` | `30000` | Read-cache TTL in milliseconds |
+| `OMNIFOCUS_READ_GRACE_MS` | `5000` | Grace window for in-flight reads on shutdown |
+| `OMNIFOCUS_WRITE_GRACE_MS` | `10000` | Grace window for in-flight writes on shutdown |
+| `OMNIFOCUS_ALLOW_RAW_SCRIPT` | — | Set to `1` to enable `run_jxa_script` / `run_omnijs_script` escape hatches |
+
+## Troubleshooting
+
+**Claude says the tool isn't available**
+- Confirm the server appears under `Settings → Developer → MCP Servers` in Claude Desktop.
+- Quit and relaunch Claude Desktop after any config change.
+
+**`OF_NOT_RUNNING` error**
+- Launch OmniFocus before starting a conversation that uses the server.
+
+**`OF_PERMISSION_DENIED` error**
+- Re-grant the Automation permission (see above).
+
+**Logs**
+- Claude Desktop logs: `~/Library/Logs/Claude/`
+- Server stderr (if configured): watch with `tail -f ~/Library/Logs/Claude/mcp-server-omnifocus.log`

--- a/docs/clients/generic-stdio.md
+++ b/docs/clients/generic-stdio.md
@@ -1,0 +1,120 @@
+# Generic stdio client — omnifocus-mcp setup
+
+Connects any MCP-compatible client that speaks the stdio transport to omnifocus-mcp.
+
+## Prerequisites
+
+- macOS 13 (Ventura) or later
+- OmniFocus 3.15+ or OmniFocus 4.x
+- Node.js 20 LTS or 22 LTS (`node --version`)
+
+## Install
+
+```bash
+npm install -g @torsday/omnifocus-mcp
+```
+
+Verify:
+
+```bash
+omnifocus-mcp --version
+```
+
+## How stdio transport works
+
+`omnifocus-mcp` speaks the [Model Context Protocol](https://modelcontextprotocol.io) over **stdio**:
+
+- **stdin** — receives JSON-RPC requests from the client
+- **stdout** — emits JSON-RPC responses back to the client
+- **stderr** — server logs only; never written to stdout
+
+The client spawns the process and pipes its stdio. No network port is opened.
+
+> ⚠️ Never attach anything to stdout of this process other than the MCP client. Any stray byte on stdout corrupts the protocol framing and causes `OF_STRAY_STDOUT` errors.
+
+## Connection string / spawn config
+
+Most MCP clients accept a command + args pair. Use:
+
+| Field | Value |
+|---|---|
+| command | `omnifocus-mcp` |
+| args | `[]` (none required) |
+| transport | `stdio` |
+
+### JSON form (used by most clients)
+
+```json
+{
+  "command": "omnifocus-mcp",
+  "args": [],
+  "env": {
+    "OMNIFOCUS_LOG_LEVEL": "info"
+  }
+}
+```
+
+### Shell invocation (for testing / scripting)
+
+```bash
+omnifocus-mcp
+```
+
+Pipe requests on stdin, read responses on stdout. The server runs until stdin closes or it receives SIGTERM/SIGINT.
+
+## Sending a request by hand
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.0.1"}}}' | omnifocus-mcp
+```
+
+The server responds with its capabilities, then waits for more requests.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OMNIFOCUS_LOG_LEVEL` | `info` | Log verbosity: `trace` / `debug` / `info` / `warn` / `error` (written to stderr) |
+| `OMNIFOCUS_CACHE_TTL_MS` | `30000` | Read-cache TTL in milliseconds |
+| `OMNIFOCUS_READ_GRACE_MS` | `5000` | Grace window for in-flight reads on SIGTERM/SIGINT |
+| `OMNIFOCUS_WRITE_GRACE_MS` | `10000` | Grace window for in-flight writes on SIGTERM/SIGINT |
+| `OMNIFOCUS_ALLOW_RAW_SCRIPT` | — | Set to `1` to enable `run_jxa_script` / `run_omnijs_script` escape hatches |
+
+## macOS Automation permission
+
+The first `osascript` call triggers a macOS Automation permission prompt from the terminal or client app that spawned the process:
+
+> **"[App]" would like to control "OmniFocus"**
+
+Click **OK**. If denied, re-grant in:
+
+**System Settings → Privacy & Security → Automation → [App] → OmniFocus** ✓
+
+The error when permission is missing is `OF_PERMISSION_DENIED` with `remediationClass: "environment"`.
+
+## Graceful shutdown
+
+Send **SIGTERM** or **SIGINT** to the process. It will:
+
+1. Stop accepting new tool calls (`OF_SHUTTING_DOWN` for any new requests)
+2. Drain in-flight reads (up to `OMNIFOCUS_READ_GRACE_MS`)
+3. Drain in-flight writes (up to `OMNIFOCUS_WRITE_GRACE_MS`)
+4. Flush logs and exit 0
+
+## Verifying connectivity
+
+After connection, call `tools/list` — you should see 60+ tools. Then call `internal_status`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "internal_status",
+    "arguments": {}
+  }
+}
+```
+
+A healthy response includes `"status": "ok"` and the OmniFocus version in `data.ofVersion`.


### PR DESCRIPTION
## Summary
- `docs/clients/claude-desktop.md` — `mcpServers` JSON snippet, env vars table, macOS permission walkthrough, troubleshooting
- `docs/clients/claude-code.md` — `claude mcp add` command, env vars, `/mcp` verification, removal
- `docs/clients/generic-stdio.md` — spawn config JSON, manual hand-testing, graceful shutdown, Automation permission

## Design link
Closes #86.

## Breaking change?
- [x] No — docs only, no code changes

## Test plan
- [x] 366 tests still pass
- [x] `pnpm lint` clean
- [x] Docs manually reviewed for accuracy against package.json (`name`, `bin`) and current env var list