### PR TITLE
feat(task_delete): add task_delete tool for hard task removal

### DIFF
--- a/src/tools/task/delete.test.ts
+++ b/src/tools/task/delete.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for task_delete tool.
+ *
+ * Covers: schema validation, successful deletion, NotFound for unknown ID,
+ * idempotency (double-delete raises NotFound), and response shape.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskDelete, taskDeleteInputSchema } from "./delete.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_delete — input schema", () => {
+  it("requires id", () => {
+    expect(() => taskDeleteInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid task ID", () => {
+    const parsed = taskDeleteInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("task_delete — handler", () => {
+  it("deletes an existing task and returns { deleted: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "To delete" });
+
+    const envelope = await handleTaskDelete({ id }, ctx);
+
+    expect(envelope.data.deleted).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true on deletion", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleTaskDelete({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("removes the task from the adapter", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskDelete({ id }, ctx);
+
+    // getTask should throw NotFound
+    await expect(adapter.getTask(id)).rejects.toThrow();
+  });
+
+  it("throws NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleTaskDelete({ id: "task_999999" as import("../../domain/ids.js").TaskId }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it("double-delete raises NotFound (not silent)", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleTaskDelete({ id }, ctx);
+    await expect(handleTaskDelete({ id }, ctx)).rejects.toThrow();
+  });
+
+  it("deleting one task does not affect sibling tasks", async () => {
+    const { ctx, adapter } = makeCtx();
+    const idA = await adapter.createTask({ name: "A" });
+    const idB = await adapter.createTask({ name: "B" });
+    await handleTaskDelete({ id: idA }, ctx);
+    const remaining = await adapter.listTasks({});
+    expect(remaining.some((t) => t.id === idB)).toBe(true);
+    expect(remaining.some((t) => t.id === idA)).toBe(false);
+  });
+});

--- a/src/tools/task/delete.ts
+++ b/src/tools/task/delete.ts
@@ -1,0 +1,85 @@
+/**
+ * `task_delete` MCP tool — hard (unrecoverable) removal of an OmniFocus task.
+ *
+ * This is a destructive, irreversible operation. OmniFocus's `deleteObject`
+ * API permanently removes the task from the database with no undo. Prefer
+ * `task_drop` when you want a recoverable status change that keeps the task
+ * accessible in the database.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/task/update.ts — task_update (patch editable fields)
+ * @see docs/domain-reference.md — drop vs. delete distinction
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_DELETE_DESCRIPTION =
+  "Permanently delete an OmniFocus task. " +
+  "IRREVERSIBLE — uses OmniFocus deleteObject; there is no undo. " +
+  "Prefer task_drop when you want a recoverable status change. " +
+  "Only use task_delete when the agent has explicit user intent to permanently remove the task. " +
+  "Returns { deleted: true, id } on success. " +
+  "Side effects: removes the task from OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need the deletion to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskDeleteInputSchema = z.object({
+  id: TaskId.schema.describe(
+    "Persistent ID of the task to delete. Get from task_list or search_query. " +
+      "Verify you have the correct ID before calling — this action is irreversible.",
+  ),
+});
+
+export type TaskDeleteToolInput = z.infer<typeof taskDeleteInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskDeleteContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `task_delete`.
+ *
+ * Delegates to `adapter.deleteTask` which handles cache invalidation and
+ * raises `NotFound` for an unknown ID.
+ *
+ * @throws {NotFound} when the task ID does not exist in OmniFocus
+ * @throws {OmniFocusNotRunning} when OmniFocus is not running
+ */
+export async function handleTaskDelete(input: TaskDeleteToolInput, ctx: TaskDeleteContext) {
+  await ctx.adapter.deleteTask(input.id);
+  return ok({ deleted: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskDeleteTool(server: McpServer, ctx: TaskDeleteContext) {
+  return server.registerTool(
+    "task_delete",
+    { description: TASK_DELETE_DESCRIPTION, inputSchema: taskDeleteInputSchema.shape },
+    async (args: TaskDeleteToolInput) => {
+      const envelope = await handleTaskDelete(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- New `task_delete` tool surfaces the existing `adapter.deleteTask` method as an MCP tool
- Description explicitly warns the operation is irreversible and recommends `task_drop` for recoverable removal
- Returns `{ deleted: true, id }` with `meta.syncPending = true`
- `NotFound` propagated for unknown or already-deleted IDs (double-delete is not silent)

## Design link
Closes #89. Follows DESIGN.md §26 (reference tool pattern). See `docs/domain-reference.md` for the drop vs. delete distinction.

## Breaking change?
- [x] No — new tool, no existing surface changed

## Test plan
- [x] 7 unit tests: schema validation, happy path, syncPending flag, adapter removal verified, NotFound for unknown ID, double-delete raises NotFound, sibling isolation
- [x] `pnpm test` — 610 tests, 39 files, all green
- [x] `pnpm lint` — zero errors
- [x] `pnpm typecheck` — zero errors
- [x] Self-reviewed