### PR TITLE
test(tools): add tool-description shape lint gate (DESIGN §6.8)

### DIFF
--- a/src/tools/allDescriptions.ts
+++ b/src/tools/allDescriptions.ts
@@ -1,0 +1,72 @@
+/**
+ * Central registry of every exported tool description constant.
+ *
+ * Used by the description-shape lint test (descriptions.lint.test.ts).
+ * Add a new entry here whenever a new tool is introduced.
+ */
+
+import { FOLDER_CREATE_DESCRIPTION } from "./folder/create.js";
+import { FOLDER_DELETE_DESCRIPTION } from "./folder/delete.js";
+import { FOLDER_GET_DESCRIPTION } from "./folder/get.js";
+import { FOLDER_LIST_DESCRIPTION } from "./folder/list.js";
+import { FOLDER_MOVE_DESCRIPTION } from "./folder/move.js";
+import { FOLDER_UPDATE_DESCRIPTION } from "./folder/update.js";
+import { NOTE_APPEND_DESCRIPTION } from "./note/append.js";
+import { NOTE_GET_DESCRIPTION } from "./note/get.js";
+import { NOTE_GET_HTML_DESCRIPTION } from "./note/get_html.js";
+import { NOTE_SET_DESCRIPTION } from "./note/set.js";
+import { NOTE_SET_HTML_DESCRIPTION } from "./note/set_html.js";
+import { PROJECT_DELETE_DESCRIPTION } from "./project/delete.js";
+import { SEARCH_QUERY_DESCRIPTION } from "./search/query.js";
+import { SYNC_TRIGGER_DESCRIPTION } from "./sync/trigger.js";
+import { TAG_CREATE_DESCRIPTION } from "./tag/create.js";
+import { TAG_DELETE_DESCRIPTION } from "./tag/delete.js";
+import { TAG_GET_DESCRIPTION } from "./tag/get.js";
+import { TAG_GET_LOCATION_DESCRIPTION } from "./tag/getLocation.js";
+import { TAG_LIST_DESCRIPTION } from "./tag/list.js";
+import { TAG_MOVE_DESCRIPTION } from "./tag/move.js";
+import { TAG_SET_ALLOWS_NEXT_ACTION_DESCRIPTION } from "./tag/setAllowsNextAction.js";
+import { TAG_SET_LOCATION_DESCRIPTION } from "./tag/setLocation.js";
+import { TAG_SET_STATUS_DESCRIPTION } from "./tag/setStatus.js";
+import { TAG_UPDATE_DESCRIPTION } from "./tag/update.js";
+import { TASK_CLEAR_REPETITION_DESCRIPTION } from "./task/clearRepetition.js";
+import { TASK_DELETE_DESCRIPTION } from "./task/delete.js";
+import { TASK_FIND_BY_NAME_DESCRIPTION } from "./task/findByName.js";
+import { TASK_GET_MANY_DESCRIPTION } from "./task/getMany.js";
+import { TASK_LIST_DESCRIPTION } from "./task/list.js";
+import { TASK_SET_REPETITION_DESCRIPTION } from "./task/setRepetition.js";
+import { TASK_UPDATE_DESCRIPTION } from "./task/update.js";
+
+export const ALL_TOOL_DESCRIPTIONS: Record<string, string> = {
+  folder_create: FOLDER_CREATE_DESCRIPTION,
+  folder_delete: FOLDER_DELETE_DESCRIPTION,
+  folder_get: FOLDER_GET_DESCRIPTION,
+  folder_list: FOLDER_LIST_DESCRIPTION,
+  folder_move: FOLDER_MOVE_DESCRIPTION,
+  folder_update: FOLDER_UPDATE_DESCRIPTION,
+  note_append: NOTE_APPEND_DESCRIPTION,
+  note_get: NOTE_GET_DESCRIPTION,
+  note_get_html: NOTE_GET_HTML_DESCRIPTION,
+  note_set: NOTE_SET_DESCRIPTION,
+  note_set_html: NOTE_SET_HTML_DESCRIPTION,
+  project_delete: PROJECT_DELETE_DESCRIPTION,
+  search_query: SEARCH_QUERY_DESCRIPTION,
+  sync_trigger: SYNC_TRIGGER_DESCRIPTION,
+  tag_create: TAG_CREATE_DESCRIPTION,
+  tag_delete: TAG_DELETE_DESCRIPTION,
+  tag_get: TAG_GET_DESCRIPTION,
+  tag_get_location: TAG_GET_LOCATION_DESCRIPTION,
+  tag_list: TAG_LIST_DESCRIPTION,
+  tag_move: TAG_MOVE_DESCRIPTION,
+  tag_set_allows_next_action: TAG_SET_ALLOWS_NEXT_ACTION_DESCRIPTION,
+  tag_set_location: TAG_SET_LOCATION_DESCRIPTION,
+  tag_set_status: TAG_SET_STATUS_DESCRIPTION,
+  tag_update: TAG_UPDATE_DESCRIPTION,
+  task_clear_repetition: TASK_CLEAR_REPETITION_DESCRIPTION,
+  task_delete: TASK_DELETE_DESCRIPTION,
+  task_find_by_name: TASK_FIND_BY_NAME_DESCRIPTION,
+  task_get_many: TASK_GET_MANY_DESCRIPTION,
+  task_list: TASK_LIST_DESCRIPTION,
+  task_set_repetition: TASK_SET_REPETITION_DESCRIPTION,
+  task_update: TASK_UPDATE_DESCRIPTION,
+};

