### PR TITLE
feat(transport): wire JxaTransport project domain methods

### DIFF
--- a/src/adapter/jxa/JxaTransport.projects.integration.test.ts
+++ b/src/adapter/jxa/JxaTransport.projects.integration.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Integration tests for `JxaTransport` — project domain methods.
+ *
+ * These tests require a running OmniFocus instance and are gated behind the
+ * `OMNIFOCUS_INTEGRATION=1` environment variable. They exercise real JXA
+ * calls via `osascript` rather than a mocked spawner.
+ *
+ * Run with:
+ *   OMNIFOCUS_INTEGRATION=1 pnpm test:integration
+ *
+ * @see src/adapter/jxa/JxaTransport.projects.test.ts — unit tests (no OF required)
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ProjectId } from "../../domain/ids.js";
+import { JxaTransport } from "./JxaTransport.js";
+
+const INTEGRATION = process.env.OMNIFOCUS_INTEGRATION === "1";
+
+describe.skipIf(!INTEGRATION)("JxaTransport — project integration", () => {
+  const t = new JxaTransport();
+  let createdProjectId: ProjectId;
+
+  beforeAll(async () => {
+    createdProjectId = await t.createProject({ name: "__mcp_test_project__" });
+  });
+
+  afterAll(async () => {
+    if (createdProjectId) {
+      await t.deleteProject(createdProjectId).catch(() => {
+        /* already deleted */
+      });
+    }
+  });
+
+  it("createProject returns a valid ID", () => {
+    expect(typeof createdProjectId).toBe("string");
+    expect(createdProjectId.length).toBeGreaterThan(0);
+  });
+
+  it("getProject returns the created project", async () => {
+    const project = await t.getProject(createdProjectId);
+    expect(project.id).toBe(createdProjectId);
+    expect(project.name).toBe("__mcp_test_project__");
+    expect(project.status).toBe("active");
+  });
+
+  it("listProjects includes the created project", async () => {
+    const projects = await t.listProjects();
+    const found = projects.find((p) => p.id === createdProjectId);
+    expect(found).toBeDefined();
+    expect(found?.name).toBe("__mcp_test_project__");
+  });
+
+  it("updateProject renames the project", async () => {
+    await t.updateProject(createdProjectId, { name: "__mcp_test_project_renamed__" });
+    const project = await t.getProject(createdProjectId);
+    expect(project.name).toBe("__mcp_test_project_renamed__");
+  });
+
+  it("markProjectReviewed does not throw", async () => {
+    await expect(t.markProjectReviewed(createdProjectId)).resolves.toBeUndefined();
+  });
+
+  it("dropProject drops the project", async () => {
+    await t.dropProject(createdProjectId);
+    const project = await t.getProject(createdProjectId);
+    expect(project.status).toBe("dropped");
+  });
+
+  it("deleteProject removes the project", async () => {
+    await t.deleteProject(createdProjectId);
+    const projects = await t.listProjects();
+    const found = projects.find((p) => p.id === createdProjectId);
+    expect(found).toBeUndefined();
+  });
+});

