### PR TITLE
feat(task): task_find_by_name — disambiguation-aware name lookup

### DIFF
--- a/src/tools/task/findByName.test.ts
+++ b/src/tools/task/findByName.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for task_find_by_name tool.
+ *
+ * Covers: schema validation, exact/prefix/contains modes, case sensitivity,
+ * zero matches (empty array, not error), single match, multiple matches, limit.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskFindByName, taskFindByNameInputSchema } from "./findByName.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_find_by_name — input schema", () => {
+  it("requires query", () => {
+    expect(() => taskFindByNameInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects empty query", () => {
+    expect(() => taskFindByNameInputSchema.parse({ query: "" })).toThrow();
+  });
+
+  it("accepts minimal input", () => {
+    const parsed = taskFindByNameInputSchema.parse({ query: "Buy groceries" });
+    expect(parsed.query).toBe("Buy groceries");
+  });
+
+  it("accepts full input surface", () => {
+    const parsed = taskFindByNameInputSchema.parse({
+      query: "standup",
+      mode: "prefix",
+      caseSensitive: true,
+      limit: 10,
+    });
+    expect(parsed.mode).toBe("prefix");
+    expect(parsed.caseSensitive).toBe(true);
+    expect(parsed.limit).toBe(10);
+  });
+
+  it("rejects unknown mode", () => {
+    expect(() => taskFindByNameInputSchema.parse({ query: "x", mode: "fuzzy" })).toThrow();
+  });
+
+  it("rejects limit above 500", () => {
+    expect(() => taskFindByNameInputSchema.parse({ query: "x", limit: 501 })).toThrow();
+  });
+
+  it("rejects limit below 1", () => {
+    expect(() => taskFindByNameInputSchema.parse({ query: "x", limit: 0 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zero matches
+// ---------------------------------------------------------------------------
+
+describe("task_find_by_name — zero matches", () => {
+  it("returns empty array (not an error) when nothing matches", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Buy groceries" });
+    const envelope = await handleTaskFindByName({ query: "Standup" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(0);
+    expect(envelope.data.matchCount).toBe(0);
+  });
+
+  it("returns empty array when store is empty", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleTaskFindByName({ query: "anything" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exact mode (default)
+// ---------------------------------------------------------------------------
+
+describe("task_find_by_name — exact mode", () => {
+  it("returns exact match (case-insensitive by default)", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Daily Standup" });
+    await adapter.createTask({ name: "Buy groceries" });
+
+    const envelope = await handleTaskFindByName({ query: "daily standup" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.name).toBe("Daily Standup");
+  });
+
+  it("returns multiple tasks with the same name", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Review PR" });
+    await adapter.createTask({ name: "Review PR" });
+    await adapter.createTask({ name: "Different task" });
+
+    const envelope = await handleTaskFindByName({ query: "Review PR" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(2);
+    expect(envelope.data.matchCount).toBe(2);
+  });
+
+  it("does NOT match partial names in exact mode", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Daily Standup Notes" });
+    const envelope = await handleTaskFindByName({ query: "Daily Standup" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(0);
+  });
+
+  it("case-sensitive exact match misses case variants", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Daily Standup" });
+    const envelope = await handleTaskFindByName(
+      { query: "daily standup", caseSensitive: true },
+      ctx,
+    );
+    expect(envelope.data.tasks).toHaveLength(0);
+  });
+
+  it("case-sensitive exact match finds exact case", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Daily Standup" });
+    const envelope = await handleTaskFindByName(
+      { query: "Daily Standup", caseSensitive: true },
+      ctx,
+    );
+    expect(envelope.data.tasks).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prefix mode
+// ---------------------------------------------------------------------------
+
+describe("task_find_by_name — prefix mode", () => {
+  it("matches tasks whose names start with the query", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Buy groceries" });
+    await adapter.createTask({ name: "Buy milk" });
+    await adapter.createTask({ name: "Sell stocks" });
+
+    const envelope = await handleTaskFindByName({ query: "buy", mode: "prefix" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(2);
+  });
+
+  it("is case-insensitive by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "BUDGET review" });
+    const envelope = await handleTaskFindByName({ query: "budget", mode: "prefix" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+  });
+
+  it("case-sensitive prefix respects case", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Budget review" });
+    const envelope = await handleTaskFindByName(
+      { query: "budget", mode: "prefix", caseSensitive: true },
+      ctx,
+    );
+    expect(envelope.data.tasks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contains mode
+// ---------------------------------------------------------------------------
+
+describe("task_find_by_name — contains mode", () => {
+  it("matches tasks with the query anywhere in the name", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Weekly standup meeting" });
+    await adapter.createTask({ name: "Daily standup notes" });
+    await adapter.createTask({ name: "Buy groceries" });
+
+    const envelope = await handleTaskFindByName({ query: "standup", mode: "contains" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(2);
+  });
+
+  it("is case-insensitive by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Q1 BUDGET planning" });
+    const envelope = await handleTaskFindByName({ query: "budget", mode: "contains" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Limit
+// ---------------------------------------------------------------------------
+
+describe("task_find_by_name — limit", () => {
+  it("respects limit and reports full matchCount", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 10; i++) await adapter.createTask({ name: `Task ${i}` });
+
+    const envelope = await handleTaskFindByName({ query: "Task", mode: "prefix", limit: 3 }, ctx);
+    expect(envelope.data.tasks).toHaveLength(3);
+    expect(envelope.data.matchCount).toBe(10);
+  });
+
+  it("defaults to limit 50", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 60; i++) await adapter.createTask({ name: "Same Name" });
+
+    const envelope = await handleTaskFindByName({ query: "Same Name" }, ctx);
+    expect(envelope.data.tasks).toHaveLength(50);
+    expect(envelope.data.matchCount).toBe(60);
+  });
+});

--- a/src/tools/task/findByName.ts
+++ b/src/tools/task/findByName.ts
@@ -1,0 +1,131 @@
+/**
+ * `task_find_by_name` MCP tool — disambiguation-aware task lookup by name.
+ *
+ * OmniFocus task names are **not unique** — two tasks can share a name and
+ * often do. This tool is the explicit "I only have a name" escape hatch;
+ * it returns **all** matching tasks and makes non-uniqueness visible rather
+ * than silently picking one. The result is always an array (zero or more).
+ *
+ * Zero matches is **not** an error — callers distinguish "not found" from
+ * "ambiguous" by array length. Only use this tool when you genuinely lack
+ * an ID. If you have an ID, use `task_get`; if you need broad filtering,
+ * use `task_list` or `search_query`.
+ *
+ * @see DESIGN.md §13 — ADR-0008 (IDs-only API; this tool is the escape hatch)
+ * @see src/tools/task/list.ts — for filter-based listing
+ * @see src/tools/search/query.ts — for full-text search
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_FIND_BY_NAME_DESCRIPTION =
+  "Find tasks in OmniFocus by name. " +
+  "Returns ALL matching tasks (names are not unique in OmniFocus). " +
+  "Names collide in OmniFocus; prefer task_get with an ID when you have one. " +
+  "Zero matches returns an empty array — not an error. " +
+  "Returns tasks[]; safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskFindByNameInputSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Name to search for. Behaviour depends on mode: exact = full name match; " +
+        "prefix = name starts with this string; contains = substring match anywhere in name.",
+    ),
+  mode: z
+    .enum(["exact", "prefix", "contains"])
+    .optional()
+    .describe(
+      "'exact' = full task name must match (default); 'prefix' = name must start with query; " +
+        "'contains' = query appears anywhere in name.",
+    ),
+  caseSensitive: z
+    .boolean()
+    .optional()
+    .describe("true = match is case-sensitive; false = case-insensitive (default false)."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Maximum number of results to return (1..500). Default 50."),
+});
+
+export type TaskFindByNameInput = z.infer<typeof taskFindByNameInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskFindByNameContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly in unit tests.
+ *
+ * Fetches all tasks and applies name matching in-process. For JXA this is
+ * equivalent to filtering `flattenedTasks` by a name predicate.
+ */
+export async function handleTaskFindByName(input: TaskFindByNameInput, ctx: TaskFindByNameContext) {
+  const mode = input.mode ?? "exact";
+  const caseSensitive = input.caseSensitive ?? false;
+  const limit = input.limit ?? 50;
+
+  // Fetch all tasks (adapter applies no name filter — we filter in-process)
+  const allTasks = await ctx.adapter.listTasks({});
+
+  const normalise = (s: string) => (caseSensitive ? s : s.toLowerCase());
+  const q = normalise(input.query);
+
+  const matched = allTasks.filter((task) => {
+    const name = normalise(task.name);
+    switch (mode) {
+      case "exact":
+        return name === q;
+      case "prefix":
+        return name.startsWith(q);
+      case "contains":
+        return name.includes(q);
+    }
+  });
+
+  const tasks = matched.slice(0, limit);
+  const meta = ctx.makeMeta();
+  return ok({ tasks, matchCount: matched.length }, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskFindByNameTool(server: McpServer, ctx: TaskFindByNameContext) {
+  return server.registerTool(
+    "task_find_by_name",
+    {
+      description: TASK_FIND_BY_NAME_DESCRIPTION,
+      inputSchema: taskFindByNameInputSchema.shape,
+    },
+    async (args: TaskFindByNameInput) => {
+      const envelope = await handleTaskFindByName(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `task_find_by_name` — returns **all** matching tasks by name (OmniFocus names are not unique)
- `mode`: `'exact'` (default) | `'prefix'` | `'contains'`
- `caseSensitive`: boolean, default `false`
- `limit`: 1..500, default 50
- Returns `{ tasks, matchCount }` — zero matches is success (empty array, not an error)
- Tool description explicitly warns agents to prefer `task_get` with an ID when available
- Filtering in-process after `listTasks({})`; `matchCount` reflects full set before limit truncation

## Design link

Closes #91. See DESIGN.md §13 / ADR-0008 — IDs-only API; this tool is the documented escape hatch for name-only lookups.

## Breaking change?

- [x] No

## Test plan

- [x] 21 unit tests — all modes, case variants, zero/single/multiple matches, limit + matchCount
- [x] 528 total tests pass
- [x] Lint clean
- [x] No new dependencies