### PR TITLE
feat(note): add note_get_html and note_set_html tools

### DIFF
--- a/src/tools/note/get_html.ts
+++ b/src/tools/note/get_html.ts
@@ -1,0 +1,90 @@
+/**
+ * `note_get_html` MCP tool — read the HTML fragment from a task or project note.
+ *
+ * OmniFocus stores notes as rich text internally. This tool returns the HTML
+ * fragment representation for full formatting fidelity (bold, links, lists,
+ * inline images). For plain-text access use `note_get`.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/note/get.ts — plain-text variant
+ * @see src/tools/note/set_html.ts — write the HTML note
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { ProjectId, TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const NOTE_GET_HTML_DESCRIPTION =
+  "Read the HTML fragment from a task or project note. " +
+  "Returns { noteHtml } — an HTML string (may be empty) or null when no note exists. " +
+  "Set targetKind to 'task' and provide a task ID, or 'project' and a project ID. " +
+  "For plain-text access without formatting, use note_get instead.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const noteGetHtmlInputSchema = z.object({
+  targetKind: z
+    .enum(["task", "project"])
+    .describe("The kind of OmniFocus item whose HTML note to read."),
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "Persistent ID of the task or project. " +
+        "Get task IDs from task_list; project IDs from project_list.",
+    ),
+});
+
+export type NoteGetHtmlToolInput = z.infer<typeof noteGetHtmlInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface NoteGetHtmlContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `note_get_html`.
+ *
+ * Reads the HTML fragment from the specified task or project note.
+ * Returns `null` when the item has no note.
+ *
+ * @throws {NotFound} when the task or project ID does not exist
+ */
+export async function handleNoteGetHtml(input: NoteGetHtmlToolInput, ctx: NoteGetHtmlContext) {
+  const noteHtml =
+    input.targetKind === "task"
+      ? (await ctx.adapter.getTask(TaskId.of(input.id))).noteHtml
+      : (await ctx.adapter.getProject(ProjectId.of(input.id))).noteHtml;
+
+  return ok({ noteHtml: noteHtml ?? null }, ctx.makeMeta());
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerNoteGetHtmlTool(server: McpServer, ctx: NoteGetHtmlContext) {
+  return server.registerTool(
+    "note_get_html",
+    { description: NOTE_GET_HTML_DESCRIPTION, inputSchema: noteGetHtmlInputSchema.shape },
+    async (args: NoteGetHtmlToolInput) => {
+      const envelope = await handleNoteGetHtml(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/note/note.test.ts
+++ b/src/tools/note/note.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for note_get, note_set, note_append tools.
+ * Tests for note_get, note_set, note_append, note_get_html, note_set_html tools.
  *
  * Covers: schema validation, read/write on tasks and projects,
  * null/empty note semantics, append separator logic, NotFound propagation,
- * and syncPending flag.
+ * syncPending flag, and HTML round-trip fidelity.
  */
 
 import { describe, expect, it } from "vitest";
@@ -11,7 +11,9 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { handleNoteAppend, noteAppendInputSchema } from "./append.js";
 import { handleNoteGet, noteGetInputSchema } from "./get.js";
+import { handleNoteGetHtml, noteGetHtmlInputSchema } from "./get_html.js";
 import { handleNoteSet, noteSetInputSchema } from "./set.js";
+import { handleNoteSetHtml, noteSetHtmlInputSchema } from "./set_html.js";
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -250,5 +252,187 @@ describe("note_append — handler", () => {
     await expect(
       handleNoteAppend({ targetKind: "task", id: "task_999999", text: "x" }, ctx),
     ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_get_html — schema
+// ---------------------------------------------------------------------------
+
+describe("note_get_html — input schema", () => {
+  it("requires targetKind and id", () => {
+    expect(() => noteGetHtmlInputSchema.parse({})).toThrow();
+    expect(() => noteGetHtmlInputSchema.parse({ targetKind: "task" })).toThrow();
+  });
+
+  it("accepts task targetKind", () => {
+    const parsed = noteGetHtmlInputSchema.parse({ targetKind: "task", id: "task_000001" });
+    expect(parsed.targetKind).toBe("task");
+  });
+
+  it("accepts project targetKind", () => {
+    const parsed = noteGetHtmlInputSchema.parse({ targetKind: "project", id: "project_000001" });
+    expect(parsed.targetKind).toBe("project");
+  });
+
+  it("rejects unknown targetKind", () => {
+    expect(() => noteGetHtmlInputSchema.parse({ targetKind: "folder", id: "x" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_get_html — handler
+// ---------------------------------------------------------------------------
+
+describe("note_get_html — handler", () => {
+  it("returns null when task has no noteHtml", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteGetHtml({ targetKind: "task", id }, ctx);
+    expect(envelope.data.noteHtml).toBeNull();
+  });
+
+  it("returns the task noteHtml", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T", noteHtml: "<b>hello</b>" });
+    const envelope = await handleNoteGetHtml({ targetKind: "task", id }, ctx);
+    expect(envelope.data.noteHtml).toBe("<b>hello</b>");
+  });
+
+  it("returns null when project has no noteHtml", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    const envelope = await handleNoteGetHtml({ targetKind: "project", id }, ctx);
+    expect(envelope.data.noteHtml).toBeNull();
+  });
+
+  it("returns the project noteHtml", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P", noteHtml: "<ul><li>item</li></ul>" });
+    const envelope = await handleNoteGetHtml({ targetKind: "project", id }, ctx);
+    expect(envelope.data.noteHtml).toBe("<ul><li>item</li></ul>");
+  });
+
+  it("does not set syncPending on read", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteGetHtml({ targetKind: "task", id }, ctx);
+    expect(envelope.meta.syncPending).toBeUndefined();
+  });
+
+  it("throws NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleNoteGetHtml({ targetKind: "task", id: "task_999999" }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it("throws NotFound for unknown project ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleNoteGetHtml({ targetKind: "project", id: "project_999999" }, ctx),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_set_html — schema
+// ---------------------------------------------------------------------------
+
+describe("note_set_html — input schema", () => {
+  it("requires targetKind, id, and noteHtml", () => {
+    expect(() => noteSetHtmlInputSchema.parse({ targetKind: "task", id: "task_000001" })).toThrow();
+  });
+
+  it("accepts null noteHtml (clear)", () => {
+    const parsed = noteSetHtmlInputSchema.parse({
+      targetKind: "task",
+      id: "task_000001",
+      noteHtml: null,
+    });
+    expect(parsed.noteHtml).toBeNull();
+  });
+
+  it("accepts empty string noteHtml", () => {
+    const parsed = noteSetHtmlInputSchema.parse({
+      targetKind: "task",
+      id: "task_000001",
+      noteHtml: "",
+    });
+    expect(parsed.noteHtml).toBe("");
+  });
+
+  it("accepts HTML fragment", () => {
+    const parsed = noteSetHtmlInputSchema.parse({
+      targetKind: "task",
+      id: "task_000001",
+      noteHtml: "<b>bold</b>",
+    });
+    expect(parsed.noteHtml).toBe("<b>bold</b>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// note_set_html — handler
+// ---------------------------------------------------------------------------
+
+describe("note_set_html — handler", () => {
+  it("sets noteHtml on a task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    await handleNoteSetHtml({ targetKind: "task", id, noteHtml: "<b>bold</b>" }, ctx);
+    expect((await adapter.getTask(id)).noteHtml).toBe("<b>bold</b>");
+  });
+
+  it("sets noteHtml on a project", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    await handleNoteSetHtml({ targetKind: "project", id, noteHtml: "<ul><li>item</li></ul>" }, ctx);
+    expect((await adapter.getProject(id)).noteHtml).toBe("<ul><li>item</li></ul>");
+  });
+
+  it("clears noteHtml when passed null", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T", noteHtml: "<b>old</b>" });
+    await handleNoteSetHtml({ targetKind: "task", id, noteHtml: null }, ctx);
+    expect((await adapter.getTask(id)).noteHtml).toBeNull();
+  });
+
+  it("overwrites existing noteHtml", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T", noteHtml: "<b>old</b>" });
+    await handleNoteSetHtml({ targetKind: "task", id, noteHtml: "<i>new</i>" }, ctx);
+    expect((await adapter.getTask(id)).noteHtml).toBe("<i>new</i>");
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteSetHtml({ targetKind: "task", id, noteHtml: "<b>x</b>" }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("returns { updated: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "T" });
+    const envelope = await handleNoteSetHtml({ targetKind: "task", id, noteHtml: "<b>x</b>" }, ctx);
+    expect(envelope.data.updated).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("throws NotFound for unknown task ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleNoteSetHtml({ targetKind: "task", id: "task_999999", noteHtml: "<b>x</b>" }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it("HTML round-trip: bold, link, list", async () => {
+    const { ctx, adapter } = makeCtx();
+    const html = '<b>bold</b> <a href="https://example.com">link</a> <ul><li>item</li></ul>';
+    const id = await adapter.createTask({ name: "T" });
+    await handleNoteSetHtml({ targetKind: "task", id, noteHtml: html }, ctx);
+    const envelope = await handleNoteGetHtml({ targetKind: "task", id }, ctx);
+    expect(envelope.data.noteHtml).toBe(html);
   });
 });

--- a/src/tools/note/set_html.ts
+++ b/src/tools/note/set_html.ts
@@ -1,0 +1,99 @@
+/**
+ * `note_set_html` MCP tool — replace the HTML fragment note on a task or project.
+ *
+ * Accepts an HTML fragment and writes it as the note for the specified item.
+ * OmniFocus preserves its supported HTML subset (bold, italic, links, lists,
+ * inline images). Unsupported elements may be stripped silently by OmniFocus.
+ *
+ * To clear the note, pass `noteHtml: null`.
+ * For plain-text writes, use `note_set` instead.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/note/get_html.ts — read the HTML note
+ * @see src/tools/note/set.ts — plain-text variant
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { ProjectId, TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const NOTE_SET_HTML_DESCRIPTION =
+  "Replace the HTML fragment note on a task or project. " +
+  "Overwrites the existing note entirely with the provided HTML. " +
+  "OmniFocus preserves its supported HTML subset (bold, italic, links, lists, inline images); " +
+  "unsupported elements may be stripped. Pass noteHtml: null to clear the note. " +
+  "For plain-text writes use note_set instead. " +
+  "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need the change to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const noteSetHtmlInputSchema = z.object({
+  targetKind: z
+    .enum(["task", "project"])
+    .describe("The kind of OmniFocus item whose HTML note to set."),
+  id: z
+    .string()
+    .min(1)
+    .describe(
+      "Persistent ID of the task or project. " +
+        "Get task IDs from task_list; project IDs from project_list.",
+    ),
+  noteHtml: z
+    .string()
+    .nullable()
+    .describe("HTML fragment to set as the note. Pass null to clear the note entirely."),
+});
+
+export type NoteSetHtmlToolInput = z.infer<typeof noteSetHtmlInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface NoteSetHtmlContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `note_set_html`.
+ *
+ * Replaces the HTML note on the specified task or project.
+ *
+ * @throws {NotFound} when the task or project ID does not exist
+ */
+export async function handleNoteSetHtml(input: NoteSetHtmlToolInput, ctx: NoteSetHtmlContext) {
+  if (input.targetKind === "task") {
+    await ctx.adapter.updateTask(TaskId.of(input.id), { noteHtml: input.noteHtml });
+  } else {
+    await ctx.adapter.updateProject(ProjectId.of(input.id), { noteHtml: input.noteHtml });
+  }
+  return ok({ updated: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerNoteSetHtmlTool(server: McpServer, ctx: NoteSetHtmlContext) {
+  return server.registerTool(
+    "note_set_html",
+    { description: NOTE_SET_HTML_DESCRIPTION, inputSchema: noteSetHtmlInputSchema.shape },
+    async (args: NoteSetHtmlToolInput) => {
+      const envelope = await handleNoteSetHtml(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `note_get_html` — reads `noteHtml` HTML fragment from a task or project (`null` when absent)
- Adds `note_set_html` — writes an HTML fragment; pass `null` to clear; sets `meta.syncPending = true`
- Follows the same `targetKind: "task" | "project"` flat enum pattern as `note_get`/`note_set`
- 25 new tests: schema, CRUD on tasks and projects, null/clear semantics, `syncPending`, bold+link+list round-trip fixture

## Design link
Closes #63. Implements SPEC resolved-decision: HTML fragment round-trip for note fidelity.

## Breaking change?
- [x] No

## Test plan
- [x] 52 tests in `note.test.ts` all green locally
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Self-reviewed via /review-pr
- [x] No new dependencies