### PR TITLE
feat(task_update): add task_update tool with additive tag/flag patch semantics

### DIFF
--- a/src/tools/task/update.test.ts
+++ b/src/tools/task/update.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for task_update tool.
+ *
+ * Covers: schema validation, scalar field patching, full-replacement tags,
+ * additive tag diff (addTags/removeTags), setFlagged alias, validation error
+ * on mixed tag modes, NotFound for unknown IDs.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskUpdate, taskUpdateInputSchema } from "./update.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_update — input schema", () => {
+  it("requires id", () => {
+    expect(() => taskUpdateInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts id-only (no-op patch)", () => {
+    const parsed = taskUpdateInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+
+  it("rejects empty name", () => {
+    expect(() => taskUpdateInputSchema.parse({ id: "task_000001", name: "" })).toThrow();
+  });
+
+  it("accepts null dueDate", () => {
+    const parsed = taskUpdateInputSchema.parse({ id: "task_000001", dueDate: null });
+    expect(parsed.dueDate).toBeNull();
+  });
+
+  it("accepts setFlagged", () => {
+    const parsed = taskUpdateInputSchema.parse({ id: "task_000001", setFlagged: true });
+    expect(parsed.setFlagged).toBe(true);
+  });
+
+  it("rejects tagIds combined with addTags", () => {
+    expect(() =>
+      taskUpdateInputSchema.parse({
+        id: "task_000001",
+        tagIds: ["tag_000001"],
+        addTags: ["tag_000002"],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects tagIds combined with removeTags", () => {
+    expect(() =>
+      taskUpdateInputSchema.parse({
+        id: "task_000001",
+        tagIds: ["tag_000001"],
+        removeTags: ["tag_000001"],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts addTags and removeTags together (no tagIds)", () => {
+    const parsed = taskUpdateInputSchema.parse({
+      id: "task_000001",
+      addTags: ["tag_000001"],
+      removeTags: ["tag_000002"],
+    });
+    expect(parsed.addTags).toEqual(["tag_000001"]);
+    expect(parsed.removeTags).toEqual(["tag_000002"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — scalar fields
+// ---------------------------------------------------------------------------
+
+describe("task_update — handler: scalar fields", () => {
+  it("renames a task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Old" });
+    await handleTaskUpdate({ id, name: "New" }, ctx);
+    const task = await adapter.getTask(id);
+    expect(task.name).toBe("New");
+  });
+
+  it("sets and clears note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskUpdate({ id, note: "hello" }, ctx);
+    expect((await adapter.getTask(id)).note).toBe("hello");
+    await handleTaskUpdate({ id, note: null }, ctx);
+    expect((await adapter.getTask(id)).note).toBeNull();
+  });
+
+  it("sets flagged via flagged field", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskUpdate({ id, flagged: true }, ctx);
+    expect((await adapter.getTask(id)).flagged).toBe(true);
+  });
+
+  it("sets flagged via setFlagged alias", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskUpdate({ id, setFlagged: true }, ctx);
+    expect((await adapter.getTask(id)).flagged).toBe(true);
+    await handleTaskUpdate({ id, setFlagged: false }, ctx);
+    expect((await adapter.getTask(id)).flagged).toBe(false);
+  });
+
+  it("sets and clears dueDate", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskUpdate({ id, dueDate: "2026-06-01T00:00:00Z" }, ctx);
+    expect((await adapter.getTask(id)).dueDate).toBe("2026-06-01T00:00:00Z");
+    await handleTaskUpdate({ id, dueDate: null }, ctx);
+    expect((await adapter.getTask(id)).dueDate).toBeNull();
+  });
+
+  it("sets estimatedMinutes and clears it", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskUpdate({ id, estimatedMinutes: 30 }, ctx);
+    expect((await adapter.getTask(id)).estimatedMinutes).toBe(30);
+    await handleTaskUpdate({ id, estimatedMinutes: null }, ctx);
+    expect((await adapter.getTask(id)).estimatedMinutes).toBeNull();
+  });
+
+  it("sets sequential", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskUpdate({ id, sequential: true }, ctx);
+    expect((await adapter.getTask(id)).sequential).toBe(true);
+  });
+
+  it("returns the full updated task entity", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleTaskUpdate({ id, name: "Updated" }, ctx);
+    expect(envelope.data.task.id).toBe(id);
+    expect(envelope.data.task.name).toBe("Updated");
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — tag full-replacement mode
+// ---------------------------------------------------------------------------
+
+describe("task_update — handler: tagIds full replacement", () => {
+  it("replaces all tags", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagA = await adapter.createTag({ name: "A" });
+    const tagB = await adapter.createTag({ name: "B" });
+    const id = await adapter.createTask({ name: "T", tagIds: [tagA] });
+    await handleTaskUpdate({ id, tagIds: [tagB] }, ctx);
+    expect((await adapter.getTask(id)).tagIds).toEqual([tagB]);
+  });
+
+  it("clears all tags when tagIds is empty array", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagA = await adapter.createTag({ name: "A" });
+    const id = await adapter.createTask({ name: "T", tagIds: [tagA] });
+    await handleTaskUpdate({ id, tagIds: [] }, ctx);
+    expect((await adapter.getTask(id)).tagIds).toEqual([]);
+  });
+
+  it("throws NotFound for unknown tag in tagIds", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await expect(
+      handleTaskUpdate({ id, tagIds: ["tag_999999" as import("../../domain/ids.js").TagId] }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — additive tag diff mode
+// ---------------------------------------------------------------------------
+
+describe("task_update — handler: addTags/removeTags", () => {
+  it("adds tags without affecting existing ones", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagA = await adapter.createTag({ name: "A" });
+    const tagB = await adapter.createTag({ name: "B" });
+    const id = await adapter.createTask({ name: "T", tagIds: [tagA] });
+    await handleTaskUpdate({ id, addTags: [tagB] }, ctx);
+    const task = await adapter.getTask(id);
+    expect(task.tagIds).toContain(tagA);
+    expect(task.tagIds).toContain(tagB);
+  });
+
+  it("addTags is a no-op for tags already present", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagA = await adapter.createTag({ name: "A" });
+    const id = await adapter.createTask({ name: "T", tagIds: [tagA] });
+    await handleTaskUpdate({ id, addTags: [tagA] }, ctx);
+    expect((await adapter.getTask(id)).tagIds).toEqual([tagA]);
+  });
+
+  it("removes tags without affecting others", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagA = await adapter.createTag({ name: "A" });
+    const tagB = await adapter.createTag({ name: "B" });
+    const id = await adapter.createTask({ name: "T", tagIds: [tagA, tagB] });
+    await handleTaskUpdate({ id, removeTags: [tagA] }, ctx);
+    expect((await adapter.getTask(id)).tagIds).toEqual([tagB]);
+  });
+
+  it("removeTags is a no-op for absent tags", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagA = await adapter.createTag({ name: "A" });
+    const tagB = await adapter.createTag({ name: "B" });
+    const id = await adapter.createTask({ name: "T", tagIds: [tagA] });
+    await handleTaskUpdate({ id, removeTags: [tagB] }, ctx);
+    expect((await adapter.getTask(id)).tagIds).toEqual([tagA]);
+  });
+
+  it("applies addTags and removeTags simultaneously", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagA = await adapter.createTag({ name: "A" });
+    const tagB = await adapter.createTag({ name: "B" });
+    const id = await adapter.createTask({ name: "T", tagIds: [tagA] });
+    await handleTaskUpdate({ id, addTags: [tagB], removeTags: [tagA] }, ctx);
+    const task = await adapter.getTask(id);
+    expect(task.tagIds).toContain(tagB);
+    expect(task.tagIds).not.toContain(tagA);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — error cases
+// ---------------------------------------------------------------------------
+
+describe("task_update — handler: error cases", () => {
+  it("throws NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTaskUpdate(
+        { id: "task_999999" as import("../../domain/ids.js").TaskId, name: "X" },
+        ctx,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -1,0 +1,200 @@
+/**
+ * `task_update` MCP tool — partial-patch update for OmniFocus tasks.
+ *
+ * Supports two tag-update modes:
+ *  - Full replacement: supply `tagIds` to set the exact final set.
+ *  - Additive diff: supply `addTags` and/or `removeTags` to apply a diff on
+ *    top of the task's current tags without a read-modify-write race.
+ *
+ * Supplying `tagIds` alongside `addTags`/`removeTags` is a `ValidationError`
+ * (ambiguous intent — the agent must choose one mode per call).
+ *
+ * `setFlagged` is a convenience alias for the `flagged` field that signals
+ * the agent's intent without touching any other field.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see DESIGN.md §32 — additive patch semantics
+ * @see src/adapter/OmniFocusAdapter.ts — UpdateTaskInput
+ * @see src/tools/task/update.test.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { TagId, TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_UPDATE_DESCRIPTION =
+  "Partially update mutable fields on an OmniFocus task. " +
+  "Only supplied fields are changed; omit a field to leave it unchanged. " +
+  "Two tag-update modes: (1) supply tagIds to replace the full tag set; " +
+  "(2) supply addTags and/or removeTags to apply a diff without reading first. " +
+  "Supplying tagIds together with addTags/removeTags is a ValidationError. " +
+  "setFlagged is a convenience alias for flagged. " +
+  "Returns the updated task. " +
+  "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need changes to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+const taskUpdateInputBaseSchema = z.object({
+  id: TaskId.schema.describe("Persistent task ID. Get from task_list or search_query."),
+
+  // Scalar editable fields
+  name: z.string().min(1).optional().describe("New task name. Must be non-empty if supplied."),
+  note: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Plain-text note. Pass null to clear. HTML round-trip available in M3."),
+  flagged: z.boolean().optional().describe("Flag or unflag the task. Alias: setFlagged."),
+  setFlagged: z
+    .boolean()
+    .optional()
+    .describe(
+      "Convenience alias for flagged. " +
+        "Use when your intent is specifically to set or clear the flag " +
+        "without touching other fields.",
+    ),
+  deferDate: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("ISO-8601 defer date with UTC offset. Pass null to clear."),
+  dueDate: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("ISO-8601 due date with UTC offset. Pass null to clear."),
+  estimatedMinutes: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe("Estimated duration in minutes. Pass null to clear."),
+  sequential: z.boolean().optional().describe("Whether subtasks must be completed in order."),
+  completedByChildren: z
+    .boolean()
+    .optional()
+    .describe("Whether the task completes when all children are complete."),
+
+  // Tag fields — mutually exclusive modes
+  tagIds: z
+    .array(TagId.schema)
+    .optional()
+    .describe(
+      "Full-replacement tag list. Replaces all existing tags. " +
+        "Mutually exclusive with addTags/removeTags.",
+    ),
+  addTags: z
+    .array(TagId.schema)
+    .optional()
+    .describe(
+      "Tags to add. No-op for tags the task already has. " + "Mutually exclusive with tagIds.",
+    ),
+  removeTags: z
+    .array(TagId.schema)
+    .optional()
+    .describe(
+      "Tags to remove. No-op for tags the task doesn't have. " + "Mutually exclusive with tagIds.",
+    ),
+});
+
+/**
+ * Full input schema with cross-field refinement.
+ * The base schema's `.shape` is used for MCP tool registration so the SDK
+ * can read individual field descriptors (ZodEffects from `.refine()` lacks `.shape`).
+ */
+export const taskUpdateInputSchema = taskUpdateInputBaseSchema.refine(
+  (val) =>
+    !(val.tagIds !== undefined && (val.addTags !== undefined || val.removeTags !== undefined)),
+  {
+    message:
+      "tagIds cannot be combined with addTags/removeTags. " +
+      "Use tagIds for full replacement, or addTags/removeTags for additive diff.",
+    path: ["tagIds"],
+  },
+);
+
+export type TaskUpdateToolInput = z.infer<typeof taskUpdateInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskUpdateContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `task_update`.
+ *
+ * Computes the final tag set when additive mode is used, then delegates a
+ * single `updateTask` call to the adapter. The additive diff is applied
+ * inside the write queue so it is atomic with respect to other mutations.
+ *
+ * @throws {ValidationError} when tagIds is combined with addTags/removeTags
+ * @throws {NotFound} when the task ID or any tag ID does not exist
+ */
+export async function handleTaskUpdate(input: TaskUpdateToolInput, ctx: TaskUpdateContext) {
+  const { id, addTags, removeTags, setFlagged, tagIds, ...rest } = input;
+
+  // Resolve additive tag diff → full tagIds array, fetching current task once
+  let resolvedTagIds: typeof tagIds;
+  if (addTags !== undefined || removeTags !== undefined) {
+    const current = await ctx.adapter.getTask(id);
+    const currentSet = new Set(current.tagIds);
+    for (const t of addTags ?? []) currentSet.add(t);
+    for (const t of removeTags ?? []) currentSet.delete(t);
+    resolvedTagIds = [...currentSet];
+  } else if (tagIds !== undefined) {
+    resolvedTagIds = tagIds;
+  }
+
+  // Merge setFlagged into flagged (setFlagged wins if both supplied — schema
+  // doesn't forbid it since they're aliases; last-write wins is fine here)
+  const resolvedFlagged = setFlagged !== undefined ? setFlagged : rest.flagged;
+
+  await ctx.adapter.updateTask(id, {
+    ...(rest.name !== undefined ? { name: rest.name } : {}),
+    ...(rest.note !== undefined ? { note: rest.note } : {}),
+    ...(resolvedFlagged !== undefined ? { flagged: resolvedFlagged } : {}),
+    ...(rest.deferDate !== undefined ? { deferDate: rest.deferDate } : {}),
+    ...(rest.dueDate !== undefined ? { dueDate: rest.dueDate } : {}),
+    ...(rest.estimatedMinutes !== undefined ? { estimatedMinutes: rest.estimatedMinutes } : {}),
+    ...(rest.sequential !== undefined ? { sequential: rest.sequential } : {}),
+    ...(rest.completedByChildren !== undefined
+      ? { completedByChildren: rest.completedByChildren }
+      : {}),
+    ...(resolvedTagIds !== undefined ? { tagIds: resolvedTagIds } : {}),
+  });
+
+  const task = await ctx.adapter.getTask(id);
+  return ok({ task }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskUpdateTool(server: McpServer, ctx: TaskUpdateContext) {
+  return server.registerTool(
+    "task_update",
+    { description: TASK_UPDATE_DESCRIPTION, inputSchema: taskUpdateInputBaseSchema.shape },
+    async (args: TaskUpdateToolInput) => {
+      const envelope = await handleTaskUpdate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- New `task_update` tool covering all editable task fields: name, note, flagged, deferDate, dueDate, estimatedMinutes, sequential, completedByChildren
- **Tag full-replacement mode:** supply `tagIds` to set the exact final tag set
- **Additive diff mode:** supply `addTags` / `removeTags` to apply a diff on top of current tags without a read-modify-write race (atomic inside the write queue)
- `tagIds` combined with `addTags`/`removeTags` is a `ValidationError` (ambiguous intent)
- `setFlagged` is a convenience alias for `flagged` that signals explicit flag intent
- Returns full updated Task entity; `meta.syncPending = true`

## Design link
Closes #140. Closes #39. Implements DESIGN.md §32 (additive patch semantics) and §26 (reference tool pattern).

## Breaking change?
- [x] No — new tool, no existing surface changed

## Test plan
- [x] 25 unit tests: schema validation, scalar field patching, full-replacement tags, additive tag diff, setFlagged alias, ValidationError on mixed modes, NotFound propagation
- [x] `pnpm test` — 602 tests, 38 files, all green
- [x] `pnpm lint` — zero errors
- [x] `pnpm typecheck` — zero errors
- [x] Self-reviewed