### PR TITLE
feat(project_delete): add project_delete tool for hard project removal

### DIFF
--- a/src/tools/project/delete.test.ts
+++ b/src/tools/project/delete.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for project_delete tool.
+ *
+ * Covers: schema validation, successful deletion, NotFound for unknown ID,
+ * double-delete raises NotFound, cascade behavior (contained tasks are
+ * disassociated from the project), and response shape.
+ *
+ * NOTE: The InMemoryAdapter orphans contained tasks (sets projectId=null)
+ * rather than hard-deleting them — this matches the observable outcome for
+ * the project scope but differs from real OmniFocus which hard-deletes tasks.
+ * Integration tests cover the JXA cascade behavior.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleProjectDelete, projectDeleteInputSchema } from "./delete.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("project_delete — input schema", () => {
+  it("requires id", () => {
+    expect(() => projectDeleteInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid project ID", () => {
+    const parsed = projectDeleteInputSchema.parse({ id: "project_000001" });
+    expect(parsed.id).toBe("project_000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("project_delete — handler", () => {
+  it("deletes an existing project and returns { deleted: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "To delete" });
+
+    const envelope = await handleProjectDelete({ id }, ctx);
+
+    expect(envelope.data.deleted).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true on deletion", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    const envelope = await handleProjectDelete({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("removes the project from the adapter", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    await handleProjectDelete({ id }, ctx);
+    await expect(adapter.getProject(id)).rejects.toThrow();
+  });
+
+  it("throws NotFound for unknown project ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleProjectDelete({ id: "project_999999" as import("../../domain/ids.js").ProjectId }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it("double-delete raises NotFound (not silent)", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    await handleProjectDelete({ id }, ctx);
+    await expect(handleProjectDelete({ id }, ctx)).rejects.toThrow();
+  });
+
+  it("cascade: contained tasks are no longer associated with the deleted project", async () => {
+    const { ctx, adapter } = makeCtx();
+    const projectId = await adapter.createProject({ name: "My Project" });
+    const taskId = await adapter.createTask({ name: "Task in project", projectId });
+
+    // Verify task is in the project before deletion
+    const before = await adapter.getTask(taskId);
+    expect(before.projectId).toBe(projectId);
+
+    await handleProjectDelete({ id: projectId }, ctx);
+
+    // After deletion, the project is gone
+    await expect(adapter.getProject(projectId)).rejects.toThrow();
+
+    // The task is orphaned (InMemoryAdapter behavior; real OF hard-deletes tasks)
+    const after = await adapter.getTask(taskId);
+    expect(after.projectId).toBeNull();
+  });
+
+  it("deleting one project does not affect sibling projects", async () => {
+    const { ctx, adapter } = makeCtx();
+    const idA = await adapter.createProject({ name: "A" });
+    const idB = await adapter.createProject({ name: "B" });
+    await handleProjectDelete({ id: idA }, ctx);
+    const remaining = await adapter.listProjects({});
+    expect(remaining.some((p) => p.id === idB)).toBe(true);
+    expect(remaining.some((p) => p.id === idA)).toBe(false);
+  });
+});

--- a/src/tools/project/delete.ts
+++ b/src/tools/project/delete.ts
@@ -1,0 +1,93 @@
+/**
+ * `project_delete` MCP tool — hard (unrecoverable) removal of an OmniFocus project.
+ *
+ * This is a destructive, irreversible operation. OmniFocus's `deleteObject`
+ * API permanently removes the project AND all its contained tasks from the
+ * database with no undo. Prefer `project_drop` when you want a recoverable
+ * status change that keeps the project accessible.
+ *
+ * There is no `confirm` guard — the caller is responsible for verifying the
+ * correct ID before calling. The description warns explicitly.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/task/delete.ts — task_delete (equivalent for tasks)
+ * @see docs/domain-reference.md — drop vs. delete distinction
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { ProjectId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_DELETE_DESCRIPTION =
+  "Permanently delete an OmniFocus project and ALL its contained tasks. " +
+  "IRREVERSIBLE — uses OmniFocus deleteObject; there is no undo. " +
+  "All tasks inside the project are also permanently deleted (cascade). " +
+  "Prefer project_drop when you want a recoverable status change. " +
+  "Only use project_delete when the agent has explicit user intent to permanently remove the project and its tasks. " +
+  "Returns { deleted: true, id } on success. " +
+  "Side effects: removes the project and its tasks from OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need the deletion to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectDeleteInputSchema = z.object({
+  id: ProjectId.schema.describe(
+    "Persistent ID of the project to delete. Get from project_list. " +
+      "Verify you have the correct ID before calling — this action is irreversible " +
+      "and deletes all contained tasks.",
+  ),
+});
+
+export type ProjectDeleteToolInput = z.infer<typeof projectDeleteInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectDeleteContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `project_delete`.
+ *
+ * Delegates to `adapter.deleteProject` which handles cascade task removal,
+ * cache invalidation, and raises `NotFound` for an unknown ID.
+ *
+ * @throws {NotFound} when the project ID does not exist in OmniFocus
+ * @throws {OmniFocusNotRunning} when OmniFocus is not running
+ */
+export async function handleProjectDelete(
+  input: ProjectDeleteToolInput,
+  ctx: ProjectDeleteContext,
+) {
+  await ctx.adapter.deleteProject(input.id);
+  return ok({ deleted: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectDeleteTool(server: McpServer, ctx: ProjectDeleteContext) {
+  return server.registerTool(
+    "project_delete",
+    { description: PROJECT_DELETE_DESCRIPTION, inputSchema: projectDeleteInputSchema.shape },
+    async (args: ProjectDeleteToolInput) => {
+      const envelope = await handleProjectDelete(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- New project_delete tool mirrors task_delete for projects
- Description explicitly warns the operation is irreversible, deletes all contained tasks (cascade), and recommends project_drop for recoverable removal
- Returns { deleted: true, id } with meta.syncPending = true
- NotFound propagated for unknown or already-deleted IDs

## Design link
Closes #90. Follows DESIGN.md section 26 (reference tool pattern).

## Breaking change?
- [x] No — new tool, no existing surface changed

## Test plan
- [x] 7 unit tests: schema validation, happy path, syncPending flag, adapter removal, NotFound, double-delete, cascade observation, sibling isolation
- [x] pnpm test: 619 tests, 40 files, all green
- [x] pnpm lint: zero errors
- [x] pnpm typecheck: zero errors