### PR TITLE
feat(task): task_set_repetition and task_clear_repetition tools

### DIFF
--- a/src/tools/task/clearRepetition.ts
+++ b/src/tools/task/clearRepetition.ts
@@ -1,0 +1,80 @@
+/**
+ * `task_clear_repetition` MCP tool — remove the repetition rule from a task.
+ *
+ * Companion to `task_set_repetition`. Clears the rule atomically without
+ * requiring a full task_update payload.
+ *
+ * @see src/tools/task/setRepetition.ts — companion tool
+ * @see DESIGN.md §26 — tool pattern
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_CLEAR_REPETITION_DESCRIPTION =
+  "Remove the repetition rule from an OmniFocus task. " +
+  "After clearing, the task becomes a one-time item. " +
+  "Use task_set_repetition to set or change a rule. " +
+  "Mutations do not sync automatically — call sync_trigger if cross-device visibility matters.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskClearRepetitionInputSchema = z.object({
+  id: TaskId.schema.describe("ID of the task to update. Get from task_list or search_query."),
+});
+
+export type TaskClearRepetitionInput = z.infer<typeof taskClearRepetitionInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskClearRepetitionContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly in unit tests.
+ */
+export async function handleTaskClearRepetition(
+  input: TaskClearRepetitionInput,
+  ctx: TaskClearRepetitionContext,
+) {
+  await ctx.adapter.updateTask(input.id, { repetition: null });
+  const meta = ctx.makeMeta();
+  return ok({ id: input.id }, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskClearRepetitionTool(
+  server: McpServer,
+  ctx: TaskClearRepetitionContext,
+) {
+  return server.registerTool(
+    "task_clear_repetition",
+    {
+      description: TASK_CLEAR_REPETITION_DESCRIPTION,
+      inputSchema: taskClearRepetitionInputSchema.shape,
+    },
+    async (args: TaskClearRepetitionInput) => {
+      const envelope = await handleTaskClearRepetition(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/task/repetition.test.ts
+++ b/src/tools/task/repetition.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for task_set_repetition and task_clear_repetition tools.
+ *
+ * Covers: schema validation, setting a rule, clearing a rule, invalid-rule
+ * rejection, and unknown-ID surfacing.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskClearRepetition, taskClearRepetitionInputSchema } from "./clearRepetition.js";
+import { handleTaskSetRepetition, taskSetRepetitionInputSchema } from "./setRepetition.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema — task_set_repetition
+// ---------------------------------------------------------------------------
+
+describe("task_set_repetition — input schema", () => {
+  it("requires id and rule", () => {
+    expect(() => taskSetRepetitionInputSchema.parse({})).toThrow();
+    expect(() => taskSetRepetitionInputSchema.parse({ id: "task_000001" })).toThrow();
+  });
+
+  it("accepts a minimal daily rule", () => {
+    const parsed = taskSetRepetitionInputSchema.parse({
+      id: "task_000001",
+      rule: { method: "fixed", unit: "days", steps: 1 },
+    });
+    expect(parsed.rule.unit).toBe("days");
+  });
+
+  it("accepts a weekly rule with weekdays", () => {
+    const parsed = taskSetRepetitionInputSchema.parse({
+      id: "task_000001",
+      rule: { method: "start-again", unit: "weeks", steps: 1, weekdays: ["monday", "friday"] },
+    });
+    expect(parsed.rule.weekdays).toEqual(["monday", "friday"]);
+  });
+
+  it("rejects weekdays on non-week unit", () => {
+    expect(() =>
+      taskSetRepetitionInputSchema.parse({
+        id: "task_000001",
+        rule: { method: "fixed", unit: "days", steps: 1, weekdays: ["monday"] },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects monthlyAnchor on non-month unit", () => {
+    expect(() =>
+      taskSetRepetitionInputSchema.parse({
+        id: "task_000001",
+        rule: { method: "fixed", unit: "weeks", steps: 1, monthlyAnchor: { day: 15 } },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects steps below 1", () => {
+    expect(() =>
+      taskSetRepetitionInputSchema.parse({
+        id: "task_000001",
+        rule: { method: "fixed", unit: "days", steps: 0 },
+      }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema — task_clear_repetition
+// ---------------------------------------------------------------------------
+
+describe("task_clear_repetition — input schema", () => {
+  it("requires id", () => {
+    expect(() => taskClearRepetitionInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts id-only input", () => {
+    const parsed = taskClearRepetitionInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — task_set_repetition
+// ---------------------------------------------------------------------------
+
+describe("task_set_repetition — handler", () => {
+  it("sets a daily fixed repetition rule on a task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Daily task" });
+
+    const envelope = await handleTaskSetRepetition(
+      { id, rule: { method: "fixed", unit: "days", steps: 1 } },
+      ctx,
+    );
+
+    expect(envelope.data.id).toBe(id);
+
+    const task = await adapter.getTask(id);
+    expect(task.repetition).toMatchObject({ method: "fixed", unit: "days", steps: 1 });
+  });
+
+  it("sets a weekly due-again rule with weekdays", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Weekly task" });
+
+    await handleTaskSetRepetition(
+      {
+        id,
+        rule: { method: "due-again", unit: "weeks", steps: 2, weekdays: ["tuesday", "thursday"] },
+      },
+      ctx,
+    );
+
+    const task = await adapter.getTask(id);
+    expect(task.repetition?.weekdays).toEqual(["tuesday", "thursday"]);
+    expect(task.repetition?.steps).toBe(2);
+  });
+
+  it("overwrites an existing rule", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Repeating task" });
+
+    await handleTaskSetRepetition({ id, rule: { method: "fixed", unit: "days", steps: 1 } }, ctx);
+    await handleTaskSetRepetition(
+      { id, rule: { method: "start-again", unit: "weeks", steps: 1 } },
+      ctx,
+    );
+
+    const task = await adapter.getTask(id);
+    expect(task.repetition?.method).toBe("start-again");
+    expect(task.repetition?.unit).toBe("weeks");
+  });
+
+  it("surfaces NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTaskSetRepetition(
+        {
+          id: "task_999999" as import("../../domain/ids.js").TaskId,
+          rule: { method: "fixed", unit: "days", steps: 1 },
+        },
+        ctx,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("returns envelope with data.id matching the task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Task X" });
+    const envelope = await handleTaskSetRepetition(
+      { id, rule: { method: "fixed", unit: "months", steps: 1, monthlyAnchor: { day: 1 } } },
+      ctx,
+    );
+    expect(envelope.data).toHaveProperty("id", id);
+    expect(envelope.meta.correlationId).toBe("test-cid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — task_clear_repetition
+// ---------------------------------------------------------------------------
+
+describe("task_clear_repetition — handler", () => {
+  it("clears an existing repetition rule", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Repeating task" });
+
+    await handleTaskSetRepetition({ id, rule: { method: "fixed", unit: "days", steps: 7 } }, ctx);
+    // Confirm it's set
+    const before = await adapter.getTask(id);
+    expect(before.repetition).not.toBeNull();
+
+    // Clear it
+    await handleTaskClearRepetition({ id }, ctx);
+
+    const after = await adapter.getTask(id);
+    expect(after.repetition).toBeNull();
+  });
+
+  it("is idempotent — clearing a task with no rule is a no-op", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Non-repeating task" });
+
+    const before = await adapter.getTask(id);
+    expect(before.repetition).toBeNull();
+
+    // Should not throw
+    await handleTaskClearRepetition({ id }, ctx);
+
+    const after = await adapter.getTask(id);
+    expect(after.repetition).toBeNull();
+  });
+
+  it("surfaces NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTaskClearRepetition({ id: "task_999999" as import("../../domain/ids.js").TaskId }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it("returns envelope with data.id matching the task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Task Y" });
+    const envelope = await handleTaskClearRepetition({ id }, ctx);
+    expect(envelope.data).toHaveProperty("id", id);
+  });
+});

--- a/src/tools/task/setRepetition.ts
+++ b/src/tools/task/setRepetition.ts
@@ -1,0 +1,92 @@
+/**
+ * `task_set_repetition` MCP tool — atomically set the repetition rule on a task.
+ *
+ * A dedicated verb for repetition keeps the operation atomic and agent-friendly:
+ * agents don't need to read the full task object before patching a single field.
+ * `task_clear_repetition` is the complementary zero-arg verb that removes the rule.
+ *
+ * When the rule is structurally valid but OF rejects it (e.g. the task is
+ * completing via children and repetition conflicts), OmniFocus surfaces the
+ * rejection as an error — the adapter maps it to `ScriptError`.
+ *
+ * @see DESIGN.md §26 — tool pattern
+ * @see src/domain/task.ts — RepetitionRule schema
+ * @see src/tools/task/clearRepetition.ts — companion tool
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { TaskId } from "../../domain/ids.js";
+import { RepetitionRuleSchema } from "../../domain/task.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_SET_REPETITION_DESCRIPTION =
+  "Set the repetition rule on an OmniFocus task. " +
+  "Overwrites any existing rule. Use task_clear_repetition to remove a rule entirely. " +
+  "Returns the updated task ID; call task_get for the full object. " +
+  "Mutations do not sync automatically — call sync_trigger if cross-device visibility matters.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskSetRepetitionInputSchema = z.object({
+  id: TaskId.schema.describe("ID of the task to update. Get from task_list or search_query."),
+  rule: RepetitionRuleSchema.describe(
+    "Repetition rule to apply. " +
+      "'method': 'fixed' repeats from the due date, 'start-again' from completion, 'due-again' from due date (alias). " +
+      "'unit': time unit for the interval. " +
+      "'steps': how many units between occurrences (minimum 1). " +
+      "'weekdays': optional array of day names — only valid when unit is 'weeks'. " +
+      "'monthlyAnchor': optional day-of-month or weekday-position — only valid when unit is 'months'.",
+  ),
+});
+
+export type TaskSetRepetitionInput = z.infer<typeof taskSetRepetitionInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskSetRepetitionContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly in unit tests.
+ */
+export async function handleTaskSetRepetition(
+  input: TaskSetRepetitionInput,
+  ctx: TaskSetRepetitionContext,
+) {
+  await ctx.adapter.updateTask(input.id, { repetition: input.rule });
+  const meta = ctx.makeMeta();
+  return ok({ id: input.id }, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskSetRepetitionTool(server: McpServer, ctx: TaskSetRepetitionContext) {
+  return server.registerTool(
+    "task_set_repetition",
+    {
+      description: TASK_SET_REPETITION_DESCRIPTION,
+      inputSchema: taskSetRepetitionInputSchema.shape,
+    },
+    async (args: TaskSetRepetitionInput) => {
+      const envelope = await handleTaskSetRepetition(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `task_set_repetition({ id, rule })` — atomically sets/overwrites a `RepetitionRule` on a task
- Add `task_clear_repetition({ id })` — atomically removes the repetition rule (null patch)
- Both follow the DESIGN §26 tool pattern: Zod input schema with `.describe()`, pure handler, registration helper, ADR-0013 envelope
- Validation of cross-field constraints (weekdays/weeks-only, monthlyAnchor/months-only) reuses `RepetitionRuleSchema` from `domain/task.ts`
- 17 unit tests cover schema validation, set, overwrite, clear, idempotent clear, and NotFound propagation

## Design link

Closes #61. See [DESIGN.md §26](./DESIGN.md) — reference tool pattern.  
Blocked by #60 (RepetitionRule schema) which is now closed.

## Breaking change?

- [x] No

## Test plan

- [x] 17 new unit tests, all green
- [x] 507 total tests pass
- [x] Lint clean
- [x] No new dependencies