### PR TITLE
fix(dates): export flexDateString, isRelativeDateShortcut, resolveRelativeDate

### DIFF
--- a/src/domain/dates.test.ts
+++ b/src/domain/dates.test.ts
@@ -1,7 +1,14 @@
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { ISO_8601_WITH_OFFSET, isIsoDateString, isoDateString } from "./dates.js";
+import {
+  ISO_8601_WITH_OFFSET,
+  flexDateString,
+  isIsoDateString,
+  isRelativeDateShortcut,
+  isoDateString,
+  resolveRelativeDate,
+} from "./dates.js";
 
 describe("isIsoDateString", () => {
   it("we accept UTC (Z) form", () => {
@@ -140,5 +147,107 @@ describe("property — strings without offset are uniformly rejected", () => {
       ),
       { numRuns: 100 },
     );
+  });
+});
+
+describe("isRelativeDateShortcut", () => {
+  it("recognises all valid shortcuts", () => {
+    for (const s of [
+      "today",
+      "tomorrow",
+      "yesterday",
+      "this-week",
+      "next-week",
+      "end-of-week",
+      "end-of-month",
+    ]) {
+      expect(isRelativeDateShortcut(s)).toBe(true);
+    }
+  });
+
+  it("rejects ISO strings, arbitrary strings, and non-strings", () => {
+    expect(isRelativeDateShortcut("2026-04-19T12:00:00Z")).toBe(false);
+    expect(isRelativeDateShortcut("next-year")).toBe(false);
+    expect(isRelativeDateShortcut(null)).toBe(false);
+    expect(isRelativeDateShortcut(42)).toBe(false);
+  });
+});
+
+describe("resolveRelativeDate", () => {
+  // Pin to a known Wednesday: 2026-04-22 (Wed)
+  const wed = new Date(2026, 3, 22, 10, 0, 0); // April 22 2026, 10:00 local
+
+  it("today resolves to start of today", () => {
+    const result = resolveRelativeDate("today", wed);
+    expect(result).toMatch(/^2026-04-22T00:00:00/);
+  });
+
+  it("tomorrow resolves to start of tomorrow", () => {
+    expect(resolveRelativeDate("tomorrow", wed)).toMatch(/^2026-04-23T00:00:00/);
+  });
+
+  it("yesterday resolves to start of yesterday", () => {
+    expect(resolveRelativeDate("yesterday", wed)).toMatch(/^2026-04-21T00:00:00/);
+  });
+
+  it("this-week resolves to the Monday of the current week", () => {
+    expect(resolveRelativeDate("this-week", wed)).toMatch(/^2026-04-20T00:00:00/); // Mon Apr 20
+  });
+
+  it("next-week resolves to the Monday of next week", () => {
+    expect(resolveRelativeDate("next-week", wed)).toMatch(/^2026-04-27T00:00:00/); // Mon Apr 27
+  });
+
+  it("end-of-week resolves to Sunday of the current week", () => {
+    expect(resolveRelativeDate("end-of-week", wed)).toMatch(/^2026-04-26T00:00:00/); // Sun Apr 26
+  });
+
+  it("end-of-month resolves to the last day of the current month", () => {
+    expect(resolveRelativeDate("end-of-month", wed)).toMatch(/^2026-04-30T00:00:00/);
+  });
+
+  it("all outputs are valid ISO-8601 strings with an offset", () => {
+    for (const shortcut of [
+      "today",
+      "tomorrow",
+      "yesterday",
+      "this-week",
+      "next-week",
+      "end-of-week",
+      "end-of-month",
+    ] as const) {
+      expect(isIsoDateString(resolveRelativeDate(shortcut, wed))).toBe(true);
+    }
+  });
+});
+
+describe("flexDateString() schema", () => {
+  it("passes through a valid ISO-8601 string unchanged", () => {
+    const iso = "2026-04-19T12:00:00-05:00";
+    expect(flexDateString().parse(iso)).toBe(iso);
+  });
+
+  it("resolves a relative shortcut to an ISO-8601 string", () => {
+    const result = flexDateString().parse("today");
+    expect(isIsoDateString(result)).toBe(true);
+  });
+
+  it("rejects bare local time with a helpful message", () => {
+    const r = flexDateString().safeParse("2026-04-19T12:00:00");
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects unknown strings with a helpful message", () => {
+    const r = flexDateString().safeParse("next-year");
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.issues[0]?.message).toContain("next-year");
+  });
+
+  it("composes with .nullable().optional()", () => {
+    const schema = flexDateString().nullable().optional();
+    expect(schema.safeParse(undefined).success).toBe(true);
+    expect(schema.safeParse(null).success).toBe(true);
+    expect(schema.safeParse("today").success).toBe(true);
+    expect(schema.safeParse("bad").success).toBe(false);
   });
 });

