### PR TITLE
feat(tag): add tag CRUD + set_status + set_allows_next_action tools

### DIFF
--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -1,21 +1,31 @@
 /**
- * `TagService` — service-layer surface for tag queries.
+ * `TagService` — service-layer surface for tag queries and mutations.
  *
- * Wraps the `OmniFocusAdapter` with a thin cache layer (ADR-0006) and
- * exposes `list()` and `get()` for the `tag_list` and `tag_get` MCP tools.
+ * Wraps `OmniFocusAdapter` and exposes read (`list`, `get`) and write
+ * (`create`, `update`, `delete`, `move`, `setStatus`, `setAllowsNextAction`)
+ * operations for the MCP tool layer.
  *
  * Design notes:
- * - `list()` delegates directly to `adapter.listTags()` — the adapter already
- *   supports `parentId` and `status` filters, so no post-filtering is needed.
- * - `get()` raises `NotFound` (via the adapter) when the id is unknown.
- * - Cache keys: `tags:list:<parentId|'all'>:<status|'all'>` and `tag:<id>`.
- *   Any tag mutation should invalidate these; that work lands in #50 (CRUD).
+ * - All reads delegate directly to the adapter — tag sets are small enough
+ *   that unbounded listing is safe (no pagination required).
+ * - Mutations delegate to `adapter.createTag / updateTag / deleteTag`.
+ *   `move`, `setStatus`, and `setAllowsNextAction` are thin specialisations of
+ *   `updateTag` exposed as separate tools to give agents atomic, composable
+ *   operations (DESIGN agent_systems §atomic).
+ * - Cache invalidation: TagService does not yet wire an LRU cache (that
+ *   integration lands with the full service-layer cache pass in #36). Any
+ *   future cache layer must be invalidated on every write method here.
  *
  * @see DESIGN.md §26 — reference implementation
  * @see docs/domain-reference.md — Tag schema
+ * @see src/adapter/OmniFocusAdapter.ts — CreateTagInput / UpdateTagInput
  */
 
-import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import type {
+  CreateTagInput,
+  OmniFocusAdapter,
+  UpdateTagInput,
+} from "../adapter/OmniFocusAdapter.js";
 import type { TagId } from "../domain/ids.js";
 import type { Tag } from "../domain/tag.js";
 
@@ -23,10 +33,9 @@ import type { Tag } from "../domain/tag.js";
 // Public shapes
 // ---------------------------------------------------------------------------
 
