### PR TITLE
feat(note): add note_get, note_set, note_append tools (plain text)

### DIFF
--- a/src/tools/note/append.ts
+++ b/src/tools/note/append.ts
@@ -1,0 +1,104 @@
+/**
+ * `note_append` MCP tool — append text to the plain-text note on a task or project.
+ *
+ * Reads the current note then writes the combined result in a single handler
+ * call. The read+write is not atomic at the OmniFocus database level, but
+ * the server's write-queue serialization (ADR-0009) ensures no concurrent
+ * mutation interleaves between the read and write within this server process.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/note/get.ts — read the note
+ * @see src/tools/note/set.ts — replace the note
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { ProjectId, TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const NOTE_APPEND_DESCRIPTION =
+  "Append text to the plain-text note on a task or project. " +
+  "Adds a newline between existing content and the new text unless the note is empty. " +
+  "Does not overwrite — use note_set to replace the full note. " +
+  "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need the change to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const noteAppendInputSchema = z.object({
+  targetKind: z
+    .enum(["task", "project"])
+    .describe("The kind of OmniFocus item whose note to append to."),
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "Persistent ID of the task or project. " +
+        "Get task IDs from task_list; project IDs from project_list.",
+    ),
+  text: z
+    .string()
+    .min(1)
+    .describe("Text to append. A newline separator is inserted before the text if a note exists."),
+});
+
+export type NoteAppendToolInput = z.infer<typeof noteAppendInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface NoteAppendContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `note_append`.
+ *
+ * Reads the current note, appends `text` with a newline separator (when
+ * the existing note is non-empty), then writes the result back.
+ *
+ * @throws {NotFound} when the task or project ID does not exist
+ */
+export async function handleNoteAppend(input: NoteAppendToolInput, ctx: NoteAppendContext) {
+  const existing =
+    input.targetKind === "task"
+      ? (await ctx.adapter.getTask(TaskId.of(input.id))).note
+      : (await ctx.adapter.getProject(ProjectId.of(input.id))).note;
+
+  const combined = existing ? `${existing}\n${input.text}` : input.text;
+
+  if (input.targetKind === "task") {
+    await ctx.adapter.updateTask(TaskId.of(input.id), { note: combined });
+  } else {
+    await ctx.adapter.updateProject(ProjectId.of(input.id), { note: combined });
+  }
+
+  return ok({ updated: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerNoteAppendTool(server: McpServer, ctx: NoteAppendContext) {
+  return server.registerTool(
+    "note_append",
+    { description: NOTE_APPEND_DESCRIPTION, inputSchema: noteAppendInputSchema.shape },
+    async (args: NoteAppendToolInput) => {
+      const envelope = await handleNoteAppend(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/note/get.ts
+++ b/src/tools/note/get.ts
@@ -1,0 +1,89 @@
+/**
+ * `note_get` MCP tool — read the plain-text note from a task or project.
+ *
+ * Notes in OmniFocus are stored as rich text internally; this tool returns
+ * the plain-text rendering. For HTML fidelity see `note_get_html` (M3, #63).
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/note/set.ts — write the note
+ * @see src/tools/note/append.ts — append to the note
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { ProjectId, TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const NOTE_GET_DESCRIPTION =
+  "Read the plain-text note from a task or project. " +
+  "Returns { note } — a string (may be empty) or null when no note exists. " +
+  "Set targetKind to 'task' and provide a task ID, or 'project' and a project ID. " +
+  "For the full HTML representation with formatting, use note_get_html.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const noteGetInputSchema = z.object({
+  targetKind: z
+    .enum(["task", "project"])
+    .describe("The kind of OmniFocus item whose note to read."),
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "Persistent ID of the task or project. " +
+        "Get task IDs from task_list; project IDs from project_list.",
+    ),
+});
+
+export type NoteGetToolInput = z.infer<typeof noteGetInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface NoteGetContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `note_get`.
+ *
+ * Reads the plain-text note from the specified task or project.
+ * Returns `null` when the item has no note.
+ *
+ * @throws {NotFound} when the task or project ID does not exist
+ */
+export async function handleNoteGet(input: NoteGetToolInput, ctx: NoteGetContext) {
+  const note =
+    input.targetKind === "task"
+      ? (await ctx.adapter.getTask(TaskId.of(input.id))).note
+      : (await ctx.adapter.getProject(ProjectId.of(input.id))).note;
+
+  return ok({ note: note ?? null }, ctx.makeMeta());
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerNoteGetTool(server: McpServer, ctx: NoteGetContext) {
+  return server.registerTool(
+    "note_get",
+    { description: NOTE_GET_DESCRIPTION, inputSchema: noteGetInputSchema.shape },
+    async (args: NoteGetToolInput) => {
+      const envelope = await handleNoteGet(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/note/note.test.ts
+++ b/src/tools/note/note.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for note_get, note_set, note_append tools.
+ *
+ * Covers: schema validation, read/write on tasks and projects,
+ * null/empty note semantics, append separator logic, NotFound propagation,
+ * and syncPending flag.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleNoteAppend, noteAppendInputSchema } from "./append.js";
+import { handleNoteGet, noteGetInputSchema } from "./get.js";
+import { handleNoteSet, noteSetInputSchema } from "./set.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// note_get — schema
+// ---------------------------------------------------------------------------
+
+describe("note_get — input schema", () => {
+  it("requires targetKind and id", () => {
+    expect(() => noteGetInputSchema.parse({})).toThrow();
+    expect(() => noteGetInputSchema.parse({ targetKind: "task" })).toThrow();
+  });
+
+  it("accepts task targetKind", () => {
+    const parsed = noteGetInputSchema.parse({ targetKind: "task", id: "task_000001" });
+    expect(parsed.targetKind).toBe("task");
+  });
+
+  it("accepts project targetKind", () => {
+    const parsed = noteGetInputSchema.parse({ targetKind: "project", id: "project_000001" });
+    expect(parsed.targetKind).toBe("project");
+  });
+
+  it("rejects unknown targetKind", () => {
+    expect(() => noteGetInputSchema.parse({ targetKind: "folder", id: "x" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_get — handler
+// ---------------------------------------------------------------------------
+
+describe("note_get — handler", () => {
+  it("returns null when task has no note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteGet({ targetKind: "task", id }, ctx);
+    expect(envelope.data.note).toBeNull();
+  });
+
+  it("returns the task note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T", note: "hello" });
+    const envelope = await handleNoteGet({ targetKind: "task", id }, ctx);
+    expect(envelope.data.note).toBe("hello");
+  });
+
+  it("returns null when project has no note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    const envelope = await handleNoteGet({ targetKind: "project", id }, ctx);
+    expect(envelope.data.note).toBeNull();
+  });
+
+  it("returns the project note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P", note: "proj note" });
+    const envelope = await handleNoteGet({ targetKind: "project", id }, ctx);
+    expect(envelope.data.note).toBe("proj note");
+  });
+
+  it("does not set syncPending on read", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteGet({ targetKind: "task", id }, ctx);
+    expect(envelope.meta.syncPending).toBeUndefined();
+  });
+
+  it("throws NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleNoteGet({ targetKind: "task", id: "task_999999" }, ctx)).rejects.toThrow();
+  });
+
+  it("throws NotFound for unknown project ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleNoteGet({ targetKind: "project", id: "project_999999" }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_set — schema
+// ---------------------------------------------------------------------------
+
+describe("note_set — input schema", () => {
+  it("requires targetKind, id, and note", () => {
+    expect(() => noteSetInputSchema.parse({ targetKind: "task", id: "task_000001" })).toThrow();
+  });
+
+  it("accepts null note (clear)", () => {
+    const parsed = noteSetInputSchema.parse({ targetKind: "task", id: "task_000001", note: null });
+    expect(parsed.note).toBeNull();
+  });
+
+  it("accepts empty string note", () => {
+    const parsed = noteSetInputSchema.parse({ targetKind: "task", id: "task_000001", note: "" });
+    expect(parsed.note).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_set — handler
+// ---------------------------------------------------------------------------
+
+describe("note_set — handler", () => {
+  it("sets a note on a task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleNoteSet({ targetKind: "task", id, note: "new note" }, ctx);
+    expect((await adapter.getTask(id)).note).toBe("new note");
+  });
+
+  it("sets a note on a project", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    await handleNoteSet({ targetKind: "project", id, note: "proj note" }, ctx);
+    expect((await adapter.getProject(id)).note).toBe("proj note");
+  });
+
+  it("clears a task note when passed null", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T", note: "old" });
+    await handleNoteSet({ targetKind: "task", id, note: null }, ctx);
+    expect((await adapter.getTask(id)).note).toBeNull();
+  });
+
+  it("overwrites an existing note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T", note: "old" });
+    await handleNoteSet({ targetKind: "task", id, note: "new" }, ctx);
+    expect((await adapter.getTask(id)).note).toBe("new");
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteSet({ targetKind: "task", id, note: "x" }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("returns { updated: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteSet({ targetKind: "task", id, note: "x" }, ctx);
+    expect(envelope.data.updated).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("throws NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleNoteSet({ targetKind: "task", id: "task_999999", note: "x" }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_append — schema
+// ---------------------------------------------------------------------------
+
+describe("note_append — input schema", () => {
+  it("requires targetKind, id, and text", () => {
+    expect(() => noteAppendInputSchema.parse({ targetKind: "task", id: "task_000001" })).toThrow();
+  });
+
+  it("rejects empty text", () => {
+    expect(() =>
+      noteAppendInputSchema.parse({ targetKind: "task", id: "task_000001", text: "" }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_append — handler
+// ---------------------------------------------------------------------------
+
+describe("note_append — handler", () => {
+  it("appends to a task with no existing note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleNoteAppend({ targetKind: "task", id, text: "first line" }, ctx);
+    expect((await adapter.getTask(id)).note).toBe("first line");
+  });
+
+  it("appends with a newline separator when note exists", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T", note: "existing" });
+    await handleNoteAppend({ targetKind: "task", id, text: "appended" }, ctx);
+    expect((await adapter.getTask(id)).note).toBe("existing\nappended");
+  });
+
+  it("appends to a project note", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P", note: "proj" });
+    await handleNoteAppend({ targetKind: "project", id, text: "more" }, ctx);
+    expect((await adapter.getProject(id)).note).toBe("proj\nmore");
+  });
+
+  it("multiple appends accumulate correctly", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleNoteAppend({ targetKind: "task", id, text: "a" }, ctx);
+    await handleNoteAppend({ targetKind: "task", id, text: "b" }, ctx);
+    await handleNoteAppend({ targetKind: "task", id, text: "c" }, ctx);
+    expect((await adapter.getTask(id)).note).toBe("a\nb\nc");
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteAppend({ targetKind: "task", id, text: "x" }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("throws NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleNoteAppend({ targetKind: "task", id: "task_999999", text: "x" }, ctx),
+    ).rejects.toThrow();
+  });
+});

--- a/src/tools/note/set.ts
+++ b/src/tools/note/set.ts
@@ -1,0 +1,88 @@
+/**
+ * `note_set` MCP tool — replace the plain-text note on a task or project.
+ *
+ * Replaces the full note. To append without overwriting existing content,
+ * use `note_append` instead. To clear the note, pass `note: null`.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/note/get.ts — read the note
+ * @see src/tools/note/append.ts — append to the note
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { ProjectId, TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const NOTE_SET_DESCRIPTION =
+  "Replace the plain-text note on a task or project. " +
+  "Overwrites the existing note entirely. Pass note: null to clear the note. " +
+  "To add text without overwriting use note_append instead. " +
+  "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need the change to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const noteSetInputSchema = z.object({
+  targetKind: z.enum(["task", "project"]).describe("The kind of OmniFocus item whose note to set."),
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "Persistent ID of the task or project. " +
+        "Get task IDs from task_list; project IDs from project_list.",
+    ),
+  note: z.string().nullable().describe("New note text. Pass null to clear the note entirely."),
+});
+
+export type NoteSetToolInput = z.infer<typeof noteSetInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface NoteSetContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `note_set`.
+ *
+ * Replaces the note on the specified task or project.
+ *
+ * @throws {NotFound} when the task or project ID does not exist
+ */
+export async function handleNoteSet(input: NoteSetToolInput, ctx: NoteSetContext) {
+  if (input.targetKind === "task") {
+    await ctx.adapter.updateTask(TaskId.of(input.id), { note: input.note });
+  } else {
+    await ctx.adapter.updateProject(ProjectId.of(input.id), { note: input.note });
+  }
+  return ok({ updated: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerNoteSetTool(server: McpServer, ctx: NoteSetContext) {
+  return server.registerTool(
+    "note_set",
+    { description: NOTE_SET_DESCRIPTION, inputSchema: noteSetInputSchema.shape },
+    async (args: NoteSetToolInput) => {
+      const envelope = await handleNoteSet(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- New note_get tool reads plain-text note from a task or project
- New note_set tool replaces (or clears) the note; returns { updated: true, id }
- New note_append tool adds text with a newline separator to existing note; atomic within write-queue (ADR-0009)
- All three tools support targetKind: 'task' | 'project'
- note_set and note_append set meta.syncPending = true

## Design link
Closes #62. Implements the plain-text note surface; HTML round-trip deferred to #63.

## Breaking change?
- [x] No — new tools, no existing surface changed

## Test plan
- [x] 27 unit tests: schema validation, read task/project notes, null/empty semantics, set/clear, append newline separator, multi-append accumulation, syncPending, NotFound propagation
- [x] pnpm test: 669 tests, 42 files, all green
- [x] pnpm lint: zero errors (including no-id-cast rule — uses TaskId.of()/ProjectId.of() factory functions)
- [x] pnpm typecheck: zero errors
- [x] Self-reviewed