### PR TITLE
feat(tools): mutation handlers return full updated entity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ This is a single-developer project and external contributions are not currently 
 - **IDs only, never names.** All API references use OF's persistent IDs. Lookup-by-name is an explicit, disambiguated tool. ([ADR-0008](./docs/adr/0008-ids-branded-opaque-strings.md))
 - **Dates are ISO-8601 with offset** at the adapter boundary. ([ADR-0007](./docs/adr/0007-dates-iso8601-with-offset.md))
 - **Response envelope.** Every tool returns `{ data, meta, pagination? }` or `{ error, meta }`. Never a raw payload. ([ADR-0013](./docs/adr/0013-tool-response-envelope.md))
+- **Mutation response contract.** Write tool handlers must return the full updated domain entity in `data` (e.g. `ok({ task }, meta)`, `ok({ tag }, meta)`, `ok({ folder }, meta)`). Delete handlers return `ok({ deleted: true, id }, meta)`. Never return a bare ID or a partial patch object — agents need the full entity to update their local view without a follow-up read.
 - **No stdout writes.** stdout is the MCP transport; any stray byte corrupts the protocol. Enforced by a hook and an integration test.
 - **No network imports.** The server has no network surface. Lint forbids `http`, `https`, `fetch`, `node-fetch`, `axios`, `undici`.
 - **Typed errors only.** No generic `Error`. Every throw is from the taxonomy in [`DESIGN.md §6.7`](./DESIGN.md#67-error-taxonomy).

--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -32,11 +32,12 @@ export interface FolderCreateContext {
 }
 
 export async function handleFolderCreate(input: FolderCreateToolInput, ctx: FolderCreateContext) {
-  const result = await ctx.folderService.create({
+  const createResult = await ctx.folderService.create({
     name: input.name,
     ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
   });
-  return ok({ id: result.id }, ctx.makeMeta());
+  const { folder } = await ctx.folderService.get(createResult.id);
+  return ok({ folder }, ctx.makeMeta());
 }
 
 export function registerFolderCreateTool(server: McpServer, ctx: FolderCreateContext) {

--- a/src/tools/folder/delete.ts
+++ b/src/tools/folder/delete.ts
@@ -41,7 +41,7 @@ export interface FolderDeleteContext {
 
 export async function handleFolderDelete(input: FolderDeleteToolInput, ctx: FolderDeleteContext) {
   await ctx.folderService.delete(input.id, input.cascade ?? false);
-  return ok({}, ctx.makeMeta());
+  return ok({ deleted: true, id: input.id }, ctx.makeMeta());
 }
 
 export function registerFolderDeleteTool(server: McpServer, ctx: FolderDeleteContext) {

--- a/src/tools/folder/folder.test.ts
+++ b/src/tools/folder/folder.test.ts
@@ -129,10 +129,14 @@ describe("folder_create — schema", () => {
 });
 
 describe("folder_create — handler", () => {
-  it("creates a folder and returns its ID", async () => {
+  it("creates a folder and returns the full folder entity", async () => {
     const { ctx, adapter } = makeCtx();
     const envelope = await handleFolderCreate({ name: "Work" }, ctx);
-    expect(envelope.data.id).toBeTruthy();
+    expect(envelope.data.folder.id).toBeTruthy();
+    expect(envelope.data.folder.name).toBe("Work");
+    // Returned entity matches a subsequent getFolder
+    const fetched = await adapter.getFolder(envelope.data.folder.id);
+    expect(fetched.id).toBe(envelope.data.folder.id);
     const folders = await adapter.listFolders();
     expect(folders).toHaveLength(1);
   });
@@ -141,7 +145,7 @@ describe("folder_create — handler", () => {
     const { ctx, adapter } = makeCtx();
     const parentId = await adapter.createFolder({ name: "Work" });
     const envelope = await handleFolderCreate({ name: "Projects", parentId }, ctx);
-    const child = await adapter.getFolder(envelope.data.id);
+    const child = await adapter.getFolder(envelope.data.folder.id);
     expect(child.parentId).toBe(parentId);
   });
 

--- a/src/tools/folder/move.ts
+++ b/src/tools/folder/move.ts
@@ -32,7 +32,8 @@ export interface FolderMoveContext {
 
 export async function handleFolderMove(input: FolderMoveToolInput, ctx: FolderMoveContext) {
   await ctx.folderService.move(input.id, input.parentId);
-  return ok({}, ctx.makeMeta());
+  const { folder } = await ctx.folderService.get(input.id);
+  return ok({ folder }, ctx.makeMeta());
 }
 
 export function registerFolderMoveTool(server: McpServer, ctx: FolderMoveContext) {

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -34,7 +34,8 @@ export async function handleFolderUpdate(input: FolderUpdateToolInput, ctx: Fold
   await ctx.folderService.update(id, {
     ...(patch.name !== undefined ? { name: patch.name } : {}),
   });
-  return ok({}, ctx.makeMeta());
+  const { folder } = await ctx.folderService.get(id);
+  return ok({ folder }, ctx.makeMeta());
 }
 
 export function registerFolderUpdateTool(server: McpServer, ctx: FolderUpdateContext) {

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -43,14 +43,15 @@ export interface TagCreateContext {
  * Pure handler for `tag_create`.
  */
 export async function handleTagCreate(input: TagCreateToolInput, ctx: TagCreateContext) {
-  const result = await ctx.tagService.create({
+  const createResult = await ctx.tagService.create({
     name: input.name,
     ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
     ...(input.status !== undefined ? { status: input.status } : {}),
     ...(input.allowsNextAction !== undefined ? { allowsNextAction: input.allowsNextAction } : {}),
   });
+  const { tag } = await ctx.tagService.get(createResult.id);
   const meta = ctx.makeMeta();
-  return ok({ id: result.id }, meta);
+  return ok({ tag }, meta);
 }
 
 export function registerTagCreateTool(server: McpServer, ctx: TagCreateContext) {

--- a/src/tools/tag/delete.ts
+++ b/src/tools/tag/delete.ts
@@ -33,7 +33,7 @@ export interface TagDeleteContext {
  */
 export async function handleTagDelete(input: TagDeleteToolInput, ctx: TagDeleteContext) {
   await ctx.tagService.delete(input.id);
-  return ok({}, ctx.makeMeta());
+  return ok({ deleted: true, id: input.id }, ctx.makeMeta());
 }
 
 export function registerTagDeleteTool(server: McpServer, ctx: TagDeleteContext) {

--- a/src/tools/tag/move.ts
+++ b/src/tools/tag/move.ts
@@ -35,7 +35,8 @@ export interface TagMoveContext {
  */
 export async function handleTagMove(input: TagMoveToolInput, ctx: TagMoveContext) {
   await ctx.tagService.move(input.id, input.parentId);
-  return ok({}, ctx.makeMeta());
+  const { tag } = await ctx.tagService.get(input.id);
+  return ok({ tag }, ctx.makeMeta());
 }
 
 export function registerTagMoveTool(server: McpServer, ctx: TagMoveContext) {

--- a/src/tools/tag/mutations.test.ts
+++ b/src/tools/tag/mutations.test.ts
@@ -72,20 +72,23 @@ describe("tag_create — input schema", () => {
 });
 
 describe("tag_create — handler", () => {
-  it("creates a tag and returns its ID", async () => {
+  it("creates a tag and returns the full tag entity", async () => {
     const { ctx, adapter } = makeCtx();
     const envelope = await handleTagCreate({ name: "Work" }, ctx);
-    expect(envelope.data.id).toBeTruthy();
+    expect(envelope.data.tag.id).toBeTruthy();
+    expect(envelope.data.tag.name).toBe("Work");
+    // Returned entity matches a subsequent getTag
+    const fetched = await adapter.getTag(envelope.data.tag.id);
+    expect(fetched.id).toBe(envelope.data.tag.id);
     const tags = await adapter.listTags();
     expect(tags).toHaveLength(1);
-    expect(tags[0]?.name).toBe("Work");
   });
 
   it("creates a nested tag when parentId is supplied", async () => {
     const { ctx, adapter } = makeCtx();
     const parentId = await adapter.createTag({ name: "Work" });
     const envelope = await handleTagCreate({ name: "Meetings", parentId }, ctx);
-    const child = await adapter.getTag(envelope.data.id);
+    const child = await adapter.getTag(envelope.data.tag.id);
     expect(child.parentId).toBe(parentId);
   });
 

--- a/src/tools/tag/setAllowsNextAction.ts
+++ b/src/tools/tag/setAllowsNextAction.ts
@@ -37,7 +37,8 @@ export async function handleTagSetAllowsNextAction(
   ctx: TagSetAllowsNextActionContext,
 ) {
   await ctx.tagService.setAllowsNextAction(input.id, input.allowsNextAction);
-  return ok({}, ctx.makeMeta());
+  const { tag } = await ctx.tagService.get(input.id);
+  return ok({ tag }, ctx.makeMeta());
 }
 
 export function registerTagSetAllowsNextActionTool(

--- a/src/tools/tag/setLocation.ts
+++ b/src/tools/tag/setLocation.ts
@@ -58,7 +58,8 @@ export async function handleTagSetLocation(
     radiusMeters: input.radiusMeters,
     trigger: input.trigger,
   });
-  return ok({}, ctx.makeMeta());
+  const { tag } = await ctx.tagService.get(input.id);
+  return ok({ tag }, ctx.makeMeta());
 }
 
 export function registerTagSetLocationTool(server: McpServer, ctx: TagSetLocationContext) {

--- a/src/tools/tag/setStatus.ts
+++ b/src/tools/tag/setStatus.ts
@@ -34,7 +34,8 @@ export interface TagSetStatusContext {
  */
 export async function handleTagSetStatus(input: TagSetStatusToolInput, ctx: TagSetStatusContext) {
   await ctx.tagService.setStatus(input.id, input.status);
-  return ok({}, ctx.makeMeta());
+  const { tag } = await ctx.tagService.get(input.id);
+  return ok({ tag }, ctx.makeMeta());
 }
 
 export function registerTagSetStatusTool(server: McpServer, ctx: TagSetStatusContext) {

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -49,7 +49,8 @@ export async function handleTagUpdate(input: TagUpdateToolInput, ctx: TagUpdateC
     ...(patch.status !== undefined ? { status: patch.status } : {}),
     ...(patch.allowsNextAction !== undefined ? { allowsNextAction: patch.allowsNextAction } : {}),
   });
-  return ok({}, ctx.makeMeta());
+  const { tag } = await ctx.tagService.get(id);
+  return ok({ tag }, ctx.makeMeta());
 }
 
 export function registerTagUpdateTool(server: McpServer, ctx: TagUpdateContext) {

--- a/src/tools/task/clearRepetition.ts
+++ b/src/tools/task/clearRepetition.ts
@@ -51,8 +51,9 @@ export async function handleTaskClearRepetition(
   ctx: TaskClearRepetitionContext,
 ) {
   await ctx.adapter.updateTask(input.id, { repetition: null });
+  const task = await ctx.adapter.getTask(input.id);
   const meta = ctx.makeMeta();
-  return ok({ id: input.id }, meta);
+  return ok({ task }, meta);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/repetition.test.ts
+++ b/src/tools/task/repetition.test.ts
@@ -114,10 +114,16 @@ describe("task_set_repetition — handler", () => {
       ctx,
     );
 
-    expect(envelope.data.id).toBe(id);
+    expect(envelope.data.task.id).toBe(id);
+    expect(envelope.data.task.repetition).toMatchObject({
+      method: "fixed",
+      unit: "days",
+      steps: 1,
+    });
 
-    const task = await adapter.getTask(id);
-    expect(task.repetition).toMatchObject({ method: "fixed", unit: "days", steps: 1 });
+    // Returned entity matches a subsequent getTask
+    const fetched = await adapter.getTask(id);
+    expect(fetched.repetition).toMatchObject(envelope.data.task.repetition ?? {});
   });
 
   it("sets a weekly due-again rule with weekdays", async () => {
@@ -165,14 +171,14 @@ describe("task_set_repetition — handler", () => {
     ).rejects.toThrow();
   });
 
-  it("returns envelope with data.id matching the task", async () => {
+  it("returns envelope with full task entity", async () => {
     const { ctx, adapter } = makeCtx();
     const id = await adapter.createTask({ name: "Task X" });
     const envelope = await handleTaskSetRepetition(
       { id, rule: { method: "fixed", unit: "months", steps: 1, monthlyAnchor: { day: 1 } } },
       ctx,
     );
-    expect(envelope.data).toHaveProperty("id", id);
+    expect(envelope.data.task.id).toBe(id);
     expect(envelope.meta.correlationId).toBe("test-cid");
   });
 });
@@ -219,10 +225,10 @@ describe("task_clear_repetition — handler", () => {
     ).rejects.toThrow();
   });
 
-  it("returns envelope with data.id matching the task", async () => {
+  it("returns envelope with full task entity", async () => {
     const { ctx, adapter } = makeCtx();
     const id = await adapter.createTask({ name: "Task Y" });
     const envelope = await handleTaskClearRepetition({ id }, ctx);
-    expect(envelope.data).toHaveProperty("id", id);
+    expect(envelope.data.task.id).toBe(id);
   });
 });

--- a/src/tools/task/setRepetition.ts
+++ b/src/tools/task/setRepetition.ts
@@ -66,8 +66,9 @@ export async function handleTaskSetRepetition(
   ctx: TaskSetRepetitionContext,
 ) {
   await ctx.adapter.updateTask(input.id, { repetition: input.rule });
+  const task = await ctx.adapter.getTask(input.id);
   const meta = ctx.makeMeta();
-  return ok({ id: input.id }, meta);
+  return ok({ task }, meta);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- All write tool handlers now return the full domain entity in `data` instead of a bare ID or empty object
- Delete handlers return `{ deleted: true, id }` for consistent tombstone responses
- Convention documented in `CONTRIBUTING.md` so future tool authors follow the same pattern

## Design link
Closes #129. Implements the mutation response contract described in `DESIGN.md §26` (reference tool implementation).

## Breaking change?
- [x] Yes — response shape changes for `task_set_repetition`, `task_clear_repetition`, tag mutation tools, and folder mutation tools. Agents previously reading `data.id` must now read `data.task.id`, `data.tag.id`, or `data.folder.id`.

## Test plan
- [x] Unit tests cover happy + edge + error
- [x] `pnpm test` — 571 tests, 36 files, all green
- [x] `pnpm typecheck` — zero errors (pre-existing mcpServer.ts issues only)
- [x] `pnpm lint` — zero errors
- [x] Response envelope + typed error used throughout
- [x] Self-reviewed