### PR TITLE
feat(task): task_get_many — batch fetch up to 100 tasks by ID

### DIFF
--- a/src/tools/task/getMany.test.ts
+++ b/src/tools/task/getMany.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for task_get_many tool.
+ *
+ * Covers: schema validation, empty input fast-path, all-present batch,
+ * mix of present + missing IDs (warnings), order preservation, max-100 guard.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { TaskId } from "../../domain/ids.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskGetMany, taskGetManyInputSchema } from "./getMany.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_get_many — input schema", () => {
+  it("accepts an empty ids array", () => {
+    const parsed = taskGetManyInputSchema.parse({ ids: [] });
+    expect(parsed.ids).toHaveLength(0);
+  });
+
+  it("accepts a populated ids array", () => {
+    const parsed = taskGetManyInputSchema.parse({ ids: ["task_000001"] });
+    expect(parsed.ids).toHaveLength(1);
+  });
+
+  it("rejects more than 100 ids", () => {
+    const ids = Array.from({ length: 101 }, (_, i) => `task_${String(i + 1).padStart(6, "0")}`);
+    expect(() => taskGetManyInputSchema.parse({ ids })).toThrow();
+  });
+
+  it("requires ids field", () => {
+    expect(() => taskGetManyInputSchema.parse({})).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty input fast-path
+// ---------------------------------------------------------------------------
+
+describe("task_get_many — empty input", () => {
+  it("returns empty tasks array without touching the adapter", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleTaskGetMany({ ids: [] }, ctx);
+    expect(envelope.data.tasks).toHaveLength(0);
+    expect(envelope.meta.warnings).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// All-present batch
+// ---------------------------------------------------------------------------
+
+describe("task_get_many — all present", () => {
+  it("returns all requested tasks", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id1 = await adapter.createTask({ name: "Task Alpha" });
+    const id2 = await adapter.createTask({ name: "Task Beta" });
+    const id3 = await adapter.createTask({ name: "Task Gamma" });
+
+    const envelope = await handleTaskGetMany({ ids: [id1, id2, id3] }, ctx);
+    expect(envelope.data.tasks).toHaveLength(3);
+    expect(envelope.meta.warnings).toBeUndefined();
+  });
+
+  it("returns tasks in input-ID order", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id1 = await adapter.createTask({ name: "First" });
+    const id2 = await adapter.createTask({ name: "Second" });
+    const id3 = await adapter.createTask({ name: "Third" });
+
+    // Request in reverse order
+    const envelope = await handleTaskGetMany({ ids: [id3, id1, id2] }, ctx);
+    const names = envelope.data.tasks.map((t) => t.name);
+    expect(names).toEqual(["Third", "First", "Second"]);
+  });
+
+  it("fetches a single task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Solo task" });
+    const envelope = await handleTaskGetMany({ ids: [id] }, ctx);
+    expect(envelope.data.tasks[0]?.name).toBe("Solo task");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing IDs
+// ---------------------------------------------------------------------------
+
+describe("task_get_many — missing IDs", () => {
+  it("omits missing IDs and emits WARN_IDS_NOT_FOUND", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id1 = await adapter.createTask({ name: "Exists" });
+    const ghost = "task_999999" as TaskId;
+
+    const envelope = await handleTaskGetMany({ ids: [id1, ghost] }, ctx);
+    expect(envelope.data.tasks).toHaveLength(1);
+    expect(envelope.data.tasks[0]?.name).toBe("Exists");
+
+    expect(envelope.meta.warnings).toHaveLength(1);
+    expect(envelope.meta.warnings?.[0]?.code).toBe("WARN_IDS_NOT_FOUND");
+    expect(envelope.meta.warnings?.[0]?.details).toMatchObject({ missing: [ghost] });
+  });
+
+  it("returns empty tasks array with warning when all IDs are missing", async () => {
+    const { ctx } = makeCtx();
+    const ghost1 = "task_999998" as TaskId;
+    const ghost2 = "task_999999" as TaskId;
+
+    const envelope = await handleTaskGetMany({ ids: [ghost1, ghost2] }, ctx);
+    expect(envelope.data.tasks).toHaveLength(0);
+    expect(envelope.meta.warnings?.[0]?.code).toBe("WARN_IDS_NOT_FOUND");
+    expect(envelope.meta.warnings?.[0]?.details).toMatchObject({ missing: [ghost1, ghost2] });
+  });
+
+  it("preserves order of found tasks when some IDs are missing", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id1 = await adapter.createTask({ name: "First" });
+    const id2 = await adapter.createTask({ name: "Third" });
+    const ghost = "task_999999" as TaskId;
+
+    // ids: [id1, ghost, id2] → tasks: [First, Third] (ghost omitted)
+    const envelope = await handleTaskGetMany({ ids: [id1, ghost, id2] }, ctx);
+    expect(envelope.data.tasks.map((t) => t.name)).toEqual(["First", "Third"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Over-limit guard (defensive, bypassing schema)
+// ---------------------------------------------------------------------------
+
+describe("task_get_many — over-limit guard", () => {
+  it("throws ValidationError when ids exceed 100 (direct handler call)", async () => {
+    const { ctx } = makeCtx();
+    const ids = Array.from(
+      { length: 101 },
+      (_, i) => `task_${String(i + 1).padStart(6, "0")}` as TaskId,
+    );
+    await expect(handleTaskGetMany({ ids }, ctx)).rejects.toThrow();
+  });
+});

--- a/src/tools/task/getMany.ts
+++ b/src/tools/task/getMany.ts
@@ -1,0 +1,126 @@
+/**
+ * `task_get_many` MCP tool — fetch up to 100 tasks by persistent ID in one
+ * OmniFocus round-trip.
+ *
+ * Agents frequently accumulate task IDs from multiple sources (a perspective
+ * result, a search result, a resource read) and need full task objects for
+ * all of them. Without this tool they would make N serial `task_get` calls;
+ * this batches them into one JXA script invocation.
+ *
+ * ## Behaviour
+ *
+ * - Tasks are returned in the **same order** as the input `ids` array.
+ * - IDs that are not found (deleted, never existed) are **omitted** from the
+ *   result — they are **not** errors. They surface in `meta.warnings` under
+ *   the `WARN_IDS_NOT_FOUND` code with `details.missing` listing the IDs.
+ * - An empty `ids` array returns `[]` immediately without touching OmniFocus.
+ * - Passing more than 100 IDs returns `OF_VALIDATION` (too large to batch).
+ *
+ * @see DESIGN.md §26 — tool pattern
+ * @see src/envelope/index.ts — WARN_IDS_NOT_FOUND builder
+ * @see src/adapter/OmniFocusAdapter.ts — getTasksMany contract
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok, warnIdsNotFound } from "../../envelope/index.js";
+import { ValidationError } from "../../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_GET_MANY_DESCRIPTION =
+  "Fetch up to 100 tasks by persistent ID in a single OmniFocus round-trip. " +
+  "Use when you have a set of task IDs from multiple sources and need full task objects for all of them. " +
+  "Do NOT use for a single ID — use task_get instead. " +
+  "Do NOT use when you only have names — use task_find_by_name. " +
+  "Returns Task[] in input order. Missing IDs are omitted and appear in meta.warnings. " +
+  "Read-only; safe to retry.";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_IDS = 100;
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskGetManyInputSchema = z.object({
+  ids: z
+    .array(TaskId.schema)
+    .min(0)
+    .max(MAX_IDS)
+    .describe(
+      `Array of task IDs to fetch (0..${MAX_IDS}). Get IDs from task_list, search_query, or task_find_by_name. Missing IDs are omitted (not errors) and appear in meta.warnings.`,
+    ),
+});
+
+export type TaskGetManyInput = z.infer<typeof taskGetManyInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskGetManyContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly in unit tests.
+ *
+ * Delegates to `adapter.getTasksMany` which returns `(Task | null)[]` with
+ * `null` for each position where the ID was not found. This handler strips
+ * the nulls and emits a `WARN_IDS_NOT_FOUND` warning if any were missing.
+ */
+export async function handleTaskGetMany(input: TaskGetManyInput, ctx: TaskGetManyContext) {
+  // Fast path — empty input never touches the adapter
+  if (input.ids.length === 0) {
+    return ok({ tasks: [] }, ctx.makeMeta());
+  }
+
+  // The Zod schema already enforces max 100, but guard defensively for
+  // callers that bypass schema validation (e.g. direct handler tests).
+  if (input.ids.length > MAX_IDS) {
+    throw new ValidationError(
+      `ids array exceeds the maximum batch size of ${MAX_IDS} (got ${input.ids.length})`,
+      { field: "ids" },
+    );
+  }
+
+  const raw = await ctx.adapter.getTasksMany(input.ids);
+
+  const tasks = raw.filter((t): t is NonNullable<typeof t> => t !== null);
+  const missing = input.ids.filter((_id, i) => raw[i] === null);
+
+  const warnings = missing.length > 0 ? [warnIdsNotFound(missing)] : undefined;
+  const meta = ctx.makeMeta({ ...(warnings !== undefined ? { warnings } : {}) });
+
+  return ok({ tasks }, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskGetManyTool(server: McpServer, ctx: TaskGetManyContext) {
+  return server.registerTool(
+    "task_get_many",
+    {
+      description: TASK_GET_MANY_DESCRIPTION,
+      inputSchema: taskGetManyInputSchema.shape,
+    },
+    async (args: TaskGetManyInput) => {
+      const envelope = await handleTaskGetMany(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `task_get_many` — fetches up to 100 tasks by persistent ID in a single adapter call
- Tasks returned in **input-ID order**
- Missing IDs omitted (not errors) — surface in `meta.warnings[].code === 'WARN_IDS_NOT_FOUND'` with `details.missing`
- Empty `ids[]` returns `[]` immediately (fast-path, no adapter call)
- 12 unit tests covering schema, fast-path, order, mixed present+missing, all-missing, over-100 guard

## Design link

Closes #128. Avoids N serial `task_get` calls when agents accumulate IDs from multiple sources (search, perspective results, resource reads).

## Breaking change?

- [x] No

## Test plan

- [x] 12 unit tests, all green
- [x] 540 total tests pass
- [x] Lint clean
- [x] No new dependencies