--- a/src/domain/dates.ts
+++ b/src/domain/dates.ts
@@ -21,6 +21,103 @@
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
+// Relative date shortcuts
+// ---------------------------------------------------------------------------
+
+/**
+ * Human-friendly date shortcut accepted anywhere an ISO-8601 date is valid.
+ * Resolved server-side to a midnight timestamp in the server's local timezone.
+ * See DESIGN.md §14 — Relative date shortcuts.
+ */
+export type RelativeDateShortcut =
+  | "today"
+  | "tomorrow"
+  | "yesterday"
+  | "this-week"
+  | "next-week"
+  | "end-of-week"
+  | "end-of-month";
+
+const RELATIVE_SHORTCUTS = new Set<string>([
+  "today",
+  "tomorrow",
+  "yesterday",
+  "this-week",
+  "next-week",
+  "end-of-week",
+  "end-of-month",
+]);
+
+/** Type guard for relative date shortcuts. */
+export function isRelativeDateShortcut(value: unknown): value is RelativeDateShortcut {
+  return typeof value === "string" && RELATIVE_SHORTCUTS.has(value);
+}
+
+/** Build an ISO-8601 string with local offset for the start of the given Date's day. */
+function localMidnightIso(date: Date): string {
+  const offset = -date.getTimezoneOffset(); // minutes east of UTC
+  const sign = offset >= 0 ? "+" : "-";
+  const abs = Math.abs(offset);
+  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
+  const mm = String(abs % 60).padStart(2, "0");
+  const yyyy = date.getFullYear();
+  const mo = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${mo}-${dd}T00:00:00${sign}${hh}:${mm}`;
+}
+
+/**
+ * Resolve a relative date shortcut to an ISO-8601 string with offset.
+ * All shortcuts resolve to midnight (00:00:00) at the start of the target day
+ * in the server's local timezone. Accepts an optional `now` for testability.
+ */
+export function resolveRelativeDate(
+  shortcut: RelativeDateShortcut,
+  now: Date = new Date(),
+): string {
+  const base = new Date(now);
+  base.setHours(0, 0, 0, 0);
+
+  switch (shortcut) {
+    case "today":
+      return localMidnightIso(base);
+    case "tomorrow": {
+      const d = new Date(base);
+      d.setDate(d.getDate() + 1);
+      return localMidnightIso(d);
+    }
+    case "yesterday": {
+      const d = new Date(base);
+      d.setDate(d.getDate() - 1);
+      return localMidnightIso(d);
+    }
+    case "this-week": {
+      const d = new Date(base);
+      const day = d.getDay(); // 0=Sun
+      d.setDate(d.getDate() + (day === 0 ? -6 : 1 - day)); // back to Monday
+      return localMidnightIso(d);
+    }
+    case "next-week": {
+      const d = new Date(base);
+      const day = d.getDay();
+      d.setDate(d.getDate() + (day === 0 ? 1 : 8 - day)); // forward to next Monday
+      return localMidnightIso(d);
+    }
+    case "end-of-week": {
+      const d = new Date(base);
+      const day = d.getDay();
+      d.setDate(d.getDate() + (day === 0 ? 0 : 7 - day)); // forward to Sunday
+      return localMidnightIso(d);
+    }
+    case "end-of-month": {
+      const d = new Date(base);
+      d.setMonth(d.getMonth() + 1, 0); // day 0 of next month = last day of this month
+      return localMidnightIso(d);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Pattern
 // ---------------------------------------------------------------------------
 
@@ -87,4 +184,31 @@ export function isoDateString() {
     .refine((s) => !Number.isNaN(Date.parse(s)), {
       message: "Well-formed ISO-8601 but not a valid date (out-of-range month, hour, or minute).",
     });
+}
+
+/**
+ * Accepts either an ISO-8601 string with offset or a relative date shortcut
+ * (`today`, `tomorrow`, `yesterday`, `this-week`, `next-week`, `end-of-week`,
+ * `end-of-month`). Shortcuts resolve to midnight in the server's local timezone.
+ *
+ * Use this instead of `isoDateString()` for filter params and task date fields
+ * where natural language shortcuts improve agent ergonomics.
+ *
+ * @example
+ *   const taskListFilters = z.object({
+ *     dueBefore: flexDateString().optional(),
+ *     deferAfter: flexDateString().nullable().optional(),
+ *   });
+ *   // agent can pass: { dueBefore: "tomorrow" } or { dueBefore: "2026-04-22T00:00:00-05:00" }
+ */
+export function flexDateString() {
+  return z.string().transform((val, ctx): string => {
+    if (isIsoDateString(val)) return val;
+    if (isRelativeDateShortcut(val)) return resolveRelativeDate(val);
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Expected ISO-8601 with offset or a relative shortcut (today, tomorrow, yesterday, this-week, next-week, end-of-week, end-of-month). Got: "${val}".`,
+    });
+    return z.NEVER;
+  });
 }


### PR DESCRIPTION
## Summary
- Restores `pnpm typecheck`, `pnpm test`, `pnpm lint` to green on `main`.
- Three recent feature merges (#150 updatedSince, task_list sortBy, taskService) import `flexDateString`, `isRelativeDateShortcut`, `resolveRelativeDate` from `src/domain/dates.ts` — but the exports were never added. Main has been TS2305-red with 3 failing tests.
- Adds the DESIGN §14 relative-date-shortcut surface end to end: type, guard, resolver, and `flexDateString()` zod transformer. Resolved timestamps are ISO-8601 with offset per ADR-0007; midnight anchored in server-local timezone.

## Design link
Closes #177. Implements DESIGN.md §14. Conforms to ADR-0007.

## Breaking change?
- [x] No — purely additive exports.

## Test plan
- [x] `pnpm typecheck` green
- [x] `pnpm test` green (610/610, up from 578 + 3 failing)
- [x] `pnpm lint` green (biome + lint-custom)
- [x] New tests cover: shortcut recognition, week/month anchoring, ISO passthrough, invalid-input rejection, `flexDateString` round-trip
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)