--- a/src/adapter/jxa/JxaTransport.projects.test.ts
+++ b/src/adapter/jxa/JxaTransport.projects.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for `JxaTransport` — project domain methods.
+ *
+ * All tests use a fake spawner that returns pre-shaped JSON, so no `osascript`
+ * binary is required. Integration tests against a live OmniFocus instance are
+ * in JxaTransport.projects.integration.test.ts and gated behind
+ * `OMNIFOCUS_INTEGRATION=1`.
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — implementation
+ * @see src/scripts/jxa/project_*.js — underlying scripts
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { FolderId, ProjectId } from "../../domain/ids.js";
+import { ScriptError } from "../../errors/index.js";
+import { JxaTransport } from "./JxaTransport.js";
+import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function spawnerReturning(payload: unknown): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: JSON.stringify(payload),
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    }),
+  );
+}
+
+function spawnerFailing(stderr: string): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: "",
+      stderr,
+      exitCode: 1,
+      timedOut: false,
+    }),
+  );
+}
+
+const BASE_PROJECT = {
+  id: "proj_aaa",
+  name: "My Project",
+  note: null,
+  noteHtml: null,
+  folderId: null,
+  tagIds: [],
+  status: "active",
+  flagged: false,
+  deferDate: null,
+  dueDate: null,
+  completionDate: null,
+  estimatedMinutes: null,
+  numberOfTasks: 0,
+  numberOfAvailableTasks: 0,
+  numberOfCompletedTasks: 0,
+  reviewIntervalDays: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  modifiedAt: "2026-01-02T00:00:00.000Z",
+};
+
+// ---------------------------------------------------------------------------
+// listProjects
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — listProjects", () => {
+  it("returns parsed projects with branded IDs", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ projects: [BASE_PROJECT] }) });
+    const projects = await t.listProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.id).toBe("proj_aaa");
+    expect(projects[0]?.name).toBe("My Project");
+    expect(projects[0]?.status).toBe("active");
+  });
+
+  it("passes folderId and status filters to the script", async () => {
+    const spawner = spawnerReturning({ projects: [] });
+    const t = new JxaTransport({ spawner });
+    await t.listProjects({ folderId: "folder_xxx" as FolderId, status: "on-hold" });
+    const call = (spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string];
+    const arg = JSON.parse(call[1] as string) as { folderId: string; status: string };
+    expect(arg.folderId).toBe("folder_xxx");
+    expect(arg.status).toBe("on-hold");
+  });
+
+  it("returns empty array when no projects", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ projects: [] }) });
+    expect(await t.listProjects()).toEqual([]);
+  });
+
+  it("surfaces ScriptError on script failure", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("OmniFocus got an error") });
+    await expect(t.listProjects()).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProject
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — getProject", () => {
+  it("returns a single project", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ project: BASE_PROJECT }) });
+    const project = await t.getProject("proj_aaa" as ProjectId);
+    expect(project.id).toBe("proj_aaa");
+    expect(project.name).toBe("My Project");
+    expect(project.flagged).toBe(false);
+  });
+
+  it("passes the id to the script", async () => {
+    const spawner = spawnerReturning({ project: BASE_PROJECT });
+    const t = new JxaTransport({ spawner });
+    await t.getProject("proj_aaa" as ProjectId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string };
+    expect(arg.id).toBe("proj_aaa");
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("project not found") });
+    await expect(t.getProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createProject
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — createProject", () => {
+  it("returns the new project's branded ID", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ project: BASE_PROJECT }) });
+    const id = await t.createProject({ name: "My Project" });
+    expect(id).toBe("proj_aaa");
+  });
+
+  it("passes name and null folderId when none supplied", async () => {
+    const spawner = spawnerReturning({ project: BASE_PROJECT });
+    const t = new JxaTransport({ spawner });
+    await t.createProject({ name: "My Project" });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { name: string; folderId: null };
+    expect(arg.name).toBe("My Project");
+    expect(arg.folderId).toBeNull();
+  });
+
+  it("passes folderId when supplied", async () => {
+    const spawner = spawnerReturning({ project: BASE_PROJECT });
+    const t = new JxaTransport({ spawner });
+    await t.createProject({ name: "My Project", folderId: "folder_yyy" as FolderId });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { folderId: string };
+    expect(arg.folderId).toBe("folder_yyy");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateProject
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — updateProject", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({
+      spawner: spawnerReturning({ project: { ...BASE_PROJECT, name: "Updated" } }),
+    });
+    await expect(
+      t.updateProject("proj_aaa" as ProjectId, { name: "Updated" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes only supplied patch fields to the script", async () => {
+    const spawner = spawnerReturning({ project: BASE_PROJECT });
+    const t = new JxaTransport({ spawner });
+    await t.updateProject("proj_aaa" as ProjectId, { flagged: true });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string; flagged: boolean; name?: string };
+    expect(arg.id).toBe("proj_aaa");
+    expect(arg.flagged).toBe(true);
+    expect(arg.name).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeProject
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — completeProject", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "proj_aaa" }) });
+    await expect(t.completeProject("proj_aaa" as ProjectId)).resolves.toBeUndefined();
+  });
+
+  it("passes id and null completionDate when none supplied", async () => {
+    const spawner = spawnerReturning({ id: "proj_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.completeProject("proj_aaa" as ProjectId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string; completionDate: string | null };
+    expect(arg.id).toBe("proj_aaa");
+    expect(arg.completionDate).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dropProject
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — dropProject", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "proj_aaa" }) });
+    await expect(t.dropProject("proj_aaa" as ProjectId)).resolves.toBeUndefined();
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("project not found") });
+    await expect(t.dropProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moveProject
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — moveProject", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "proj_aaa" }) });
+    await expect(
+      t.moveProject("proj_aaa" as ProjectId, { folderId: "folder_zzz" as FolderId }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes id and folderId to the script", async () => {
+    const spawner = spawnerReturning({ id: "proj_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.moveProject("proj_aaa" as ProjectId, { folderId: "folder_zzz" as FolderId });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string; folderId: string };
+    expect(arg.id).toBe("proj_aaa");
+    expect(arg.folderId).toBe("folder_zzz");
+  });
+
+  it("passes null folderId when moving to top level", async () => {
+    const spawner = spawnerReturning({ id: "proj_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.moveProject("proj_aaa" as ProjectId, { folderId: null });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { folderId: null };
+    expect(arg.folderId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteProject
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — deleteProject", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "proj_aaa" }) });
+    await expect(t.deleteProject("proj_aaa" as ProjectId)).resolves.toBeUndefined();
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("project not found") });
+    await expect(t.deleteProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markProjectReviewed
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — markProjectReviewed", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "proj_aaa" }) });
+    await expect(t.markProjectReviewed("proj_aaa" as ProjectId)).resolves.toBeUndefined();
+  });
+
+  it("passes id to the script", async () => {
+    const spawner = spawnerReturning({ id: "proj_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.markProjectReviewed("proj_aaa" as ProjectId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string };
+    expect(arg.id).toBe("proj_aaa");
+  });
+});

--- a/src/adapter/jxa/JxaTransport.tags-folders.test.ts
+++ b/src/adapter/jxa/JxaTransport.tags-folders.test.ts
@@ -82,7 +82,7 @@ describe("JxaTransport — listTags", () => {
     const spawner = spawnerReturning({ tags: [] });
     const t = new JxaTransport({ spawner });
     await t.listTags({ parentId: "tag_parent" as TagId, status: "on-hold" });
-    const call = (spawner as ReturnType<typeof vi.fn>).mock.calls[0];
+    const call = (spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string];
     const arg = JSON.parse(call[1] as string) as { parentId: string; status: string };
     expect(arg.parentId).toBe("tag_parent");
     expect(arg.status).toBe("on-hold");
@@ -117,7 +117,7 @@ describe("JxaTransport — getTag", () => {
     const t = new JxaTransport({ spawner });
     await t.getTag("tag_aaa" as TagId);
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { id: string };
     expect(arg.id).toBe("tag_aaa");
   });
@@ -144,7 +144,7 @@ describe("JxaTransport — createTag", () => {
     const t = new JxaTransport({ spawner });
     await t.createTag({ name: "Work", parentId: "tag_parent" as TagId });
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { name: string; parentId: string };
     expect(arg.name).toBe("Work");
     expect(arg.parentId).toBe("tag_parent");
@@ -155,7 +155,7 @@ describe("JxaTransport — createTag", () => {
     const t = new JxaTransport({ spawner });
     await t.createTag({ name: "Work" });
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { parentId: null };
     expect(arg.parentId).toBeNull();
   });
@@ -178,7 +178,7 @@ describe("JxaTransport — updateTag", () => {
     const t = new JxaTransport({ spawner });
     await t.updateTag("tag_aaa" as TagId, { status: "on-hold" });
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { id: string; status: string; name?: string };
     expect(arg.id).toBe("tag_aaa");
     expect(arg.status).toBe("on-hold");
@@ -201,7 +201,7 @@ describe("JxaTransport — deleteTag", () => {
     const t = new JxaTransport({ spawner });
     await t.deleteTag("tag_aaa" as TagId);
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { id: string };
     expect(arg.id).toBe("tag_aaa");
   });
@@ -231,7 +231,7 @@ describe("JxaTransport — listFolders", () => {
     const t = new JxaTransport({ spawner });
     await t.listFolders({ parentId: "folder_parent" as FolderId });
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { parentId: string };
     expect(arg.parentId).toBe("folder_parent");
   });
@@ -259,7 +259,7 @@ describe("JxaTransport — getFolder", () => {
     const t = new JxaTransport({ spawner });
     await t.getFolder("folder_bbb" as FolderId);
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { id: string };
     expect(arg.id).toBe("folder_bbb");
   });
@@ -281,7 +281,7 @@ describe("JxaTransport — createFolder", () => {
     const t = new JxaTransport({ spawner });
     await t.createFolder({ name: "Personal" });
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { name: string; parentId: null };
     expect(arg.name).toBe("Personal");
     expect(arg.parentId).toBeNull();
@@ -307,7 +307,7 @@ describe("JxaTransport — updateFolder", () => {
     const t = new JxaTransport({ spawner });
     await t.updateFolder("folder_bbb" as FolderId, { name: "Renamed" });
     const arg = JSON.parse(
-      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as string[])[1],
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
     ) as { id: string; name: string };
     expect(arg.id).toBe("folder_bbb");
     expect(arg.name).toBe("Renamed");
@@ -341,12 +341,6 @@ describe("JxaTransport — not-yet-wired stubs still throw after tag/folder wiri
 
   it("listTasks throws not-yet-wired", async () => {
     const err = await t.listTasks({}).catch((e) => e);
-    expect(err).toBeInstanceOf(ScriptError);
-    expect((err as ScriptError).details).toMatchObject({ reason: "not-yet-wired" });
-  });
-
-  it("listProjects throws not-yet-wired", async () => {
-    const err = await t.listProjects().catch((e) => e);
     expect(err).toBeInstanceOf(ScriptError);
     expect((err as ScriptError).details).toMatchObject({ reason: "not-yet-wired" });
   });

--- a/src/adapter/jxa/JxaTransport.test.ts
+++ b/src/adapter/jxa/JxaTransport.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import type { ProjectId, TaskId } from "../../domain/ids.js";
+import type { TaskId } from "../../domain/ids.js";
 import { ScriptError } from "../../errors/index.js";
 import { JxaTransport } from "./JxaTransport.js";
 import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
@@ -79,12 +79,11 @@ describe("JxaTransport — not-yet-wired stubs", () => {
   // Note: listTags, getTag, createTag, updateTag, deleteTag, listFolders,
   // getFolder, createFolder, updateFolder, deleteFolder are now wired and
   // tested in JxaTransport.tags-folders.test.ts.
+  // listProjects, getProject etc are wired and tested in JxaTransport.projects.test.ts.
   const cases: Array<readonly [string, () => Promise<unknown>]> = [
     ["listTasks", () => t.listTasks({})],
     ["getTask", () => t.getTask("task_000001" as TaskId)],
     ["createTask", () => t.createTask({ name: "x" })],
-    ["listProjects", () => t.listProjects()],
-    ["getProject", () => t.getProject("proj_000001" as ProjectId)],
   ];
 
   for (const [method, call] of cases) {

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -27,6 +27,7 @@ import {
   type FolderId,
   FolderId as FolderIdCtor,
   type ProjectId,
+  ProjectId as ProjectIdCtor,
   type TagId,
   TagId as TagIdCtor,
   type TaskId,
@@ -40,6 +41,15 @@ import folderDeleteScript from "../../scripts/jxa/folder_delete.js";
 import folderGetScript from "../../scripts/jxa/folder_get.js";
 import folderListScript from "../../scripts/jxa/folder_list.js";
 import folderUpdateScript from "../../scripts/jxa/folder_update.js";
+import projectCompleteScript from "../../scripts/jxa/project_complete.js";
+import projectCreateScript from "../../scripts/jxa/project_create.js";
+import projectDeleteScript from "../../scripts/jxa/project_delete.js";
+import projectDropScript from "../../scripts/jxa/project_drop.js";
+import projectGetScript from "../../scripts/jxa/project_get.js";
+import projectListScript from "../../scripts/jxa/project_list.js";
+import projectMarkReviewedScript from "../../scripts/jxa/project_mark_reviewed.js";
+import projectMoveScript from "../../scripts/jxa/project_move.js";
+import projectUpdateScript from "../../scripts/jxa/project_update.js";
 import syncTriggerScript from "../../scripts/jxa/sync_trigger.js";
 import tagCreateScript from "../../scripts/jxa/tag_create.js";
 import tagDeleteScript from "../../scripts/jxa/tag_delete.js";
@@ -141,36 +151,103 @@ export class JxaTransport implements OmniFocusAdapter {
     return notYetWired("moveTask");
   }
 
-  // -- Projects -------------------------------------------------------------
+  // -- Projects (wired) -----------------------------------------------------
 
-  async listProjects(_filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<
+  async listProjects(filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<
     Project[]
   > {
-    return notYetWired("listProjects");
+    const result = await runJxaScript<{ projects: Project[] }>(
+      projectListScript,
+      { folderId: filter?.folderId ?? null, status: filter?.status ?? null },
+      { ...this.runOpts, scriptName: "project_list" },
+    );
+    return result.projects.map((p) => ({ ...p, id: ProjectIdCtor.of(p.id) }));
   }
-  async getProject(_id: ProjectId): Promise<Project> {
-    return notYetWired("getProject");
+
+  async getProject(id: ProjectId): Promise<Project> {
+    const result = await runJxaScript<{ project: Project }>(
+      projectGetScript,
+      { id },
+      { ...this.runOpts, scriptName: "project_get" },
+    );
+    return { ...result.project, id: ProjectIdCtor.of(result.project.id) };
   }
-  async createProject(_input: CreateProjectInput): Promise<ProjectId> {
-    return notYetWired("createProject");
+
+  async createProject(input: CreateProjectInput): Promise<ProjectId> {
+    const result = await runJxaScript<{ project: Project }>(
+      projectCreateScript,
+      {
+        name: input.name,
+        folderId: input.folderId ?? null,
+        note: input.note ?? null,
+        deferDate: input.deferDate ?? null,
+        dueDate: input.dueDate ?? null,
+        estimatedMinutes: input.estimatedMinutes ?? null,
+        flagged: input.flagged ?? false,
+        status: input.status ?? null,
+      },
+      { ...this.runOpts, scriptName: "project_create" },
+    );
+    return ProjectIdCtor.of(result.project.id);
   }
-  async updateProject(_id: ProjectId, _patch: UpdateProjectInput): Promise<void> {
-    return notYetWired("updateProject");
+
+  async updateProject(id: ProjectId, patch: UpdateProjectInput): Promise<void> {
+    await runJxaScript<{ project: Project }>(
+      projectUpdateScript,
+      {
+        id,
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
+        ...(patch.note !== undefined ? { note: patch.note } : {}),
+        ...(patch.flagged !== undefined ? { flagged: patch.flagged } : {}),
+        ...(patch.estimatedMinutes !== undefined
+          ? { estimatedMinutes: patch.estimatedMinutes }
+          : {}),
+        ...(patch.deferDate !== undefined ? { deferDate: patch.deferDate } : {}),
+        ...(patch.dueDate !== undefined ? { dueDate: patch.dueDate } : {}),
+        ...(patch.status !== undefined ? { status: patch.status } : {}),
+      },
+      { ...this.runOpts, scriptName: "project_update" },
+    );
   }
-  async completeProject(_id: ProjectId, _at?: Date): Promise<void> {
-    return notYetWired("completeProject");
+
+  async completeProject(id: ProjectId, at?: Date): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      projectCompleteScript,
+      { id, completionDate: at?.toISOString() ?? null },
+      { ...this.runOpts, scriptName: "project_complete" },
+    );
   }
-  async dropProject(_id: ProjectId, _at?: Date): Promise<void> {
-    return notYetWired("dropProject");
+
+  async dropProject(id: ProjectId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      projectDropScript,
+      { id },
+      { ...this.runOpts, scriptName: "project_drop" },
+    );
   }
-  async moveProject(_id: ProjectId, _destination: { folderId: FolderId | null }): Promise<void> {
-    return notYetWired("moveProject");
+
+  async moveProject(id: ProjectId, destination: { folderId: FolderId | null }): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      projectMoveScript,
+      { id, folderId: destination.folderId ?? null },
+      { ...this.runOpts, scriptName: "project_move" },
+    );
   }
-  async deleteProject(_id: ProjectId): Promise<void> {
-    return notYetWired("deleteProject");
+
+  async deleteProject(id: ProjectId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      projectDeleteScript,
+      { id },
+      { ...this.runOpts, scriptName: "project_delete" },
+    );
   }
-  async markProjectReviewed(_id: ProjectId): Promise<void> {
-    return notYetWired("markProjectReviewed");
+
+  async markProjectReviewed(id: ProjectId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      projectMarkReviewedScript,
+      { id },
+      { ...this.runOpts, scriptName: "project_mark_reviewed" },
+    );
   }
 
   // -- Tags (wired) ---------------------------------------------------------

--- a/src/scripts/jxa/project_complete.d.ts
+++ b/src/scripts/jxa/project_complete.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_complete.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_complete.js
+++ b/src/scripts/jxa/project_complete.js
@@ -1,0 +1,36 @@
+/**
+ * JXA: mark a project complete.
+ *
+ * Args (argv[0] JSON): { id: string, completionDate?: string|null }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allProjects = ofApp.defaultDocument.flattenedProjects();
+  let target = null;
+  for (let i = 0; i < allProjects.length; i++) {
+    if (allProjects[i].id() === args.id) {
+      target = allProjects[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Project not found: ${args.id}`);
+
+  ofApp.markComplete(target);
+
+  if (args.completionDate != null) {
+    try {
+      target.completionDate = new Date(args.completionDate);
+    } catch (_e) {}
+  }
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/project_create.d.ts
+++ b/src/scripts/jxa/project_create.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_create.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_create.js
+++ b/src/scripts/jxa/project_create.js
@@ -1,0 +1,168 @@
+/**
+ * JXA: create a new project.
+ *
+ * Args (argv[0] JSON): { name: string, folderId?: string|null, note?: string|null,
+ *   deferDate?: string|null, dueDate?: string|null, estimatedMinutes?: number|null,
+ *   flagged?: boolean, status?: string|null, tagIds?: string[] }
+ * Returns JSON: { project: Project }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function normalizeStatus(raw) {
+    if (raw === "on hold") return "on-hold";
+    if (raw === "done") return "completed";
+    return raw;
+  }
+
+  function buildProject(proj) {
+    let folderId = null;
+    try {
+      const f = proj.folder();
+      if (f && f.class() !== "document") folderId = f.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = proj.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = proj.status();
+    } catch (_e) {}
+    const status = normalizeStatus(rawStatus);
+
+    let deferDate = null;
+    try {
+      const dd = proj.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = proj.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = proj.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = proj.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = proj.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (proj.noteHtml) noteHtml = proj.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = proj.flagged();
+    } catch (_e) {}
+
+    let reviewIntervalDays = null;
+    try {
+      const ri = proj.reviewInterval();
+      if (ri?.steps) reviewIntervalDays = ri.steps();
+    } catch (_e) {}
+
+    let nextReviewDate = null;
+    try {
+      const nrd = proj.nextReviewDate();
+      if (nrd) nextReviewDate = nrd.toISOString();
+    } catch (_e) {}
+
+    let lastReviewDate = null;
+    try {
+      const lrd = proj.lastReviewDate ? proj.lastReviewDate() : null;
+      if (lrd) lastReviewDate = lrd.toISOString();
+    } catch (_e) {}
+
+    let taskCount = 0;
+    try {
+      taskCount = proj.numberOfTasks();
+    } catch (_e) {}
+
+    let completedTaskCount = 0;
+    try {
+      completedTaskCount = proj.numberOfCompletedTasks();
+    } catch (_e) {}
+
+    let completionCriterion = "parallel";
+    try {
+      const cc = proj.completionCriterion ? proj.completionCriterion() : "parallel";
+      completionCriterion = cc;
+    } catch (_e) {}
+
+    return {
+      id: proj.id(),
+      name: proj.name(),
+      note: note,
+      noteHtml: noteHtml,
+      folderId: folderId,
+      tagIds: tagIds,
+      status: status,
+      completionCriterion: completionCriterion,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      reviewIntervalDays: reviewIntervalDays,
+      nextReviewDate: nextReviewDate,
+      lastReviewDate: lastReviewDate,
+      completed: status === "completed",
+      completedAt: completedAt,
+      dropped: status === "dropped",
+      droppedAt: status === "dropped" ? completedAt : null,
+      taskCount: taskCount,
+      completedTaskCount: completedTaskCount,
+      createdAt: proj.creationDate ? proj.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: proj.modificationDate
+        ? proj.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const props = { name: args.name };
+  if (args.note != null) props.note = args.note;
+  if (args.deferDate != null) props.deferDate = new Date(args.deferDate);
+  if (args.dueDate != null) props.dueDate = new Date(args.dueDate);
+  if (args.estimatedMinutes != null) props.estimatedMinutes = args.estimatedMinutes;
+  if (args.flagged != null) props.flagged = args.flagged;
+  if (args.status != null) {
+    props.status = args.status === "on-hold" ? "on hold" : args.status;
+  }
+
+  let newProj;
+  if (args.folderId) {
+    const folder = ofApp.defaultDocument.folders.byId(args.folderId);
+    if (!folder) throw new Error(`Folder not found: ${args.folderId}`);
+    newProj = ofApp.make({ new: "project", at: folder.projects.end, withProperties: props });
+  } else {
+    newProj = ofApp.defaultDocument.make({ new: "project", withProperties: props });
+  }
+
+  return JSON.stringify({ project: buildProject(newProj) });
+}

--- a/src/scripts/jxa/project_delete.d.ts
+++ b/src/scripts/jxa/project_delete.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_delete.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_delete.js
+++ b/src/scripts/jxa/project_delete.js
@@ -1,0 +1,30 @@
+/**
+ * JXA: delete a project by ID.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allProjects = ofApp.defaultDocument.flattenedProjects();
+  let target = null;
+  for (let i = 0; i < allProjects.length; i++) {
+    if (allProjects[i].id() === args.id) {
+      target = allProjects[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Project not found: ${args.id}`);
+
+  ofApp.delete(target);
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/project_drop.d.ts
+++ b/src/scripts/jxa/project_drop.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_drop.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_drop.js
+++ b/src/scripts/jxa/project_drop.js
@@ -1,0 +1,30 @@
+/**
+ * JXA: mark a project dropped.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allProjects = ofApp.defaultDocument.flattenedProjects();
+  let target = null;
+  for (let i = 0; i < allProjects.length; i++) {
+    if (allProjects[i].id() === args.id) {
+      target = allProjects[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Project not found: ${args.id}`);
+
+  target.status = "dropped";
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/project_get.d.ts
+++ b/src/scripts/jxa/project_get.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_get.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_get.js
+++ b/src/scripts/jxa/project_get.js
@@ -1,0 +1,154 @@
+/**
+ * JXA: fetch one project by ID.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { project: Project }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function normalizeStatus(raw) {
+    if (raw === "on hold") return "on-hold";
+    if (raw === "done") return "completed";
+    return raw;
+  }
+
+  function buildProject(proj) {
+    let folderId = null;
+    try {
+      const f = proj.folder();
+      if (f && f.class() !== "document") folderId = f.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = proj.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = proj.status();
+    } catch (_e) {}
+    const status = normalizeStatus(rawStatus);
+
+    let deferDate = null;
+    try {
+      const dd = proj.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = proj.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = proj.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = proj.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = proj.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (proj.noteHtml) noteHtml = proj.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = proj.flagged();
+    } catch (_e) {}
+
+    let reviewIntervalDays = null;
+    try {
+      const ri = proj.reviewInterval();
+      if (ri?.steps) reviewIntervalDays = ri.steps();
+    } catch (_e) {}
+
+    let nextReviewDate = null;
+    try {
+      const nrd = proj.nextReviewDate();
+      if (nrd) nextReviewDate = nrd.toISOString();
+    } catch (_e) {}
+
+    let lastReviewDate = null;
+    try {
+      const lrd = proj.lastReviewDate ? proj.lastReviewDate() : null;
+      if (lrd) lastReviewDate = lrd.toISOString();
+    } catch (_e) {}
+
+    let taskCount = 0;
+    try {
+      taskCount = proj.numberOfTasks();
+    } catch (_e) {}
+
+    let completedTaskCount = 0;
+    try {
+      completedTaskCount = proj.numberOfCompletedTasks();
+    } catch (_e) {}
+
+    let completionCriterion = "parallel";
+    try {
+      const cc = proj.completionCriterion ? proj.completionCriterion() : "parallel";
+      completionCriterion = cc;
+    } catch (_e) {}
+
+    return {
+      id: proj.id(),
+      name: proj.name(),
+      note: note,
+      noteHtml: noteHtml,
+      folderId: folderId,
+      tagIds: tagIds,
+      status: status,
+      completionCriterion: completionCriterion,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      reviewIntervalDays: reviewIntervalDays,
+      nextReviewDate: nextReviewDate,
+      lastReviewDate: lastReviewDate,
+      completed: status === "completed",
+      completedAt: completedAt,
+      dropped: status === "dropped",
+      droppedAt: status === "dropped" ? completedAt : null,
+      taskCount: taskCount,
+      completedTaskCount: completedTaskCount,
+      createdAt: proj.creationDate ? proj.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: proj.modificationDate
+        ? proj.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allProjects = ofApp.defaultDocument.flattenedProjects();
+  for (let i = 0; i < allProjects.length; i++) {
+    if (allProjects[i].id() === args.id) {
+      return JSON.stringify({ project: buildProject(allProjects[i]) });
+    }
+  }
+
+  throw new Error(`Project not found: ${args.id}`);
+}

--- a/src/scripts/jxa/project_list.d.ts
+++ b/src/scripts/jxa/project_list.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_list.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_list.js
+++ b/src/scripts/jxa/project_list.js
@@ -1,0 +1,166 @@
+/**
+ * JXA: list projects, optionally filtered by folderId or status.
+ *
+ * Args (argv[0] JSON): { folderId?: string|null, status?: string|null }
+ * Returns JSON: { projects: Project[] }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function normalizeStatus(raw) {
+    if (raw === "on hold") return "on-hold";
+    if (raw === "done") return "completed";
+    return raw; // "active", "dropped"
+  }
+
+  function buildProject(proj) {
+    let folderId = null;
+    try {
+      const f = proj.folder();
+      if (f && f.class() !== "document") folderId = f.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = proj.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = proj.status();
+    } catch (_e) {}
+    const status = normalizeStatus(rawStatus);
+
+    let deferDate = null;
+    try {
+      const dd = proj.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = proj.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = proj.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = proj.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = proj.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (proj.noteHtml) noteHtml = proj.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = proj.flagged();
+    } catch (_e) {}
+
+    let reviewIntervalDays = null;
+    try {
+      const ri = proj.reviewInterval();
+      if (ri?.steps) reviewIntervalDays = ri.steps();
+    } catch (_e) {}
+
+    let nextReviewDate = null;
+    try {
+      const nrd = proj.nextReviewDate();
+      if (nrd) nextReviewDate = nrd.toISOString();
+    } catch (_e) {}
+
+    let lastReviewDate = null;
+    try {
+      const lrd = proj.lastReviewDate ? proj.lastReviewDate() : null;
+      if (lrd) lastReviewDate = lrd.toISOString();
+    } catch (_e) {}
+
+    let taskCount = 0;
+    try {
+      taskCount = proj.numberOfTasks();
+    } catch (_e) {}
+
+    let completedTaskCount = 0;
+    try {
+      completedTaskCount = proj.numberOfCompletedTasks();
+    } catch (_e) {}
+
+    let completionCriterion = "parallel";
+    try {
+      const cc = proj.completionCriterion ? proj.completionCriterion() : "parallel";
+      completionCriterion = cc;
+    } catch (_e) {}
+
+    return {
+      id: proj.id(),
+      name: proj.name(),
+      note: note,
+      noteHtml: noteHtml,
+      folderId: folderId,
+      tagIds: tagIds,
+      status: status,
+      completionCriterion: completionCriterion,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      reviewIntervalDays: reviewIntervalDays,
+      nextReviewDate: nextReviewDate,
+      lastReviewDate: lastReviewDate,
+      completed: status === "completed",
+      completedAt: completedAt,
+      dropped: status === "dropped",
+      droppedAt: status === "dropped" ? completedAt : null,
+      taskCount: taskCount,
+      completedTaskCount: completedTaskCount,
+      createdAt: proj.creationDate ? proj.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: proj.modificationDate
+        ? proj.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  let projects;
+  if (args.folderId) {
+    try {
+      const folder = ofApp.defaultDocument.folders.byId(args.folderId);
+      projects = folder.projects();
+    } catch (_e) {
+      throw new Error(`Folder not found: ${args.folderId}`);
+    }
+  } else {
+    projects = ofApp.defaultDocument.flattenedProjects();
+  }
+
+  const result = [];
+  for (let i = 0; i < projects.length; i++) {
+    const built = buildProject(projects[i]);
+    if (args.status !== null && args.status !== undefined && built.status !== args.status) continue;
+    result.push(built);
+  }
+
+  return JSON.stringify({ projects: result });
+}

--- a/src/scripts/jxa/project_mark_reviewed.d.ts
+++ b/src/scripts/jxa/project_mark_reviewed.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_mark_reviewed.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_mark_reviewed.js
+++ b/src/scripts/jxa/project_mark_reviewed.js
@@ -1,0 +1,31 @@
+/**
+ * JXA: mark a project as reviewed (sets lastReviewDate to now).
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allProjects = ofApp.defaultDocument.flattenedProjects();
+  let target = null;
+  for (let i = 0; i < allProjects.length; i++) {
+    if (allProjects[i].id() === args.id) {
+      target = allProjects[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Project not found: ${args.id}`);
+
+  // Mark the project reviewed — sets lastReviewDate and advances nextReviewDate
+  ofApp.markReviewed(target);
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/project_move.d.ts
+++ b/src/scripts/jxa/project_move.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_move.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_move.js
+++ b/src/scripts/jxa/project_move.js
@@ -1,0 +1,36 @@
+/**
+ * JXA: move a project to a folder (or to the root if folderId is null).
+ *
+ * Args (argv[0] JSON): { id: string, folderId?: string|null }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allProjects = ofApp.defaultDocument.flattenedProjects();
+  let target = null;
+  for (let i = 0; i < allProjects.length; i++) {
+    if (allProjects[i].id() === args.id) {
+      target = allProjects[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Project not found: ${args.id}`);
+
+  if (args.folderId) {
+    const folder = ofApp.defaultDocument.folders.byId(args.folderId);
+    if (!folder) throw new Error(`Folder not found: ${args.folderId}`);
+    target.move({ to: folder.projects.end });
+  } else {
+    target.move({ to: ofApp.defaultDocument.projects.end });
+  }
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/project_update.d.ts
+++ b/src/scripts/jxa/project_update.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_update.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/project_update.js
+++ b/src/scripts/jxa/project_update.js
@@ -1,0 +1,180 @@
+/**
+ * JXA: update mutable fields on an existing project.
+ *
+ * Args (argv[0] JSON): { id: string, name?: string, note?: string|null,
+ *   noteHtml?: string|null, status?: string, folderId?: string|null,
+ *   deferDate?: string|null, dueDate?: string|null, flagged?: boolean,
+ *   estimatedMinutes?: number|null }
+ * Returns JSON: { project: Project }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function normalizeStatus(raw) {
+    if (raw === "on hold") return "on-hold";
+    if (raw === "done") return "completed";
+    return raw;
+  }
+
+  function buildProject(proj) {
+    let folderId = null;
+    try {
+      const f = proj.folder();
+      if (f && f.class() !== "document") folderId = f.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = proj.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let rawStatus = "active";
+    try {
+      rawStatus = proj.status();
+    } catch (_e) {}
+    const status = normalizeStatus(rawStatus);
+
+    let deferDate = null;
+    try {
+      const dd = proj.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = proj.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = proj.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = proj.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = proj.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (proj.noteHtml) noteHtml = proj.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = proj.flagged();
+    } catch (_e) {}
+
+    let reviewIntervalDays = null;
+    try {
+      const ri = proj.reviewInterval();
+      if (ri?.steps) reviewIntervalDays = ri.steps();
+    } catch (_e) {}
+
+    let nextReviewDate = null;
+    try {
+      const nrd = proj.nextReviewDate();
+      if (nrd) nextReviewDate = nrd.toISOString();
+    } catch (_e) {}
+
+    let lastReviewDate = null;
+    try {
+      const lrd = proj.lastReviewDate ? proj.lastReviewDate() : null;
+      if (lrd) lastReviewDate = lrd.toISOString();
+    } catch (_e) {}
+
+    let taskCount = 0;
+    try {
+      taskCount = proj.numberOfTasks();
+    } catch (_e) {}
+
+    let completedTaskCount = 0;
+    try {
+      completedTaskCount = proj.numberOfCompletedTasks();
+    } catch (_e) {}
+
+    let completionCriterion = "parallel";
+    try {
+      const cc = proj.completionCriterion ? proj.completionCriterion() : "parallel";
+      completionCriterion = cc;
+    } catch (_e) {}
+
+    return {
+      id: proj.id(),
+      name: proj.name(),
+      note: note,
+      noteHtml: noteHtml,
+      folderId: folderId,
+      tagIds: tagIds,
+      status: status,
+      completionCriterion: completionCriterion,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      reviewIntervalDays: reviewIntervalDays,
+      nextReviewDate: nextReviewDate,
+      lastReviewDate: lastReviewDate,
+      completed: status === "completed",
+      completedAt: completedAt,
+      dropped: status === "dropped",
+      droppedAt: status === "dropped" ? completedAt : null,
+      taskCount: taskCount,
+      completedTaskCount: completedTaskCount,
+      createdAt: proj.creationDate ? proj.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: proj.modificationDate
+        ? proj.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allProjects = ofApp.defaultDocument.flattenedProjects();
+  let target = null;
+  for (let i = 0; i < allProjects.length; i++) {
+    if (allProjects[i].id() === args.id) {
+      target = allProjects[i];
+      break;
+    }
+  }
+  if (!target) throw new Error(`Project not found: ${args.id}`);
+
+  if (args.name !== undefined) target.name = args.name;
+  if (args.note !== undefined) target.note = args.note ?? "";
+  if (args.flagged !== undefined) target.flagged = args.flagged;
+  if (args.estimatedMinutes !== undefined) target.estimatedMinutes = args.estimatedMinutes ?? 0;
+  if (args.deferDate !== undefined)
+    target.deferDate = args.deferDate ? new Date(args.deferDate) : null;
+  if (args.dueDate !== undefined) target.dueDate = args.dueDate ? new Date(args.dueDate) : null;
+  if (args.status !== undefined) {
+    const jxaStatus = args.status === "on-hold" ? "on hold" : args.status;
+    target.status = jxaStatus;
+  }
+  if (args.folderId !== undefined) {
+    if (args.folderId) {
+      const folder = ofApp.defaultDocument.folders.byId(args.folderId);
+      target.move({ to: folder.projects.end });
+    } else {
+      target.move({ to: ofApp.defaultDocument.projects.end });
+    }
+  }
+
+  return JSON.stringify({ project: buildProject(target) });
+}


### PR DESCRIPTION
## Summary
- Adds 9 JXA scripts (`project_list/get/create/update/complete/drop/move/delete/mark_reviewed`) under `src/scripts/jxa/` with sibling `.d.ts` shims
- Replaces `notYetWired()` stubs in `JxaTransport` for all project methods with `runJxaScript<>()` calls
- Branded ID wrapping via `ProjectIdCtor.of()` on all returned project IDs
- 23 unit tests with mocked spawner + integration tests gated behind `OMNIFOCUS_INTEGRATION=1`
- Fixes pre-existing typecheck violations in `JxaTransport.tags-folders.test.ts` (tuple casts instead of `!` non-null assertions)

## Design link
Closes #145. Follows ADR-0002 (JXA transport), ADR-0005 (scripts as first-class files), ADR-0008 (branded IDs). Same wiring pattern as #185 (tag/folder methods).

## Breaking change?
- [x] No

## Test plan
- [x] 802 unit tests passing, 18 skipped (integration gated)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (Biome + custom rules)
- [x] Self-reviewed via /review-pr
- [x] No new dependencies