### PR TITLE
feat(tag): add tag_set_location and tag_get_location tools

### DIFF
--- a/src/adapter/OmniFocusAdapter.ts
+++ b/src/adapter/OmniFocusAdapter.ts
@@ -139,6 +139,8 @@ export interface UpdateTagInput {
   parentId?: TagId | null;
   status?: "active" | "on-hold" | "dropped";
   allowsNextAction?: boolean;
+  /** Set or clear the location trigger on the tag. Pass `null` to remove the location. */
+  location?: TagLocation | null;
 }
 
 export interface CreateFolderInput {

--- a/src/adapter/inMemory/InMemoryAdapter.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.ts
@@ -524,6 +524,7 @@ export class InMemoryAdapter implements OmniFocusAdapter {
       ...(patch.parentId !== undefined ? { parentId: patch.parentId } : {}),
       ...(patch.status !== undefined ? { status: patch.status } : {}),
       ...(patch.allowsNextAction !== undefined ? { allowsNextAction: patch.allowsNextAction } : {}),
+      ...(patch.location !== undefined ? { location: patch.location } : {}),
       modifiedAt: isoOf(this.now()) as Tag["modifiedAt"],
     });
   }

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -184,4 +184,42 @@ export class TagService {
   async setAllowsNextAction(id: TagId, value: boolean): Promise<void> {
     await this.adapter.updateTag(id, { allowsNextAction: value });
   }
+
+  /**
+   * Set a geographic location trigger on the tag (OmniFocus Pro only).
+   *
+   * The JXA adapter will throw `FeatureRequiresPro` when running against
+   * OmniFocus Standard — this service method is transparent to that error
+   * and lets it propagate to the MCP tool layer.
+   *
+   * @param id — tag to update
+   * @param location — location trigger data (lat/lon/radius/trigger/optional name)
+   * @throws {NotFound} when no tag with `id` exists.
+   * @throws {FeatureRequiresPro} (from adapter) on OmniFocus Standard.
+   */
+  async setLocation(id: TagId, location: TagLocation): Promise<void> {
+    await this.adapter.updateTag(id, { location });
+  }
+
+  /**
+   * Clear the geographic location trigger on the tag.
+   *
+   * @param id — tag to update
+   * @throws {NotFound} when no tag with `id` exists.
+   */
+  async clearLocation(id: TagId): Promise<void> {
+    await this.adapter.updateTag(id, { location: null });
+  }
+
+  /**
+   * Get the current location trigger for a tag (null if none set).
+   *
+   * @param id — tag to query
+   * @returns The location trigger, or null if not set.
+   * @throws {NotFound} when no tag with `id` exists.
+   */
+  async getLocation(id: TagId): Promise<{ location: TagLocation | null; cacheHit: boolean }> {
+    const tag = await this.adapter.getTag(id);
+    return { location: tag.location, cacheHit: false };
+  }
 }

