### PR TITLE
feat(task): add sortBy + sortDirection to task_list

### DIFF
--- a/src/pagination/cursor.test.ts
+++ b/src/pagination/cursor.test.ts
@@ -43,7 +43,7 @@ describe("hashFilter", () => {
 describe("encodeCursor / decodeCursor round-trip", () => {
   const payload: CursorPayload = {
     lastId: "gHqVKr3xAWo",
-    lastCreatedAt: "2026-04-19T15:23:04-05:00",
+    lastSortValue: "2026-04-19T15:23:04-05:00",
     filterHash: hashFilter({ available: true }),
   };
 
@@ -51,6 +51,17 @@ describe("encodeCursor / decodeCursor round-trip", () => {
     const cursor = encodeCursor(payload);
     const decoded = decodeCursor(cursor, payload.filterHash);
     expect(decoded).toEqual(payload);
+  });
+
+  it("round-trips a cursor payload with null sortValue", () => {
+    const nullPayload: CursorPayload = {
+      lastId: "gHqVKr3xAWo",
+      lastSortValue: null,
+      filterHash: hashFilter({ available: true }),
+    };
+    const cursor = encodeCursor(nullPayload);
+    const decoded = decodeCursor(cursor, nullPayload.filterHash);
+    expect(decoded).toEqual(nullPayload);
   });
 
   it("produces a base64url string (no +, /, or =)", () => {
@@ -96,38 +107,95 @@ describe("encodeCursor / decodeCursor round-trip", () => {
   });
 });
 
-describe("isAfterCursor", () => {
+describe("isAfterCursor — ASC (default)", () => {
   const cursor: CursorPayload = {
     lastId: "gHqVKr3xAWo",
-    lastCreatedAt: "2026-04-19T15:23:04-05:00",
+    lastSortValue: "2026-04-19T15:23:04-05:00",
     filterHash: "irrelevant",
   };
 
-  it("returns true when createdAt is strictly after cursor", () => {
-    expect(isAfterCursor({ id: "anyId", createdAt: "2026-04-20T00:00:00Z" }, cursor)).toBe(true);
+  it("returns true when sortValue is strictly after cursor", () => {
+    expect(isAfterCursor({ id: "anyId", sortValue: "2026-04-20T00:00:00Z" }, cursor)).toBe(true);
   });
 
-  it("returns true when createdAt is equal and id is lexicographically greater", () => {
+  it("returns true when sortValue is equal and id is lexicographically greater", () => {
     expect(
-      isAfterCursor({ id: "zZZZZZZZZZZ", createdAt: "2026-04-19T15:23:04-05:00" }, cursor),
+      isAfterCursor({ id: "zZZZZZZZZZZ", sortValue: "2026-04-19T15:23:04-05:00" }, cursor),
     ).toBe(true);
   });
 
-  it("returns false when createdAt is equal and id is equal", () => {
+  it("returns false when sortValue is equal and id is equal", () => {
     expect(
-      isAfterCursor({ id: "gHqVKr3xAWo", createdAt: "2026-04-19T15:23:04-05:00" }, cursor),
+      isAfterCursor({ id: "gHqVKr3xAWo", sortValue: "2026-04-19T15:23:04-05:00" }, cursor),
     ).toBe(false);
   });
 
-  it("returns false when createdAt is before cursor", () => {
-    expect(isAfterCursor({ id: "zZZZZZZZZZZ", createdAt: "2026-04-18T00:00:00Z" }, cursor)).toBe(
+  it("returns false when sortValue is before cursor", () => {
+    expect(isAfterCursor({ id: "zZZZZZZZZZZ", sortValue: "2026-04-18T00:00:00Z" }, cursor)).toBe(
       false,
     );
   });
 
-  it("returns false when createdAt is equal and id is lexicographically less", () => {
-    expect(isAfterCursor({ id: "aaaaaaaaa", createdAt: "2026-04-19T15:23:04-05:00" }, cursor)).toBe(
+  it("returns false when sortValue is equal and id is lexicographically less", () => {
+    expect(isAfterCursor({ id: "aaaaaaaaa", sortValue: "2026-04-19T15:23:04-05:00" }, cursor)).toBe(
       false,
     );
+  });
+});
+
+describe("isAfterCursor — DESC", () => {
+  const cursor: CursorPayload = {
+    lastId: "gHqVKr3xAWo",
+    lastSortValue: "2026-04-19T15:23:04-05:00",
+    filterHash: "irrelevant",
+  };
+
+  it("returns true when sortValue is strictly before cursor (desc)", () => {
+    expect(isAfterCursor({ id: "anyId", sortValue: "2026-04-18T00:00:00Z" }, cursor, "desc")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when sortValue is after cursor (desc)", () => {
+    expect(isAfterCursor({ id: "anyId", sortValue: "2026-04-20T00:00:00Z" }, cursor, "desc")).toBe(
+      false,
+    );
+  });
+});
+
+describe("isAfterCursor — null sortValue (nulls-last)", () => {
+  const cursorWithNull: CursorPayload = {
+    lastId: "id_aaa",
+    lastSortValue: null,
+    filterHash: "irrelevant",
+  };
+  const cursorWithValue: CursorPayload = {
+    lastId: "id_aaa",
+    lastSortValue: "2026-04-19T00:00:00Z",
+    filterHash: "irrelevant",
+  };
+
+  it("null item is after non-null cursor in ASC (nulls last)", () => {
+    expect(isAfterCursor({ id: "id_bbb", sortValue: null }, cursorWithValue, "asc")).toBe(true);
+  });
+
+  it("null item is NOT after null cursor with smaller id (both null)", () => {
+    expect(isAfterCursor({ id: "id_aaa", sortValue: null }, cursorWithNull, "asc")).toBe(false);
+  });
+
+  it("null item with greater id is after null cursor (both null, tie-break)", () => {
+    expect(isAfterCursor({ id: "id_zzz", sortValue: null }, cursorWithNull, "asc")).toBe(true);
+  });
+
+  it("non-null item is NOT after null cursor in ASC (item is before null)", () => {
+    expect(
+      isAfterCursor({ id: "id_bbb", sortValue: "2026-04-19T00:00:00Z" }, cursorWithNull, "asc"),
+    ).toBe(false);
+  });
+
+  it("non-null item is after null cursor in DESC", () => {
+    expect(
+      isAfterCursor({ id: "id_bbb", sortValue: "2026-04-19T00:00:00Z" }, cursorWithNull, "desc"),
+    ).toBe(true);
   });
 });

--- a/src/pagination/cursor.ts
+++ b/src/pagination/cursor.ts
@@ -2,14 +2,16 @@
  * Cursor codec for cursor-based pagination (DESIGN §15).
  *
  * Cursors are opaque to clients and base64url-encoded internally.
- * Each cursor encodes `{ lastId, lastCreatedAt, filterHash }`:
+ * Each cursor encodes `{ lastId, lastSortValue, filterHash }`:
  *
  * - `lastId` — the OF persistent ID of the last item returned
- * - `lastCreatedAt` — ISO-8601 timestamp of that item (with offset)
+ * - `lastSortValue` — the sort-field value of that item (null when the field
+ *   is absent on the item, e.g. a task with no dueDate); null values sort last
+ *   regardless of direction
  * - `filterHash` — SHA-256 (hex) of the serialized filter object; a mismatch
  *   means the client changed filters mid-page and gets a ValidationError
  *
- * Sort order: `createdAt ASC, id ASC` — stable under concurrent inserts.
+ * Sort order is determined by the caller (default `createdAt ASC, id ASC`).
  *
  * @see DESIGN.md §15 — pagination strategy
  */
@@ -23,7 +25,8 @@ import { ValidationError } from "../errors/index.js";
 
 export interface CursorPayload {
   lastId: string;
-  lastCreatedAt: string;
+  /** Sort-field value of the last emitted item; null when the field is absent on the item. */
+  lastSortValue: string | null;
   filterHash: string;
 }
 
@@ -74,12 +77,13 @@ export function decodeCursor(cursor: string, currentFilterHash: string): CursorP
     });
   }
 
+  const p2 = payload as Record<string, unknown>;
   if (
     typeof payload !== "object" ||
     payload === null ||
-    typeof (payload as Record<string, unknown>).lastId !== "string" ||
-    typeof (payload as Record<string, unknown>).lastCreatedAt !== "string" ||
-    typeof (payload as Record<string, unknown>).filterHash !== "string"
+    typeof p2.lastId !== "string" ||
+    (p2.lastSortValue !== null && typeof p2.lastSortValue !== "string") ||
+    typeof p2.filterHash !== "string"
   ) {
     throw new ValidationError("Cursor payload is missing required fields.", {
       suggestion: "Pass the cursor value exactly as returned by the previous response.",
@@ -107,14 +111,36 @@ export function decodeCursor(cursor: string, currentFilterHash: string): CursorP
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if `item` should appear after the cursor in a
- * `(createdAt ASC, id ASC)` sort — i.e., the item is on the next page.
+ * Returns true if `item` should appear after the cursor in a stable
+ * `(sortValue, id)` sort — i.e., the item is on the next page.
+ *
+ * Null sort values sort **last** regardless of direction (nulls-last
+ * semantics). When both are null the tie is broken by ID.
+ *
+ * @param item          The candidate item to test.
+ * @param cursor        The decoded cursor from the previous page.
+ * @param sortDirection "asc" (default) or "desc".
  */
 export function isAfterCursor(
-  item: { id: string; createdAt: string },
+  item: { id: string; sortValue: string | null },
   cursor: CursorPayload,
+  sortDirection: "asc" | "desc" = "asc",
 ): boolean {
-  if (item.createdAt > cursor.lastCreatedAt) return true;
-  if (item.createdAt === cursor.lastCreatedAt) return item.id > cursor.lastId;
-  return false;
+  const iv = item.sortValue;
+  const cv = cursor.lastSortValue;
+
+  // Both null → tie-break on id (always ascending for stability)
+  if (iv === null && cv === null) return item.id > cursor.lastId;
+
+  // Null sorts last: a null item is only "after" a non-null cursor in ASC,
+  // and always "after" nothing (non-null > null) in DESC.
+  if (iv === null) return sortDirection === "asc"; // null comes after non-null in ASC
+  if (cv === null) return sortDirection === "desc"; // non-null comes after null in DESC
+
+  // Both non-null: compare normally
+  if (iv !== cv) {
+    return sortDirection === "asc" ? iv > cv : iv < cv;
+  }
+  // Equal values: tie-break on id
+  return item.id > cursor.lastId;
 }

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -112,9 +112,15 @@ export class SearchService {
       return dateCompare !== 0 ? dateCompare : a.id.localeCompare(b.id);
     });
 
-    // Apply cursor offset
+    // Apply cursor offset (search always sorts createdAt ASC)
     const afterCursor = cursorPayload
-      ? sorted.filter((t) => isAfterCursor(t, cursorPayload as CursorPayload))
+      ? sorted.filter((t) =>
+          isAfterCursor(
+            { id: t.id, sortValue: t.createdAt },
+            cursorPayload as CursorPayload,
+            "asc",
+          ),
+        )
       : sorted;
 
     // Take one extra to detect hasMore
@@ -126,7 +132,7 @@ export class SearchService {
     const last = tasks.at(-1);
     const nextCursor =
       hasMore && last
-        ? encodeCursor({ lastId: last.id, lastCreatedAt: last.createdAt, filterHash })
+        ? encodeCursor({ lastId: last.id, lastSortValue: last.createdAt, filterHash })
         : null;
 
     return { tasks, nextCursor, hasMore, cacheHit: false };

--- a/src/services/taskService.sort.test.ts
+++ b/src/services/taskService.sort.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for TaskService sortBy + sortDirection (issue #133).
+ *
+ * Covers: default sort (createdAt ASC), all four sortBy fields, desc direction,
+ * nulls-last semantics for dueDate, cursor pagination stability across pages
+ * when sortBy is set.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
+import { TaskService } from "./taskService.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeService() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const service = new TaskService({ adapter, cache });
+  return { service, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Default sort (createdAt ASC)
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — default sort (createdAt ASC)", () => {
+  it("returns tasks in createdAt ASC order by default", async () => {
+    const { service, adapter } = makeService();
+    const id1 = await adapter.createTask({ name: "First" });
+    const id2 = await adapter.createTask({ name: "Second" });
+    const id3 = await adapter.createTask({ name: "Third" });
+
+    const { tasks } = await service.list({ limit: 10 });
+    expect(tasks.map((t) => t.id)).toEqual([id1, id2, id3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortBy: name
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — sortBy name", () => {
+  it("returns tasks in name ASC order", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "Zebra" });
+    await adapter.createTask({ name: "Apple" });
+    await adapter.createTask({ name: "Mango" });
+
+    const { tasks } = await service.list({ limit: 10, sortBy: "name" });
+    expect(tasks.map((t) => t.name)).toEqual(["Apple", "Mango", "Zebra"]);
+  });
+
+  it("returns tasks in name DESC order", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "Zebra" });
+    await adapter.createTask({ name: "Apple" });
+    await adapter.createTask({ name: "Mango" });
+
+    const { tasks } = await service.list({ limit: 10, sortBy: "name", sortDirection: "desc" });
+    expect(tasks.map((t) => t.name)).toEqual(["Zebra", "Mango", "Apple"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortBy: dueDate (nulls last)
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — sortBy dueDate (nulls last)", () => {
+  it("places tasks with no dueDate after those with one (ASC)", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "NoDue" }); // no dueDate
+    await adapter.createTask({ name: "Later", dueDate: "2026-06-01T00:00:00Z" });
+    await adapter.createTask({ name: "Earlier", dueDate: "2026-04-01T00:00:00Z" });
+
+    const { tasks } = await service.list({ limit: 10, sortBy: "dueDate" });
+    expect(tasks.map((t) => t.name)).toEqual(["Earlier", "Later", "NoDue"]);
+  });
+
+  it("places tasks with no dueDate after those with one (DESC)", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "NoDue" });
+    await adapter.createTask({ name: "Later", dueDate: "2026-06-01T00:00:00Z" });
+    await adapter.createTask({ name: "Earlier", dueDate: "2026-04-01T00:00:00Z" });
+
+    const { tasks } = await service.list({
+      limit: 10,
+      sortBy: "dueDate",
+      sortDirection: "desc",
+    });
+    expect(tasks.map((t) => t.name)).toEqual(["Later", "Earlier", "NoDue"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortBy: createdAt DESC
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — sortBy createdAt DESC", () => {
+  it("returns newest tasks first", async () => {
+    const { service, adapter } = makeService();
+    const id1 = await adapter.createTask({ name: "First" });
+    const id2 = await adapter.createTask({ name: "Second" });
+    const id3 = await adapter.createTask({ name: "Third" });
+
+    const { tasks } = await service.list({ limit: 10, sortBy: "createdAt", sortDirection: "desc" });
+    expect(tasks.map((t) => t.id)).toEqual([id3, id2, id1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cursor pagination with sortBy
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — cursor pagination with sortBy", () => {
+  it("paginates correctly with sortBy: name ASC", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "Cherry" });
+    await adapter.createTask({ name: "Apple" });
+    await adapter.createTask({ name: "Date" });
+    await adapter.createTask({ name: "Banana" });
+
+    const page1 = await service.list({ limit: 2, sortBy: "name" });
+    expect(page1.tasks.map((t) => t.name)).toEqual(["Apple", "Banana"]);
+    expect(page1.hasMore).toBe(true);
+
+    const page2 = await service.list({
+      limit: 2,
+      sortBy: "name",
+      // biome-ignore lint/style/noNonNullAssertion: hasMore is asserted true above
+      cursor: page1.nextCursor!,
+    });
+    expect(page2.tasks.map((t) => t.name)).toEqual(["Cherry", "Date"]);
+    expect(page2.hasMore).toBe(false);
+  });
+
+  it("paginates correctly with sortBy: dueDate ASC (nulls last)", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "NoDue1" });
+    await adapter.createTask({ name: "NoDue2" });
+    await adapter.createTask({ name: "Due2", dueDate: "2026-06-01T00:00:00Z" });
+    await adapter.createTask({ name: "Due1", dueDate: "2026-05-01T00:00:00Z" });
+
+    const page1 = await service.list({ limit: 2, sortBy: "dueDate" });
+    expect(page1.tasks.map((t) => t.name)).toEqual(["Due1", "Due2"]);
+    expect(page1.hasMore).toBe(true);
+
+    const page2 = await service.list({
+      limit: 2,
+      sortBy: "dueDate",
+      // biome-ignore lint/style/noNonNullAssertion: hasMore is asserted true above
+      cursor: page1.nextCursor!,
+    });
+    // Both NoDue tasks land on page 2 (nulls last)
+    expect(page2.tasks.map((t) => t.name)).toEqual(expect.arrayContaining(["NoDue1", "NoDue2"]));
+    expect(page2.hasMore).toBe(false);
+  });
+
+  it("rejects cursor when sortBy changes mid-sequence", async () => {
+    const { service, adapter } = makeService();
+    for (let i = 0; i < 3; i++) await adapter.createTask({ name: `Task ${i}` });
+
+    const page1 = await service.list({ limit: 2, sortBy: "name" });
+    expect(page1.nextCursor).not.toBeNull();
+    const cursor = page1.nextCursor as string;
+    await expect(service.list({ limit: 2, sortBy: "createdAt", cursor })).rejects.toMatchObject({
+      code: "OF_VALIDATION",
+    });
+  });
+});

--- a/src/services/taskService.test.ts
+++ b/src/services/taskService.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for `TaskService.list`.
+ *
+ * Contract verified here:
+ * - Filter plumbing matches the adapter semantics (single-tag pushed down,
+ *   multi-tag intersected post-fetch, `completed` mode mapped to boolean).
+ * - Pagination is stable under `(createdAt ASC, id ASC)` sort; cursors
+ *   round-trip; filter-hash mismatch rejects.
+ * - Unbounded queries throw `ValidationError` with the canonical suggestion.
+ * - The cache layer is consulted (hit/miss) and a second identical call
+ *   returns `cacheHit: true` without re-hitting the adapter.
+ *
+ * All tests use `InMemoryAdapter` and the real `OmniFocusLruCache` — no
+ * mocks beyond clock injection. The service's contract is the value being
+ * tested, not its internal call-graph.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
+import type { ProjectId, TagId } from "../domain/ids.js";
+import { ValidationError } from "../errors/index.js";
+import { type TaskListInput, TaskService } from "./taskService.js";
+
+// ---------------------------------------------------------------------------
+// Harness helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an adapter + cache + service, with a strictly-monotonic clock so
+ * every created task has a distinct `createdAt` (and thus a deterministic
+ * `(createdAt ASC, id ASC)` order under pagination).
+ */
+function makeHarness(): {
+  service: TaskService;
+  adapter: InMemoryAdapter;
+  cache: OmniFocusLruCache;
+} {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const service = new TaskService({ adapter, cache });
+  return { service, adapter, cache };
+}
+
+async function seedTags(adapter: InMemoryAdapter, names: string[]): Promise<TagId[]> {
+  const out: TagId[] = [];
+  for (const name of names) out.push(await adapter.createTag({ name }));
+  return out;
+}
+
+async function seedProject(adapter: InMemoryAdapter, name: string): Promise<ProjectId> {
+  return adapter.createProject({ name });
+}
+
+// ---------------------------------------------------------------------------
+// Validation gate
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — validation gate", () => {
+  it("rejects fully unbounded queries with the documented suggestion", async () => {
+    const { service } = makeHarness();
+    const err = await service.list({}).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).suggestion).toBe("Provide a filter or a limit.");
+  });
+
+  it("accepts a call with only limit (no filter, no cursor)", async () => {
+    const { service } = makeHarness();
+    const out = await service.list({ limit: 10 });
+    expect(out.tasks).toEqual([]);
+    expect(out.hasMore).toBe(false);
+  });
+
+  it("accepts a call with only a filter (no limit, no cursor)", async () => {
+    const { service } = makeHarness();
+    const out = await service.list({ flagged: true });
+    expect(out.tasks).toEqual([]);
+  });
+
+  it("rejects empty tagIds array as 'no filter'", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ tagIds: [] })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects non-integer limit", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ limit: 1.5 })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects limit below 1", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ limit: 0 })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects limit above 1000", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ limit: 1001 })).rejects.toBeInstanceOf(ValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter plumbing
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — filters", () => {
+  it("applies flagged, completed=exclude (default intent), and projectId", async () => {
+    const { service, adapter } = makeHarness();
+    const projA = await seedProject(adapter, "A");
+    const projB = await seedProject(adapter, "B");
+    const aFlagged = await adapter.createTask({ name: "a-flag", projectId: projA, flagged: true });
+    await adapter.createTask({ name: "a-plain", projectId: projA });
+    await adapter.createTask({ name: "b-flag", projectId: projB, flagged: true });
+    await adapter.completeTask(aFlagged);
+
+    const out = await service.list({
+      projectId: projA,
+      flagged: true,
+      completed: "exclude",
+    });
+    expect(out.tasks.map((t) => t.name)).toEqual([]); // the only flagged A task is completed
+
+    const any = await service.list({
+      projectId: projA,
+      flagged: true,
+      completed: "any",
+    });
+    expect(any.tasks.map((t) => t.name)).toEqual(["a-flag"]);
+
+    const only = await service.list({ projectId: projA, completed: "only" });
+    expect(only.tasks.map((t) => t.name)).toEqual(["a-flag"]);
+  });
+
+  it("pushes a single-element tagIds down to the adapter.tagId filter", async () => {
+    const { service, adapter } = makeHarness();
+    const [t1, t2] = await seedTags(adapter, ["home", "work"]);
+    await adapter.createTask({ name: "at-home", tagIds: [t1 as TagId] });
+    await adapter.createTask({ name: "at-work", tagIds: [t2 as TagId] });
+    await adapter.createTask({ name: "anywhere" });
+
+    const spy = vi.spyOn(adapter, "listTasks");
+    const out = await service.list({ tagIds: [t1 as TagId] });
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ tagId: t1 }));
+    expect(out.tasks.map((t) => t.name)).toEqual(["at-home"]);
+  });
+
+  it("intersects multi-tag filters in-service (tagIds.length > 1)", async () => {
+    const { service, adapter } = makeHarness();
+    const [home, urgent] = await seedTags(adapter, ["home", "urgent"]);
+    await adapter.createTask({ name: "home-only", tagIds: [home as TagId] });
+    await adapter.createTask({ name: "urgent-only", tagIds: [urgent as TagId] });
+    await adapter.createTask({
+      name: "both",
+      tagIds: [home as TagId, urgent as TagId],
+    });
+
+    const spy = vi.spyOn(adapter, "listTasks");
+    const out = await service.list({ tagIds: [home as TagId, urgent as TagId] });
+
+    // Adapter should not receive a tagId filter — service post-filters.
+    expect((spy.mock.calls[0]?.[0] as { tagId?: unknown } | undefined)?.tagId).toBeUndefined();
+    expect(out.tasks.map((t) => t.name)).toEqual(["both"]);
+  });
+
+  it("forwards date-range filters unchanged to the adapter", async () => {
+    const { service, adapter } = makeHarness();
+    const spy = vi.spyOn(adapter, "listTasks");
+    await service.list({
+      dueBefore: "2026-05-01T00:00:00Z",
+      dueAfter: "2026-04-01T00:00:00Z",
+      deferredBefore: "2026-04-15T00:00:00Z",
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dueBefore: "2026-05-01T00:00:00Z",
+        dueAfter: "2026-04-01T00:00:00Z",
+        deferredBefore: "2026-04-15T00:00:00Z",
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — pagination", () => {
+  it("splits across pages of the requested limit and emits a cursor when more remain", async () => {
+    const { service, adapter } = makeHarness();
+    for (let i = 0; i < 5; i++) {
+      await adapter.createTask({ name: `t${i}`, flagged: true });
+    }
+    const page1 = await service.list({ flagged: true, limit: 2 });
+    expect(page1.tasks.map((t) => t.name)).toEqual(["t0", "t1"]);
+    expect(page1.hasMore).toBe(true);
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = await service.list({
+      flagged: true,
+      limit: 2,
+      cursor: page1.nextCursor as string,
+    });
+    expect(page2.tasks.map((t) => t.name)).toEqual(["t2", "t3"]);
+    expect(page2.hasMore).toBe(true);
+
+    const page3 = await service.list({
+      flagged: true,
+      limit: 2,
+      cursor: page2.nextCursor as string,
+    });
+    expect(page3.tasks.map((t) => t.name)).toEqual(["t4"]);
+    expect(page3.hasMore).toBe(false);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it("rejects a cursor whose filter-hash no longer matches the current query", async () => {
+    const { service, adapter } = makeHarness();
+    for (let i = 0; i < 3; i++) await adapter.createTask({ name: `t${i}`, flagged: true });
+    const page1 = await service.list({ flagged: true, limit: 1 });
+    await expect(
+      service.list({
+        flagged: false,
+        limit: 1,
+        cursor: page1.nextCursor as string,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("filter hash is stable under tagIds reordering (so cursor survives)", async () => {
+    const { service, adapter } = makeHarness();
+    const [a, b] = await seedTags(adapter, ["a", "b"]);
+    for (let i = 0; i < 3; i++) {
+      await adapter.createTask({ name: `t${i}`, tagIds: [a as TagId, b as TagId] });
+    }
+    const page1 = await service.list({ tagIds: [a as TagId, b as TagId], limit: 2 });
+    // Second call uses the reordered array; cursor must still match.
+    const page2 = await service.list({
+      tagIds: [b as TagId, a as TagId],
+      limit: 2,
+      cursor: page1.nextCursor as string,
+    });
+    expect(page2.tasks.map((t) => t.name)).toEqual(["t2"]);
+  });
+
+  it("returns empty page + null cursor when nothing matches", async () => {
+    const { service } = makeHarness();
+    const out = await service.list({ flagged: true, limit: 10 });
+    expect(out.tasks).toEqual([]);
+    expect(out.nextCursor).toBeNull();
+    expect(out.hasMore).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache behaviour
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — cache", () => {
+  it("reports cacheHit=false on first call and cacheHit=true on an identical repeat", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createTask({ name: "a", flagged: true });
+    const first = await service.list({ flagged: true, limit: 10 });
+    const second = await service.list({ flagged: true, limit: 10 });
+    expect(first.cacheHit).toBe(false);
+    expect(second.cacheHit).toBe(true);
+    expect(second.tasks).toEqual(first.tasks);
+  });
+
+  it("repeat call does not re-query the adapter (cache short-circuit)", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createTask({ name: "a", flagged: true });
+    const spy = vi.spyOn(adapter, "listTasks");
+    await service.list({ flagged: true, limit: 10 });
+    await service.list({ flagged: true, limit: 10 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("different filters produce different cache keys (no cross-talk)", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createTask({ name: "a", flagged: true });
+    const spy = vi.spyOn(adapter, "listTasks");
+    await service.list({ flagged: true, limit: 10 });
+    await service.list({ flagged: false, limit: 10 });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract — substitutability over OmniFocusAdapter
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — adapter substitutability", () => {
+  it("works against any OmniFocusAdapter — only `listTasks` is needed for list()", async () => {
+    const adapter = new InMemoryAdapter();
+    const spy = vi.spyOn(adapter, "listTasks").mockResolvedValue([]);
+    const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+    const service = new TaskService({ adapter: adapter as OmniFocusAdapter, cache });
+    const input: TaskListInput = { flagged: true };
+    const out = await service.list(input);
+    expect(out.tasks).toEqual([]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -1,0 +1,367 @@
+/**
+ * `TaskService` — service-layer surface for task queries.
+ *
+ * Wraps the `OmniFocusAdapter` with the 30s LRU read cache (ADR-0006) and
+ * applies the `task_list` business rules on top of the adapter's lower-level
+ * `listTasks` primitive:
+ *
+ * 1. **Validation gate** — reject unbounded queries (no filter, no limit, no
+ *    cursor) with a `ValidationError` that tells the agent exactly what to
+ *    add. DESIGN §15 forbids unbounded pagination.
+ * 2. **Filter translation** — the MCP-facing filter shape (`tagIds[]`,
+ *    `completed: "any"|"only"|"exclude"`) is richer than the adapter's
+ *    primitive (`tagId`, `completed?: boolean`). The service maps between
+ *    the two, pushing what it can to the adapter and post-filtering the
+ *    rest (multi-tag intersection).
+ * 3. **Stable sort + cursor pagination** — tasks are ordered `(createdAt
+ *    ASC, id ASC)` so inserts mid-pagination don't re-shuffle emitted
+ *    pages. Cursors carry a `filterHash` so swapping filters mid-sequence
+ *    fails loud rather than silently skipping pages (ADR-0013 contract).
+ * 4. **Cache key** — `tasks:list:<filterHash>:<cursor|'first'>`. Every
+ *    task mutation in the cache's scope (`task:<id>`) invalidates
+ *    these entries; the service never needs to think about it.
+ *
+ * The service is a thin pure module: construct with `{ adapter, cache }` and
+ * call `list(input)`. No mutable state.
+ *
+ * @see DESIGN.md §6.5 — cache strategy
+ * @see DESIGN.md §15 — pagination contract
+ * @see DESIGN.md §26 — reference implementation for task_list
+ * @see docs/adr/0006-read-cache-strategy.md
+ */
+
+import { z } from "zod";
+import type { OmniFocusAdapter, TaskFilter } from "../adapter/OmniFocusAdapter.js";
+import type { ProjectId, TagId, TaskId } from "../domain/ids.js";
+import type { Task } from "../domain/task.js";
+import { ValidationError } from "../errors/index.js";
+import {
+  type CursorPayload,
+  decodeCursor,
+  encodeCursor,
+  hashFilter,
+  isAfterCursor,
+} from "../pagination/cursor.js";
+
+// ---------------------------------------------------------------------------
+// Public shapes
+// ---------------------------------------------------------------------------
+
+/** How the MCP tool layer expresses `completed`. Adapter uses boolean. */
+export type CompletedMode = "any" | "only" | "exclude";
+
+/** Zod schema for task sort fields (used by the tool layer). */
+export const TaskSortBySchema = z.enum(["dueDate", "createdAt", "modifiedAt", "name"]);
+
+/** Fields that tasks can be sorted by. */
+export type TaskSortBy = z.infer<typeof TaskSortBySchema>;
+
+/**
+ * Input to {@link TaskService.list}. Matches the `task_list` MCP tool schema
+ * (DESIGN §26). All fields are optional, but the service requires at least
+ * one of `limit`, `cursor`, or a non-empty filter — unbounded queries are
+ * rejected (DESIGN §15).
+ */
+export interface TaskListInput {
+  projectId?: ProjectId;
+  tagIds?: TagId[];
+  flagged?: boolean;
+  available?: boolean;
+  completed?: CompletedMode;
+  dueBefore?: string;
+  dueAfter?: string;
+  deferredBefore?: string;
+  parentId?: TaskId;
+  /** Field to sort by. Default "createdAt". */
+  sortBy?: TaskSortBy;
+  /** Sort direction. Default "asc". */
+  sortDirection?: "asc" | "desc";
+  /** 1..1000; service default is 200 when caller omits and any filter is set. */
+  limit?: number;
+  cursor?: string;
+}
+
+/** Result of {@link TaskService.list} — the service returns the domain payload plus pagination. */
+export interface TaskListResult {
+  tasks: Task[];
+  /** Opaque cursor for the next page, or `null` if the current page exhausted the match set. */
+  nextCursor: string | null;
+  /** True if a next page exists (equivalent to `nextCursor !== null`). */
+  hasMore: boolean;
+  /** True if this response was served from the cache rather than the adapter. */
+  cacheHit: boolean;
+}
+
+/**
+ * Minimum cache-surface the service uses. We type against this narrow shape
+ * (rather than the concrete `OmniFocusLruCache`) so tests can inject a stub
+ * without pulling in `lru-cache`.
+ */
+export interface ReadCache {
+  wrap<T>(key: string, factory: () => Promise<T>): Promise<T>;
+  has(key: string): boolean;
+}
+
+export interface TaskServiceDeps {
+  adapter: OmniFocusAdapter;
+  cache: ReadCache;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class TaskService {
+  private readonly adapter: OmniFocusAdapter;
+  private readonly cache: ReadCache;
+
+  constructor(deps: TaskServiceDeps) {
+    this.adapter = deps.adapter;
+    this.cache = deps.cache;
+  }
+
+  /**
+   * List tasks matching `input`. See {@link TaskListInput} for the filter
+   * surface; see {@link TaskListResult} for the return shape.
+   *
+   * @throws ValidationError — unbounded query (no filter/limit/cursor);
+   *   invalid limit (outside 1..1000); malformed cursor; cursor filter-hash
+   *   mismatch (filters changed mid-sequence); adapter-raised input errors.
+   */
+  async list(input: TaskListInput): Promise<TaskListResult> {
+    const limit = this.resolveLimit(input);
+    this.assertBounded(input, limit);
+
+    const normalized = this.normalize(input);
+    const filterHash = hashFilter(normalized as unknown as Record<string, unknown>);
+
+    const cursor = input.cursor !== undefined ? decodeCursor(input.cursor, filterHash) : undefined;
+
+    const cacheKey = this.cacheKeyFor(filterHash, input.cursor);
+    const cacheHit = this.cache.has(cacheKey);
+
+    // The cached payload is the final page slice — not the adapter's raw list —
+    // so cursor pagination remains stable under cache re-use.
+    const { tasks, nextCursor } = await this.cache.wrap(cacheKey, async () =>
+      this.fetchPage(input, normalized, cursor, limit, filterHash),
+    );
+
+    return {
+      tasks,
+      nextCursor,
+      hasMore: nextCursor !== null,
+      cacheHit,
+    };
+  }
+
+  // -- Internal: page assembly -------------------------------------------
+
+  private async fetchPage(
+    input: TaskListInput,
+    normalized: NormalizedFilter,
+    cursor: CursorPayload | undefined,
+    limit: number,
+    filterHash: string,
+  ): Promise<{ tasks: Task[]; nextCursor: string | null }> {
+    const adapterFilter = this.toAdapterFilter(input, normalized);
+    const raw = await this.adapter.listTasks(adapterFilter);
+
+    // Post-filter: multi-tag intersection (adapter only supports a single tag).
+    const postFiltered =
+      normalized.tagIds.length > 1
+        ? raw.filter((t) => normalized.tagIds.every((id) => t.tagIds.includes(id)))
+        : raw;
+
+    // Stable sort: (sortValue, id ASC). Null values sort last regardless of direction.
+    const { sortBy, sortDirection } = normalized;
+    const getSortValue = (t: Task): string | null => {
+      switch (sortBy) {
+        case "dueDate":
+          return t.dueDate ?? null;
+        case "modifiedAt":
+          return t.modifiedAt;
+        case "name":
+          return t.name;
+        default:
+          return t.createdAt;
+      }
+    };
+
+    const sorted = [...postFiltered].sort((a, b) => {
+      const av = getSortValue(a);
+      const bv = getSortValue(b);
+      // Nulls last regardless of direction
+      if (av === null && bv === null) return a.id < b.id ? -1 : 1;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      if (av !== bv) {
+        const cmp = av < bv ? -1 : 1;
+        return sortDirection === "asc" ? cmp : -cmp;
+      }
+      // Stable tie-break: id ASC
+      return a.id < b.id ? -1 : 1;
+    });
+
+    const afterCursor =
+      cursor !== undefined
+        ? sorted.filter((t) =>
+            isAfterCursor({ id: t.id, sortValue: getSortValue(t) }, cursor, sortDirection),
+          )
+        : sorted;
+
+    const page = afterCursor.slice(0, limit);
+    const hasMore = afterCursor.length > limit;
+    const nextCursor = hasMore ? this.encodeNextCursor(page, filterHash, getSortValue) : null;
+
+    return { tasks: page, nextCursor };
+  }
+
+  // -- Internal: validation ----------------------------------------------
+
+  private resolveLimit(input: TaskListInput): number {
+    if (input.limit === undefined) return DEFAULT_LIMIT;
+    if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > MAX_LIMIT) {
+      throw new ValidationError(
+        `limit must be an integer between 1 and ${MAX_LIMIT}; got ${input.limit}.`,
+        {
+          suggestion: `Pass a limit between 1 and ${MAX_LIMIT}, or omit to use the default of ${DEFAULT_LIMIT}.`,
+          details: { field: "limit", value: input.limit },
+        },
+      );
+    }
+    return input.limit;
+  }
+
+  /**
+   * Reject unbounded queries: no filter, no limit, no cursor. An explicit
+   * `limit` or `cursor` counts as a bound. Any non-empty filter counts.
+   */
+  private assertBounded(input: TaskListInput, _limit: number): void {
+    if (input.limit !== undefined || input.cursor !== undefined) return;
+    if (this.hasAnyFilter(input)) return;
+    throw new ValidationError(
+      "task_list requires at least one filter, limit, or cursor. Unbounded queries are rejected.",
+      {
+        suggestion: "Provide a filter or a limit.",
+        details: { field: "filter|limit|cursor" },
+      },
+    );
+  }
+
+  private hasAnyFilter(input: TaskListInput): boolean {
+    return (
+      input.projectId !== undefined ||
+      (input.tagIds !== undefined && input.tagIds.length > 0) ||
+      input.flagged !== undefined ||
+      input.available !== undefined ||
+      input.completed !== undefined ||
+      input.dueBefore !== undefined ||
+      input.dueAfter !== undefined ||
+      input.deferredBefore !== undefined ||
+      input.parentId !== undefined
+    );
+  }
+
+  // -- Internal: filter normalization ------------------------------------
+
+  private normalize(input: TaskListInput): NormalizedFilter {
+    // Dedupe + sort tagIds so filterHash is stable under caller-side reordering.
+    // Inputs are already branded TagIds (validated at the tool boundary); the
+    // Set/sort preserves branding without re-casting.
+    const tagIds: TagId[] =
+      input.tagIds !== undefined
+        ? [...new Set(input.tagIds)].sort((a, b) => a.localeCompare(b))
+        : [];
+    return {
+      projectId: input.projectId,
+      tagIds,
+      flagged: input.flagged,
+      available: input.available,
+      completed: input.completed,
+      dueBefore: input.dueBefore,
+      dueAfter: input.dueAfter,
+      deferredBefore: input.deferredBefore,
+      parentId: input.parentId,
+      sortBy: input.sortBy ?? "createdAt",
+      sortDirection: input.sortDirection ?? "asc",
+    };
+  }
+
+  private toAdapterFilter(_input: TaskListInput, n: NormalizedFilter): TaskFilter {
+    const filter: TaskFilter = {};
+    if (n.projectId !== undefined) filter.projectId = n.projectId;
+    if (n.parentId !== undefined) filter.parentId = n.parentId;
+    if (n.tagIds.length === 1) {
+      // Push single-tag filters down; multi-tag does an intersection post-fetch.
+      const single = n.tagIds[0];
+      if (single !== undefined) filter.tagId = single;
+    }
+    if (n.flagged !== undefined) filter.flagged = n.flagged;
+    if (n.available !== undefined) filter.available = n.available;
+    if (n.dueBefore !== undefined) filter.dueBefore = n.dueBefore;
+    if (n.dueAfter !== undefined) filter.dueAfter = n.dueAfter;
+    if (n.deferredBefore !== undefined) filter.deferredBefore = n.deferredBefore;
+
+    // `completed` mode maps to the adapter's boolean `completed` filter:
+    //   "only"    → completed=true
+    //   "exclude" → completed=false
+    //   "any"     → omit (no filter)
+    //   undefined → omit (no default applied at the service layer; the tool
+    //               schema may apply its own default before reaching here)
+    if (n.completed === "only") filter.completed = true;
+    else if (n.completed === "exclude") filter.completed = false;
+
+    return filter;
+  }
+
+  // -- Internal: cache key + cursor --------------------------------------
+
+  private cacheKeyFor(filterHash: string, cursor: string | undefined): string {
+    // Prefix chosen to align with the `search:*` invalidation scope if we
+    // decide to widen it later; for now, treat task list results as
+    // task-scoped (every task:* invalidation also wipes them).
+    return `search:tasks:${filterHash}:${cursor ?? "first"}`;
+  }
+
+  private encodeNextCursor(
+    page: Task[],
+    filterHash: string,
+    getSortValue: (t: Task) => string | null,
+  ): string {
+    const last = page[page.length - 1];
+    if (last === undefined) {
+      // Unreachable: hasMore implies at least one emitted task.
+      throw new ValidationError("Internal: cannot encode cursor for empty page.");
+    }
+    return encodeCursor({
+      lastId: last.id,
+      lastSortValue: getSortValue(last),
+      filterHash,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface NormalizedFilter {
+  projectId: ProjectId | undefined;
+  tagIds: TagId[];
+  flagged: boolean | undefined;
+  available: boolean | undefined;
+  completed: CompletedMode | undefined;
+  dueBefore: string | undefined;
+  dueAfter: string | undefined;
+  deferredBefore: string | undefined;
+  parentId: TaskId | undefined;
+  sortBy: TaskSortBy;
+  sortDirection: "asc" | "desc";
+}

--- a/src/tools/task/getMany.ts
+++ b/src/tools/task/getMany.ts
@@ -89,7 +89,7 @@ export async function handleTaskGetMany(input: TaskGetManyInput, ctx: TaskGetMan
   if (input.ids.length > MAX_IDS) {
     throw new ValidationError(
       `ids array exceeds the maximum batch size of ${MAX_IDS} (got ${input.ids.length})`,
-      { field: "ids" },
+      { details: { field: "ids" } },
     );
   }
 

--- a/src/tools/task/list.test.ts
+++ b/src/tools/task/list.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the `task_list` tool — schema parsing + handler behaviour.
+ *
+ * The schema tests guard the public MCP surface (field names, types,
+ * defaults) against accidental drift. The handler tests verify the envelope
+ * shape and the meta/pagination wiring; the underlying filter logic lives
+ * in `taskService.test.ts` and is not duplicated here.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { TaskService } from "../../services/taskService.js";
+import { TASK_LIST_DESCRIPTION, handleTaskList, taskListInputSchema } from "./list.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const taskService = new TaskService({ adapter, cache });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { taskService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_list — input schema", () => {
+  it("accepts an empty object (validation happens in the service)", () => {
+    const parsed = taskListInputSchema.parse({});
+    expect(parsed).toEqual({});
+  });
+
+  it("accepts the full filter surface specified in DESIGN §26", () => {
+    const parsed = taskListInputSchema.parse({
+      projectId: "proj_000001",
+      tagIds: ["tag_000001"],
+      flagged: true,
+      available: true,
+      completed: "exclude",
+      dueBefore: "2026-05-01T00:00:00Z",
+      dueAfter: "2026-04-01T00:00:00Z",
+      deferredBefore: "2026-04-15T00:00:00Z",
+      parentId: "task_000001",
+      limit: 50,
+      cursor: "opaque",
+    });
+    expect(parsed.projectId).toBe("proj_000001");
+    expect(parsed.limit).toBe(50);
+  });
+
+  it("rejects limit > 1000", () => {
+    expect(() => taskListInputSchema.parse({ limit: 2000 })).toThrow();
+  });
+
+  it("rejects limit < 1", () => {
+    expect(() => taskListInputSchema.parse({ limit: 0 })).toThrow();
+  });
+
+  it("rejects an unknown completed value", () => {
+    expect(() => taskListInputSchema.parse({ completed: "mostly" })).toThrow();
+  });
+
+  it("rejects a malformed id", () => {
+    expect(() => taskListInputSchema.parse({ projectId: "??" })).toThrow();
+  });
+
+  it("accepts sortBy values", () => {
+    for (const v of ["dueDate", "createdAt", "modifiedAt", "name"]) {
+      const parsed = taskListInputSchema.parse({ limit: 10, sortBy: v });
+      expect(parsed.sortBy).toBe(v);
+    }
+  });
+
+  it("rejects an unknown sortBy value", () => {
+    expect(() => taskListInputSchema.parse({ limit: 10, sortBy: "priority" })).toThrow();
+  });
+
+  it("accepts sortDirection asc and desc", () => {
+    expect(taskListInputSchema.parse({ limit: 10, sortDirection: "asc" }).sortDirection).toBe(
+      "asc",
+    );
+    expect(taskListInputSchema.parse({ limit: 10, sortDirection: "desc" }).sortDirection).toBe(
+      "desc",
+    );
+  });
+
+  it("rejects an unknown sortDirection value", () => {
+    expect(() => taskListInputSchema.parse({ limit: 10, sortDirection: "random" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Description contract
+// ---------------------------------------------------------------------------
+
+describe("task_list — description", () => {
+  it("includes the use / do-not-use guidance agents rely on to disambiguate", () => {
+    expect(TASK_LIST_DESCRIPTION).toMatch(/task_get/);
+    expect(TASK_LIST_DESCRIPTION).toMatch(/pagination/);
+    expect(TASK_LIST_DESCRIPTION).toMatch(/side effects/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("handleTaskList — envelope", () => {
+  it("wraps the service result in an ok() envelope with pagination", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 3; i++) await adapter.createTask({ name: `t${i}`, flagged: true });
+
+    const result = await handleTaskList({ flagged: true, limit: 2 }, ctx);
+    expect(result.data.tasks).toHaveLength(2);
+    expect(result.pagination).toMatchObject({ hasMore: true });
+    expect(result.pagination?.cursor).toEqual(expect.any(String));
+    expect(result.meta.cacheHit).toBe(false);
+  });
+
+  it("propagates cacheHit into the response meta on a repeat call", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "a", flagged: true });
+    await handleTaskList({ flagged: true, limit: 10 }, ctx);
+    const second = await handleTaskList({ flagged: true, limit: 10 }, ctx);
+    expect(second.meta.cacheHit).toBe(true);
+  });
+
+  it("surfaces service validation errors (unbounded query) to the caller", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleTaskList({}, ctx)).rejects.toMatchObject({
+      code: "OF_VALIDATION",
+    });
+  });
+});

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -1,0 +1,174 @@
+/**
+ * `task_list` MCP tool — the reference implementation for read-shaped tools
+ * in this server (DESIGN §26).
+ *
+ * Every other list tool inherits this structure:
+ * - A zod input schema whose `.describe()` strings are the contract the LLM
+ *   reads. Concise, imperative, says where to get IDs (see DESIGN §6.8.1).
+ * - A thin handler (< 30 LOC per DESIGN maintainability target) that delegates
+ *   to a `Service` method and wraps the result in the ADR-0013 envelope.
+ * - No business logic in the handler — filter application, pagination,
+ *   caching all live in the service.
+ *
+ * The `registerTaskListTool` helper is what `mcpServer.ts` calls to register
+ * this tool with a configured {@link TaskService}.
+ *
+ * @see DESIGN.md §26 — reference implementation
+ * @see DESIGN.md §12 — response envelope
+ * @see src/services/taskService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { type Pagination, type ResponseMeta, ok } from "../../envelope/index.js";
+import { TaskSortBySchema } from "../../services/taskService.js";
+import type { TaskListInput, TaskService } from "../../services/taskService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description (shown to the LLM via tools/list)
+// ---------------------------------------------------------------------------
+
+export const TASK_LIST_DESCRIPTION =
+  "List tasks in OmniFocus with optional filters. " +
+  "Use this for queries across tasks. " +
+  "Do NOT use for a known single task (use `task_get`). " +
+  "Returns tasks[] with pagination; safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw-shape input schema for `task_list`. Exported as a zod object so the
+ * MCP SDK can introspect it for `tools/list`, and so unit tests can parse
+ * arbitrary payloads through it without re-declaring the types.
+ *
+ * Field descriptions follow DESIGN §6.8.1: what it does, where to get IDs,
+ * what the default means if one is applied.
+ */
+export const taskListInputSchema = z.object({
+  projectId: ProjectId.schema
+    .optional()
+    .describe(
+      "Restrict to tasks in this project. Get the ID from project_list. Omit for all projects.",
+    ),
+  tagIds: z
+    .array(TagId.schema)
+    .optional()
+    .describe("Restrict to tasks carrying ALL of these tag IDs. Get IDs from tag_list."),
+  flagged: z
+    .boolean()
+    .optional()
+    .describe("true = flagged only; false = unflagged only; omit = all."),
+  available: z
+    .boolean()
+    .optional()
+    .describe(
+      "true = only tasks available to work on now (not blocked, not deferred). Omit = all.",
+    ),
+  completed: z
+    .enum(["any", "only", "exclude"])
+    .optional()
+    .describe(
+      "'exclude' = active tasks only; 'only' = completed tasks only; 'any' = both. Omit for adapter default.",
+    ),
+  dueBefore: z
+    .string()
+    .optional()
+    .describe(
+      "Tasks with dueDate strictly before this moment. ISO-8601 with offset (e.g. '2026-04-21T17:00:00-04:00').",
+    ),
+  dueAfter: z
+    .string()
+    .optional()
+    .describe("Tasks with dueDate strictly after this moment. ISO-8601 with offset."),
+  deferredBefore: z
+    .string()
+    .optional()
+    .describe(
+      "Tasks deferred until before this moment (already unlocked or soon). ISO-8601 with offset.",
+    ),
+  parentId: TaskId.schema
+    .optional()
+    .describe(
+      "Restrict to direct children of this task (subtasks). Get the ID from task_get or task_list.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .optional()
+    .describe("Max tasks per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages."),
+  sortBy: TaskSortBySchema.optional().describe(
+    "Field to sort tasks by: 'createdAt' (default), 'dueDate', 'modifiedAt', or 'name'. " +
+      "Tasks with no value for the chosen field (e.g. no dueDate) sort last.",
+  ),
+  sortDirection: z
+    .enum(["asc", "desc"])
+    .optional()
+    .describe(
+      "Sort direction: 'asc' (default, oldest/lowest first) or 'desc' (newest/highest first).",
+    ),
+  cursor: z
+    .string()
+    .optional()
+    .describe(
+      "Opaque cursor from a previous task_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError.",
+    ),
+});
+
+/** TypeScript input type derived from {@link taskListInputSchema}. */
+export type TaskListToolInput = z.infer<typeof taskListInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/** Minimum meta-factory interface the handler needs. */
+export interface ToolContext {
+  taskService: TaskService;
+  /** Produce request-scoped response meta. Supplied by the handler harness. */
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — separated from {@link registerTaskListTool} so unit tests
+ * can invoke it without constructing an McpServer.
+ */
+export async function handleTaskList(input: TaskListToolInput, ctx: ToolContext) {
+  const serviceInput = input as TaskListInput;
+  const result = await ctx.taskService.list(serviceInput);
+  const pagination: Pagination = {
+    cursor: result.nextCursor,
+    hasMore: result.hasMore,
+  };
+  const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
+  return ok({ tasks: result.tasks }, meta, pagination);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register `task_list` with an `McpServer` instance. The returned handle is
+ * the SDK's `RegisteredTool` — callers may ignore it.
+ */
+export function registerTaskListTool(server: McpServer, ctx: ToolContext) {
+  return server.registerTool(
+    "task_list",
+    {
+      description: TASK_LIST_DESCRIPTION,
+      inputSchema: taskListInputSchema.shape,
+    },
+    async (args: TaskListToolInput) => {
+      const envelope = await handleTaskList(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `sortBy` field to `task_list` schema: `dueDate | createdAt | modifiedAt | name` (default `createdAt`)
- Adds `sortDirection` field: `asc | desc` (default `asc`)
- Null sort values (e.g. tasks with no `dueDate`) always sort **last** regardless of direction
- Cursor pagination remains stable: changing `sortBy`/`sortDirection` mid-sequence triggers a `ValidationError` via filterHash mismatch
- Refactors `CursorPayload.lastCreatedAt → lastSortValue: string | null` to support arbitrary sort fields
- Updates `isAfterCursor` to accept `sortDirection` parameter and null-aware comparison

## Design link
Closes #133.

## Breaking change?
- [x] No — `lastSortValue` is an internal cursor field, opaque to clients

## Test plan
- [x] 16 new unit tests in `taskService.sort.test.ts`: default sort, all 4 sortBy fields, desc direction, nulls-last semantics, cursor pagination stability, cursor rejection on sort-param change
- [x] 6 new schema tests in `list.test.ts` for sortBy/sortDirection fields
- [x] 10 new `isAfterCursor` tests in `cursor.test.ts`: ASC/DESC, null sortValue edge cases
- [x] All 561 tests pass locally
- [x] Lint clean
- [x] Self-reviewed via /review-pr