### PR TITLE
feat(transport): wire JxaTransport tag and folder domain methods

### DIFF
--- a/src/adapter/jxa/JxaTransport.tags-folders.integration.test.ts
+++ b/src/adapter/jxa/JxaTransport.tags-folders.integration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration tests for `JxaTransport` — tag and folder domain methods.
+ *
+ * These tests require a running OmniFocus instance and are gated behind the
+ * `OMNIFOCUS_INTEGRATION=1` environment variable. They exercise real JXA
+ * calls via `osascript` rather than a mocked spawner.
+ *
+ * Run with:
+ *   OMNIFOCUS_INTEGRATION=1 pnpm test:integration
+ *
+ * @see src/adapter/jxa/JxaTransport.tags-folders.test.ts — unit tests (no OF required)
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { FolderId, TagId } from "../../domain/ids.js";
+import { JxaTransport } from "./JxaTransport.js";
+
+const INTEGRATION = process.env.OMNIFOCUS_INTEGRATION === "1";
+
+describe.skipIf(!INTEGRATION)("JxaTransport — tag integration", () => {
+  const t = new JxaTransport();
+  let createdTagId: TagId;
+
+  beforeAll(async () => {
+    createdTagId = await t.createTag({ name: "__mcp_test_tag__" });
+  });
+
+  afterAll(async () => {
+    if (createdTagId) {
+      await t.deleteTag(createdTagId).catch(() => {
+        /* already deleted */
+      });
+    }
+  });
+
+  it("createTag returns a valid ID", () => {
+    expect(typeof createdTagId).toBe("string");
+    expect(createdTagId.length).toBeGreaterThan(0);
+  });
+
+  it("getTag returns the created tag", async () => {
+    const tag = await t.getTag(createdTagId);
+    expect(tag.id).toBe(createdTagId);
+    expect(tag.name).toBe("__mcp_test_tag__");
+    expect(tag.status).toBe("active");
+  });
+
+  it("listTags includes the created tag", async () => {
+    const tags = await t.listTags();
+    const found = tags.find((tag) => tag.id === createdTagId);
+    expect(found).toBeDefined();
+    expect(found?.name).toBe("__mcp_test_tag__");
+  });
+
+  it("updateTag renames the tag", async () => {
+    await t.updateTag(createdTagId, { name: "__mcp_test_tag_renamed__" });
+    const tag = await t.getTag(createdTagId);
+    expect(tag.name).toBe("__mcp_test_tag_renamed__");
+  });
+
+  it("updateTag sets status to on-hold", async () => {
+    await t.updateTag(createdTagId, { status: "on-hold" });
+    const tag = await t.getTag(createdTagId);
+    expect(tag.status).toBe("on-hold");
+  });
+
+  it("deleteTag removes the tag", async () => {
+    await t.deleteTag(createdTagId);
+    const tags = await t.listTags();
+    const found = tags.find((tag) => tag.id === createdTagId);
+    expect(found).toBeUndefined();
+  });
+});
+
+describe.skipIf(!INTEGRATION)("JxaTransport — folder integration", () => {
+  const t = new JxaTransport();
+  let createdFolderId: FolderId;
+
+  beforeAll(async () => {
+    createdFolderId = await t.createFolder({ name: "__mcp_test_folder__" });
+  });
+
+  afterAll(async () => {
+    if (createdFolderId) {
+      await t.deleteFolder(createdFolderId).catch(() => {
+        /* already deleted */
+      });
+    }
+  });
+
+  it("createFolder returns a valid ID", () => {
+    expect(typeof createdFolderId).toBe("string");
+    expect(createdFolderId.length).toBeGreaterThan(0);
+  });
+
+  it("getFolder returns the created folder", async () => {
+    const folder = await t.getFolder(createdFolderId);
+    expect(folder.id).toBe(createdFolderId);
+    expect(folder.name).toBe("__mcp_test_folder__");
+    expect(folder.parentId).toBeNull();
+  });
+
+  it("listFolders includes the created folder", async () => {
+    const folders = await t.listFolders();
+    const found = folders.find((f) => f.id === createdFolderId);
+    expect(found).toBeDefined();
+    expect(found?.name).toBe("__mcp_test_folder__");
+  });
+
+  it("updateFolder renames the folder", async () => {
+    await t.updateFolder(createdFolderId, { name: "__mcp_test_folder_renamed__" });
+    const folder = await t.getFolder(createdFolderId);
+    expect(folder.name).toBe("__mcp_test_folder_renamed__");
+  });
+
+  it("deleteFolder removes the folder", async () => {
+    await t.deleteFolder(createdFolderId);
+    const folders = await t.listFolders();
+    const found = folders.find((f) => f.id === createdFolderId);
+    expect(found).toBeUndefined();
+  });
+});

