### PR TITLE
feat(sync): add sync_trigger tool and meta.syncPending signal

### DIFF
--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -37,7 +37,7 @@ export async function handleFolderCreate(input: FolderCreateToolInput, ctx: Fold
     ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
   });
   const { folder } = await ctx.folderService.get(createResult.id);
-  return ok({ folder }, ctx.makeMeta());
+  return ok({ folder }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerFolderCreateTool(server: McpServer, ctx: FolderCreateContext) {

--- a/src/tools/folder/delete.ts
+++ b/src/tools/folder/delete.ts
@@ -41,7 +41,7 @@ export interface FolderDeleteContext {
 
 export async function handleFolderDelete(input: FolderDeleteToolInput, ctx: FolderDeleteContext) {
   await ctx.folderService.delete(input.id, input.cascade ?? false);
-  return ok({ deleted: true, id: input.id }, ctx.makeMeta());
+  return ok({ deleted: true, id: input.id }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerFolderDeleteTool(server: McpServer, ctx: FolderDeleteContext) {

--- a/src/tools/folder/move.ts
+++ b/src/tools/folder/move.ts
@@ -33,7 +33,7 @@ export interface FolderMoveContext {
 export async function handleFolderMove(input: FolderMoveToolInput, ctx: FolderMoveContext) {
   await ctx.folderService.move(input.id, input.parentId);
   const { folder } = await ctx.folderService.get(input.id);
-  return ok({ folder }, ctx.makeMeta());
+  return ok({ folder }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerFolderMoveTool(server: McpServer, ctx: FolderMoveContext) {

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -35,7 +35,7 @@ export async function handleFolderUpdate(input: FolderUpdateToolInput, ctx: Fold
     ...(patch.name !== undefined ? { name: patch.name } : {}),
   });
   const { folder } = await ctx.folderService.get(id);
-  return ok({ folder }, ctx.makeMeta());
+  return ok({ folder }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerFolderUpdateTool(server: McpServer, ctx: FolderUpdateContext) {

--- a/src/tools/sync/trigger.test.ts
+++ b/src/tools/sync/trigger.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for sync_trigger tool and the meta.syncPending lifecycle.
+ *
+ * Covers: schema validation, handler returns lastSyncAt + syncPending=false,
+ * write tools set syncPending=true, and the full lifecycle:
+ *   write → syncPending=true → sync_trigger → syncPending=false.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { TagService } from "../../services/tagService.js";
+import { handleTagCreate } from "../tag/create.js";
+import { handleSyncTrigger, syncTriggerInputSchema } from "./trigger.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const tagService = new TagService({ adapter });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { adapter, tagService, makeMeta };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("sync_trigger — input schema", () => {
+  it("accepts an empty object", () => {
+    expect(syncTriggerInputSchema.parse({})).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("sync_trigger — handler", () => {
+  it("returns lastSyncAt and inFlight=false", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    const envelope = await handleSyncTrigger({}, { adapter, makeMeta });
+    expect(envelope.data.inFlight).toBe(false);
+    expect(typeof envelope.data.lastSyncAt).toBe("string");
+  });
+
+  it("returns meta.syncPending = false", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    const envelope = await handleSyncTrigger({}, { adapter, makeMeta });
+    expect(envelope.meta.syncPending).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncPending lifecycle
+// ---------------------------------------------------------------------------
+
+describe("meta.syncPending lifecycle", () => {
+  it("write tool sets meta.syncPending = true", async () => {
+    const { tagService, makeMeta } = makeCtx();
+    const envelope = await handleTagCreate({ name: "Work" }, { tagService, makeMeta });
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("read (non-mutation) does not set syncPending", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    const envelope = await handleSyncTrigger({}, { adapter, makeMeta });
+    // After sync, syncPending is explicitly false — not absent
+    expect(envelope.meta.syncPending).toBe(false);
+  });
+
+  it("write → pending=true; sync_trigger → pending=false", async () => {
+    const { adapter, tagService, makeMeta } = makeCtx();
+
+    // 1. Perform a write — should have syncPending=true
+    const writeEnvelope = await handleTagCreate({ name: "Work" }, { tagService, makeMeta });
+    expect(writeEnvelope.meta.syncPending).toBe(true);
+
+    // 2. Trigger sync — should report syncPending=false
+    const syncEnvelope = await handleSyncTrigger({}, { adapter, makeMeta });
+    expect(syncEnvelope.meta.syncPending).toBe(false);
+  });
+});

--- a/src/tools/sync/trigger.ts
+++ b/src/tools/sync/trigger.ts
@@ -1,0 +1,79 @@
+/**
+ * `sync_trigger` MCP tool — kick off an OmniFocus sync with Omni Sync Server.
+ *
+ * Mutations on this server do not automatically propagate to other devices.
+ * Every mutation response carries `meta.syncPending = true` to signal that
+ * uncommitted writes exist. Agents call this tool to flush them.
+ *
+ * The underlying `synchronize()` call returns immediately — it is not a
+ * blocking wait for the sync to complete. The response reflects the kickoff
+ * time, not completion. If you need to confirm sync completion, poll
+ * `sync_status` after an appropriate interval.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/scripts/jxa/sync_trigger.js — JXA script
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const SYNC_TRIGGER_DESCRIPTION =
+  "Kick off an OmniFocus sync with Omni Sync Server. " +
+  "Call this after any sequence of mutations (task_create, task_update, folder_create, etc.) " +
+  "when you need changes to appear on other devices. " +
+  "The sync starts immediately but completes asynchronously — this tool does not block until done. " +
+  "Returns meta.syncPending = false to confirm the sync was initiated. " +
+  "Returns lastSyncAt (ISO-8601) and inFlight: false (sync kicked off, not yet confirmed complete).";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const syncTriggerInputSchema = z.object({});
+export type SyncTriggerInput = z.infer<typeof syncTriggerInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface SyncTriggerContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly in unit tests.
+ *
+ * Returns `meta.syncPending = false` to signal that the sync was initiated
+ * and the server's pending-write flag has been cleared.
+ */
+export async function handleSyncTrigger(_input: SyncTriggerInput, ctx: SyncTriggerContext) {
+  const status = await ctx.adapter.syncTrigger();
+  // syncPending: false — sync was kicked off; pending writes are now in-flight.
+  const meta = ctx.makeMeta({ syncPending: false });
+  return ok({ lastSyncAt: status.lastSyncAt, inFlight: status.inFlight }, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerSyncTriggerTool(server: McpServer, ctx: SyncTriggerContext) {
+  return server.registerTool(
+    "sync_trigger",
+    { description: SYNC_TRIGGER_DESCRIPTION, inputSchema: syncTriggerInputSchema.shape },
+    async (args: SyncTriggerInput) => {
+      const envelope = await handleSyncTrigger(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -50,7 +50,7 @@ export async function handleTagCreate(input: TagCreateToolInput, ctx: TagCreateC
     ...(input.allowsNextAction !== undefined ? { allowsNextAction: input.allowsNextAction } : {}),
   });
   const { tag } = await ctx.tagService.get(createResult.id);
-  const meta = ctx.makeMeta();
+  const meta = ctx.makeMeta({ syncPending: true });
   return ok({ tag }, meta);
 }
 

--- a/src/tools/tag/delete.ts
+++ b/src/tools/tag/delete.ts
@@ -33,7 +33,7 @@ export interface TagDeleteContext {
  */
 export async function handleTagDelete(input: TagDeleteToolInput, ctx: TagDeleteContext) {
   await ctx.tagService.delete(input.id);
-  return ok({ deleted: true, id: input.id }, ctx.makeMeta());
+  return ok({ deleted: true, id: input.id }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerTagDeleteTool(server: McpServer, ctx: TagDeleteContext) {

--- a/src/tools/tag/move.ts
+++ b/src/tools/tag/move.ts
@@ -36,7 +36,7 @@ export interface TagMoveContext {
 export async function handleTagMove(input: TagMoveToolInput, ctx: TagMoveContext) {
   await ctx.tagService.move(input.id, input.parentId);
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta());
+  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerTagMoveTool(server: McpServer, ctx: TagMoveContext) {

--- a/src/tools/tag/setAllowsNextAction.ts
+++ b/src/tools/tag/setAllowsNextAction.ts
@@ -38,7 +38,7 @@ export async function handleTagSetAllowsNextAction(
 ) {
   await ctx.tagService.setAllowsNextAction(input.id, input.allowsNextAction);
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta());
+  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerTagSetAllowsNextActionTool(

--- a/src/tools/tag/setLocation.ts
+++ b/src/tools/tag/setLocation.ts
@@ -59,7 +59,7 @@ export async function handleTagSetLocation(
     trigger: input.trigger,
   });
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta());
+  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerTagSetLocationTool(server: McpServer, ctx: TagSetLocationContext) {

--- a/src/tools/tag/setStatus.ts
+++ b/src/tools/tag/setStatus.ts
@@ -35,7 +35,7 @@ export interface TagSetStatusContext {
 export async function handleTagSetStatus(input: TagSetStatusToolInput, ctx: TagSetStatusContext) {
   await ctx.tagService.setStatus(input.id, input.status);
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta());
+  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerTagSetStatusTool(server: McpServer, ctx: TagSetStatusContext) {

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -50,7 +50,7 @@ export async function handleTagUpdate(input: TagUpdateToolInput, ctx: TagUpdateC
     ...(patch.allowsNextAction !== undefined ? { allowsNextAction: patch.allowsNextAction } : {}),
   });
   const { tag } = await ctx.tagService.get(id);
-  return ok({ tag }, ctx.makeMeta());
+  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
 }
 
 export function registerTagUpdateTool(server: McpServer, ctx: TagUpdateContext) {

--- a/src/tools/task/clearRepetition.ts
+++ b/src/tools/task/clearRepetition.ts
@@ -52,7 +52,7 @@ export async function handleTaskClearRepetition(
 ) {
   await ctx.adapter.updateTask(input.id, { repetition: null });
   const task = await ctx.adapter.getTask(input.id);
-  const meta = ctx.makeMeta();
+  const meta = ctx.makeMeta({ syncPending: true });
   return ok({ task }, meta);
 }
 

--- a/src/tools/task/setRepetition.ts
+++ b/src/tools/task/setRepetition.ts
@@ -67,7 +67,7 @@ export async function handleTaskSetRepetition(
 ) {
   await ctx.adapter.updateTask(input.id, { repetition: input.rule });
   const task = await ctx.adapter.getTask(input.id);
-  const meta = ctx.makeMeta();
+  const meta = ctx.makeMeta({ syncPending: true });
   return ok({ task }, meta);
 }
 


### PR DESCRIPTION
## Summary
- New `sync_trigger` tool kicks off OmniFocus sync with Omni Sync Server
- All 13 mutation handlers now return `meta.syncPending = true` so agents know to call sync_trigger without relying on documentation alone
- `sync_trigger` response returns `meta.syncPending = false` to confirm writes are in-flight
- Read-only handlers leave `syncPending` absent (undefined)

## Design link
Closes #130. Implements `meta.syncPending` described in `DESIGN.md §12` (tool response envelope).

## Breaking change?
- [x] No — `syncPending` is additive to `ResponseMeta`; existing consumers that ignore unknown fields are unaffected.

## Test plan
- [x] Unit tests cover: schema, handler returns correct shape, write sets `syncPending=true`, sync_trigger returns `syncPending=false`, full lifecycle
- [x] `pnpm test` — 577 tests, 37 files, all green
- [x] `pnpm lint` — zero errors
- [x] `pnpm typecheck` — zero errors
- [x] Self-reviewed