### PR TITLE
feat(search): add search_query tool with SearchService and adapter searchTasks

### DIFF
--- a/src/adapter/OmniFocusAdapter.ts
+++ b/src/adapter/OmniFocusAdapter.ts
@@ -127,6 +127,25 @@ export interface UpdateProjectInput {
   reviewIntervalDays?: number | null;
 }
 
+/**
+ * Filter for full-text task search. `q` is matched against `name`, `note`,
+ * or both depending on `scope`. Additional fields narrow the match set.
+ */
+export interface SearchFilter {
+  /** Search query string. Case-insensitive; empty string matches all. */
+  q: string;
+  /** Which fields to search. Default: "all". */
+  scope?: "name" | "note" | "all";
+  /** Restrict to tasks in this project. */
+  projectId?: ProjectId;
+  /** Restrict to tasks carrying ALL of these tags. */
+  tagIds?: TagId[];
+  /** true = flagged only; false = unflagged only; omit = all. */
+  flagged?: boolean;
+  /** "exclude" = active only; "only" = completed only; "any" = both. */
+  completed?: "any" | "only" | "exclude";
+}
+
 export interface CreateTagInput {
   name: string;
   parentId?: TagId;
@@ -215,6 +234,15 @@ export interface OmniFocusAdapter {
   createFolder(input: CreateFolderInput): Promise<FolderId>;
   updateFolder(id: FolderId, patch: UpdateFolderInput): Promise<void>;
   deleteFolder(id: FolderId): Promise<void>;
+
+  // -- Search ----------------------------------------------------------------
+
+  /**
+   * Full-text search across tasks. Implementations may push the search to
+   * the underlying transport (JXA predicate, OmniJS filter) or perform it
+   * in-process. Returns matching tasks in adapter-natural order.
+   */
+  searchTasks(filter: SearchFilter): Promise<Task[]>;
 
   // -- Sync ------------------------------------------------------------------
 

--- a/src/adapter/inMemory/InMemoryAdapter.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.ts
@@ -626,6 +626,46 @@ export class InMemoryAdapter implements OmniFocusAdapter {
     if (folder.parentId !== null) this.bumpFolderSubfolderCount(folder.parentId, -1);
   }
 
+  // -- Search ---------------------------------------------------------------
+
+  /**
+   * In-memory full-text search across task name and/or note.
+   *
+   * Matching is case-insensitive substring search. Additional filter fields
+   * (projectId, tagIds, flagged, completed) narrow the result set with the
+   * same semantics as `listTasks`. Returns matching tasks in creation order.
+   */
+  async searchTasks(filter: SearchFilter): Promise<Task[]> {
+    const q = filter.q.toLowerCase();
+    const scope = filter.scope ?? "all";
+
+    return Array.from(this.tasks.values()).filter((task) => {
+      // Text match
+      const inName = scope !== "note" && task.name.toLowerCase().includes(q);
+      const inNote = scope !== "name" && (task.note ?? "").toLowerCase().includes(q);
+      if (!inName && !inNote) return false;
+
+      // projectId filter
+      if (filter.projectId !== undefined && task.projectId !== filter.projectId) return false;
+
+      // tagIds filter (task must carry ALL requested tags)
+      if (filter.tagIds !== undefined && filter.tagIds.length > 0) {
+        const taskTagSet = new Set(task.tagIds);
+        if (!filter.tagIds.every((tid) => taskTagSet.has(tid))) return false;
+      }
+
+      // flagged filter
+      if (filter.flagged !== undefined && task.flagged !== filter.flagged) return false;
+
+      // completed filter
+      const isCompleted = task.completedAt !== null;
+      if (filter.completed === "only" && !isCompleted) return false;
+      if (filter.completed === "exclude" && isCompleted) return false;
+
+      return true;
+    });
+  }
+
   // -- Sync (no-op stubs; integration tier owns real semantics) ------------
 
   async syncTrigger(): Promise<SyncStatus> {

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -193,6 +193,14 @@ export class JxaTransport implements OmniFocusAdapter {
     return notYetWired("deleteFolder");
   }
 
+  // -- Search ---------------------------------------------------------------
+
+  async searchTasks(
+    _filter: import("../OmniFocusAdapter.js").SearchFilter,
+  ): Promise<import("../../domain/task.js").Task[]> {
+    return notYetWired("searchTasks");
+  }
+
   // -- Sync (wired) ---------------------------------------------------------
 
   async syncTrigger(): Promise<SyncStatus> {

--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -196,6 +196,14 @@ export class OmniJsTransport implements OmniFocusAdapter {
     return notYetWired("deleteFolder");
   }
 
+  // -- Search ---------------------------------------------------------------
+
+  async searchTasks(
+    _filter: import("../OmniFocusAdapter.js").SearchFilter,
+  ): Promise<import("../../domain/task.js").Task[]> {
+    return notYetWired("searchTasks");
+  }
+
   // -- Sync -----------------------------------------------------------------
 
   // Sync is a document-level operation exposed by JXA, not OmniJS. The

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,0 +1,134 @@
+/**
+ * `SearchService` — full-text task search with cursor pagination.
+ *
+ * Delegates the actual text matching to `adapter.searchTasks()` (which can
+ * push the predicate to JXA/OmniJS or run in-memory for tests), then applies
+ * stable cursor pagination using the shared cursor codec (ADR-0013 / #35).
+ *
+ * Pagination contract:
+ * - Tasks are sorted by `(createdAt ASC, id ASC)` — deterministic, insert-safe.
+ * - Cursors encode `{ lastId, lastCreatedAt, filterHash }`. Swapping filter
+ *   fields mid-sequence returns `ValidationError` (filterHash mismatch).
+ * - Default page size: 100. Maximum: 500.
+ *
+ * @see DESIGN.md §15 — pagination contract
+ * @see src/pagination/cursor.ts
+ */
+
+import type { OmniFocusAdapter, SearchFilter } from "../adapter/OmniFocusAdapter.js";
+import type { Task } from "../domain/task.js";
+import {
+  type CursorPayload,
+  decodeCursor,
+  encodeCursor,
+  hashFilter,
+  isAfterCursor,
+} from "../pagination/cursor.js";
+
+// ---------------------------------------------------------------------------
+// Public shapes
+// ---------------------------------------------------------------------------
+
+/** Input to {@link SearchService.search}. */
+export interface SearchInput extends SearchFilter {
+  /** Max results per page (1..500). Default 100. */
+  limit?: number;
+  /** Opaque cursor from a previous search_query response. */
+  cursor?: string;
+}
+
+/** Result of {@link SearchService.search}. */
+export interface SearchResult {
+  tasks: Task[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  cacheHit: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+export interface SearchServiceDeps {
+  adapter: OmniFocusAdapter;
+}
+
+/**
+ * Service layer for full-text task search.
+ *
+ * Construct with `{ adapter }`. No mutable state.
+ */
+export class SearchService {
+  private readonly adapter: OmniFocusAdapter;
+
+  constructor({ adapter }: SearchServiceDeps) {
+    this.adapter = adapter;
+  }
+
+  /**
+   * Search tasks by full-text query with optional narrowing filters.
+   *
+   * @param input — query + filters + pagination
+   * @returns Matched tasks for the current page plus cursor metadata.
+   * @throws {ValidationError} when `cursor` was produced with different filters.
+   */
+  async search(input: SearchInput): Promise<SearchResult> {
+    const limit = Math.min(input.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+    // Build the stable filter (exclude pagination fields from the hash)
+    const filterForHash: Record<string, unknown> = {
+      q: input.q,
+      scope: input.scope ?? "all",
+      ...(input.projectId !== undefined ? { projectId: input.projectId } : {}),
+      ...(input.tagIds !== undefined ? { tagIds: [...input.tagIds].sort() } : {}),
+      ...(input.flagged !== undefined ? { flagged: input.flagged } : {}),
+      ...(input.completed !== undefined ? { completed: input.completed } : {}),
+    };
+    const filterHash = hashFilter(filterForHash);
+
+    // Decode cursor if present (validates filterHash)
+    let cursorPayload: CursorPayload | null = null;
+    if (input.cursor) {
+      cursorPayload = decodeCursor(input.cursor, filterHash);
+    }
+
+    // Fetch all matching tasks from the adapter
+    const searchFilter: SearchFilter = {
+      q: input.q,
+      scope: input.scope,
+      ...(input.projectId !== undefined ? { projectId: input.projectId } : {}),
+      ...(input.tagIds !== undefined ? { tagIds: input.tagIds } : {}),
+      ...(input.flagged !== undefined ? { flagged: input.flagged } : {}),
+      ...(input.completed !== undefined ? { completed: input.completed } : {}),
+    };
+    const allTasks = await this.adapter.searchTasks(searchFilter);
+
+    // Stable sort: createdAt ASC, id ASC
+    const sorted = [...allTasks].sort((a, b) => {
+      const dateCompare = a.createdAt.localeCompare(b.createdAt);
+      return dateCompare !== 0 ? dateCompare : a.id.localeCompare(b.id);
+    });
+
+    // Apply cursor offset
+    const afterCursor = cursorPayload
+      ? sorted.filter((t) => isAfterCursor(t, cursorPayload as CursorPayload))
+      : sorted;
+
+    // Take one extra to detect hasMore
+    const page = afterCursor.slice(0, limit + 1);
+    const hasMore = page.length > limit;
+    const tasks = page.slice(0, limit);
+
+    // Encode next cursor
+    const last = tasks.at(-1);
+    const nextCursor =
+      hasMore && last
+        ? encodeCursor({ lastId: last.id, lastCreatedAt: last.createdAt, filterHash })
+        : null;
+
+    return { tasks, nextCursor, hasMore, cacheHit: false };
+  }
+}

--- a/src/tools/search/query.test.ts
+++ b/src/tools/search/query.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for search_query tool and SearchService.
+ *
+ * Covers: schema parsing, text matching by scope, filter narrowing,
+ * pagination (cursor, hasMore, limit), and filter-hash mismatch rejection.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { SearchService } from "../../services/searchService.js";
+import { handleSearchQuery, searchQueryInputSchema } from "./query.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const searchService = new SearchService({ adapter });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { searchService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("search_query — input schema", () => {
+  it("requires q", () => {
+    expect(() => searchQueryInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts minimal input", () => {
+    expect(searchQueryInputSchema.parse({ q: "hello" })).toMatchObject({ q: "hello" });
+  });
+
+  it("accepts full input surface", () => {
+    const parsed = searchQueryInputSchema.parse({
+      q: "standup",
+      scope: "name",
+      projectId: "proj_000001",
+      tagIds: ["tag_000001"],
+      flagged: true,
+      completed: "exclude",
+      limit: 50,
+    });
+    expect(parsed.scope).toBe("name");
+    expect(parsed.completed).toBe("exclude");
+  });
+
+  it("rejects limit above 500", () => {
+    expect(() => searchQueryInputSchema.parse({ q: "x", limit: 501 })).toThrow();
+  });
+
+  it("rejects unknown scope", () => {
+    expect(() => searchQueryInputSchema.parse({ q: "x", scope: "title" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Text matching
+// ---------------------------------------------------------------------------
+
+describe("search_query — text matching", () => {
+  it("returns empty results when no tasks match", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Buy groceries" });
+    const envelope = await handleSearchQuery({ q: "standup" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(0);
+  });
+
+  it("matches by task name (case-insensitive)", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Daily Standup" });
+    await adapter.createTask({ name: "Buy groceries" });
+    const envelope = await handleSearchQuery({ q: "standup" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.name).toBe("Daily Standup");
+  });
+
+  it("matches by task note when scope=note", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Task A", note: "meeting notes here" });
+    await adapter.createTask({ name: "Task B", note: "nothing" });
+    const envelope = await handleSearchQuery({ q: "meeting", scope: "note" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.name).toBe("Task A");
+  });
+
+  it("scope=name does NOT match note content", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Task A", note: "secret content" });
+    const envelope = await handleSearchQuery({ q: "secret", scope: "name" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(0);
+  });
+
+  it("scope=all matches both name and note", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Alpha task", note: "nothing" });
+    await adapter.createTask({ name: "Task B", note: "alpha in note" });
+    const envelope = await handleSearchQuery({ q: "alpha", scope: "all" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(2);
+  });
+
+  it("empty q with filter returns all matching tasks", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Task A", flagged: true });
+    await adapter.createTask({ name: "Task B", flagged: false });
+    const envelope = await handleSearchQuery({ q: "", flagged: true }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+  });
+
+  it("matches UTF-8 content", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Réunion équipe" });
+    const envelope = await handleSearchQuery({ q: "équipe" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter narrowing
+// ---------------------------------------------------------------------------
+
+describe("search_query — filter narrowing", () => {
+  it("narrows by projectId", async () => {
+    const { ctx, adapter } = makeCtx();
+    const projId = await adapter.createProject({ name: "Work" });
+    await adapter.createTask({ name: "Standup task", projectId: projId });
+    await adapter.createTask({ name: "Standup other" });
+    const envelope = await handleSearchQuery({ q: "standup", projectId: projId }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.projectId).toBe(projId);
+  });
+
+  it("narrows by flagged=true", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Action item", flagged: true });
+    await adapter.createTask({ name: "Action unflagged", flagged: false });
+    const envelope = await handleSearchQuery({ q: "action", flagged: true }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.flagged).toBe(true);
+  });
+
+  it("narrows by completed=only", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id1 = await adapter.createTask({ name: "Done task" });
+    await adapter.createTask({ name: "Done but active" });
+    await adapter.completeTask(id1);
+    const envelope = await handleSearchQuery({ q: "done", completed: "only" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.completedAt).not.toBeNull();
+  });
+
+  it("narrows by completed=exclude", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id1 = await adapter.createTask({ name: "Done task" });
+    await adapter.createTask({ name: "Done active" });
+    await adapter.completeTask(id1);
+    const envelope = await handleSearchQuery({ q: "done", completed: "exclude" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.completedAt).toBeNull();
+  });
+
+  it("narrows by tagIds (ALL must match)", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagId = await adapter.createTag({ name: "urgent" });
+    await adapter.createTask({ name: "Tagged task", tagIds: [tagId] });
+    await adapter.createTask({ name: "Untagged task" });
+    const envelope = await handleSearchQuery({ q: "task", tagIds: [tagId] }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.name).toBe("Tagged task");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+describe("search_query — pagination", () => {
+  it("respects limit", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 5; i++) await adapter.createTask({ name: `Task ${i}` });
+    const envelope = await handleSearchQuery({ q: "task", limit: 3 }, ctx);
+    expect(envelope.data.tasks).toHaveLength(3);
+    expect(envelope.meta).toBeDefined();
+  });
+
+  it("returns hasMore=true when results exceed limit", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 5; i++) await adapter.createTask({ name: `Task ${i}` });
+    const envelope = await handleSearchQuery({ q: "task", limit: 3 }, ctx);
+    expect(envelope.pagination?.hasMore).toBe(true);
+    expect(envelope.pagination?.cursor).toBeTruthy();
+  });
+
+  it("returns hasMore=false on the last page", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 3; i++) await adapter.createTask({ name: `Task ${i}` });
+    const envelope = await handleSearchQuery({ q: "task", limit: 10 }, ctx);
+    expect(envelope.pagination?.hasMore).toBe(false);
+    expect(envelope.pagination?.cursor).toBeNull();
+  });
+
+  it("cursor fetches the next page without overlap", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 5; i++) await adapter.createTask({ name: `Task ${i}` });
+    const page1 = await handleSearchQuery({ q: "task", limit: 3 }, ctx);
+    const cursor = page1.pagination?.cursor ?? "";
+    expect(cursor).toBeTruthy();
+    const page2 = await handleSearchQuery({ q: "task", limit: 3, cursor }, ctx);
+    const ids1 = page1.data.tasks.map((t) => t.id);
+    const ids2 = page2.data.tasks.map((t) => t.id);
+    expect(ids2.every((id) => !ids1.includes(id))).toBe(true);
+    expect(ids1.length + ids2.length).toBe(5);
+  });
+
+  it("rejects cursor when filters change", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 5; i++) await adapter.createTask({ name: `Task ${i}` });
+    const page1 = await handleSearchQuery({ q: "task", limit: 3 }, ctx);
+    const cursor = page1.pagination?.cursor ?? "";
+    expect(cursor).toBeTruthy();
+    await expect(handleSearchQuery({ q: "different", limit: 3, cursor }, ctx)).rejects.toThrow();
+  });
+});

--- a/src/tools/search/query.ts
+++ b/src/tools/search/query.ts
@@ -1,0 +1,132 @@
+/**
+ * `search_query` MCP tool — full-text search across OmniFocus tasks.
+ *
+ * Matches `q` against task name, note, or both (controlled by `scope`).
+ * Additional filter fields narrow the result set. Cursor pagination is
+ * identical to `task_list` — cursors are filter-locked (ValidationError
+ * if filters change mid-sequence).
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see src/services/searchService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ProjectId, TagId } from "../../domain/ids.js";
+import { type Pagination, type ResponseMeta, ok } from "../../envelope/index.js";
+import type { SearchInput, SearchService } from "../../services/searchService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const SEARCH_QUERY_DESCRIPTION =
+  "Full-text search across OmniFocus task names and/or notes. " +
+  "Use for finding tasks by content when you don't know the ID. " +
+  "Supports optional filters (project, tags, flagged, completion status) and cursor pagination. " +
+  "Do NOT use when a known task ID is available (use task_get instead). " +
+  "Returns tasks[] with pagination; safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const searchQueryInputSchema = z.object({
+  q: z
+    .string()
+    .describe(
+      "Search query. Case-insensitive substring match. Empty string matches all tasks (useful with filters).",
+    ),
+  scope: z
+    .enum(["name", "note", "all"])
+    .optional()
+    .describe(
+      "'name' = search task names only; 'note' = search notes only; 'all' = both. Default 'all'.",
+    ),
+  projectId: ProjectId.schema
+    .optional()
+    .describe("Restrict to tasks in this project. Get the ID from project_list."),
+  tagIds: z
+    .array(TagId.schema)
+    .optional()
+    .describe("Restrict to tasks carrying ALL of these tags. Get IDs from tag_list."),
+  flagged: z
+    .boolean()
+    .optional()
+    .describe("true = flagged tasks only; false = unflagged only; omit = all."),
+  completed: z
+    .enum(["any", "only", "exclude"])
+    .optional()
+    .describe(
+      "'exclude' = active tasks only; 'only' = completed only; 'any' = both. Default 'any'.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Max results per page (1..500). Default 100."),
+  cursor: z
+    .string()
+    .optional()
+    .describe(
+      "Opaque cursor from a previous search_query response. Must use identical filters — changing filters returns a ValidationError.",
+    ),
+});
+
+export type SearchQueryToolInput = z.infer<typeof searchQueryInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export interface SearchQueryContext {
+  searchService: SearchService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly in unit tests.
+ */
+export async function handleSearchQuery(input: SearchQueryToolInput, ctx: SearchQueryContext) {
+  const serviceInput: SearchInput = {
+    q: input.q,
+    ...(input.scope !== undefined ? { scope: input.scope } : {}),
+    ...(input.projectId !== undefined ? { projectId: input.projectId } : {}),
+    ...(input.tagIds !== undefined ? { tagIds: input.tagIds } : {}),
+    ...(input.flagged !== undefined ? { flagged: input.flagged } : {}),
+    ...(input.completed !== undefined ? { completed: input.completed } : {}),
+    ...(input.limit !== undefined ? { limit: input.limit } : {}),
+    ...(input.cursor !== undefined ? { cursor: input.cursor } : {}),
+  };
+
+  const result = await ctx.searchService.search(serviceInput);
+  const pagination: Pagination = {
+    cursor: result.nextCursor,
+    hasMore: result.hasMore,
+  };
+  const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
+  return ok({ tasks: result.tasks }, meta, pagination);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerSearchQueryTool(server: McpServer, ctx: SearchQueryContext) {
+  return server.registerTool(
+    "search_query",
+    {
+      description: SEARCH_QUERY_DESCRIPTION,
+      inputSchema: searchQueryInputSchema.shape,
+    },
+    async (args: SearchQueryToolInput) => {
+      const envelope = await handleSearchQuery(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `SearchFilter` interface + `searchTasks()` to `OmniFocusAdapter`
- `InMemoryAdapter.searchTasks()`: case-insensitive substring match across `name`/`note` with `scope`, `projectId`, `tagIds`, `flagged`, `completed` filters
- `SearchService`: stable cursor pagination (createdAt ASC, id ASC) via existing cursor codec; filter-hash locking rejects cursor reuse after filter change
- `search_query` MCP tool: full schema with `.describe()` on every field, cursor pagination, size 1..500
- `JxaTransport` and `OmniJsTransport` stubbed with `notYetWired("searchTasks")`
- 22 new unit tests; all 490 pass

## Design link
Closes #57. Cursor codec from #35. DESIGN §26 reference pattern.

## Breaking change?
- [x] No

## Test plan
- [x] Text matching: by name, note, scope combinations, UTF-8
- [x] Filter narrowing: project, tags, flagged, completed
- [x] Pagination: limit, hasMore, cursor round-trip, filter-mismatch rejection
- [x] `pnpm lint` clean; `pnpm typecheck` no new errors introduced by this PR