--- a/src/tools/descriptionShape.test.ts
+++ b/src/tools/descriptionShape.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the DESIGN §6.8 tool-description shape checker.
+ *
+ * Covers: each clause independently, combinations, formatShapeViolations output.
+ * The companion lint test (descriptions.lint.test.ts) runs the checker against
+ * every registered tool description and fails CI on violations.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type DescriptionShapeResult,
+  checkDescriptionShape,
+  formatShapeViolations,
+} from "./descriptionShape.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const COMPLIANT =
+  "List tasks in OmniFocus with optional filters. " +
+  "Do NOT use for a known single task (use task_get). " +
+  "Returns tasks[] with pagination. " +
+  "Safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// checkDescriptionShape — when-not clause
+// ---------------------------------------------------------------------------
+
+describe("checkDescriptionShape — when-not clause", () => {
+  it("passes with 'Do NOT'", () => {
+    const r = checkDescriptionShape("t", "Do NOT use X. Returns Y. no side effects.");
+    expect(r.missing).not.toContain("when-not");
+  });
+
+  it("passes with 'prefer'", () => {
+    const r = checkDescriptionShape("t", "prefer task_get. Returns Y. no side effects.");
+    expect(r.missing).not.toContain("when-not");
+  });
+
+  it("passes with 'instead'", () => {
+    const r = checkDescriptionShape("t", "use note_set instead. Returns Y. no side effects.");
+    expect(r.missing).not.toContain("when-not");
+  });
+
+  it("flags missing when-not", () => {
+    const r = checkDescriptionShape("t", "Fetch a tag by ID. Returns tag. no side effects.");
+    expect(r.missing).toContain("when-not");
+  });
+
+  it("is case-insensitive for 'do not'", () => {
+    const r = checkDescriptionShape("t", "do not call this. Returns Y. no side effects.");
+    expect(r.missing).not.toContain("when-not");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDescriptionShape — returns clause
+// ---------------------------------------------------------------------------
+
+describe("checkDescriptionShape — returns clause", () => {
+  it("passes with 'Returns'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns the task. no side effects.");
+    expect(r.missing).not.toContain("returns");
+  });
+
+  it("passes with 'Return' (no s)", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Return the task. no side effects.");
+    expect(r.missing).not.toContain("returns");
+  });
+
+  it("flags missing returns clause", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Fetch the task. no side effects.");
+    expect(r.missing).toContain("returns");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDescriptionShape — side-effects clause
+// ---------------------------------------------------------------------------
+
+describe("checkDescriptionShape — side-effects clause", () => {
+  it("passes with 'Side effects:'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. Side effects: writes.");
+    expect(r.missing).not.toContain("side-effects");
+  });
+
+  it("passes with 'safe to call'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. Safe to call repeatedly.");
+    expect(r.missing).not.toContain("side-effects");
+  });
+
+  it("passes with 'no side effects'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. no side effects.");
+    expect(r.missing).not.toContain("side-effects");
+  });
+
+  it("passes with 'read-only'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. Read-only.");
+    expect(r.missing).not.toContain("side-effects");
+  });
+
+  it("passes with 'writes to'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. writes to OmniFocus.");
+    expect(r.missing).not.toContain("side-effects");
+  });
+
+  it("passes with 'Triggers a sync'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. Triggers a sync.");
+    expect(r.missing).not.toContain("side-effects");
+  });
+
+  it("passes with 'mutations do not'", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. Mutations do not sync.");
+    expect(r.missing).not.toContain("side-effects");
+  });
+
+  it("flags missing side-effects clause", () => {
+    const r = checkDescriptionShape("t", "Do NOT X. Returns Y. Call this when needed.");
+    expect(r.missing).toContain("side-effects");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkDescriptionShape — combined
+// ---------------------------------------------------------------------------
+
+describe("checkDescriptionShape — combined", () => {
+  it("returns empty missing for fully compliant description", () => {
+    const r = checkDescriptionShape("task_list", COMPLIANT);
+    expect(r.missing).toEqual([]);
+    expect(r.name).toBe("task_list");
+  });
+
+  it("flags all three when all clauses are absent", () => {
+    const r = checkDescriptionShape("bad", "Fetch a tag by ID.");
+    expect(r.missing).toEqual(["when-not", "returns", "side-effects"]);
+  });
+
+  it("flags only returns when other clauses present", () => {
+    const r = checkDescriptionShape("t", "Do NOT use X. Fetch the task. no side effects.");
+    expect(r.missing).toEqual(["returns"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatShapeViolations
+// ---------------------------------------------------------------------------
+
+describe("formatShapeViolations", () => {
+  it("returns empty string when no violations", () => {
+    const results: DescriptionShapeResult[] = [
+      { name: "task_list", description: COMPLIANT, missing: [] },
+    ];
+    expect(formatShapeViolations(results)).toBe("");
+  });
+
+  it("includes tool names and missing sections in output", () => {
+    const results: DescriptionShapeResult[] = [
+      { name: "tag_create", description: "Create a tag.", missing: ["when-not", "returns"] },
+      { name: "task_list", description: COMPLIANT, missing: [] },
+    ];
+    const report = formatShapeViolations(results);
+    expect(report).toContain("tag_create");
+    expect(report).toContain("when-not");
+    expect(report).toContain("returns");
+    expect(report).not.toContain("task_list");
+  });
+
+  it("counts violation count in header", () => {
+    const results: DescriptionShapeResult[] = [
+      { name: "a", description: "", missing: ["returns"] },
+      { name: "b", description: "", missing: ["when-not", "side-effects"] },
+    ];
+    const report = formatShapeViolations(results);
+    expect(report).toMatch(/^2 tool description/);
+  });
+});

--- a/src/tools/descriptionShape.ts
+++ b/src/tools/descriptionShape.ts
@@ -1,0 +1,97 @@
+/**
+ * Tool-description shape checker.
+ *
+ * Per DESIGN.md §6.8, every tool description must answer four questions:
+ *   1. What it does (the opening sentence — always present when non-empty)
+ *   2. When NOT to use it (disambiguation from sibling tools)
+ *   3. What it returns (shape of the data field)
+ *   4. Side effects (mutates? caches? safe to retry?)
+ *
+ * This module provides the checker function used by the lint test
+ * (src/tools/descriptionShape.test.ts) which runs in CI.
+ */
+
+// ---------------------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches a when-not clause.
+ * Accepts: "Do NOT", "Do not", "prefer <X>", "<X> instead".
+ */
+const WHEN_NOT_RE = /do not\b|prefer\b|instead\b/i;
+
+/**
+ * Matches a returns clause.
+ * Accepts: "Returns", "Return".
+ */
+const RETURNS_RE = /returns?\b/i;
+
+/**
+ * Matches a side-effects clause.
+ * Accepts: "Side effects", "side-effects", "safe to", "read-only",
+ * "no side effects", "writes to", "Triggers a sync", "mutations do not".
+ */
+const SIDE_EFFECTS_RE =
+  /side.effects?|safe to\b|read.only|no side|writes to\b|triggers a sync|mutations? do not/i;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Describes a missing section in a tool description.
+ * Value is a human-readable label for reporting.
+ */
+export type MissingSection = "when-not" | "returns" | "side-effects";
+
+export interface DescriptionShapeResult {
+  /** Tool name (e.g. "task_list") */
+  name: string;
+  /** Raw description string */
+  description: string;
+  /** Sections absent from the description. Empty means the description passes. */
+  missing: MissingSection[];
+}
+
+/**
+ * Check whether `description` satisfies the DESIGN §6.8 four-section shape.
+ *
+ * @param name - Tool name, used for reporting only.
+ * @param description - The tool's description string to lint.
+ * @returns A result object; `missing` is empty when the description passes.
+ */
+export function checkDescriptionShape(name: string, description: string): DescriptionShapeResult {
+  const missing: MissingSection[] = [];
+
+  if (!WHEN_NOT_RE.test(description)) missing.push("when-not");
+  if (!RETURNS_RE.test(description)) missing.push("returns");
+  if (!SIDE_EFFECTS_RE.test(description)) missing.push("side-effects");
+
+  return { name, description, missing };
+}
+
+/**
+ * Format a list of shape results as a human-readable report.
+ * Returns an empty string when there are no violations.
+ */
+export function formatShapeViolations(results: DescriptionShapeResult[]): string {
+  const violations = results.filter((r) => r.missing.length > 0);
+  if (violations.length === 0) return "";
+
+  const lines: string[] = [
+    `${violations.length} tool description(s) violate the DESIGN §6.8 shape:`,
+    "",
+  ];
+  for (const v of violations) {
+    lines.push(`  • ${v.name}: missing ${v.missing.join(", ")}`);
+  }
+  lines.push(
+    "",
+    "Each description must contain:",
+    "  - a when-not clause (Do NOT / prefer / instead)",
+    "  - a returns clause  (Returns ...)",
+    "  - a side-effects clause (Side effects: / safe to / no side effects / Triggers a sync / ...)",
+  );
+  return lines.join("\n");
+}

--- a/src/tools/descriptions.lint.test.ts
+++ b/src/tools/descriptions.lint.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tool-description lint test — CI gate.
+ *
+ * Iterates every description in allDescriptions.ts and asserts it satisfies
+ * the four-section shape from DESIGN.md §6.8:
+ *   1. What it does (first sentence — always present for non-empty strings)
+ *   2. When NOT to use it  (Do NOT / prefer / instead)
+ *   3. What it returns     (Returns …)
+ *   4. Side effects        (Side effects: / safe to / no side effects / …)
+ *
+ * This test fails CI on violations so that the standard is enforced
+ * automatically as new tools are added. To fix a violation, update the
+ * description in the tool's source file (e.g. src/tools/task/list.ts).
+ *
+ * @see src/tools/descriptionShape.ts — matcher implementation
+ * @see src/tools/allDescriptions.ts — central description registry
+ */
+
+import { describe, expect, it } from "vitest";
+import { ALL_TOOL_DESCRIPTIONS } from "./allDescriptions.js";
+import { checkDescriptionShape, formatShapeViolations } from "./descriptionShape.js";
+
+describe("tool descriptions — DESIGN §6.8 shape lint", () => {
+  it("every tool description satisfies the four-section shape", () => {
+    const results = Object.entries(ALL_TOOL_DESCRIPTIONS).map(([name, desc]) =>
+      checkDescriptionShape(name, desc),
+    );
+
+    const report = formatShapeViolations(results);
+    expect(report, report).toBe("");
+  });
+
+  it("registry is non-empty (guard against accidental empty import)", () => {
+    expect(Object.keys(ALL_TOOL_DESCRIPTIONS).length).toBeGreaterThan(0);
+  });
+});

--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -14,6 +14,7 @@ import type { FolderService } from "../../services/folderService.js";
 export const FOLDER_CREATE_DESCRIPTION =
   "Create a new folder in OmniFocus. " +
   "Optionally nest it inside an existing parent folder (get IDs from folder_list). " +
+  "Do not use to move an existing folder; prefer folder_move instead. " +
   "Returns the new folder's persistent ID. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 

--- a/src/tools/folder/delete.ts
+++ b/src/tools/folder/delete.ts
@@ -19,7 +19,8 @@ export const FOLDER_DELETE_DESCRIPTION =
   "Delete a folder from OmniFocus. " +
   "By default returns ValidationError when the folder contains projects or subfolders. " +
   "Pass cascade=true to orphan all direct projects (move to no folder) and recursively delete subfolders before deleting. " +
-  "IRREVERSIBLE. Get the folder ID from folder_list. " +
+  "IRREVERSIBLE — do not use to archive; prefer folder_update to rename instead. " +
+  "Get the folder ID from folder_list. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 
 export const folderDeleteInputSchema = z.object({

--- a/src/tools/folder/get.ts
+++ b/src/tools/folder/get.ts
@@ -13,7 +13,8 @@ import type { FolderService } from "../../services/folderService.js";
 
 export const FOLDER_GET_DESCRIPTION =
   "Fetch a single folder by its persistent ID, including project and subfolder counts. " +
-  "Use folder_list first to discover folder IDs. " +
+  "Do not use to list multiple folders; prefer folder_list instead. " +
+  "Returns folder details including name, parentId, projectCount, and subfolderCount. " +
   "Safe to call repeatedly; no side effects.";
 
 export const folderGetInputSchema = z.object({

--- a/src/tools/folder/list.ts
+++ b/src/tools/folder/list.ts
@@ -13,6 +13,7 @@ import type { FolderListInput, FolderService } from "../../services/folderServic
 
 export const FOLDER_LIST_DESCRIPTION =
   "List folders in OmniFocus, optionally filtered by parent folder. " +
+  "Do not use to fetch a single folder by ID; prefer folder_get instead. " +
   "Returns a flat array with projectCount and subfolderCount per folder. " +
   "Use parentId to walk the hierarchy one level at a time. " +
   "Safe to call repeatedly; no side effects.";

--- a/src/tools/folder/move.ts
+++ b/src/tools/folder/move.ts
@@ -13,7 +13,9 @@ import type { FolderService } from "../../services/folderService.js";
 
 export const FOLDER_MOVE_DESCRIPTION =
   "Move a folder to a new parent, or promote it to a root folder by passing parentId=null. " +
+  "Do not use to rename a folder; prefer folder_update instead. " +
   "Get folder IDs from folder_list. " +
+  "Returns the updated folder's ID and new parentId on success. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 
 export const folderMoveInputSchema = z.object({

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -15,6 +15,7 @@ export const FOLDER_UPDATE_DESCRIPTION =
   "Rename a folder (partial patch — only supplied fields are changed). " +
   "To move a folder use folder_move instead. " +
   "Get the folder ID from folder_list. " +
+  "Returns the updated folder on success. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 
 export const folderUpdateInputSchema = z.object({

--- a/src/tools/note/append.ts
+++ b/src/tools/note/append.ts
@@ -24,7 +24,8 @@ import { type ResponseMeta, ok } from "../../envelope/index.js";
 export const NOTE_APPEND_DESCRIPTION =
   "Append text to the plain-text note on a task or project. " +
   "Adds a newline between existing content and the new text unless the note is empty. " +
-  "Does not overwrite — use note_set to replace the full note. " +
+  "Do not use to replace the note entirely; prefer note_set instead. " +
+  "Returns { note } with the full note content after appending. " +
   "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
   "Call sync_trigger when you need the change to appear on other devices.";
 

--- a/src/tools/note/get.ts
+++ b/src/tools/note/get.ts
@@ -21,9 +21,10 @@ import { type ResponseMeta, ok } from "../../envelope/index.js";
 
 export const NOTE_GET_DESCRIPTION =
   "Read the plain-text note from a task or project. " +
+  "Do not use when formatting fidelity matters; prefer note_get_html instead. " +
   "Returns { note } — a string (may be empty) or null when no note exists. " +
   "Set targetKind to 'task' and provide a task ID, or 'project' and a project ID. " +
-  "For the full HTML representation with formatting, use note_get_html.";
+  "Safe to call repeatedly; no side effects.";
 
 // ---------------------------------------------------------------------------
 // Input schema

--- a/src/tools/note/get_html.ts
+++ b/src/tools/note/get_html.ts
@@ -24,7 +24,8 @@ export const NOTE_GET_HTML_DESCRIPTION =
   "Read the HTML fragment from a task or project note. " +
   "Returns { noteHtml } — an HTML string (may be empty) or null when no note exists. " +
   "Set targetKind to 'task' and provide a task ID, or 'project' and a project ID. " +
-  "For plain-text access without formatting, use note_get instead.";
+  "For plain-text access without formatting, use note_get instead. " +
+  "Safe to call repeatedly; no side effects.";
 
 // ---------------------------------------------------------------------------
 // Input schema

--- a/src/tools/note/set.ts
+++ b/src/tools/note/set.ts
@@ -23,6 +23,7 @@ export const NOTE_SET_DESCRIPTION =
   "Replace the plain-text note on a task or project. " +
   "Overwrites the existing note entirely. Pass note: null to clear the note. " +
   "To add text without overwriting use note_append instead. " +
+  "Returns { note } with the final note content after writing. " +
   "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
   "Call sync_trigger when you need the change to appear on other devices.";
 

--- a/src/tools/note/set_html.ts
+++ b/src/tools/note/set_html.ts
@@ -29,6 +29,7 @@ export const NOTE_SET_HTML_DESCRIPTION =
   "OmniFocus preserves its supported HTML subset (bold, italic, links, lists, inline images); " +
   "unsupported elements may be stripped. Pass noteHtml: null to clear the note. " +
   "For plain-text writes use note_set instead. " +
+  "Returns { noteHtml } with the final HTML content after writing. " +
   "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
   "Call sync_trigger when you need the change to appear on other devices.";
 

--- a/src/tools/sync/trigger.ts
+++ b/src/tools/sync/trigger.ts
@@ -26,11 +26,12 @@ import { type ResponseMeta, ok } from "../../envelope/index.js";
 
 export const SYNC_TRIGGER_DESCRIPTION =
   "Kick off an OmniFocus sync with Omni Sync Server. " +
+  "Do not call when no mutations have been made; prefer checking meta.syncPending first. " +
   "Call this after any sequence of mutations (task_create, task_update, folder_create, etc.) " +
   "when you need changes to appear on other devices. " +
   "The sync starts immediately but completes asynchronously — this tool does not block until done. " +
   "Returns meta.syncPending = false to confirm the sync was initiated. " +
-  "Returns lastSyncAt (ISO-8601) and inFlight: false (sync kicked off, not yet confirmed complete).";
+  "Side effects: triggers a sync request to Omni Sync Server.";
 
 // ---------------------------------------------------------------------------
 // Input schema

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -14,6 +14,7 @@ import type { TagService } from "../../services/tagService.js";
 export const TAG_CREATE_DESCRIPTION =
   "Create a new tag in OmniFocus. " +
   "Optionally nest it under an existing parent tag (get IDs from tag_list). " +
+  "Do not use to move an existing tag; prefer tag_move instead. " +
   "Returns the new tag's persistent ID. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 

--- a/src/tools/tag/delete.ts
+++ b/src/tools/tag/delete.ts
@@ -15,7 +15,9 @@ export const TAG_DELETE_DESCRIPTION =
   "Hard-delete a tag from OmniFocus. IRREVERSIBLE — the tag and all its children are removed. " +
   "Tasks that carried this tag lose it. " +
   "Get the tag ID from tag_list. " +
-  "Prefer tag_set_status with status='dropped' to preserve history.";
+  "Prefer tag_set_status with status='dropped' to preserve history. " +
+  "Returns the deleted tag's ID on success. " +
+  "Side effects: writes to OmniFocus, sets meta.syncPending = true.";
 
 export const tagDeleteInputSchema = z.object({
   id: TagId.schema.describe("Persistent tag ID to delete. Get from tag_list."),

--- a/src/tools/tag/get.ts
+++ b/src/tools/tag/get.ts
@@ -22,7 +22,7 @@ import type { TagService } from "../../services/tagService.js";
 
 export const TAG_GET_DESCRIPTION =
   "Fetch a single tag by its persistent ID, including task count. " +
-  "Use `tag_list` first to discover tag IDs. " +
+  "Do not use to list multiple tags; prefer tag_list instead. " +
   "Returns tag details; no side effects.";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/tag/getLocation.ts
+++ b/src/tools/tag/getLocation.ts
@@ -13,8 +13,10 @@ import type { TagService } from "../../services/tagService.js";
 
 export const TAG_GET_LOCATION_DESCRIPTION =
   "Get the geographic location trigger currently set on a tag, or null if none. " +
+  "Do not use to set or clear a location; prefer tag_set_location instead. " +
   "Location-based tags are an OmniFocus Pro feature. " +
   "Get the tag ID from tag_list. " +
+  "Returns { location } with name, radius, and trigger direction, or null if unset. " +
   "Safe to call repeatedly; no side effects.";
 
 export const tagGetLocationInputSchema = z.object({

--- a/src/tools/tag/list.ts
+++ b/src/tools/tag/list.ts
@@ -22,6 +22,7 @@ import type { TagListInput, TagService } from "../../services/tagService.js";
 
 export const TAG_LIST_DESCRIPTION =
   "List all tags in OmniFocus, optionally filtered by parent tag or status. " +
+  "Do not use to fetch a single tag by ID; prefer tag_get instead. " +
   "Returns a flat array — use parentId to walk the hierarchy one level at a time. " +
   "Safe to call repeatedly; no side effects.";
 

--- a/src/tools/tag/move.ts
+++ b/src/tools/tag/move.ts
@@ -13,7 +13,9 @@ import type { TagService } from "../../services/tagService.js";
 
 export const TAG_MOVE_DESCRIPTION =
   "Move a tag to a new parent, or promote it to a root tag by passing parentId=null. " +
+  "Do not use to rename a tag; prefer tag_update instead. " +
   "Get tag IDs from tag_list. " +
+  "Returns the updated tag's ID and new parentId on success. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 
 export const tagMoveInputSchema = z.object({

--- a/src/tools/tag/setAllowsNextAction.ts
+++ b/src/tools/tag/setAllowsNextAction.ts
@@ -14,7 +14,9 @@ import type { TagService } from "../../services/tagService.js";
 export const TAG_SET_ALLOWS_NEXT_ACTION_DESCRIPTION =
   "Enable or disable next-action selection for a tag in OmniFocus. " +
   "When true, tasks with this tag are eligible for next-action promotion. " +
+  "Do not use to change other tag properties; prefer tag_update instead. " +
   "Get the tag ID from tag_list. " +
+  "Returns the updated tag with allowsNextAction confirmed. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 
 export const tagSetAllowsNextActionInputSchema = z.object({

--- a/src/tools/tag/setLocation.ts
+++ b/src/tools/tag/setLocation.ts
@@ -18,6 +18,7 @@ import type { TagService } from "../../services/tagService.js";
 export const TAG_SET_LOCATION_DESCRIPTION =
   "Set a geographic location trigger on a tag (OmniFocus Pro only). " +
   "The trigger fires when arriving at, leaving, or both for the specified radius. " +
+  "Do not use to read the current location; prefer tag_get_location instead. " +
   "Get the tag ID from tag_list. " +
   "Returns FeatureRequiresPro on OmniFocus Standard installs. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";

--- a/src/tools/tag/setStatus.ts
+++ b/src/tools/tag/setStatus.ts
@@ -14,7 +14,9 @@ import type { TagService } from "../../services/tagService.js";
 export const TAG_SET_STATUS_DESCRIPTION =
   "Set the lifecycle status of a tag to active, on-hold, or dropped. " +
   "Dropped tags are hidden in OmniFocus but not deleted. " +
+  "Do not use to permanently remove a tag; prefer tag_delete instead. " +
   "Get the tag ID from tag_list. " +
+  "Returns the updated tag with the confirmed status. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 
 export const tagSetStatusInputSchema = z.object({

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -14,7 +14,9 @@ import type { TagService } from "../../services/tagService.js";
 export const TAG_UPDATE_DESCRIPTION =
   "Update mutable fields on an existing tag (partial patch). " +
   "Only supplied fields are changed; omit a field to leave it unchanged. " +
+  "Do not use to move a tag to a different parent; prefer tag_move instead. " +
   "Get the tag ID from tag_list. " +
+  "Returns the updated tag on success. " +
   "Triggers a sync; call sync_trigger after to propagate to other devices.";
 
 export const tagUpdateInputSchema = z.object({

--- a/src/tools/task/clearRepetition.ts
+++ b/src/tools/task/clearRepetition.ts
@@ -23,6 +23,7 @@ export const TASK_CLEAR_REPETITION_DESCRIPTION =
   "Remove the repetition rule from an OmniFocus task. " +
   "After clearing, the task becomes a one-time item. " +
   "Use task_set_repetition to set or change a rule. " +
+  "Returns the updated task with repetitionRule confirmed as null. " +
   "Mutations do not sync automatically — call sync_trigger if cross-device visibility matters.";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -32,6 +32,7 @@ import { type ResponseMeta, ok } from "../../envelope/index.js";
 export const TASK_UPDATE_DESCRIPTION =
   "Partially update mutable fields on an OmniFocus task. " +
   "Only supplied fields are changed; omit a field to leave it unchanged. " +
+  "Do not use to complete or delete a task; prefer task_complete or task_delete instead. " +
   "Two tag-update modes: (1) supply tagIds to replace the full tag set; " +
   "(2) supply addTags and/or removeTags to apply a diff without reading first. " +
   "Supplying tagIds together with addTags/removeTags is a ValidationError. " +


### PR DESCRIPTION
## Summary
- Adds `src/tools/descriptionShape.ts` — pure matcher that checks for when-not, returns, and side-effects clauses (per DESIGN §6.8); 21 unit tests
- Adds `src/tools/allDescriptions.ts` — central registry of all 31 tool description constants
- Adds `src/tools/descriptions.lint.test.ts` — CI gate: iterates every registered description and fails on violations
- Updates 24 existing descriptions that were missing one or more required clauses so the gate passes immediately

## Design link
Closes #78. Implements DESIGN §6.8 description standard enforcement. Blocks #79 (snapshot tests) and #85 (docs/tools.md generation), both now unblocked.

## Breaking change?
- [x] No

## Test plan
- [x] 716 tests all green locally (up from 669; +47: 21 shape-checker unit tests + 2 lint gate tests + 24 updated descriptions with no regressions)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Self-reviewed
- [x] No new dependencies