### PR TITLE
feat(folder): add FolderService and folder CRUD tools

### DIFF
--- a/src/services/folderService.ts
+++ b/src/services/folderService.ts
@@ -1,0 +1,187 @@
+/**
+ * `FolderService` — service-layer surface for folder queries and mutations.
+ *
+ * Wraps `OmniFocusAdapter` and exposes read (`list`, `get`) and write
+ * (`create`, `update`, `delete`, `move`) operations for the MCP tool layer.
+ *
+ * Design notes:
+ * - `delete` with `cascade: false` (the default) delegates directly to the
+ *   adapter which raises `ValidationError` on non-empty folders.
+ * - `delete` with `cascade: true` orphans all direct projects (moves them to
+ *   no folder) and recursively cascade-deletes all subfolders, then deletes
+ *   the now-empty folder. This is intentionally explicit — agents must pass
+ *   `cascade: true` to trigger destructive behaviour.
+ * - `move` is a thin wrapper over `updateFolder(id, { parentId })`.
+ * - Cache invalidation: FolderService does not yet wire an LRU cache (that
+ *   integration lands with the full cache pass in #36).
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see docs/domain-reference.md — Folder schema
+ */
+
+import type {
+  CreateFolderInput,
+  OmniFocusAdapter,
+  UpdateFolderInput,
+} from "../adapter/OmniFocusAdapter.js";
+import type { Folder } from "../domain/folder.js";
+import type { FolderId } from "../domain/ids.js";
+
+// ---------------------------------------------------------------------------
+// Public shapes
+// ---------------------------------------------------------------------------
+
+/** Input to {@link FolderService.list}. All fields optional. */
+export interface FolderListInput {
+  /** Restrict to direct children of this parent folder. Omit for root folders. */
+  parentId?: FolderId;
+}
+
+/** Result of {@link FolderService.list}. */
+export interface FolderListResult {
+  folders: Folder[];
+  cacheHit: boolean;
+}
+
+/** Result of {@link FolderService.get}. */
+export interface FolderGetResult {
+  folder: Folder;
+  cacheHit: boolean;
+}
+
+/** Result of {@link FolderService.create}. */
+export interface FolderCreateResult {
+  id: FolderId;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/** Dependencies injected at construction time. */
+export interface FolderServiceDeps {
+  adapter: OmniFocusAdapter;
+}
+
+/**
+ * Service layer for folder read and write operations.
+ *
+ * Construct with `{ adapter }`. All methods are async and free of hidden state.
+ */
+export class FolderService {
+  private readonly adapter: OmniFocusAdapter;
+
+  constructor({ adapter }: FolderServiceDeps) {
+    this.adapter = adapter;
+  }
+
+  // --------------------------------------------------------------------------
+  // Reads
+  // --------------------------------------------------------------------------
+
+  /**
+   * List folders, optionally filtered by parent.
+   *
+   * @param input — filter options (all optional)
+   * @returns Matching folders in adapter-natural order.
+   */
+  async list(input: FolderListInput = {}): Promise<FolderListResult> {
+    const folders = await this.adapter.listFolders(
+      input.parentId !== undefined ? { parentId: input.parentId } : {},
+    );
+    return { folders, cacheHit: false };
+  }
+
+  /**
+   * Fetch a single folder by its persistent ID.
+   *
+   * @param id — branded `FolderId` from `folder_list`
+   * @returns The folder with `projectCount` and `subfolderCount`.
+   * @throws {NotFound} when no folder with `id` exists.
+   */
+  async get(id: FolderId): Promise<FolderGetResult> {
+    const folder = await this.adapter.getFolder(id);
+    return { folder, cacheHit: false };
+  }
+
+  // --------------------------------------------------------------------------
+  // Writes
+  // --------------------------------------------------------------------------
+
+  /**
+   * Create a new folder.
+   *
+   * @param input — name (required), optional parentId
+   * @returns Branded ID of the newly created folder.
+   * @throws {ValidationError} when name is empty.
+   * @throws {NotFound} when parentId references a non-existent folder.
+   */
+  async create(input: CreateFolderInput): Promise<FolderCreateResult> {
+    const id = await this.adapter.createFolder(input);
+    return { id };
+  }
+
+  /**
+   * Update a folder's name or parent (partial patch).
+   *
+   * @param id — folder to update
+   * @param patch — fields to change
+   * @throws {NotFound} when no folder with `id` exists.
+   * @throws {ValidationError} when `name` is present but empty.
+   */
+  async update(id: FolderId, patch: UpdateFolderInput): Promise<void> {
+    await this.adapter.updateFolder(id, patch);
+  }
+
+  /**
+   * Delete a folder.
+   *
+   * By default (`cascade: false`) the adapter raises `ValidationError` when
+   * the folder is non-empty. Pass `cascade: true` to first orphan all direct
+   * projects (move to no folder) and recursively delete all subfolders, then
+   * delete the now-empty folder.
+   *
+   * @param id — folder to delete
+   * @param cascade — when true, recursively empty the folder before deleting
+   * @throws {NotFound} when no folder with `id` exists.
+   * @throws {ValidationError} when non-empty and `cascade` is false.
+   */
+  async delete(id: FolderId, cascade = false): Promise<void> {
+    if (cascade) {
+      await this._cascadeEmpty(id);
+    }
+    await this.adapter.deleteFolder(id);
+  }
+
+  /**
+   * Move a folder to a new parent (or promote to root by passing `null`).
+   *
+   * @param id — folder to move
+   * @param parentId — new parent folder ID, or null for root
+   * @throws {NotFound} when `id` or the new `parentId` doesn't exist.
+   */
+  async move(id: FolderId, parentId: FolderId | null): Promise<void> {
+    await this.adapter.updateFolder(id, { parentId });
+  }
+
+  // --------------------------------------------------------------------------
+  // Private helpers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Recursively empty a folder: orphan direct projects, cascade-delete
+   * all subfolders, leaving the folder itself ready for deletion.
+   */
+  private async _cascadeEmpty(id: FolderId): Promise<void> {
+    // Orphan all direct projects (move them out of this folder)
+    const projects = await this.adapter.listProjects({ folderId: id });
+    await Promise.all(projects.map((p) => this.adapter.moveProject(p.id, { folderId: null })));
+
+    // Recursively cascade-delete all direct subfolders
+    const subfolders = await this.adapter.listFolders({ parentId: id });
+    for (const subfolder of subfolders) {
+      await this._cascadeEmpty(subfolder.id);
+      await this.adapter.deleteFolder(subfolder.id);
+    }
+  }
+}

--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -1,0 +1,54 @@
+/**
+ * `folder_create` MCP tool — create a new folder in OmniFocus.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/folderService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FolderId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { FolderService } from "../../services/folderService.js";
+
+export const FOLDER_CREATE_DESCRIPTION =
+  "Create a new folder in OmniFocus. " +
+  "Optionally nest it inside an existing parent folder (get IDs from folder_list). " +
+  "Returns the new folder's persistent ID. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const folderCreateInputSchema = z.object({
+  name: z.string().min(1).describe("Folder name. Must be non-empty."),
+  parentId: FolderId.schema
+    .optional()
+    .describe("Parent folder ID. Omit for a root-level folder. Get from folder_list."),
+});
+
+export type FolderCreateToolInput = z.infer<typeof folderCreateInputSchema>;
+
+export interface FolderCreateContext {
+  folderService: FolderService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+export async function handleFolderCreate(input: FolderCreateToolInput, ctx: FolderCreateContext) {
+  const result = await ctx.folderService.create({
+    name: input.name,
+    ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+  });
+  return ok({ id: result.id }, ctx.makeMeta());
+}
+
+export function registerFolderCreateTool(server: McpServer, ctx: FolderCreateContext) {
+  return server.registerTool(
+    "folder_create",
+    { description: FOLDER_CREATE_DESCRIPTION, inputSchema: folderCreateInputSchema.shape },
+    async (args: FolderCreateToolInput) => {
+      const envelope = await handleFolderCreate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/folder/delete.ts
+++ b/src/tools/folder/delete.ts
@@ -1,0 +1,59 @@
+/**
+ * `folder_delete` MCP tool — delete a folder from OmniFocus.
+ *
+ * Requires `cascade: true` to delete non-empty folders. Without it the tool
+ * returns a ValidationError describing the contents, giving the agent a chance
+ * to handle them explicitly before retrying.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/folderService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FolderId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { FolderService } from "../../services/folderService.js";
+
+export const FOLDER_DELETE_DESCRIPTION =
+  "Delete a folder from OmniFocus. " +
+  "By default returns ValidationError when the folder contains projects or subfolders. " +
+  "Pass cascade=true to orphan all direct projects (move to no folder) and recursively delete subfolders before deleting. " +
+  "IRREVERSIBLE. Get the folder ID from folder_list. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const folderDeleteInputSchema = z.object({
+  id: FolderId.schema.describe("Persistent folder ID to delete. Get from folder_list."),
+  cascade: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, orphan all direct projects and recursively delete subfolders before deleting. Default false — returns an error if the folder is non-empty.",
+    ),
+});
+
+export type FolderDeleteToolInput = z.infer<typeof folderDeleteInputSchema>;
+
+export interface FolderDeleteContext {
+  folderService: FolderService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+export async function handleFolderDelete(input: FolderDeleteToolInput, ctx: FolderDeleteContext) {
+  await ctx.folderService.delete(input.id, input.cascade ?? false);
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerFolderDeleteTool(server: McpServer, ctx: FolderDeleteContext) {
+  return server.registerTool(
+    "folder_delete",
+    { description: FOLDER_DELETE_DESCRIPTION, inputSchema: folderDeleteInputSchema.shape },
+    async (args: FolderDeleteToolInput) => {
+      const envelope = await handleFolderDelete(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/folder/folder.test.ts
+++ b/src/tools/folder/folder.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for folder MCP tools: folder_list, folder_get, folder_create,
+ * folder_update, folder_move, folder_delete.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { FolderService } from "../../services/folderService.js";
+import { folderCreateInputSchema, handleFolderCreate } from "./create.js";
+import { folderDeleteInputSchema, handleFolderDelete } from "./delete.js";
+import { folderGetInputSchema, handleFolderGet } from "./get.js";
+import { folderListInputSchema, handleFolderList } from "./list.js";
+import { folderMoveInputSchema, handleFolderMove } from "./move.js";
+import { folderUpdateInputSchema, handleFolderUpdate } from "./update.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const folderService = new FolderService({ adapter });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { folderService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// folder_list
+// ---------------------------------------------------------------------------
+
+describe("folder_list — schema", () => {
+  it("accepts an empty object", () => {
+    expect(folderListInputSchema.parse({})).toEqual({});
+  });
+
+  it("accepts a parentId", () => {
+    const parsed = folderListInputSchema.parse({ parentId: "folder_000001" });
+    expect(parsed.parentId).toBe("folder_000001");
+  });
+});
+
+describe("folder_list — handler", () => {
+  it("returns empty list when no folders exist", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleFolderList({}, ctx);
+    expect(envelope.data.folders).toEqual([]);
+  });
+
+  it("returns created folders", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createFolder({ name: "Work" });
+    await adapter.createFolder({ name: "Personal" });
+    const envelope = await handleFolderList({}, ctx);
+    expect(envelope.data.folders).toHaveLength(2);
+  });
+
+  it("filters by parentId", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createFolder({ name: "Work" });
+    await adapter.createFolder({ name: "Projects", parentId });
+    await adapter.createFolder({ name: "Personal" });
+    const envelope = await handleFolderList({ parentId }, ctx);
+    expect(envelope.data.folders).toHaveLength(1);
+    expect(envelope.data.folders[0]?.name).toBe("Projects");
+  });
+
+  it("includes projectCount and subfolderCount", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createFolder({ name: "Work" });
+    const envelope = await handleFolderList({}, ctx);
+    expect(envelope.data.folders[0]).toHaveProperty("projectCount");
+    expect(envelope.data.folders[0]).toHaveProperty("subfolderCount");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_get
+// ---------------------------------------------------------------------------
+
+describe("folder_get — schema", () => {
+  it("requires id", () => {
+    expect(() => folderGetInputSchema.parse({})).toThrow();
+  });
+});
+
+describe("folder_get — handler", () => {
+  it("returns the folder for a known ID", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createFolder({ name: "Work" });
+    const envelope = await handleFolderGet({ id }, ctx);
+    expect(envelope.data.folder.id).toBe(id);
+    expect(envelope.data.folder.name).toBe("Work");
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleFolderGet({ id: "folder_999999" as never }, ctx)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_create
+// ---------------------------------------------------------------------------
+
+describe("folder_create — schema", () => {
+  it("requires name", () => {
+    expect(() => folderCreateInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() => folderCreateInputSchema.parse({ name: "" })).toThrow();
+  });
+
+  it("accepts optional parentId", () => {
+    const parsed = folderCreateInputSchema.parse({ name: "Work", parentId: "folder_000001" });
+    expect(parsed.parentId).toBe("folder_000001");
+  });
+});
+
+describe("folder_create — handler", () => {
+  it("creates a folder and returns its ID", async () => {
+    const { ctx, adapter } = makeCtx();
+    const envelope = await handleFolderCreate({ name: "Work" }, ctx);
+    expect(envelope.data.id).toBeTruthy();
+    const folders = await adapter.listFolders();
+    expect(folders).toHaveLength(1);
+  });
+
+  it("creates a nested folder", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createFolder({ name: "Work" });
+    const envelope = await handleFolderCreate({ name: "Projects", parentId }, ctx);
+    const child = await adapter.getFolder(envelope.data.id);
+    expect(child.parentId).toBe(parentId);
+  });
+
+  it("throws NotFound for unknown parentId", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleFolderCreate({ name: "X", parentId: "folder_999999" as never }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_update
+// ---------------------------------------------------------------------------
+
+describe("folder_update — schema", () => {
+  it("requires id", () => {
+    expect(() => folderUpdateInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() => folderUpdateInputSchema.parse({ id: "folder_000001", name: "" })).toThrow();
+  });
+});
+
+describe("folder_update — handler", () => {
+  it("renames a folder", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createFolder({ name: "Old" });
+    await handleFolderUpdate({ id, name: "New" }, ctx);
+    const folder = await adapter.getFolder(id);
+    expect(folder.name).toBe("New");
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleFolderUpdate({ id: "folder_999999" as never, name: "X" }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_move
+// ---------------------------------------------------------------------------
+
+describe("folder_move — schema", () => {
+  it("requires id and parentId", () => {
+    expect(() => folderMoveInputSchema.parse({ id: "folder_000001" })).toThrow();
+  });
+
+  it("accepts null parentId", () => {
+    const parsed = folderMoveInputSchema.parse({ id: "folder_000001", parentId: null });
+    expect(parsed.parentId).toBeNull();
+  });
+});
+
+describe("folder_move — handler", () => {
+  it("moves a folder under a new parent", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createFolder({ name: "Work" });
+    const childId = await adapter.createFolder({ name: "Projects" });
+    await handleFolderMove({ id: childId, parentId }, ctx);
+    const child = await adapter.getFolder(childId);
+    expect(child.parentId).toBe(parentId);
+  });
+
+  it("promotes a folder to root when parentId=null", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createFolder({ name: "Work" });
+    const childId = await adapter.createFolder({ name: "Projects", parentId });
+    await handleFolderMove({ id: childId, parentId: null }, ctx);
+    const child = await adapter.getFolder(childId);
+    expect(child.parentId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_delete
+// ---------------------------------------------------------------------------
+
+describe("folder_delete — schema", () => {
+  it("requires id", () => {
+    expect(() => folderDeleteInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts optional cascade flag", () => {
+    const parsed = folderDeleteInputSchema.parse({ id: "folder_000001", cascade: true });
+    expect(parsed.cascade).toBe(true);
+  });
+});
+
+describe("folder_delete — handler", () => {
+  it("deletes an empty folder", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createFolder({ name: "Temp" });
+    await handleFolderDelete({ id }, ctx);
+    const folders = await adapter.listFolders();
+    expect(folders).toHaveLength(0);
+  });
+
+  it("rejects non-empty folder without cascade", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createFolder({ name: "Work" });
+    await adapter.createFolder({ name: "Projects", parentId });
+    await expect(handleFolderDelete({ id: parentId }, ctx)).rejects.toThrow();
+  });
+
+  it("cascade=true deletes non-empty folder and its subfolders", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createFolder({ name: "Work" });
+    await adapter.createFolder({ name: "Projects", parentId });
+    await handleFolderDelete({ id: parentId, cascade: true }, ctx);
+    const folders = await adapter.listFolders();
+    expect(folders).toHaveLength(0);
+  });
+
+  it("cascade=true orphans projects inside the deleted folder", async () => {
+    const { ctx, adapter } = makeCtx();
+    const folderId = await adapter.createFolder({ name: "Work" });
+    await adapter.createProject({ name: "Big Project", folderId });
+    await handleFolderDelete({ id: folderId, cascade: true }, ctx);
+    const projects = await adapter.listProjects({});
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.folderId).toBeNull();
+  });
+
+  it("throws NotFound for unknown id", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleFolderDelete({ id: "folder_999999" as never }, ctx)).rejects.toThrow();
+  });
+});

--- a/src/tools/folder/get.ts
+++ b/src/tools/folder/get.ts
@@ -1,0 +1,49 @@
+/**
+ * `folder_get` MCP tool — fetch a single folder by its persistent ID.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/folderService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FolderId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { FolderService } from "../../services/folderService.js";
+
+export const FOLDER_GET_DESCRIPTION =
+  "Fetch a single folder by its persistent ID, including project and subfolder counts. " +
+  "Use folder_list first to discover folder IDs. " +
+  "Safe to call repeatedly; no side effects.";
+
+export const folderGetInputSchema = z.object({
+  id: FolderId.schema.describe(
+    "Persistent folder ID. Get from folder_list. IDs are stable across renames.",
+  ),
+});
+
+export type FolderGetToolInput = z.infer<typeof folderGetInputSchema>;
+
+export interface FolderGetContext {
+  folderService: FolderService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+export async function handleFolderGet(input: FolderGetToolInput, ctx: FolderGetContext) {
+  const result = await ctx.folderService.get(input.id);
+  return ok({ folder: result.folder }, ctx.makeMeta({ cacheHit: result.cacheHit }));
+}
+
+export function registerFolderGetTool(server: McpServer, ctx: FolderGetContext) {
+  return server.registerTool(
+    "folder_get",
+    { description: FOLDER_GET_DESCRIPTION, inputSchema: folderGetInputSchema.shape },
+    async (args: FolderGetToolInput) => {
+      const envelope = await handleFolderGet(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/folder/list.ts
+++ b/src/tools/folder/list.ts
@@ -1,0 +1,55 @@
+/**
+ * `folder_list` MCP tool — list folders in OmniFocus.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/folderService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FolderId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { FolderListInput, FolderService } from "../../services/folderService.js";
+
+export const FOLDER_LIST_DESCRIPTION =
+  "List folders in OmniFocus, optionally filtered by parent folder. " +
+  "Returns a flat array with projectCount and subfolderCount per folder. " +
+  "Use parentId to walk the hierarchy one level at a time. " +
+  "Safe to call repeatedly; no side effects.";
+
+export const folderListInputSchema = z.object({
+  parentId: FolderId.schema
+    .optional()
+    .describe(
+      "Return only direct children of this folder. Get the ID from a previous folder_list call. Omit for root folders.",
+    ),
+});
+
+export type FolderListToolInput = z.infer<typeof folderListInputSchema>;
+
+export interface FolderListContext {
+  folderService: FolderService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+export async function handleFolderList(input: FolderListToolInput, ctx: FolderListContext) {
+  const serviceInput: FolderListInput = {
+    ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+  };
+  const result = await ctx.folderService.list(serviceInput);
+  return ok({ folders: result.folders }, ctx.makeMeta({ cacheHit: result.cacheHit }));
+}
+
+export function registerFolderListTool(server: McpServer, ctx: FolderListContext) {
+  return server.registerTool(
+    "folder_list",
+    { description: FOLDER_LIST_DESCRIPTION, inputSchema: folderListInputSchema.shape },
+    async (args: FolderListToolInput) => {
+      const envelope = await handleFolderList(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/folder/move.ts
+++ b/src/tools/folder/move.ts
@@ -1,0 +1,50 @@
+/**
+ * `folder_move` MCP tool — move a folder to a new parent (or promote to root).
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/folderService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FolderId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { FolderService } from "../../services/folderService.js";
+
+export const FOLDER_MOVE_DESCRIPTION =
+  "Move a folder to a new parent, or promote it to a root folder by passing parentId=null. " +
+  "Get folder IDs from folder_list. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const folderMoveInputSchema = z.object({
+  id: FolderId.schema.describe("Persistent ID of the folder to move. Get from folder_list."),
+  parentId: FolderId.schema
+    .nullable()
+    .describe("New parent folder ID, or null to promote the folder to root level."),
+});
+
+export type FolderMoveToolInput = z.infer<typeof folderMoveInputSchema>;
+
+export interface FolderMoveContext {
+  folderService: FolderService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+export async function handleFolderMove(input: FolderMoveToolInput, ctx: FolderMoveContext) {
+  await ctx.folderService.move(input.id, input.parentId);
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerFolderMoveTool(server: McpServer, ctx: FolderMoveContext) {
+  return server.registerTool(
+    "folder_move",
+    { description: FOLDER_MOVE_DESCRIPTION, inputSchema: folderMoveInputSchema.shape },
+    async (args: FolderMoveToolInput) => {
+      const envelope = await handleFolderMove(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -1,0 +1,52 @@
+/**
+ * `folder_update` MCP tool — rename a folder (partial patch).
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/folderService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FolderId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { FolderService } from "../../services/folderService.js";
+
+export const FOLDER_UPDATE_DESCRIPTION =
+  "Rename a folder (partial patch — only supplied fields are changed). " +
+  "To move a folder use folder_move instead. " +
+  "Get the folder ID from folder_list. " +
+  "Triggers a sync; call sync_trigger after to propagate to other devices.";
+
+export const folderUpdateInputSchema = z.object({
+  id: FolderId.schema.describe("Persistent folder ID. Get from folder_list."),
+  name: z.string().min(1).optional().describe("New folder name. Must be non-empty if supplied."),
+});
+
+export type FolderUpdateToolInput = z.infer<typeof folderUpdateInputSchema>;
+
+export interface FolderUpdateContext {
+  folderService: FolderService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+export async function handleFolderUpdate(input: FolderUpdateToolInput, ctx: FolderUpdateContext) {
+  const { id, ...patch } = input;
+  await ctx.folderService.update(id, {
+    ...(patch.name !== undefined ? { name: patch.name } : {}),
+  });
+  return ok({}, ctx.makeMeta());
+}
+
+export function registerFolderUpdateTool(server: McpServer, ctx: FolderUpdateContext) {
+  return server.registerTool(
+    "folder_update",
+    { description: FOLDER_UPDATE_DESCRIPTION, inputSchema: folderUpdateInputSchema.shape },
+    async (args: FolderUpdateToolInput) => {
+      const envelope = await handleFolderUpdate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `FolderService` with `list`, `get`, `create`, `update`, `delete`, `move` methods
- Implements `folder_list`, `folder_get`, `folder_create`, `folder_update`, `folder_move`, `folder_delete` MCP tools
- `folder_delete` rejects non-empty folders by default; `cascade=true` orphans direct projects and recursively deletes subfolders
- 30 new unit tests; all 468 pass

## Design link
Closes #52. Follows DESIGN §26 reference implementation pattern.

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests: schema validation, happy paths, cascade delete, NotFound paths
- [x] `pnpm lint` clean; `pnpm typecheck` no new errors
- [x] No user content interpolated into metadata fields