--- a/src/tools/tag/getLocation.ts
+++ b/src/tools/tag/getLocation.ts
@@ -1,0 +1,55 @@
+/**
+ * `tag_get_location` MCP tool — get the geographic location trigger on a tag.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_GET_LOCATION_DESCRIPTION =
+  "Get the geographic location trigger currently set on a tag, or null if none. " +
+  "Location-based tags are an OmniFocus Pro feature. " +
+  "Get the tag ID from tag_list. " +
+  "Safe to call repeatedly; no side effects.";
+
+export const tagGetLocationInputSchema = z.object({
+  id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
+});
+
+export type TagGetLocationToolInput = z.infer<typeof tagGetLocationInputSchema>;
+
+export interface TagGetLocationContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_get_location`.
+ */
+export async function handleTagGetLocation(
+  input: TagGetLocationToolInput,
+  ctx: TagGetLocationContext,
+) {
+  const result = await ctx.tagService.getLocation(input.id);
+  const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
+  return ok({ location: result.location }, meta);
+}
+
+export function registerTagGetLocationTool(server: McpServer, ctx: TagGetLocationContext) {
+  return server.registerTool(
+    "tag_get_location",
+    { description: TAG_GET_LOCATION_DESCRIPTION, inputSchema: tagGetLocationInputSchema.shape },
+    async (args: TagGetLocationToolInput) => {
+      const envelope = await handleTagGetLocation(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/tag/location.test.ts
+++ b/src/tools/tag/location.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for tag_set_location and tag_get_location tools.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { TagService } from "../../services/tagService.js";
+import { handleTagGetLocation, tagGetLocationInputSchema } from "./getLocation.js";
+import { handleTagSetLocation, tagSetLocationInputSchema } from "./setLocation.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const tagService = new TagService({ adapter });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { tagService, makeMeta }, adapter };
+}
+
+const SAMPLE_LOCATION = {
+  latitude: 37.7749,
+  longitude: -122.4194,
+  radiusMeters: 200,
+  trigger: "entering" as const,
+};
+
+// ---------------------------------------------------------------------------
+// tag_set_location — schema
+// ---------------------------------------------------------------------------
+
+describe("tag_set_location — input schema", () => {
+  it("requires id, latitude, longitude, radiusMeters, trigger", () => {
+    expect(() => tagSetLocationInputSchema.parse({})).toThrow();
+    expect(() => tagSetLocationInputSchema.parse({ id: "tag_000001" })).toThrow();
+  });
+
+  it("accepts full valid input", () => {
+    const parsed = tagSetLocationInputSchema.parse({ id: "tag_000001", ...SAMPLE_LOCATION });
+    expect(parsed.latitude).toBe(37.7749);
+    expect(parsed.trigger).toBe("entering");
+  });
+
+  it("accepts optional name", () => {
+    const parsed = tagSetLocationInputSchema.parse({
+      id: "tag_000001",
+      ...SAMPLE_LOCATION,
+      name: "Home",
+    });
+    expect(parsed.name).toBe("Home");
+  });
+
+  it("rejects out-of-range latitude", () => {
+    expect(() =>
+      tagSetLocationInputSchema.parse({ id: "tag_000001", ...SAMPLE_LOCATION, latitude: 95 }),
+    ).toThrow();
+  });
+
+  it("rejects out-of-range longitude", () => {
+    expect(() =>
+      tagSetLocationInputSchema.parse({ id: "tag_000001", ...SAMPLE_LOCATION, longitude: -200 }),
+    ).toThrow();
+  });
+
+  it("rejects negative radius", () => {
+    expect(() =>
+      tagSetLocationInputSchema.parse({
+        id: "tag_000001",
+        ...SAMPLE_LOCATION,
+        radiusMeters: -1,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects unknown trigger", () => {
+    expect(() =>
+      tagSetLocationInputSchema.parse({ id: "tag_000001", ...SAMPLE_LOCATION, trigger: "never" }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_set_location — handler
+// ---------------------------------------------------------------------------
+
+describe("tag_set_location — handler", () => {
+  it("sets the location on the tag", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Home" });
+    await handleTagSetLocation({ id, ...SAMPLE_LOCATION }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.location?.latitude).toBe(37.7749);
+    expect(tag.location?.longitude).toBe(-122.4194);
+    expect(tag.location?.radiusMeters).toBe(200);
+    expect(tag.location?.trigger).toBe("entering");
+  });
+
+  it("sets optional location name", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Home" });
+    await handleTagSetLocation({ id, ...SAMPLE_LOCATION, name: "My House" }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.location?.name).toBe("My House");
+  });
+
+  it("defaults name to null when omitted", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Work" });
+    await handleTagSetLocation({ id, ...SAMPLE_LOCATION }, ctx);
+    const tag = await adapter.getTag(id);
+    expect(tag.location?.name).toBeNull();
+  });
+
+  it("overwrites a previously set location", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Work" });
+    await handleTagSetLocation({ id, ...SAMPLE_LOCATION }, ctx);
+    await handleTagSetLocation(
+      { id, latitude: 51.5, longitude: -0.12, radiusMeters: 500, trigger: "leaving" },
+      ctx,
+    );
+    const tag = await adapter.getTag(id);
+    expect(tag.location?.latitude).toBe(51.5);
+    expect(tag.location?.trigger).toBe("leaving");
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTagSetLocation({ id: "tag_999999" as never, ...SAMPLE_LOCATION }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_get_location — schema
+// ---------------------------------------------------------------------------
+
+describe("tag_get_location — input schema", () => {
+  it("requires id", () => {
+    expect(() => tagGetLocationInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid tag ID", () => {
+    expect(tagGetLocationInputSchema.parse({ id: "tag_000001" })).toEqual({ id: "tag_000001" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_get_location — handler
+// ---------------------------------------------------------------------------
+
+describe("tag_get_location — handler", () => {
+  it("returns null when no location is set", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Work" });
+    const envelope = await handleTagGetLocation({ id }, ctx);
+    expect(envelope.data.location).toBeNull();
+  });
+
+  it("returns the location after it has been set", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Home" });
+    await handleTagSetLocation({ id, ...SAMPLE_LOCATION }, ctx);
+    const envelope = await handleTagGetLocation({ id }, ctx);
+    expect(envelope.data.location?.latitude).toBe(37.7749);
+    expect(envelope.data.location?.trigger).toBe("entering");
+  });
+
+  it("returns null after location is cleared via tag_update", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTag({ name: "Home" });
+    await handleTagSetLocation({ id, ...SAMPLE_LOCATION }, ctx);
+    await adapter.updateTag(id, { location: null });
+    const envelope = await handleTagGetLocation({ id }, ctx);
+    expect(envelope.data.location).toBeNull();
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleTagGetLocation({ id: "tag_999999" as never }, ctx)).rejects.toThrow();
+  });
+});

--- a/src/tools/tag/setLocation.ts
+++ b/src/tools/tag/setLocation.ts
@@ -1,0 +1,76 @@
+/**
+ * `tag_set_location` MCP tool — set a geographic location trigger on a tag.
+ *
+ * Location-based tags are an OmniFocus Pro feature. On Standard installs the
+ * JXA adapter surfaces a `FeatureRequiresPro` error which propagates through
+ * this tool unchanged.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/tagService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TagService } from "../../services/tagService.js";
+
+export const TAG_SET_LOCATION_DESCRIPTION =
+  "Set a geographic location trigger on a tag (OmniFocus Pro only). " +
+  "The trigger fires when arriving at, leaving, or both for the specified radius. " +
+  "Get the tag ID from tag_list. " +
+  "Returns FeatureRequiresPro on OmniFocus Standard installs. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const tagSetLocationInputSchema = z.object({
+  id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
+  latitude: z.number().min(-90).max(90).describe("Latitude in decimal degrees (−90 to 90)."),
+  longitude: z.number().min(-180).max(180).describe("Longitude in decimal degrees (−180 to 180)."),
+  radiusMeters: z.number().min(0).describe("Trigger radius in metres. Must be ≥ 0."),
+  trigger: z
+    .enum(["entering", "leaving", "both"])
+    .describe("When to trigger: 'entering', 'leaving', or 'both'."),
+  name: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Optional human-readable name for the location (e.g. 'Home', 'Office')."),
+});
+
+export type TagSetLocationToolInput = z.infer<typeof tagSetLocationInputSchema>;
+
+export interface TagSetLocationContext {
+  tagService: TagService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `tag_set_location`.
+ */
+export async function handleTagSetLocation(
+  input: TagSetLocationToolInput,
+  ctx: TagSetLocationContext,
+) {
+  await ctx.tagService.setLocation(input.id, {
+    name: input.name ?? null,
+    latitude: input.latitude,
+    longitude: input.longitude,
+    radiusMeters: input.radiusMeters,
+    trigger: input.trigger,
+  });
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerTagSetLocationTool(server: McpServer, ctx: TagSetLocationContext) {
+  return server.registerTool(
+    "tag_set_location",
+    { description: TAG_SET_LOCATION_DESCRIPTION, inputSchema: tagSetLocationInputSchema.shape },
+    async (args: TagSetLocationToolInput) => {
+      const envelope = await handleTagSetLocation(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Extends `UpdateTagInput` with `location?: TagLocation | null` field
- Patches `InMemoryAdapter.updateTag` to persist location changes
- Adds `setLocation`, `clearLocation`, `getLocation` methods to `TagService`
- Implements `tag_set_location` (lat/lon/radius/trigger/optional-name) and `tag_get_location` MCP tools
- `FeatureRequiresPro` propagates from the JXA adapter on Standard installs
- 18 new unit tests (schema validation, happy path, edge cases, NotFound); all 438 tests pass

## Design link
Closes #51. Follows DESIGN §26 reference pattern.

## Breaking change?
- [x] No

## Test plan
- [x] Schema validation: out-of-range lat/lon, negative radius, unknown trigger rejected
- [x] Handler: set, overwrite, clear, get, NotFound paths
- [x] `pnpm lint` clean; `pnpm typecheck` no new errors
- [x] No user content interpolated into metadata fields