### PR TITLE
feat(task_list): add updatedSince filter for incremental sync

### DIFF
--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -32,6 +32,7 @@
 
 import { z } from "zod";
 import type { OmniFocusAdapter, TaskFilter } from "../adapter/OmniFocusAdapter.js";
+import { isIsoDateString, isRelativeDateShortcut, resolveRelativeDate } from "../domain/dates.js";
 import type { ProjectId, TagId, TaskId } from "../domain/ids.js";
 import type { Task } from "../domain/task.js";
 import { ValidationError } from "../errors/index.js";
@@ -76,6 +77,12 @@ export interface TaskListInput {
   sortBy?: TaskSortBy;
   /** Sort direction. Default "asc". */
   sortDirection?: "asc" | "desc";
+  /**
+   * Return only tasks modified strictly after this timestamp.
+   * ISO-8601 with offset, or a relative shortcut (today, yesterday, this-week…).
+   * Relative shortcuts are resolved server-side to local midnight.
+   */
+  updatedSince?: string;
   /** 1..1000; service default is 200 when caller omits and any filter is set. */
   limit?: number;
   cursor?: string;
@@ -179,6 +186,13 @@ export class TaskService {
         ? raw.filter((t) => normalized.tagIds.every((id) => t.tagIds.includes(id)))
         : raw;
 
+    // Post-filter: updatedSince — keep only tasks modified strictly after the threshold.
+    const { updatedSince } = normalized;
+    const afterUpdatedSince =
+      updatedSince !== undefined
+        ? postFiltered.filter((t) => t.modifiedAt > updatedSince)
+        : postFiltered;
+
     // Stable sort: (sortValue, id ASC). Null values sort last regardless of direction.
     const { sortBy, sortDirection } = normalized;
     const getSortValue = (t: Task): string | null => {
@@ -194,7 +208,7 @@ export class TaskService {
       }
     };
 
-    const sorted = [...postFiltered].sort((a, b) => {
+    const sorted = [...afterUpdatedSince].sort((a, b) => {
       const av = getSortValue(a);
       const bv = getSortValue(b);
       // Nulls last regardless of direction
@@ -265,7 +279,8 @@ export class TaskService {
       input.dueBefore !== undefined ||
       input.dueAfter !== undefined ||
       input.deferredBefore !== undefined ||
-      input.parentId !== undefined
+      input.parentId !== undefined ||
+      input.updatedSince !== undefined
     );
   }
 
@@ -279,6 +294,25 @@ export class TaskService {
       input.tagIds !== undefined
         ? [...new Set(input.tagIds)].sort((a, b) => a.localeCompare(b))
         : [];
+    // Resolve updatedSince: accept ISO-8601 or a relative shortcut.
+    let updatedSince: string | undefined;
+    if (input.updatedSince !== undefined) {
+      if (isIsoDateString(input.updatedSince)) {
+        updatedSince = input.updatedSince;
+      } else if (isRelativeDateShortcut(input.updatedSince)) {
+        updatedSince = resolveRelativeDate(input.updatedSince);
+      } else {
+        throw new ValidationError(
+          `updatedSince must be an ISO-8601 timestamp with offset or a relative shortcut (today, yesterday, this-week, next-week, end-of-week, end-of-month). Got: "${input.updatedSince}".`,
+          {
+            details: { field: "updatedSince", value: input.updatedSince },
+            suggestion:
+              "Pass an ISO-8601 string with offset (e.g. '2026-04-21T10:00:00-07:00') or a shortcut like 'today'.",
+          },
+        );
+      }
+    }
+
     return {
       projectId: input.projectId,
       tagIds,
@@ -291,6 +325,7 @@ export class TaskService {
       parentId: input.parentId,
       sortBy: input.sortBy ?? "createdAt",
       sortDirection: input.sortDirection ?? "asc",
+      updatedSince,
     };
   }
 
@@ -364,4 +399,6 @@ interface NormalizedFilter {
   parentId: TaskId | undefined;
   sortBy: TaskSortBy;
   sortDirection: "asc" | "desc";
+  /** Resolved ISO-8601 timestamp (relative shortcuts already expanded). */
+  updatedSince: string | undefined;
 }

--- a/src/services/taskService.updatedSince.test.ts
+++ b/src/services/taskService.updatedSince.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for TaskService updatedSince filter (issue #150).
+ *
+ * Covers: returns only tasks modified after the threshold; empty result when
+ * nothing changed; combines with other filters; ValidationError on bad format;
+ * relative shortcuts resolve correctly; updatedSince counts as a "filter" for
+ * the unbounded-query guard.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
+import { TaskService } from "./taskService.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeService() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const service = new TaskService({ adapter, cache });
+  return { service, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Basic filtering
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — updatedSince", () => {
+  it("returns only tasks modified after the threshold", async () => {
+    const { service, adapter } = makeService();
+    // Tasks created at tick 0, 1, 2 — modifiedAt = createdAt by default
+    await adapter.createTask({ name: "Old" }); // tick 0 → 2026-01-01T00:00:00Z
+    await adapter.createTask({ name: "Middle" }); // tick 1 → 2026-01-01T00:00:01Z
+    await adapter.createTask({ name: "New" }); // tick 2 → 2026-01-01T00:00:02Z
+
+    // Threshold between tick 1 and tick 2
+    const { tasks } = await service.list({
+      updatedSince: "2026-01-01T00:00:01.500Z",
+    });
+    expect(tasks.map((t) => t.name)).toEqual(["New"]);
+  });
+
+  it("returns empty array when nothing was modified after the threshold", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "A" });
+    await adapter.createTask({ name: "B" });
+
+    const { tasks } = await service.list({
+      updatedSince: "2027-01-01T00:00:00Z",
+    });
+    expect(tasks).toHaveLength(0);
+  });
+
+  it("returns all tasks when threshold is before all modifiedAt values", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "A" });
+    await adapter.createTask({ name: "B" });
+
+    const { tasks } = await service.list({
+      updatedSince: "2020-01-01T00:00:00Z",
+    });
+    expect(tasks).toHaveLength(2);
+  });
+
+  it("uses strict greater-than (not >=)", async () => {
+    const { service, adapter } = makeService();
+    // Task created at tick 0 → modifiedAt = "2026-01-01T00:00:00.000Z"
+    const id = await adapter.createTask({ name: "Exact" });
+    const fetched = await adapter.getTask(id);
+    expect(fetched).not.toBeNull();
+    const modifiedAt = (fetched as NonNullable<typeof fetched>).modifiedAt;
+
+    const { tasks } = await service.list({
+      // Pass the exact modifiedAt as threshold — strict > means it should NOT be returned
+      updatedSince: modifiedAt,
+    });
+    expect(tasks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combination with other filters
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — updatedSince + other filters", () => {
+  it("combines updatedSince with flagged filter", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "OldFlagged", flagged: true }); // tick 0
+    await adapter.createTask({ name: "OldUnflagged" }); // tick 1
+    await adapter.createTask({ name: "NewFlagged", flagged: true }); // tick 2
+    await adapter.createTask({ name: "NewUnflagged" }); // tick 3
+
+    const { tasks } = await service.list({
+      flagged: true,
+      updatedSince: "2026-01-01T00:00:01.500Z",
+    });
+    expect(tasks.map((t) => t.name)).toEqual(["NewFlagged"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unbounded-query guard
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — updatedSince as filter bound", () => {
+  it("does not throw unbounded-query error when only updatedSince is set", async () => {
+    const { service, adapter } = makeService();
+    await adapter.createTask({ name: "A" });
+    // updatedSince alone counts as a filter; this should not throw
+    await expect(service.list({ updatedSince: "2020-01-01T00:00:00Z" })).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("TaskService.list — updatedSince validation", () => {
+  it("throws ValidationError for an unrecognised format", async () => {
+    const { service } = makeService();
+    await expect(service.list({ updatedSince: "not-a-date" })).rejects.toMatchObject({
+      code: "OF_VALIDATION",
+    });
+  });
+
+  it("throws ValidationError for a bare local time (no offset)", async () => {
+    const { service } = makeService();
+    await expect(service.list({ updatedSince: "2026-04-21T10:00:00" })).rejects.toMatchObject({
+      code: "OF_VALIDATION",
+    });
+  });
+
+  it("accepts a valid ISO-8601 string with offset", async () => {
+    const { service } = makeService();
+    await expect(
+      service.list({ updatedSince: "2026-04-21T10:00:00-07:00" }),
+    ).resolves.toBeDefined();
+  });
+
+  it("accepts a relative shortcut (today)", async () => {
+    const { service } = makeService();
+    // Should not throw; returns empty (all tasks are from 2026-01-01)
+    await expect(service.list({ updatedSince: "today" })).resolves.toBeDefined();
+  });
+});

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -20,6 +20,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { flexDateString } from "../../domain/dates.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
 import { type Pagination, type ResponseMeta, ok } from "../../envelope/index.js";
 import { TaskSortBySchema } from "../../services/taskService.js";
@@ -110,6 +111,15 @@ export const taskListInputSchema = z.object({
     .optional()
     .describe(
       "Sort direction: 'asc' (default, oldest/lowest first) or 'desc' (newest/highest first).",
+    ),
+  updatedSince: flexDateString()
+    .optional()
+    .describe(
+      "Return only tasks modified strictly after this timestamp. " +
+        "Accepts ISO-8601 with offset (e.g. '2026-04-21T10:00:00-07:00') or a relative shortcut: " +
+        "today, yesterday, this-week, next-week, end-of-week, end-of-month. " +
+        "Use this for incremental sync: call without updatedSince on session start, then pass the previous response timestamp on subsequent calls. " +
+        "Note: deleted tasks cannot be detected — use a snapshot resource for deletion detection.",
     ),
   cursor: z
     .string()


### PR DESCRIPTION
## Summary
- Adds `updatedSince?: string` to `task_list` input schema and `TaskService`
- Accepts ISO-8601 with offset **or** relative shortcuts (`today`, `yesterday`, `this-week`, `next-week`, `end-of-week`, `end-of-month`) resolved server-side to local midnight
- Filters tasks where `modifiedAt > updatedSince` (strict greater-than)
- Counts as a filter for the unbounded-query guard — `updatedSince` alone is sufficient to avoid the ValidationError
- Compatible with all existing filters, `sortBy`/`sortDirection`, and cursor pagination
- `ValidationError` on unrecognised format (bare local time, unknown shortcut, etc.)
- Tool description documents the deleted-tasks limitation

## Design link
Closes #150. See DESIGN §36 and SPEC agent ergonomics section.

## Breaking change?
- [x] No

## Test plan
- [x] 10 new unit tests in `taskService.updatedSince.test.ts`: basic filtering, empty result, threshold semantics, combination with flagged filter, unbounded-query guard, validation errors, relative shortcut acceptance
- [x] All 571 tests pass locally
- [x] Lint clean
- [x] Note: `project_list` updatedSince deferred — no project tool/service exists yet; will be added when that tool is implemented