-/** Input to {@link TagService.list}. All fields are optional — the full tag
- *  set is small enough that an unfiltered list is always safe. */
+/** Input to {@link TagService.list}. All fields optional. */
 export interface TagListInput {
-  /** Restrict to direct children of this parent tag. Omit for all root tags. */
+  /** Restrict to direct children of this parent tag. Omit for root tags. */
   parentId?: TagId;
   /** Filter by status. Omit for all statuses. */
   status?: Tag["status"];
@@ -35,31 +44,34 @@ export interface TagListInput {
 /** Result of {@link TagService.list}. */
 export interface TagListResult {
   tags: Tag[];
-  /** True if this response came from cache. */
   cacheHit: boolean;
 }
 
 /** Result of {@link TagService.get}. */
 export interface TagGetResult {
   tag: Tag;
-  /** True if this response came from cache. */
   cacheHit: boolean;
+}
+
+/** Result of write operations that return an ID. */
+export interface TagCreateResult {
+  id: TagId;
 }
 
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
-/** Dependencies the service needs — injected at construction time. */
+/** Dependencies injected at construction time. */
 export interface TagServiceDeps {
   adapter: OmniFocusAdapter;
 }
 
 /**
- * Service layer for tag read operations.
+ * Service layer for tag read and write operations.
  *
- * Construct with `{ adapter }`. All methods are async and pure — they have
- * no side effects beyond populating / reading the adapter's data.
+ * Construct with `{ adapter }`. All methods are async and
+ * free of hidden state — side effects are limited to the adapter.
  */
 export class TagService {
   private readonly adapter: OmniFocusAdapter;
@@ -67,6 +79,10 @@ export class TagService {
   constructor({ adapter }: TagServiceDeps) {
     this.adapter = adapter;
   }
+
+  // --------------------------------------------------------------------------
+  // Reads
+  // --------------------------------------------------------------------------
 
   /**
    * List tags, optionally filtered by parent or status.
@@ -92,5 +108,80 @@ export class TagService {
   async get(id: TagId): Promise<TagGetResult> {
     const tag = await this.adapter.getTag(id);
     return { tag, cacheHit: false };
+  }
+
+  // --------------------------------------------------------------------------
+  // Writes
+  // --------------------------------------------------------------------------
+
+  /**
+   * Create a new tag.
+   *
+   * @param input — name (required), optional parentId, status, allowsNextAction
+   * @returns Branded ID of the newly created tag.
+   * @throws {ValidationError} when name is empty.
+   * @throws {NotFound} when parentId references a non-existent tag.
+   */
+  async create(input: CreateTagInput): Promise<TagCreateResult> {
+    const id = await this.adapter.createTag(input);
+    return { id };
+  }
+
+  /**
+   * Update mutable fields on an existing tag (partial patch).
+   *
+   * @param id — tag to update
+   * @param patch — fields to change (omit to leave unchanged)
+   * @throws {NotFound} when no tag with `id` exists.
+   * @throws {ValidationError} when `name` is present but empty.
+   */
+  async update(id: TagId, patch: UpdateTagInput): Promise<void> {
+    await this.adapter.updateTag(id, patch);
+  }
+
+  /**
+   * Hard-delete a tag.  Irreversible.
+   *
+   * @param id — tag to delete
+   * @throws {NotFound} when no tag with `id` exists.
+   */
+  async delete(id: TagId): Promise<void> {
+    await this.adapter.deleteTag(id);
+  }
+
+  /**
+   * Move a tag to a new parent (or promote it to root by passing `null`).
+   *
+   * Implemented as `updateTag(id, { parentId })` — a distinct tool
+   * is exposed so agents have an atomic, intention-clear operation.
+   *
+   * @param id — tag to move
+   * @param parentId — new parent tag ID, or `null` to promote to root
+   * @throws {NotFound} when `id` or the new `parentId` doesn't exist.
+   */
+  async move(id: TagId, parentId: TagId | null): Promise<void> {
+    await this.adapter.updateTag(id, { parentId });
+  }
+
+  /**
+   * Set the lifecycle status of a tag (active / on-hold / dropped).
+   *
+   * @param id — tag to update
+   * @param status — new status value
+   * @throws {NotFound} when no tag with `id` exists.
+   */
+  async setStatus(id: TagId, status: Tag["status"]): Promise<void> {
+    await this.adapter.updateTag(id, { status });
+  }
+
+  /**
+   * Toggle whether the tag allows next-action selection in OmniFocus.
+   *
+   * @param id — tag to update
+   * @param value — true to enable, false to disable
+   * @throws {NotFound} when no tag with `id` exists.
+   */
+  async setAllowsNextAction(id: TagId, value: boolean): Promise<void> {
+    await this.adapter.updateTag(id, { allowsNextAction: value });
   }
 }

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -1,0 +1,68 @@
+/**
+ * `tag_create` MCP tool — create a new tag in OmniFocus.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_CREATE_DESCRIPTION =
+  "Create a new tag in OmniFocus. " +
+  "Optionally nest it under an existing parent tag (get IDs from tag_list). " +
+  "Returns the new tag's persistent ID. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const tagCreateInputSchema = z.object({
+  name: z.string().min(1).describe("Tag name. Must be non-empty."),
+  parentId: TagId.schema
+    .optional()
+    .describe("Parent tag ID to nest under. Omit for a root tag. Get from tag_list."),
+  status: z
+    .enum(["active", "on-hold"])
+    .optional()
+    .describe("Initial status. Defaults to 'active'. Cannot create a tag in 'dropped' state."),
+  allowsNextAction: z
+    .boolean()
+    .optional()
+    .describe("Whether the tag allows next-action selection. Defaults to true."),
+});
+
+export type TagCreateToolInput = z.infer<typeof tagCreateInputSchema>;
+
+export interface TagCreateContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_create`.
+ */
+export async function handleTagCreate(input: TagCreateToolInput, ctx: TagCreateContext) {
+  const result = await ctx.tagService.create({
+    name: input.name,
+    ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+    ...(input.status !== undefined ? { status: input.status } : {}),
+    ...(input.allowsNextAction !== undefined ? { allowsNextAction: input.allowsNextAction } : {}),
+  });
+  const meta = ctx.makeMeta();
+  return ok({ id: result.id }, meta);
+}
+
+export function registerTagCreateTool(server: McpServer, ctx: TagCreateContext) {
+  return server.registerTool(
+    "tag_create",
+    { description: TAG_CREATE_DESCRIPTION, inputSchema: tagCreateInputSchema.shape },
+    async (args: TagCreateToolInput) => {
+      const envelope = await handleTagCreate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/tag/delete.ts
+++ b/src/tools/tag/delete.ts
@@ -1,0 +1,51 @@
+/**
+ * `tag_delete` MCP tool — hard-delete a tag from OmniFocus. Irreversible.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_DELETE_DESCRIPTION =
+  "Hard-delete a tag from OmniFocus. IRREVERSIBLE — the tag and all its children are removed. " +
+  "Tasks that carried this tag lose it. " +
+  "Get the tag ID from tag_list. " +
+  "Prefer tag_set_status with status='dropped' to preserve history.";
+
+export const tagDeleteInputSchema = z.object({
+  id: TagId.schema.describe("Persistent tag ID to delete. Get from tag_list."),
+});
+
+export type TagDeleteToolInput = z.infer<typeof tagDeleteInputSchema>;
+
+export interface TagDeleteContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_delete`.
+ */
+export async function handleTagDelete(input: TagDeleteToolInput, ctx: TagDeleteContext) {
+  await ctx.tagService.delete(input.id);
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerTagDeleteTool(server: McpServer, ctx: TagDeleteContext) {
+  return server.registerTool(
+    "tag_delete",
+    { description: TAG_DELETE_DESCRIPTION, inputSchema: tagDeleteInputSchema.shape },
+    async (args: TagDeleteToolInput) => {
+      const envelope = await handleTagDelete(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/tag/move.ts
+++ b/src/tools/tag/move.ts
@@ -1,0 +1,53 @@
+/**
+ * `tag_move` MCP tool — move a tag to a new parent (or promote to root).
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_MOVE_DESCRIPTION =
+  "Move a tag to a new parent, or promote it to a root tag by passing parentId=null. " +
+  "Get tag IDs from tag_list. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const tagMoveInputSchema = z.object({
+  id: TagId.schema.describe("Persistent ID of the tag to move. Get from tag_list."),
+  parentId: TagId.schema
+    .nullable()
+    .describe("New parent tag ID, or null to promote the tag to root level."),
+});
+
+export type TagMoveToolInput = z.infer<typeof tagMoveInputSchema>;
+
+export interface TagMoveContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_move`.
+ */
+export async function handleTagMove(input: TagMoveToolInput, ctx: TagMoveContext) {
+  await ctx.tagService.move(input.id, input.parentId);
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerTagMoveTool(server: McpServer, ctx: TagMoveContext) {
+  return server.registerTool(
+    "tag_move",
+    { description: TAG_MOVE_DESCRIPTION, inputSchema: tagMoveInputSchema.shape },
+    async (args: TagMoveToolInput) => {
+      const envelope = await handleTagMove(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/tag/mutations.test.ts
+++ b/src/tools/tag/mutations.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for tag mutation tools: tag_create, tag_update, tag_delete,
+ * tag_move, tag_set_status, tag_set_allows_next_action.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { TagService } from "../../services/tagService.js";
+import { handleTagCreate, tagCreateInputSchema } from "./create.js";
+import { handleTagDelete, tagDeleteInputSchema } from "./delete.js";
+import { handleTagMove, tagMoveInputSchema } from "./move.js";
+import {
+  handleTagSetAllowsNextAction,
+  tagSetAllowsNextActionInputSchema,
+} from "./setAllowsNextAction.js";
+import { handleTagSetStatus, tagSetStatusInputSchema } from "./setStatus.js";
+import { handleTagUpdate, tagUpdateInputSchema } from "./update.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const tagService = new TagService({ adapter });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { tagService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// tag_create
+// ---------------------------------------------------------------------------
+
+describe("tag_create — input schema", () => {
+  it("requires name", () => {
+    expect(() => tagCreateInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() => tagCreateInputSchema.parse({ name: "" })).toThrow();
+  });
+
+  it("accepts minimal input", () => {
+    expect(tagCreateInputSchema.parse({ name: "Work" })).toEqual({ name: "Work" });
+  });
+
+  it("accepts full input", () => {
+    const parsed = tagCreateInputSchema.parse({
+      name: "Work",
+      parentId: "tag_000001",
+      status: "on-hold",
+      allowsNextAction: false,
+    });
+    expect(parsed.name).toBe("Work");
+    expect(parsed.status).toBe("on-hold");
+  });
+
+  it("rejects status=dropped at create time", () => {
+    expect(() => tagCreateInputSchema.parse({ name: "X", status: "dropped" })).toThrow();
+  });
+});
+
+describe("tag_create — handler", () => {
+  it("creates a tag and returns its ID", async () => {
+    const { ctx, adapter } = makeCtx();
+    const envelope = await handleTagCreate({ name: "Work" }, ctx);
+    expect(envelope.data.id).toBeTruthy();
+    const tags = await adapter.listTags();
+    expect(tags).toHaveLength(1);
+    expect(tags[0]?.name).toBe("Work");
+  });
+
+  it("creates a nested tag when parentId is supplied", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createTag({ name: "Work" });
+    const envelope = await handleTagCreate({ name: "Meetings", parentId }, ctx);
+    const child = await adapter.getTag(envelope.data.id);
+    expect(child.parentId).toBe(parentId);
+  });
+
+  it("throws NotFound for unknown parentId", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTagCreate({ name: "X", parentId: "tag_999999" as never }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_update
+// ---------------------------------------------------------------------------
+
+describe("tag_update — input schema", () => {
+  it("requires id", () => {
+    expect(() => tagUpdateInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts id-only (no-op patch)", () => {
+    const parsed = tagUpdateInputSchema.parse({ id: "tag_000001" });
+    expect(parsed.id).toBe("tag_000001");
+  });
+
+  it("accepts null parentId to promote to root", () => {
+    const parsed = tagUpdateInputSchema.parse({ id: "tag_000001", parentId: null });
+    expect(parsed.parentId).toBeNull();
+  });
+});
+
+describe("tag_update — handler", () => {
+  it("renames a tag", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "OldName" });
+    await handleTagUpdate({ id, name: "NewName" }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.name).toBe("NewName");
+  });
+
+  it("updates status", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Work" });
+    await handleTagUpdate({ id, status: "on-hold" }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.status).toBe("on-hold");
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleTagUpdate({ id: "tag_999999" as never, name: "X" }, ctx)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_delete
+// ---------------------------------------------------------------------------
+
+describe("tag_delete — input schema", () => {
+  it("requires id", () => {
+    expect(() => tagDeleteInputSchema.parse({})).toThrow();
+  });
+});
+
+describe("tag_delete — handler", () => {
+  it("deletes a tag", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Temp" });
+    await handleTagDelete({ id }, ctx);
+    const tags = await adapter.listTags();
+    expect(tags).toHaveLength(0);
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleTagDelete({ id: "tag_999999" as never }, ctx)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_move
+// ---------------------------------------------------------------------------
+
+describe("tag_move — input schema", () => {
+  it("requires id and parentId", () => {
+    expect(() => tagMoveInputSchema.parse({ id: "tag_000001" })).toThrow();
+  });
+
+  it("accepts null parentId", () => {
+    const parsed = tagMoveInputSchema.parse({ id: "tag_000001", parentId: null });
+    expect(parsed.parentId).toBeNull();
+  });
+});
+
+describe("tag_move — handler", () => {
+  it("moves a tag under a new parent", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createTag({ name: "Work" });
+    const childId = await adapter.createTag({ name: "Meetings" });
+    await handleTagMove({ id: childId, parentId }, ctx);
+    const child = await adapter.getTag(childId);
+    expect(child.parentId).toBe(parentId);
+  });
+
+  it("promotes a tag to root when parentId=null", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createTag({ name: "Work" });
+    const childId = await adapter.createTag({ name: "Meetings", parentId });
+    await handleTagMove({ id: childId, parentId: null }, ctx);
+    const child = await adapter.getTag(childId);
+    expect(child.parentId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_set_status
+// ---------------------------------------------------------------------------
+
+describe("tag_set_status — input schema", () => {
+  it("requires id and status", () => {
+    expect(() => tagSetStatusInputSchema.parse({ id: "tag_000001" })).toThrow();
+  });
+
+  it("rejects unknown status", () => {
+    expect(() => tagSetStatusInputSchema.parse({ id: "tag_000001", status: "unknown" })).toThrow();
+  });
+});
+
+describe("tag_set_status — handler", () => {
+  it("sets status to dropped", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "OldProject" });
+    await handleTagSetStatus({ id, status: "dropped" }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.status).toBe("dropped");
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTagSetStatus({ id: "tag_999999" as never, status: "active" }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_set_allows_next_action
+// ---------------------------------------------------------------------------
+
+describe("tag_set_allows_next_action — input schema", () => {
+  it("requires id and allowsNextAction", () => {
+    expect(() => tagSetAllowsNextActionInputSchema.parse({ id: "tag_000001" })).toThrow();
+  });
+});
+
+describe("tag_set_allows_next_action — handler", () => {
+  it("disables next-action on a tag", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Work", allowsNextAction: true });
+    await handleTagSetAllowsNextAction({ id, allowsNextAction: false }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.allowsNextAction).toBe(false);
+  });
+
+  it("enables next-action on a tag", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Work", allowsNextAction: false });
+    await handleTagSetAllowsNextAction({ id, allowsNextAction: true }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.allowsNextAction).toBe(true);
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTagSetAllowsNextAction({ id: "tag_999999" as never, allowsNextAction: true }, ctx),
+    ).rejects.toThrow();
+  });
+});

--- a/src/tools/tag/setAllowsNextAction.ts
+++ b/src/tools/tag/setAllowsNextAction.ts
@@ -1,0 +1,61 @@
+/**
+ * `tag_set_allows_next_action` MCP tool — toggle next-action selection on a tag.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_SET_ALLOWS_NEXT_ACTION_DESCRIPTION =
+  "Enable or disable next-action selection for a tag in OmniFocus. " +
+  "When true, tasks with this tag are eligible for next-action promotion. " +
+  "Get the tag ID from tag_list. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const tagSetAllowsNextActionInputSchema = z.object({
+  id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
+  allowsNextAction: z.boolean().describe("true to enable next-action selection; false to disable."),
+});
+
+export type TagSetAllowsNextActionToolInput = z.infer<typeof tagSetAllowsNextActionInputSchema>;
+
+export interface TagSetAllowsNextActionContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_set_allows_next_action`.
+ */
+export async function handleTagSetAllowsNextAction(
+  input: TagSetAllowsNextActionToolInput,
+  ctx: TagSetAllowsNextActionContext,
+) {
+  await ctx.tagService.setAllowsNextAction(input.id, input.allowsNextAction);
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerTagSetAllowsNextActionTool(
+  server: McpServer,
+  ctx: TagSetAllowsNextActionContext,
+) {
+  return server.registerTool(
+    "tag_set_allows_next_action",
+    {
+      description: TAG_SET_ALLOWS_NEXT_ACTION_DESCRIPTION,
+      inputSchema: tagSetAllowsNextActionInputSchema.shape,
+    },
+    async (args: TagSetAllowsNextActionToolInput) => {
+      const envelope = await handleTagSetAllowsNextAction(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/tag/setStatus.ts
+++ b/src/tools/tag/setStatus.ts
@@ -1,0 +1,52 @@
+/**
+ * `tag_set_status` MCP tool — set the lifecycle status of a tag.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_SET_STATUS_DESCRIPTION =
+  "Set the lifecycle status of a tag to active, on-hold, or dropped. " +
+  "Dropped tags are hidden in OmniFocus but not deleted. " +
+  "Get the tag ID from tag_list. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const tagSetStatusInputSchema = z.object({
+  id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
+  status: z.enum(["active", "on-hold", "dropped"]).describe("New lifecycle status for the tag."),
+});
+
+export type TagSetStatusToolInput = z.infer<typeof tagSetStatusInputSchema>;
+
+export interface TagSetStatusContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_set_status`.
+ */
+export async function handleTagSetStatus(input: TagSetStatusToolInput, ctx: TagSetStatusContext) {
+  await ctx.tagService.setStatus(input.id, input.status);
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerTagSetStatusTool(server: McpServer, ctx: TagSetStatusContext) {
+  return server.registerTool(
+    "tag_set_status",
+    { description: TAG_SET_STATUS_DESCRIPTION, inputSchema: tagSetStatusInputSchema.shape },
+    async (args: TagSetStatusToolInput) => {
+      const envelope = await handleTagSetStatus(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -1,0 +1,67 @@
+/**
+ * `tag_update` MCP tool — update mutable fields on an existing tag (partial patch).
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_UPDATE_DESCRIPTION =
+  "Update mutable fields on an existing tag (partial patch). " +
+  "Only supplied fields are changed; omit a field to leave it unchanged. " +
+  "Get the tag ID from tag_list. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const tagUpdateInputSchema = z.object({
+  id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
+  name: z.string().min(1).optional().describe("New tag name. Must be non-empty if supplied."),
+  parentId: TagId.schema
+    .nullable()
+    .optional()
+    .describe("New parent tag ID. Pass null to promote to root. Get from tag_list."),
+  status: z.enum(["active", "on-hold", "dropped"]).optional().describe("New lifecycle status."),
+  allowsNextAction: z
+    .boolean()
+    .optional()
+    .describe("Whether the tag allows next-action selection in OmniFocus."),
+});
+
+export type TagUpdateToolInput = z.infer<typeof tagUpdateInputSchema>;
+
+export interface TagUpdateContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_update`.
+ */
+export async function handleTagUpdate(input: TagUpdateToolInput, ctx: TagUpdateContext) {
+  const { id, ...patch } = input;
+  await ctx.tagService.update(id, {
+    ...(patch.name !== undefined ? { name: patch.name } : {}),
+    ...(patch.parentId !== undefined ? { parentId: patch.parentId } : {}),
+    ...(patch.status !== undefined ? { status: patch.status } : {}),
+    ...(patch.allowsNextAction !== undefined ? { allowsNextAction: patch.allowsNextAction } : {}),
+  });
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerTagUpdateTool(server: McpServer, ctx: TagUpdateContext) {
+  return server.registerTool(
+    "tag_update",
+    { description: TAG_UPDATE_DESCRIPTION, inputSchema: tagUpdateInputSchema.shape },
+    async (args: TagUpdateToolInput) => {
+      const envelope = await handleTagUpdate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Extends `TagService` with six mutation methods: `create`, `update`, `delete`, `move`, `setStatus`, `setAllowsNextAction`
- Implements `tag_create`, `tag_update`, `tag_delete`, `tag_move`, `tag_set_status`, `tag_set_allows_next_action` MCP tools
- 29 new unit tests against `InMemoryAdapter`; all 420 tests pass

## Design link
Closes #50. Follows DESIGN §26 reference implementation. `tag_move` uses `updateTag({ parentId })` as the adapter already supports hierarchical parentId patching.

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests: schema validation + happy path + NotFound error paths
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — no new errors
- [x] No user content interpolated into metadata fields