### PR TITLE
feat(project): add ProjectService + project_list + project_get

### DIFF
--- a/src/services/projectService.test.ts
+++ b/src/services/projectService.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Unit tests for `ProjectService.list` and `ProjectService.get`.
+ *
+ * Contract verified here:
+ * - Filter plumbing (folderId + status pushed to adapter; flagged +
+ *   reviewDueBefore post-filtered in-service).
+ * - Unbounded query rejection (no filter/limit/cursor → ValidationError).
+ * - Pagination stable under `(createdAt ASC, id ASC)`; cursor round-trip;
+ *   filter-hash mismatch rejects.
+ * - Cache layer consulted (hit/miss) with short-circuit on identical repeat.
+ * - `get` attaches tasks only when `includeTaskTree` is true (default).
+ *
+ * Uses `InMemoryAdapter` + real `OmniFocusLruCache` with a monotonic clock
+ * so every created project has a distinct `createdAt` and ordering is
+ * deterministic.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
+import type { FolderId } from "../domain/ids.js";
+import { ValidationError } from "../errors/index.js";
+import { ProjectService } from "./projectService.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeHarness(): {
+  service: ProjectService;
+  adapter: InMemoryAdapter;
+  cache: OmniFocusLruCache;
+} {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const service = new ProjectService({ adapter, cache });
+  return { service, adapter, cache };
+}
+
+// ---------------------------------------------------------------------------
+// Validation gate
+// ---------------------------------------------------------------------------
+
+describe("ProjectService.list — validation gate", () => {
+  it("rejects fully unbounded queries", async () => {
+    const { service } = makeHarness();
+    const err = await service.list({}).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).suggestion).toBe("Provide a filter or a limit.");
+  });
+
+  it("accepts a call with only limit", async () => {
+    const { service } = makeHarness();
+    const out = await service.list({ limit: 10 });
+    expect(out.projects).toEqual([]);
+    expect(out.hasMore).toBe(false);
+  });
+
+  it("accepts a call with only a filter", async () => {
+    const { service } = makeHarness();
+    const out = await service.list({ flagged: true });
+    expect(out.projects).toEqual([]);
+  });
+
+  it("rejects non-integer limit", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ limit: 1.5 })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects limit below 1", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ limit: 0 })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects limit above 1000", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ limit: 1001 })).rejects.toBeInstanceOf(ValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter plumbing
+// ---------------------------------------------------------------------------
+
+describe("ProjectService.list — filters", () => {
+  it("pushes folderId + status down to the adapter", async () => {
+    const { service, adapter } = makeHarness();
+    const folder = await adapter.createFolder({ name: "F" });
+    await adapter.createProject({ name: "in-folder", folderId: folder });
+    await adapter.createProject({ name: "loose" });
+
+    const spy = vi.spyOn(adapter, "listProjects");
+    const out = await service.list({ folderId: folder, status: "active" });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ folderId: folder, status: "active" }),
+    );
+    expect(out.projects.map((p) => p.name)).toEqual(["in-folder"]);
+  });
+
+  it("post-filters flagged in-service (adapter doesn't accept it)", async () => {
+    const { service, adapter } = makeHarness();
+    const flaggedId = await adapter.createProject({ name: "flag" });
+    await adapter.createProject({ name: "plain" });
+    await adapter.updateProject(flaggedId, { flagged: true });
+
+    const spy = vi.spyOn(adapter, "listProjects");
+    const out = await service.list({ flagged: true });
+    expect((spy.mock.calls[0]?.[0] as { flagged?: unknown } | undefined)?.flagged).toBeUndefined();
+    expect(out.projects.map((p) => p.name)).toEqual(["flag"]);
+  });
+
+  it("post-filters reviewDueBefore; excludes projects without a review interval", async () => {
+    const { service, adapter } = makeHarness();
+    const a = await adapter.createProject({ name: "soon" });
+    const b = await adapter.createProject({ name: "later" });
+    await adapter.createProject({ name: "no-review" });
+    // markProjectReviewed sets nextReviewDate = now + reviewIntervalDays.
+    // With a monotonic clock anchored at 2026-01-01, 1 day ≈ Jan 2, 180 days ≈ Jun 30.
+    await adapter.updateProject(a, { reviewIntervalDays: 1 });
+    await adapter.markProjectReviewed(a);
+    await adapter.updateProject(b, { reviewIntervalDays: 180 });
+    await adapter.markProjectReviewed(b);
+
+    const out = await service.list({ reviewDueBefore: "2026-05-01T00:00:00Z" });
+    expect(out.projects.map((p) => p.name)).toEqual(["soon"]);
+  });
+
+  it("combines status + flagged filters (adapter + post-filter)", async () => {
+    const { service, adapter } = makeHarness();
+    const activeFlaggedId = await adapter.createProject({ name: "active-flag" });
+    const onHoldFlaggedId = await adapter.createProject({ name: "on-hold-flag" });
+    await adapter.updateProject(activeFlaggedId, { flagged: true });
+    await adapter.updateProject(onHoldFlaggedId, { flagged: true, status: "on-hold" });
+
+    const out = await service.list({ status: "active", flagged: true });
+    expect(out.projects.map((p) => p.name)).toEqual(["active-flag"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+describe("ProjectService.list — pagination", () => {
+  it("splits across pages and emits a cursor when more remain", async () => {
+    const { service, adapter } = makeHarness();
+    for (let i = 0; i < 5; i++) await adapter.createProject({ name: `p${i}` });
+
+    const page1 = await service.list({ status: "active", limit: 2 });
+    expect(page1.projects.map((p) => p.name)).toEqual(["p0", "p1"]);
+    expect(page1.hasMore).toBe(true);
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = await service.list({
+      status: "active",
+      limit: 2,
+      cursor: page1.nextCursor as string,
+    });
+    expect(page2.projects.map((p) => p.name)).toEqual(["p2", "p3"]);
+    expect(page2.hasMore).toBe(true);
+
+    const page3 = await service.list({
+      status: "active",
+      limit: 2,
+      cursor: page2.nextCursor as string,
+    });
+    expect(page3.projects.map((p) => p.name)).toEqual(["p4"]);
+    expect(page3.hasMore).toBe(false);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it("rejects a cursor whose filter-hash no longer matches the current query", async () => {
+    const { service, adapter } = makeHarness();
+    for (let i = 0; i < 3; i++) await adapter.createProject({ name: `p${i}` });
+    const page1 = await service.list({ status: "active", limit: 1 });
+    await expect(
+      service.list({
+        status: "on-hold",
+        limit: 1,
+        cursor: page1.nextCursor as string,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("malformed cursor → ValidationError", async () => {
+    const { service } = makeHarness();
+    await expect(service.list({ flagged: true, cursor: "???" })).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+  });
+
+  it("returns empty page + null cursor when nothing matches", async () => {
+    const { service } = makeHarness();
+    const out = await service.list({ flagged: true, limit: 10 });
+    expect(out.projects).toEqual([]);
+    expect(out.nextCursor).toBeNull();
+    expect(out.hasMore).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache behaviour
+// ---------------------------------------------------------------------------
+
+describe("ProjectService.list — cache", () => {
+  it("reports cacheHit=false then true on identical repeat", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createProject({ name: "p" });
+    const first = await service.list({ status: "active", limit: 10 });
+    const second = await service.list({ status: "active", limit: 10 });
+    expect(first.cacheHit).toBe(false);
+    expect(second.cacheHit).toBe(true);
+    expect(second.projects).toEqual(first.projects);
+  });
+
+  it("repeat call does not re-query the adapter", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createProject({ name: "p" });
+    const spy = vi.spyOn(adapter, "listProjects");
+    await service.list({ status: "active", limit: 10 });
+    await service.list({ status: "active", limit: 10 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get
+// ---------------------------------------------------------------------------
+
+describe("ProjectService.get", () => {
+  it("returns the project and its tasks by default (includeTaskTree=true)", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "P" });
+    await adapter.createTask({ name: "t1", projectId: p });
+    await adapter.createTask({ name: "t2", projectId: p });
+
+    const out = await service.get({ id: p });
+    expect(out.project.id).toBe(p);
+    expect(out.tasks?.map((t) => t.name).sort()).toEqual(["t1", "t2"]);
+  });
+
+  it("omits tasks when includeTaskTree=false", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "P" });
+    await adapter.createTask({ name: "t1", projectId: p });
+
+    const out = await service.get({ id: p, includeTaskTree: false });
+    expect(out.project.id).toBe(p);
+    expect(out.tasks).toBeUndefined();
+  });
+
+  it("throws NotFound for unknown ID", async () => {
+    const { service } = makeHarness();
+    await expect(
+      service.get({ id: "proj_999999" as import("../domain/ids.js").ProjectId }),
+    ).rejects.toThrow();
+  });
+
+  it("caches the result; repeat call short-circuits the adapter", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "P" });
+    const spy = vi.spyOn(adapter, "getProject");
+    const first = await service.get({ id: p });
+    const second = await service.get({ id: p });
+    expect(first.cacheHit).toBe(false);
+    expect(second.cacheHit).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches with-tasks and solo variants separately", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "P" });
+    const spy = vi.spyOn(adapter, "getProject");
+    await service.get({ id: p, includeTaskTree: true });
+    await service.get({ id: p, includeTaskTree: false });
+    // Distinct cache keys → adapter hit for each variant
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type-level smoke: FolderId filter is the branded type
+// ---------------------------------------------------------------------------
+
+describe("ProjectService — type plumbing", () => {
+  it("accepts a branded FolderId in the filter", async () => {
+    const { service, adapter } = makeHarness();
+    const folder = (await adapter.createFolder({ name: "F" })) satisfies FolderId;
+    await expect(service.list({ folderId: folder })).resolves.toBeTruthy();
+  });
+});

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -1,0 +1,302 @@
+/**
+ * `ProjectService` — service-layer surface for project queries.
+ *
+ * Wraps the `OmniFocusAdapter` with the 30s LRU read cache (ADR-0006) and
+ * applies the `project_list` / `project_get` business rules on top of the
+ * adapter's lower-level primitives. Mirrors the structure of `TaskService`
+ * (DESIGN §26) so the two read surfaces have identical ergonomics.
+ *
+ * Filter plumbing:
+ *   `folderId` and `status` map 1:1 to the adapter's narrow filter.
+ *   `flagged` and `reviewDueBefore` are post-filtered in-service because
+ *   the adapter's primitive does not accept them.
+ *
+ * Pagination is stable `(createdAt ASC, id ASC)` — inserts mid-page do not
+ * shuffle the emitted page set. Cursors carry a `filterHash` so swapping
+ * filters mid-sequence fails loud rather than silently skipping pages.
+ *
+ * `get(id, { includeTaskTree })` optionally attaches the project's full task
+ * set (flat array; clients rebuild the tree via `parentId`) behind a cache
+ * key that invalidates on `task:*` / `project:*` writes.
+ *
+ * @see DESIGN.md §6.5 — cache strategy
+ * @see DESIGN.md §15 — pagination contract
+ * @see DESIGN.md §26 — reference implementation (task_list)
+ * @see src/services/taskService.ts — sibling service for tasks
+ */
+
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import type { FolderId, ProjectId } from "../domain/ids.js";
+import type { Project } from "../domain/project.js";
+import type { Task } from "../domain/task.js";
+import { ValidationError } from "../errors/index.js";
+import {
+  type CursorPayload,
+  decodeCursor,
+  encodeCursor,
+  hashFilter,
+  isAfterCursor,
+} from "../pagination/cursor.js";
+
+// ---------------------------------------------------------------------------
+// Public shapes
+// ---------------------------------------------------------------------------
+
+/** Project status filter — accepts the raw domain enum values. */
+export type ProjectStatusFilter = Project["status"];
+
+/**
+ * Input to {@link ProjectService.list}. Matches the `project_list` MCP tool
+ * schema. All fields are optional, but the service requires at least one of
+ * `limit`, `cursor`, or a non-empty filter — unbounded queries are rejected
+ * (DESIGN §15).
+ */
+export interface ProjectListInput {
+  folderId?: FolderId;
+  status?: ProjectStatusFilter;
+  flagged?: boolean;
+  /**
+   * Return only projects whose `nextReviewDate` is strictly before this
+   * moment. ISO-8601 with offset. Projects without a review interval
+   * (`nextReviewDate === null`) are excluded.
+   */
+  reviewDueBefore?: string;
+  /** 1..1000; service default is 200 when caller omits and any filter is set. */
+  limit?: number;
+  cursor?: string;
+}
+
+/** Result of {@link ProjectService.list}. Same envelope shape as TaskService. */
+export interface ProjectListResult {
+  projects: Project[];
+  /** Opaque cursor for the next page, or `null` when exhausted. */
+  nextCursor: string | null;
+  /** `true` iff `nextCursor !== null`. */
+  hasMore: boolean;
+  /** `true` when the response was served from the LRU cache. */
+  cacheHit: boolean;
+}
+
+/** Input to {@link ProjectService.get}. */
+export interface ProjectGetInput {
+  id: ProjectId;
+  /** Default `true`. When `false`, `tasks` is omitted from the result. */
+  includeTaskTree?: boolean;
+}
+
+/** Result of {@link ProjectService.get}. */
+export interface ProjectGetResult {
+  project: Project;
+  /** Flat task list belonging to this project; omitted when `includeTaskTree=false`. */
+  tasks?: Task[];
+  cacheHit: boolean;
+}
+
+/** Narrow cache surface — same as `TaskService.ReadCache`. */
+export interface ReadCache {
+  wrap<T>(key: string, factory: () => Promise<T>): Promise<T>;
+  has(key: string): boolean;
+}
+
+export interface ProjectServiceDeps {
+  adapter: OmniFocusAdapter;
+  cache: ReadCache;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ProjectService {
+  private readonly adapter: OmniFocusAdapter;
+  private readonly cache: ReadCache;
+
+  constructor(deps: ProjectServiceDeps) {
+    this.adapter = deps.adapter;
+    this.cache = deps.cache;
+  }
+
+  /**
+   * List projects matching `input`. See {@link ProjectListInput}.
+   *
+   * @throws ValidationError — unbounded query (no filter/limit/cursor);
+   *   invalid limit (outside 1..1000); malformed cursor; cursor filter-hash
+   *   mismatch.
+   */
+  async list(input: ProjectListInput): Promise<ProjectListResult> {
+    const limit = this.resolveLimit(input);
+    this.assertBounded(input);
+
+    const normalized = this.normalize(input);
+    const filterHash = hashFilter(normalized as unknown as Record<string, unknown>);
+
+    const cursor = input.cursor !== undefined ? decodeCursor(input.cursor, filterHash) : undefined;
+
+    const cacheKey = this.listCacheKey(filterHash, input.cursor);
+    const cacheHit = this.cache.has(cacheKey);
+
+    const { projects, nextCursor } = await this.cache.wrap(cacheKey, async () =>
+      this.fetchPage(normalized, cursor, limit, filterHash),
+    );
+
+    return {
+      projects,
+      nextCursor,
+      hasMore: nextCursor !== null,
+      cacheHit,
+    };
+  }
+
+  /**
+   * Fetch a single project by ID, optionally attaching its task tree.
+   *
+   * @throws NotFound when the project ID does not exist.
+   */
+  async get(input: ProjectGetInput): Promise<ProjectGetResult> {
+    const includeTaskTree = input.includeTaskTree ?? true;
+    const cacheKey = this.getCacheKey(input.id, includeTaskTree);
+    const cacheHit = this.cache.has(cacheKey);
+
+    const payload = await this.cache.wrap(cacheKey, async () => {
+      const project = await this.adapter.getProject(input.id);
+      if (!includeTaskTree) return { project };
+      const tasks = await this.adapter.listTasks({ projectId: input.id });
+      return { project, tasks };
+    });
+
+    return { ...payload, cacheHit };
+  }
+
+  // -- Internal: page assembly -------------------------------------------
+
+  private async fetchPage(
+    normalized: NormalizedFilter,
+    cursor: CursorPayload | undefined,
+    limit: number,
+    filterHash: string,
+  ): Promise<{ projects: Project[]; nextCursor: string | null }> {
+    // Push folderId + status down; adapter rejects unknown keys.
+    const adapterFilter: { folderId?: FolderId; status?: Project["status"] } = {};
+    if (normalized.folderId !== undefined) adapterFilter.folderId = normalized.folderId;
+    if (normalized.status !== undefined) adapterFilter.status = normalized.status;
+
+    const raw = await this.adapter.listProjects(adapterFilter);
+
+    // Post-filter: flagged + reviewDueBefore (adapter primitive doesn't accept these).
+    const { flagged, reviewDueBefore } = normalized;
+    const filtered = raw.filter((p) => {
+      if (flagged !== undefined && p.flagged !== flagged) return false;
+      if (reviewDueBefore !== undefined) {
+        if (p.nextReviewDate === null) return false;
+        if (p.nextReviewDate >= reviewDueBefore) return false;
+      }
+      return true;
+    });
+
+    // Stable sort: (createdAt ASC, id ASC).
+    const sorted = [...filtered].sort((a, b) => {
+      if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+      return a.id < b.id ? -1 : 1;
+    });
+
+    const afterCursor =
+      cursor !== undefined
+        ? sorted.filter((p) => isAfterCursor({ id: p.id, sortValue: p.createdAt }, cursor, "asc"))
+        : sorted;
+
+    const page = afterCursor.slice(0, limit);
+    const hasMore = afterCursor.length > limit;
+    const nextCursor = hasMore ? this.encodeNextCursor(page, filterHash) : null;
+
+    return { projects: page, nextCursor };
+  }
+
+  // -- Internal: validation ----------------------------------------------
+
+  private resolveLimit(input: ProjectListInput): number {
+    if (input.limit === undefined) return DEFAULT_LIMIT;
+    if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > MAX_LIMIT) {
+      throw new ValidationError(
+        `limit must be an integer between 1 and ${MAX_LIMIT}; got ${input.limit}.`,
+        {
+          suggestion: `Pass a limit between 1 and ${MAX_LIMIT}, or omit to use the default of ${DEFAULT_LIMIT}.`,
+          details: { field: "limit", value: input.limit },
+        },
+      );
+    }
+    return input.limit;
+  }
+
+  private assertBounded(input: ProjectListInput): void {
+    if (input.limit !== undefined || input.cursor !== undefined) return;
+    if (this.hasAnyFilter(input)) return;
+    throw new ValidationError(
+      "project_list requires at least one filter, limit, or cursor. Unbounded queries are rejected.",
+      {
+        suggestion: "Provide a filter or a limit.",
+        details: { field: "filter|limit|cursor" },
+      },
+    );
+  }
+
+  private hasAnyFilter(input: ProjectListInput): boolean {
+    return (
+      input.folderId !== undefined ||
+      input.status !== undefined ||
+      input.flagged !== undefined ||
+      input.reviewDueBefore !== undefined
+    );
+  }
+
+  // -- Internal: normalize + cursor --------------------------------------
+
+  private normalize(input: ProjectListInput): NormalizedFilter {
+    return {
+      folderId: input.folderId,
+      status: input.status,
+      flagged: input.flagged,
+      reviewDueBefore: input.reviewDueBefore,
+    };
+  }
+
+  private listCacheKey(filterHash: string, cursor: string | undefined): string {
+    // Prefix on `search:` so task-mutation / project-mutation invalidations
+    // that emit `search:*` also flush stale list pages. See docs/cache-invalidation.md.
+    return `search:projects:${filterHash}:${cursor ?? "first"}`;
+  }
+
+  private getCacheKey(id: ProjectId, includeTaskTree: boolean): string {
+    return `project:${id}:${includeTaskTree ? "with-tasks" : "solo"}`;
+  }
+
+  private encodeNextCursor(page: Project[], filterHash: string): string {
+    const last = page[page.length - 1];
+    if (last === undefined) {
+      // Unreachable: hasMore implies ≥1 emitted project.
+      throw new ValidationError("Internal: cannot encode cursor for empty page.");
+    }
+    return encodeCursor({
+      lastId: last.id,
+      lastSortValue: last.createdAt,
+      filterHash,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface NormalizedFilter {
+  folderId: FolderId | undefined;
+  status: ProjectStatusFilter | undefined;
+  flagged: boolean | undefined;
+  reviewDueBefore: string | undefined;
+}

--- a/src/tools/project/get.test.ts
+++ b/src/tools/project/get.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the `project_get` tool — schema parsing + handler envelope.
+ *
+ * Service-layer task-attachment logic lives in `projectService.test.ts`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { ProjectService } from "../../services/projectService.js";
+import { PROJECT_GET_DESCRIPTION, handleProjectGet, projectGetInputSchema } from "./get.js";
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const projectService = new ProjectService({ adapter, cache });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { projectService, makeMeta }, adapter };
+}
+
+describe("project_get — input schema", () => {
+  it("requires id", () => {
+    expect(() => projectGetInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts id and defaulted includeTaskTree", () => {
+    const parsed = projectGetInputSchema.parse({ id: "proj_000001" });
+    expect(parsed.id).toBe("proj_000001");
+    expect(parsed.includeTaskTree).toBeUndefined();
+  });
+
+  it("accepts includeTaskTree=false", () => {
+    const parsed = projectGetInputSchema.parse({ id: "proj_000001", includeTaskTree: false });
+    expect(parsed.includeTaskTree).toBe(false);
+  });
+
+  it("rejects a malformed id", () => {
+    expect(() => projectGetInputSchema.parse({ id: "??" })).toThrow();
+  });
+});
+
+describe("project_get — description", () => {
+  it("mentions includeTaskTree default and read-only intent", () => {
+    expect(PROJECT_GET_DESCRIPTION).toMatch(/includeTaskTree/);
+    expect(PROJECT_GET_DESCRIPTION).toMatch(/no side effects/i);
+  });
+});
+
+describe("project_get — handler", () => {
+  it("returns { project, tasks } by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    const p = await adapter.createProject({ name: "P" });
+    await adapter.createTask({ name: "t1", projectId: p });
+
+    const envelope = await handleProjectGet({ id: p }, ctx);
+    expect(envelope.data.project.id).toBe(p);
+    expect(envelope.data.tasks?.map((t) => t.name)).toEqual(["t1"]);
+  });
+
+  it("omits tasks when includeTaskTree=false", async () => {
+    const { ctx, adapter } = makeCtx();
+    const p = await adapter.createProject({ name: "P" });
+    await adapter.createTask({ name: "t1", projectId: p });
+
+    const envelope = await handleProjectGet({ id: p, includeTaskTree: false }, ctx);
+    expect(envelope.data.project.id).toBe(p);
+    expect(envelope.data.tasks).toBeUndefined();
+  });
+
+  it("propagates NotFound for an unknown ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleProjectGet({ id: "proj_999999" as import("../../domain/ids.js").ProjectId }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it("reports cacheHit on repeat calls", async () => {
+    const { ctx, adapter } = makeCtx();
+    const p = await adapter.createProject({ name: "P" });
+
+    const first = await handleProjectGet({ id: p }, ctx);
+    const second = await handleProjectGet({ id: p }, ctx);
+    expect(first.meta.cacheHit).toBe(false);
+    expect(second.meta.cacheHit).toBe(true);
+  });
+});

--- a/src/tools/project/get.ts
+++ b/src/tools/project/get.ts
@@ -1,0 +1,92 @@
+/**
+ * `project_get` MCP tool — fetch a single project by persistent ID.
+ *
+ * Optionally attaches the project's full task set (flat array; clients can
+ * rebuild the nested tree via `parentId`). The task attachment is cached
+ * behind a distinct key so `includeTaskTree=false` callers don't pay for
+ * tree fetches.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/services/projectService.ts
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ProjectId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { ProjectService } from "../../services/projectService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_GET_DESCRIPTION =
+  "Fetch a single OmniFocus project by persistent ID. " +
+  "Do NOT use for queries across projects — use project_list. " +
+  "When includeTaskTree=true (default), the project's flat task list is attached. " +
+  "Returns { project, tasks? }; safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectGetInputSchema = z.object({
+  id: ProjectId.schema.describe("Persistent project ID. Get from project_list or search_query."),
+  includeTaskTree: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to attach the project's tasks (flat array; clients rebuild the tree via parentId). " +
+        "Default true. Set to false for a fast project-only read.",
+    ),
+});
+
+export type ProjectGetToolInput = z.infer<typeof projectGetInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectGetContext {
+  projectService: ProjectService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly from unit tests.
+ *
+ * @throws NotFound when the project ID does not exist.
+ */
+export async function handleProjectGet(input: ProjectGetToolInput, ctx: ProjectGetContext) {
+  const result = await ctx.projectService.get({
+    id: input.id,
+    ...(input.includeTaskTree !== undefined ? { includeTaskTree: input.includeTaskTree } : {}),
+  });
+  const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
+  const data: { project: typeof result.project; tasks?: typeof result.tasks } = {
+    project: result.project,
+  };
+  if (result.tasks !== undefined) data.tasks = result.tasks;
+  return ok(data, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectGetTool(server: McpServer, ctx: ProjectGetContext) {
+  return server.registerTool(
+    "project_get",
+    {
+      description: PROJECT_GET_DESCRIPTION,
+      inputSchema: projectGetInputSchema.shape,
+    },
+    async (args: ProjectGetToolInput) => {
+      const envelope = await handleProjectGet(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/project/list.test.ts
+++ b/src/tools/project/list.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the `project_list` tool — schema parsing + handler envelope.
+ *
+ * Filter/pagination semantics live in `projectService.test.ts` and are not
+ * duplicated here. These tests guard the MCP surface and the handler's meta
+ * + pagination wiring.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { ProjectService } from "../../services/projectService.js";
+import { PROJECT_LIST_DESCRIPTION, handleProjectList, projectListInputSchema } from "./list.js";
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const projectService = new ProjectService({ adapter, cache });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { projectService, makeMeta }, adapter };
+}
+
+describe("project_list — input schema", () => {
+  it("accepts an empty object (service performs the bounded-query gate)", () => {
+    expect(projectListInputSchema.parse({})).toEqual({});
+  });
+
+  it("accepts the full filter surface", () => {
+    const parsed = projectListInputSchema.parse({
+      folderId: "folder_000001",
+      status: "active",
+      flagged: true,
+      reviewDueBefore: "2026-05-01T00:00:00Z",
+      limit: 50,
+      cursor: "opaque",
+    });
+    expect(parsed.folderId).toBe("folder_000001");
+    expect(parsed.status).toBe("active");
+  });
+
+  it("rejects an unknown status", () => {
+    expect(() => projectListInputSchema.parse({ status: "paused" })).toThrow();
+  });
+
+  it("rejects limit > 1000", () => {
+    expect(() => projectListInputSchema.parse({ limit: 2000 })).toThrow();
+  });
+
+  it("rejects limit < 1", () => {
+    expect(() => projectListInputSchema.parse({ limit: 0 })).toThrow();
+  });
+
+  it("rejects a malformed folderId", () => {
+    expect(() => projectListInputSchema.parse({ folderId: "??" })).toThrow();
+  });
+});
+
+describe("project_list — description", () => {
+  it("documents read-only + filter surface + pagination", () => {
+    expect(PROJECT_LIST_DESCRIPTION).toMatch(/project/i);
+    expect(PROJECT_LIST_DESCRIPTION).toMatch(/no side effects/i);
+    expect(PROJECT_LIST_DESCRIPTION).toMatch(/pagination/i);
+  });
+});
+
+describe("project_list — handler", () => {
+  it("returns the ADR-0013 envelope with projects + pagination + cacheHit meta", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createProject({ name: "p1" });
+    await adapter.createProject({ name: "p2" });
+
+    const envelope = await handleProjectList({ status: "active", limit: 10 }, ctx);
+    expect(envelope.data.projects.map((p) => p.name)).toEqual(["p1", "p2"]);
+    expect(envelope.pagination?.hasMore).toBe(false);
+    expect(envelope.pagination?.cursor).toBeNull();
+    expect(envelope.meta.cacheHit).toBe(false);
+
+    const repeat = await handleProjectList({ status: "active", limit: 10 }, ctx);
+    expect(repeat.meta.cacheHit).toBe(true);
+  });
+
+  it("propagates ValidationError from the service (unbounded query)", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleProjectList({}, ctx)).rejects.toThrow();
+  });
+});

--- a/src/tools/project/list.ts
+++ b/src/tools/project/list.ts
@@ -1,0 +1,121 @@
+/**
+ * `project_list` MCP tool — paginated project read surface.
+ *
+ * Mirrors `task_list` (DESIGN §26) in shape and semantics. Filters are narrow
+ * by design: folder, status, flagged, review-due. Richer project queries
+ * (e.g. tag-based) live in `search_query`.
+ *
+ * @see src/services/projectService.ts
+ * @see src/tools/task/list.ts — sibling reference tool
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { FolderId } from "../../domain/ids.js";
+import { type Pagination, type ResponseMeta, ok } from "../../envelope/index.js";
+import type { ProjectListInput, ProjectService } from "../../services/projectService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_LIST_DESCRIPTION =
+  "List projects in OmniFocus with optional filters. " +
+  "Use for queries across projects. " +
+  "Do NOT use for a known single project (use project_get). " +
+  "Filters: folderId, status, flagged, reviewDueBefore. " +
+  "Returns projects[] with pagination; safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectListInputSchema = z.object({
+  folderId: FolderId.schema
+    .optional()
+    .describe(
+      "Restrict to projects inside this folder. Get the ID from folder_list. Omit for all folders.",
+    ),
+  status: z
+    .enum(["active", "on-hold", "done", "dropped"])
+    .optional()
+    .describe(
+      "Restrict to projects with this status. " +
+        "'active' = available; 'on-hold' = paused; 'done' = completed; 'dropped' = abandoned. " +
+        "Omit for any status.",
+    ),
+  flagged: z
+    .boolean()
+    .optional()
+    .describe("true = flagged only; false = unflagged only; omit = both."),
+  reviewDueBefore: z
+    .string()
+    .optional()
+    .describe(
+      "Restrict to projects whose next review date is strictly before this moment. " +
+        "ISO-8601 with offset (e.g. '2026-05-01T00:00:00-07:00'). " +
+        "Projects without a review interval are excluded.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .optional()
+    .describe(
+      "Max projects per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages.",
+    ),
+  cursor: z
+    .string()
+    .optional()
+    .describe(
+      "Opaque cursor from a previous project_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError.",
+    ),
+});
+
+export type ProjectListToolInput = z.infer<typeof projectListInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectListContext {
+  projectService: ProjectService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — separated from registration so unit tests can invoke it
+ * without constructing an `McpServer`.
+ */
+export async function handleProjectList(input: ProjectListToolInput, ctx: ProjectListContext) {
+  const serviceInput = input as ProjectListInput;
+  const result = await ctx.projectService.list(serviceInput);
+  const pagination: Pagination = {
+    cursor: result.nextCursor,
+    hasMore: result.hasMore,
+  };
+  const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
+  return ok({ projects: result.projects }, meta, pagination);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectListTool(server: McpServer, ctx: ProjectListContext) {
+  return server.registerTool(
+    "project_list",
+    {
+      description: PROJECT_LIST_DESCRIPTION,
+      inputSchema: projectListInputSchema.shape,
+    },
+    async (args: ProjectListToolInput) => {
+      const envelope = await handleProjectList(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `ProjectService.list` with folderId/status/flagged/reviewDueBefore filters and stable cursor pagination (mirrors `TaskService.list`).
- `ProjectService.get({ id, includeTaskTree? })` with task-tree attachment and a distinct cache key so solo reads don't pay for task fetches.
- `project_list` + `project_get` MCP tools returning the ADR-0013 envelope.

## Design link
Closes #42. Follows DESIGN.md §15 (pagination), §26 (reference tool pattern) and ADR-0013 (envelope).

## Breaking change?
- [x] No

## Test plan
- [x] 24 new unit tests (service contract + handler envelope + schema), all 756 tests green
- [x] Self-reviewed via /review-pr
- [x] No new dependencies