--- a/src/adapter/jxa/JxaTransport.tags-folders.test.ts
+++ b/src/adapter/jxa/JxaTransport.tags-folders.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Unit tests for `JxaTransport` — tag and folder domain methods.
+ *
+ * All tests use a fake spawner that returns pre-shaped JSON, so no `osascript`
+ * binary is required. Integration tests against a live OmniFocus instance are
+ * in JxaTransport.tags-folders.integration.test.ts and gated behind
+ * `OMNIFOCUS_INTEGRATION=1`.
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — implementation
+ * @see src/scripts/jxa/tag_*.js / folder_*.js — underlying scripts
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { FolderId, TagId } from "../../domain/ids.js";
+import { ScriptError } from "../../errors/index.js";
+import { JxaTransport } from "./JxaTransport.js";
+import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function spawnerReturning(payload: unknown): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: JSON.stringify(payload),
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    }),
+  );
+}
+
+function spawnerFailing(stderr: string): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: "",
+      stderr,
+      exitCode: 1,
+      timedOut: false,
+    }),
+  );
+}
+
+const BASE_TAG = {
+  id: "tag_aaa",
+  name: "Work",
+  parentId: null,
+  status: "active",
+  location: null,
+  allowsNextAction: true,
+  taskCount: 3,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  modifiedAt: "2026-01-02T00:00:00.000Z",
+};
+
+const BASE_FOLDER = {
+  id: "folder_bbb",
+  name: "Personal",
+  parentId: null,
+  projectCount: 2,
+  subfolderCount: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  modifiedAt: "2026-01-02T00:00:00.000Z",
+};
+
+// ---------------------------------------------------------------------------
+// listTags
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — listTags", () => {
+  it("returns parsed tags with branded IDs", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ tags: [BASE_TAG] }) });
+    const tags = await t.listTags();
+    expect(tags).toHaveLength(1);
+    expect(tags[0]?.id).toBe("tag_aaa");
+    expect(tags[0]?.name).toBe("Work");
+    expect(tags[0]?.status).toBe("active");
+  });
+
+  it("passes parentId and status filters to the script", async () => {
+    const spawner = spawnerReturning({ tags: [] });
+    const t = new JxaTransport({ spawner });
+    await t.listTags({ parentId: "tag_parent" as TagId, status: "on-hold" });
+    const call = (spawner as ReturnType<typeof vi.fn>).mock.calls[0];
+    const arg = JSON.parse(call[1] as string) as { parentId: string; status: string };
+    expect(arg.parentId).toBe("tag_parent");
+    expect(arg.status).toBe("on-hold");
+  });
+
+  it("returns empty array when no tags", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ tags: [] }) });
+    expect(await t.listTags()).toEqual([]);
+  });
+
+  it("surfaces ScriptError on script failure", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("OmniFocus got an error") });
+    await expect(t.listTags()).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTag
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — getTag", () => {
+  it("returns a single tag", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ tag: BASE_TAG }) });
+    const tag = await t.getTag("tag_aaa" as TagId);
+    expect(tag.id).toBe("tag_aaa");
+    expect(tag.allowsNextAction).toBe(true);
+    expect(tag.taskCount).toBe(3);
+  });
+
+  it("passes the id to the script", async () => {
+    const spawner = spawnerReturning({ tag: BASE_TAG });
+    const t = new JxaTransport({ spawner });
+    await t.getTag("tag_aaa" as TagId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { id: string };
+    expect(arg.id).toBe("tag_aaa");
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("tag not found") });
+    await expect(t.getTag("tag_missing" as TagId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTag
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — createTag", () => {
+  it("returns the new tag's branded ID", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ tag: BASE_TAG }) });
+    const id = await t.createTag({ name: "Work" });
+    expect(id).toBe("tag_aaa");
+  });
+
+  it("passes name and parentId to the script", async () => {
+    const spawner = spawnerReturning({ tag: BASE_TAG });
+    const t = new JxaTransport({ spawner });
+    await t.createTag({ name: "Work", parentId: "tag_parent" as TagId });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { name: string; parentId: string };
+    expect(arg.name).toBe("Work");
+    expect(arg.parentId).toBe("tag_parent");
+  });
+
+  it("passes null parentId when none supplied", async () => {
+    const spawner = spawnerReturning({ tag: BASE_TAG });
+    const t = new JxaTransport({ spawner });
+    await t.createTag({ name: "Work" });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { parentId: null };
+    expect(arg.parentId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateTag
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — updateTag", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({
+      spawner: spawnerReturning({ tag: { ...BASE_TAG, name: "Updated" } }),
+    });
+    await expect(t.updateTag("tag_aaa" as TagId, { name: "Updated" })).resolves.toBeUndefined();
+  });
+
+  it("passes only supplied patch fields to the script", async () => {
+    const spawner = spawnerReturning({ tag: BASE_TAG });
+    const t = new JxaTransport({ spawner });
+    await t.updateTag("tag_aaa" as TagId, { status: "on-hold" });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { id: string; status: string; name?: string };
+    expect(arg.id).toBe("tag_aaa");
+    expect(arg.status).toBe("on-hold");
+    expect(arg.name).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteTag
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — deleteTag", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "tag_aaa" }) });
+    await expect(t.deleteTag("tag_aaa" as TagId)).resolves.toBeUndefined();
+  });
+
+  it("passes id to the script", async () => {
+    const spawner = spawnerReturning({ id: "tag_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.deleteTag("tag_aaa" as TagId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { id: string };
+    expect(arg.id).toBe("tag_aaa");
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("tag not found") });
+    await expect(t.deleteTag("tag_missing" as TagId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listFolders
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — listFolders", () => {
+  it("returns parsed folders with branded IDs", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ folders: [BASE_FOLDER] }) });
+    const folders = await t.listFolders();
+    expect(folders).toHaveLength(1);
+    expect(folders[0]?.id).toBe("folder_bbb");
+    expect(folders[0]?.name).toBe("Personal");
+    expect(folders[0]?.projectCount).toBe(2);
+  });
+
+  it("passes parentId filter to the script", async () => {
+    const spawner = spawnerReturning({ folders: [] });
+    const t = new JxaTransport({ spawner });
+    await t.listFolders({ parentId: "folder_parent" as FolderId });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { parentId: string };
+    expect(arg.parentId).toBe("folder_parent");
+  });
+
+  it("surfaces ScriptError on script failure", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("Error: -1700") });
+    await expect(t.listFolders()).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFolder
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — getFolder", () => {
+  it("returns a single folder", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ folder: BASE_FOLDER }) });
+    const folder = await t.getFolder("folder_bbb" as FolderId);
+    expect(folder.id).toBe("folder_bbb");
+    expect(folder.subfolderCount).toBe(1);
+  });
+
+  it("passes the id to the script", async () => {
+    const spawner = spawnerReturning({ folder: BASE_FOLDER });
+    const t = new JxaTransport({ spawner });
+    await t.getFolder("folder_bbb" as FolderId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { id: string };
+    expect(arg.id).toBe("folder_bbb");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createFolder
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — createFolder", () => {
+  it("returns the new folder's branded ID", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ folder: BASE_FOLDER }) });
+    const id = await t.createFolder({ name: "Personal" });
+    expect(id).toBe("folder_bbb");
+  });
+
+  it("passes name and null parentId when none supplied", async () => {
+    const spawner = spawnerReturning({ folder: BASE_FOLDER });
+    const t = new JxaTransport({ spawner });
+    await t.createFolder({ name: "Personal" });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { name: string; parentId: null };
+    expect(arg.name).toBe("Personal");
+    expect(arg.parentId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateFolder
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — updateFolder", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({
+      spawner: spawnerReturning({ folder: { ...BASE_FOLDER, name: "Updated" } }),
+    });
+    await expect(
+      t.updateFolder("folder_bbb" as FolderId, { name: "Updated" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes id and name to the script", async () => {
+    const spawner = spawnerReturning({ folder: BASE_FOLDER });
+    const t = new JxaTransport({ spawner });
+    await t.updateFolder("folder_bbb" as FolderId, { name: "Renamed" });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+    ) as { id: string; name: string };
+    expect(arg.id).toBe("folder_bbb");
+    expect(arg.name).toBe("Renamed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteFolder
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — deleteFolder", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "folder_bbb" }) });
+    await expect(t.deleteFolder("folder_bbb" as FolderId)).resolves.toBeUndefined();
+  });
+
+  it("surfaces ScriptError when folder non-empty", async () => {
+    const t = new JxaTransport({
+      spawner: spawnerFailing("Cannot delete non-empty folder"),
+    });
+    await expect(t.deleteFolder("folder_bbb" as FolderId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// not-yet-wired stubs still throw (regression guard)
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — not-yet-wired stubs still throw after tag/folder wiring", () => {
+  const t = new JxaTransport({ spawner: spawnerReturning({}) });
+
+  it("listTasks throws not-yet-wired", async () => {
+    const err = await t.listTasks({}).catch((e) => e);
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details).toMatchObject({ reason: "not-yet-wired" });
+  });
+
+  it("listProjects throws not-yet-wired", async () => {
+    const err = await t.listProjects().catch((e) => e);
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).details).toMatchObject({ reason: "not-yet-wired" });
+  });
+});

--- a/src/adapter/jxa/JxaTransport.test.ts
+++ b/src/adapter/jxa/JxaTransport.test.ts
@@ -76,14 +76,15 @@ describe("JxaTransport — not-yet-wired stubs", () => {
   const t = new JxaTransport({ spawner: spawnerReturning("{}") });
 
   // Sample one method per domain group; the per-method shape is uniform.
+  // Note: listTags, getTag, createTag, updateTag, deleteTag, listFolders,
+  // getFolder, createFolder, updateFolder, deleteFolder are now wired and
+  // tested in JxaTransport.tags-folders.test.ts.
   const cases: Array<readonly [string, () => Promise<unknown>]> = [
     ["listTasks", () => t.listTasks({})],
     ["getTask", () => t.getTask("task_000001" as TaskId)],
     ["createTask", () => t.createTask({ name: "x" })],
     ["listProjects", () => t.listProjects()],
     ["getProject", () => t.getProject("proj_000001" as ProjectId)],
-    ["listTags", () => t.listTags()],
-    ["listFolders", () => t.listFolders()],
   ];
 
   for (const [method, call] of cases) {

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -8,11 +8,10 @@
  * loads the right script and shapes the response into the domain types
  * defined by `OmniFocusAdapter`.
  *
- * **Status (M0 keystone):** This file ships the transport scaffolding plus
- * one wired method (`syncTrigger`) as proof. Per-domain scripts (tasks,
- * projects, tags, folders, forecast, search, notes, repetition,
- * attachments, review) land via follow-up issues so each can carry its
- * own JXA script + tests + smoke without piling into a single mega-PR.
+ * **Wired domains:** sync, tags, folders.
+ * **Stubbed domains:** tasks, projects, search, forecast, notes, repetition,
+ * attachments, review — these arrive via follow-up issues so each can carry
+ * its own JXA script + tests without piling into a single mega-PR.
  * Stubbed methods throw `ScriptError` with `details.reason: "not-yet-wired"`
  * so `TransportRouter` (#19) can route around them and tests can detect
  * the partial-implementation state precisely.
@@ -24,12 +23,29 @@
  */
 
 import type { Folder } from "../../domain/folder.js";
-import type { FolderId, ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import {
+  type FolderId,
+  FolderId as FolderIdCtor,
+  type ProjectId,
+  type TagId,
+  TagId as TagIdCtor,
+  type TaskId,
+} from "../../domain/ids.js";
 import type { Project } from "../../domain/project.js";
 import type { Tag } from "../../domain/tag.js";
 import type { Task } from "../../domain/task.js";
 import { ScriptError } from "../../errors/index.js";
+import folderCreateScript from "../../scripts/jxa/folder_create.js";
+import folderDeleteScript from "../../scripts/jxa/folder_delete.js";
+import folderGetScript from "../../scripts/jxa/folder_get.js";
+import folderListScript from "../../scripts/jxa/folder_list.js";
+import folderUpdateScript from "../../scripts/jxa/folder_update.js";
 import syncTriggerScript from "../../scripts/jxa/sync_trigger.js";
+import tagCreateScript from "../../scripts/jxa/tag_create.js";
+import tagDeleteScript from "../../scripts/jxa/tag_delete.js";
+import tagGetScript from "../../scripts/jxa/tag_get.js";
+import tagListScript from "../../scripts/jxa/tag_list.js";
+import tagUpdateScript from "../../scripts/jxa/tag_update.js";
 import type {
   CreateFolderInput,
   CreateProjectInput,
@@ -157,40 +173,104 @@ export class JxaTransport implements OmniFocusAdapter {
     return notYetWired("markProjectReviewed");
   }
 
-  // -- Tags -----------------------------------------------------------------
+  // -- Tags (wired) ---------------------------------------------------------
 
-  async listTags(_filter?: { parentId?: TagId; status?: Tag["status"] }): Promise<Tag[]> {
-    return notYetWired("listTags");
-  }
-  async getTag(_id: TagId): Promise<Tag> {
-    return notYetWired("getTag");
-  }
-  async createTag(_input: CreateTagInput): Promise<TagId> {
-    return notYetWired("createTag");
-  }
-  async updateTag(_id: TagId, _patch: UpdateTagInput): Promise<void> {
-    return notYetWired("updateTag");
-  }
-  async deleteTag(_id: TagId): Promise<void> {
-    return notYetWired("deleteTag");
+  async listTags(filter?: { parentId?: TagId; status?: Tag["status"] }): Promise<Tag[]> {
+    const result = await runJxaScript<{ tags: Tag[] }>(
+      tagListScript,
+      {
+        parentId: filter?.parentId ?? null,
+        status: filter?.status ?? null,
+      },
+      { ...this.runOpts, scriptName: "tag_list" },
+    );
+    return result.tags.map((t) => ({ ...t, id: TagIdCtor.of(t.id) }));
   }
 
-  // -- Folders --------------------------------------------------------------
+  async getTag(id: TagId): Promise<Tag> {
+    const result = await runJxaScript<{ tag: Tag }>(
+      tagGetScript,
+      { id },
+      { ...this.runOpts, scriptName: "tag_get" },
+    );
+    return { ...result.tag, id: TagIdCtor.of(result.tag.id) };
+  }
 
-  async listFolders(_filter?: { parentId?: FolderId }): Promise<Folder[]> {
-    return notYetWired("listFolders");
+  async createTag(input: CreateTagInput): Promise<TagId> {
+    const result = await runJxaScript<{ tag: Tag }>(
+      tagCreateScript,
+      { name: input.name, parentId: input.parentId ?? null },
+      { ...this.runOpts, scriptName: "tag_create" },
+    );
+    return TagIdCtor.of(result.tag.id);
   }
-  async getFolder(_id: FolderId): Promise<Folder> {
-    return notYetWired("getFolder");
+
+  async updateTag(id: TagId, patch: UpdateTagInput): Promise<void> {
+    await runJxaScript<{ tag: Tag }>(
+      tagUpdateScript,
+      {
+        id,
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
+        ...(patch.status !== undefined ? { status: patch.status } : {}),
+        ...(patch.allowsNextAction !== undefined
+          ? { allowsNextAction: patch.allowsNextAction }
+          : {}),
+      },
+      { ...this.runOpts, scriptName: "tag_update" },
+    );
   }
-  async createFolder(_input: CreateFolderInput): Promise<FolderId> {
-    return notYetWired("createFolder");
+
+  async deleteTag(id: TagId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      tagDeleteScript,
+      { id },
+      { ...this.runOpts, scriptName: "tag_delete" },
+    );
   }
-  async updateFolder(_id: FolderId, _patch: UpdateFolderInput): Promise<void> {
-    return notYetWired("updateFolder");
+
+  // -- Folders (wired) ------------------------------------------------------
+
+  async listFolders(filter?: { parentId?: FolderId }): Promise<Folder[]> {
+    const result = await runJxaScript<{ folders: Folder[] }>(
+      folderListScript,
+      { parentId: filter?.parentId ?? null },
+      { ...this.runOpts, scriptName: "folder_list" },
+    );
+    return result.folders.map((f) => ({ ...f, id: FolderIdCtor.of(f.id) }));
   }
-  async deleteFolder(_id: FolderId): Promise<void> {
-    return notYetWired("deleteFolder");
+
+  async getFolder(id: FolderId): Promise<Folder> {
+    const result = await runJxaScript<{ folder: Folder }>(
+      folderGetScript,
+      { id },
+      { ...this.runOpts, scriptName: "folder_get" },
+    );
+    return { ...result.folder, id: FolderIdCtor.of(result.folder.id) };
+  }
+
+  async createFolder(input: CreateFolderInput): Promise<FolderId> {
+    const result = await runJxaScript<{ folder: Folder }>(
+      folderCreateScript,
+      { name: input.name, parentId: input.parentId ?? null },
+      { ...this.runOpts, scriptName: "folder_create" },
+    );
+    return FolderIdCtor.of(result.folder.id);
+  }
+
+  async updateFolder(id: FolderId, patch: UpdateFolderInput): Promise<void> {
+    await runJxaScript<{ folder: Folder }>(
+      folderUpdateScript,
+      { id, ...(patch.name !== undefined ? { name: patch.name } : {}) },
+      { ...this.runOpts, scriptName: "folder_update" },
+    );
+  }
+
+  async deleteFolder(id: FolderId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      folderDeleteScript,
+      { id },
+      { ...this.runOpts, scriptName: "folder_delete" },
+    );
   }
 
   // -- Search ---------------------------------------------------------------

--- a/src/linting/customRules.ts
+++ b/src/linting/customRules.ts
@@ -43,7 +43,9 @@ export const ID_CAST_ALLOWED_RE = /src[/\\]domain[/\\]ids\.(ts|js)$/;
 export const THROW_NEW_ERROR_RE = /\bthrow\s+new\s+Error\s*\(/;
 
 /** Files allowed to contain `throw new Error(` */
-export const THROW_ALLOWED_RE = /src[/\\]errors[/\\]/;
+// JXA scripts (src/scripts/jxa/) run inside osascript and cannot import typed
+// errors — plain `throw new Error(...)` is the only option there.
+export const THROW_ALLOWED_RE = /src[/\\]errors[/\\]|src[/\\]scripts[/\\]jxa[/\\]/;
 
 /**
  * Match user-content property accesses that must not appear in metadata

--- a/src/scripts/jxa/folder_create.d.ts
+++ b/src/scripts/jxa/folder_create.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `folder_create.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/folder_create.js
+++ b/src/scripts/jxa/folder_create.js
@@ -1,0 +1,64 @@
+/**
+ * JXA: create a folder, optionally under a parent folder.
+ *
+ * Args (argv[0] JSON): { name: string, parentId?: string }
+ * Returns JSON: { folder: Folder }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/folder.ts — Folder domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildFolder(folder) {
+    let parentId = null;
+    try {
+      const p = folder.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    return {
+      id: folder.id(),
+      name: folder.name(),
+      parentId: parentId,
+      projectCount: folder.projects ? folder.projects().length : 0,
+      subfolderCount: folder.folders ? folder.folders().length : 0,
+      createdAt: folder.creationDate
+        ? folder.creationDate().toISOString()
+        : new Date().toISOString(),
+      modifiedAt: folder.modificationDate
+        ? folder.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  let newFolder;
+  if (args.parentId) {
+    const allFolders = ofApp.defaultDocument.flattenedFolders();
+    let parentFolder = null;
+    for (let i = 0; i < allFolders.length; i++) {
+      if (allFolders[i].id() === args.parentId) {
+        parentFolder = allFolders[i];
+        break;
+      }
+    }
+    if (!parentFolder) throw new Error(`Parent folder not found: ${args.parentId}`);
+    newFolder = ofApp.make({
+      new: "folder",
+      at: parentFolder.folders.end,
+      withProperties: { name: args.name },
+    });
+  } else {
+    newFolder = ofApp.make({
+      new: "folder",
+      at: ofApp.defaultDocument.folders.end,
+      withProperties: { name: args.name },
+    });
+  }
+
+  return JSON.stringify({ folder: buildFolder(newFolder) });
+}

--- a/src/scripts/jxa/folder_delete.d.ts
+++ b/src/scripts/jxa/folder_delete.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `folder_delete.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/folder_delete.js
+++ b/src/scripts/jxa/folder_delete.js
@@ -1,0 +1,38 @@
+/**
+ * JXA: delete a folder by ID. Refuses if the folder has projects or subfolders.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/folder.ts — Folder domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allFolders = ofApp.defaultDocument.flattenedFolders();
+  let target = null;
+  for (let i = 0; i < allFolders.length; i++) {
+    if (allFolders[i].id() === args.id) {
+      target = allFolders[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Folder not found: ${args.id}`);
+
+  const projectCount = target.projects ? target.projects().length : 0;
+  const subfolderCount = target.folders ? target.folders().length : 0;
+  if (projectCount > 0 || subfolderCount > 0) {
+    throw new Error(
+      `Folder is not empty (projects: ${projectCount}, subfolders: ${subfolderCount}). Remove contents before deleting.`,
+    );
+  }
+
+  ofApp.delete(target);
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/folder_get.d.ts
+++ b/src/scripts/jxa/folder_get.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `folder_get.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/folder_get.js
+++ b/src/scripts/jxa/folder_get.js
@@ -1,0 +1,47 @@
+/**
+ * JXA: fetch one folder by ID.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { folder: Folder }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/folder.ts — Folder domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildFolder(folder) {
+    let parentId = null;
+    try {
+      const p = folder.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    return {
+      id: folder.id(),
+      name: folder.name(),
+      parentId: parentId,
+      projectCount: folder.projects ? folder.projects().length : 0,
+      subfolderCount: folder.folders ? folder.folders().length : 0,
+      createdAt: folder.creationDate
+        ? folder.creationDate().toISOString()
+        : new Date().toISOString(),
+      modifiedAt: folder.modificationDate
+        ? folder.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allFolders = ofApp.defaultDocument.flattenedFolders();
+  for (let i = 0; i < allFolders.length; i++) {
+    if (allFolders[i].id() === args.id) {
+      return JSON.stringify({ folder: buildFolder(allFolders[i]) });
+    }
+  }
+
+  throw new Error(`Folder not found: ${args.id}`);
+}

--- a/src/scripts/jxa/folder_list.d.ts
+++ b/src/scripts/jxa/folder_list.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `folder_list.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/folder_list.js
+++ b/src/scripts/jxa/folder_list.js
@@ -1,0 +1,49 @@
+/**
+ * JXA: list all folders, optionally filtered by parentId.
+ *
+ * Args (argv[0] JSON): { parentId?: string }
+ * Returns JSON: { folders: Folder[] }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/folder.ts — Folder domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildFolder(folder) {
+    let parentId = null;
+    try {
+      const p = folder.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    return {
+      id: folder.id(),
+      name: folder.name(),
+      parentId: parentId,
+      projectCount: folder.projects ? folder.projects().length : 0,
+      subfolderCount: folder.folders ? folder.folders().length : 0,
+      createdAt: folder.creationDate
+        ? folder.creationDate().toISOString()
+        : new Date().toISOString(),
+      modifiedAt: folder.modificationDate
+        ? folder.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allFolders = ofApp.defaultDocument.flattenedFolders();
+  const result = [];
+
+  for (let i = 0; i < allFolders.length; i++) {
+    const built = buildFolder(allFolders[i]);
+    if (args.parentId !== undefined && built.parentId !== args.parentId) continue;
+    result.push(built);
+  }
+
+  return JSON.stringify({ folders: result });
+}

--- a/src/scripts/jxa/folder_update.d.ts
+++ b/src/scripts/jxa/folder_update.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `folder_update.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/folder_update.js
+++ b/src/scripts/jxa/folder_update.js
@@ -1,0 +1,52 @@
+/**
+ * JXA: rename a folder.
+ *
+ * Args (argv[0] JSON): { id: string, name: string }
+ * Returns JSON: { folder: Folder }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/folder.ts — Folder domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildFolder(folder) {
+    let parentId = null;
+    try {
+      const p = folder.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    return {
+      id: folder.id(),
+      name: folder.name(),
+      parentId: parentId,
+      projectCount: folder.projects ? folder.projects().length : 0,
+      subfolderCount: folder.folders ? folder.folders().length : 0,
+      createdAt: folder.creationDate
+        ? folder.creationDate().toISOString()
+        : new Date().toISOString(),
+      modifiedAt: folder.modificationDate
+        ? folder.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allFolders = ofApp.defaultDocument.flattenedFolders();
+  let target = null;
+  for (let i = 0; i < allFolders.length; i++) {
+    if (allFolders[i].id() === args.id) {
+      target = allFolders[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Folder not found: ${args.id}`);
+
+  target.name = args.name;
+
+  return JSON.stringify({ folder: buildFolder(target) });
+}

--- a/src/scripts/jxa/tag_create.d.ts
+++ b/src/scripts/jxa/tag_create.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `tag_create.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/tag_create.js
+++ b/src/scripts/jxa/tag_create.js
@@ -1,0 +1,84 @@
+/**
+ * JXA: create a tag, optionally under a parent tag.
+ *
+ * Args (argv[0] JSON): { name: string, parentId?: string }
+ * Returns JSON: { tag: Tag }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/tag.ts — Tag domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildTag(tag) {
+    let parentId = null;
+    try {
+      const p = tag.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    let location = null;
+    try {
+      const loc = tag.location();
+      if (loc) {
+        location = {
+          name: loc.locationName ? loc.locationName() : null,
+          latitude: loc.latitude(),
+          longitude: loc.longitude(),
+          radiusMeters: loc.radius ? loc.radius() : 0,
+          trigger: "both",
+        };
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = tag.status();
+    } catch (_e) {}
+    const status = rawStatus === "on hold" ? "on-hold" : rawStatus;
+
+    return {
+      id: tag.id(),
+      name: tag.name(),
+      parentId: parentId,
+      status: status,
+      location: location,
+      allowsNextAction: tag.allowsNextAction ? tag.allowsNextAction() : false,
+      taskCount: tag.tasks ? tag.tasks().length : 0,
+      createdAt: tag.creationDate ? tag.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: tag.modificationDate
+        ? tag.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  let newTag;
+  if (args.parentId) {
+    const allTags = ofApp.defaultDocument.flattenedTags();
+    let parentTag = null;
+    for (let i = 0; i < allTags.length; i++) {
+      if (allTags[i].id() === args.parentId) {
+        parentTag = allTags[i];
+        break;
+      }
+    }
+    if (!parentTag) throw new Error(`Parent tag not found: ${args.parentId}`);
+    newTag = ofApp.make({
+      new: "tag",
+      at: parentTag.tags.end,
+      withProperties: { name: args.name },
+    });
+  } else {
+    newTag = ofApp.make({
+      new: "tag",
+      at: ofApp.defaultDocument.tags.end,
+      withProperties: { name: args.name },
+    });
+  }
+
+  return JSON.stringify({ tag: buildTag(newTag) });
+}

--- a/src/scripts/jxa/tag_delete.d.ts
+++ b/src/scripts/jxa/tag_delete.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `tag_delete.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/tag_delete.js
+++ b/src/scripts/jxa/tag_delete.js
@@ -1,0 +1,30 @@
+/**
+ * JXA: delete a tag by ID.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/tag.ts — Tag domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allTags = ofApp.defaultDocument.flattenedTags();
+  let target = null;
+  for (let i = 0; i < allTags.length; i++) {
+    if (allTags[i].id() === args.id) {
+      target = allTags[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Tag not found: ${args.id}`);
+
+  ofApp.delete(target);
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/tag_get.d.ts
+++ b/src/scripts/jxa/tag_get.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `tag_get.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/tag_get.js
+++ b/src/scripts/jxa/tag_get.js
@@ -1,0 +1,67 @@
+/**
+ * JXA: fetch one tag by ID.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { tag: Tag }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/tag.ts — Tag domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildTag(tag) {
+    let parentId = null;
+    try {
+      const p = tag.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    let location = null;
+    try {
+      const loc = tag.location();
+      if (loc) {
+        location = {
+          name: loc.locationName ? loc.locationName() : null,
+          latitude: loc.latitude(),
+          longitude: loc.longitude(),
+          radiusMeters: loc.radius ? loc.radius() : 0,
+          trigger: "both",
+        };
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = tag.status();
+    } catch (_e) {}
+    const status = rawStatus === "on hold" ? "on-hold" : rawStatus;
+
+    return {
+      id: tag.id(),
+      name: tag.name(),
+      parentId: parentId,
+      status: status,
+      location: location,
+      allowsNextAction: tag.allowsNextAction ? tag.allowsNextAction() : false,
+      taskCount: tag.tasks ? tag.tasks().length : 0,
+      createdAt: tag.creationDate ? tag.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: tag.modificationDate
+        ? tag.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allTags = ofApp.defaultDocument.flattenedTags();
+  for (let i = 0; i < allTags.length; i++) {
+    if (allTags[i].id() === args.id) {
+      return JSON.stringify({ tag: buildTag(allTags[i]) });
+    }
+  }
+
+  throw new Error(`Tag not found: ${args.id}`);
+}

--- a/src/scripts/jxa/tag_list.d.ts
+++ b/src/scripts/jxa/tag_list.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `tag_list.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/tag_list.js
+++ b/src/scripts/jxa/tag_list.js
@@ -1,0 +1,73 @@
+/**
+ * JXA: list all tags, optionally filtered by parentId or status.
+ *
+ * Args (argv[0] JSON): { parentId?: string, status?: string }
+ * Returns JSON: { tags: Tag[] }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/tag.ts — Tag domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildTag(tag) {
+    let parentId = null;
+    try {
+      const p = tag.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    let location = null;
+    try {
+      const loc = tag.location();
+      if (loc) {
+        location = {
+          name: loc.locationName ? loc.locationName() : null,
+          latitude: loc.latitude(),
+          longitude: loc.longitude(),
+          radiusMeters: loc.radius ? loc.radius() : 0,
+          trigger: "both",
+        };
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = tag.status();
+    } catch (_e) {}
+    const status = rawStatus === "on hold" ? "on-hold" : rawStatus;
+
+    return {
+      id: tag.id(),
+      name: tag.name(),
+      parentId: parentId,
+      status: status,
+      location: location,
+      allowsNextAction: tag.allowsNextAction ? tag.allowsNextAction() : false,
+      taskCount: tag.tasks ? tag.tasks().length : 0,
+      createdAt: tag.creationDate ? tag.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: tag.modificationDate
+        ? tag.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allTags = ofApp.defaultDocument.flattenedTags();
+  const result = [];
+
+  for (let i = 0; i < allTags.length; i++) {
+    const tag = allTags[i];
+    const built = buildTag(tag);
+
+    if (args.parentId !== undefined && built.parentId !== args.parentId) continue;
+    if (args.status !== undefined && built.status !== args.status) continue;
+
+    result.push(built);
+  }
+
+  return JSON.stringify({ tags: result });
+}

--- a/src/scripts/jxa/tag_update.d.ts
+++ b/src/scripts/jxa/tag_update.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `tag_update.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/tag_update.js
+++ b/src/scripts/jxa/tag_update.js
@@ -1,0 +1,78 @@
+/**
+ * JXA: update mutable fields on an existing tag.
+ *
+ * Args (argv[0] JSON): { id: string, name?: string, status?: string, allowsNextAction?: boolean }
+ * Returns JSON: { tag: Tag }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/tag.ts — Tag domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildTag(tag) {
+    let parentId = null;
+    try {
+      const p = tag.parent();
+      if (p && p.class() !== "document") parentId = p.id();
+    } catch (_e) {}
+
+    let location = null;
+    try {
+      const loc = tag.location();
+      if (loc) {
+        location = {
+          name: loc.locationName ? loc.locationName() : null,
+          latitude: loc.latitude(),
+          longitude: loc.longitude(),
+          radiusMeters: loc.radius ? loc.radius() : 0,
+          trigger: "both",
+        };
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = tag.status();
+    } catch (_e) {}
+    const status = rawStatus === "on hold" ? "on-hold" : rawStatus;
+
+    return {
+      id: tag.id(),
+      name: tag.name(),
+      parentId: parentId,
+      status: status,
+      location: location,
+      allowsNextAction: tag.allowsNextAction ? tag.allowsNextAction() : false,
+      taskCount: tag.tasks ? tag.tasks().length : 0,
+      createdAt: tag.creationDate ? tag.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: tag.modificationDate
+        ? tag.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allTags = ofApp.defaultDocument.flattenedTags();
+  let target = null;
+  for (let i = 0; i < allTags.length; i++) {
+    if (allTags[i].id() === args.id) {
+      target = allTags[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Tag not found: ${args.id}`);
+
+  if (args.name !== undefined) target.name = args.name;
+  if (args.status !== undefined) {
+    // Normalize from domain format to JXA format
+    const jxaStatus = args.status === "on-hold" ? "on hold" : args.status;
+    target.status = jxaStatus;
+  }
+  if (args.allowsNextAction !== undefined) target.allowsNextAction = args.allowsNextAction;
+
+  return JSON.stringify({ tag: buildTag(target) });
+}


### PR DESCRIPTION
## Summary
- Adds 10 JXA scripts (`tag_list/get/create/update/delete`, `folder_list/get/create/update/delete`) with sibling `.d.ts` type shims
- Replaces `notYetWired()` stubs in `JxaTransport` for all tag and folder methods
- Tag status normalized: JXA `"on hold"` → domain `"on-hold"` on read, reversed on write
- Parent detection guards against document-root objects; location and date fields fall back gracefully
- Branded `TagId`/`FolderId` constructors applied to all IDs returned from script payloads
- Exempts `src/scripts/jxa/` from `no-generic-error` lint rule (JXA scripts cannot import typed errors)
- 28 unit tests with mocked spawner; integration tests in `JxaTransport.tags-folders.integration.test.ts` gated behind `OMNIFOCUS_INTEGRATION=1`

## Design link
Closes #146. Implements ADR-0005 (scripts as first-class files) for tag and folder domains.

## Breaking change?
- [x] No

## Test plan
- [x] 782 unit tests passing locally
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (including custom rules)
- [x] Self-reviewed
- [x] No new dependencies