### PR TITLE
feat(transport): wire JxaTransport task domain methods

### DIFF
--- a/src/adapter/jxa/JxaTransport.tags-folders.test.ts
+++ b/src/adapter/jxa/JxaTransport.tags-folders.test.ts
@@ -336,12 +336,4 @@ describe("JxaTransport — deleteFolder", () => {
 // not-yet-wired stubs still throw (regression guard)
 // ---------------------------------------------------------------------------
 
-describe("JxaTransport — not-yet-wired stubs still throw after tag/folder wiring", () => {
-  const t = new JxaTransport({ spawner: spawnerReturning({}) });
-
-  it("listTasks throws not-yet-wired", async () => {
-    const err = await t.listTasks({}).catch((e) => e);
-    expect(err).toBeInstanceOf(ScriptError);
-    expect((err as ScriptError).details).toMatchObject({ reason: "not-yet-wired" });
-  });
-});
+// All task, project, tag, and folder methods are now wired — no not-yet-wired stubs remain.

--- a/src/adapter/jxa/JxaTransport.tasks.integration.test.ts
+++ b/src/adapter/jxa/JxaTransport.tasks.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration tests for `JxaTransport` — task domain methods.
+ *
+ * These tests require a running OmniFocus instance and are gated behind the
+ * `OMNIFOCUS_INTEGRATION=1` environment variable. They exercise real JXA
+ * calls via `osascript` rather than a mocked spawner.
+ *
+ * Run with:
+ *   OMNIFOCUS_INTEGRATION=1 pnpm test:integration
+ *
+ * @see src/adapter/jxa/JxaTransport.tasks.test.ts — unit tests (no OF required)
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { TaskId } from "../../domain/ids.js";
+import { JxaTransport } from "./JxaTransport.js";
+
+const INTEGRATION = process.env.OMNIFOCUS_INTEGRATION === "1";
+
+describe.skipIf(!INTEGRATION)("JxaTransport — task integration", () => {
+  const t = new JxaTransport();
+  let createdTaskId: TaskId;
+
+  beforeAll(async () => {
+    createdTaskId = await t.createTask({ name: "__mcp_test_task__" });
+  });
+
+  afterAll(async () => {
+    if (createdTaskId) {
+      await t.deleteTask(createdTaskId).catch(() => {
+        /* already deleted */
+      });
+    }
+  });
+
+  it("createTask returns a valid ID", () => {
+    expect(typeof createdTaskId).toBe("string");
+    expect(createdTaskId.length).toBeGreaterThan(0);
+  });
+
+  it("getTask returns the created task", async () => {
+    const task = await t.getTask(createdTaskId);
+    expect(task.id).toBe(createdTaskId);
+    expect(task.name).toBe("__mcp_test_task__");
+    expect(task.completed).toBe(false);
+  });
+
+  it("listTasks includes the created task", async () => {
+    const tasks = await t.listTasks({});
+    const found = tasks.find((task) => task.id === createdTaskId);
+    expect(found).toBeDefined();
+    expect(found?.name).toBe("__mcp_test_task__");
+  });
+
+  it("getTasksMany returns the created task by id", async () => {
+    const results = await t.getTasksMany([createdTaskId]);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe(createdTaskId);
+  });
+
+  it("updateTask renames the task", async () => {
+    await t.updateTask(createdTaskId, { name: "__mcp_test_task_renamed__" });
+    const task = await t.getTask(createdTaskId);
+    expect(task.name).toBe("__mcp_test_task_renamed__");
+  });
+
+  it("updateTask sets flagged", async () => {
+    await t.updateTask(createdTaskId, { flagged: true });
+    const task = await t.getTask(createdTaskId);
+    expect(task.flagged).toBe(true);
+  });
+
+  it("dropTask marks task as dropped", async () => {
+    await t.dropTask(createdTaskId);
+    const task = await t.getTask(createdTaskId);
+    expect(task.dropped).toBe(true);
+  });
+
+  it("undropTask restores task from dropped", async () => {
+    await t.undropTask(createdTaskId);
+    const task = await t.getTask(createdTaskId);
+    expect(task.dropped).toBe(false);
+  });
+
+  it("completeTask marks task completed", async () => {
+    await t.completeTask(createdTaskId);
+    const task = await t.getTask(createdTaskId);
+    expect(task.completed).toBe(true);
+  });
+
+  it("uncompleteTask marks task incomplete", async () => {
+    await t.uncompleteTask(createdTaskId);
+    const task = await t.getTask(createdTaskId);
+    expect(task.completed).toBe(false);
+  });
+
+  it("deleteTask removes the task", async () => {
+    await t.deleteTask(createdTaskId);
+    const tasks = await t.listTasks({});
+    const found = tasks.find((task) => task.id === createdTaskId);
+    expect(found).toBeUndefined();
+  });
+});

--- a/src/adapter/jxa/JxaTransport.tasks.test.ts
+++ b/src/adapter/jxa/JxaTransport.tasks.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for `JxaTransport` — task domain methods.
+ *
+ * All tests use a fake spawner that returns pre-shaped JSON, so no `osascript`
+ * binary is required. Integration tests against a live OmniFocus instance are
+ * in JxaTransport.tasks.integration.test.ts and gated behind
+ * `OMNIFOCUS_INTEGRATION=1`.
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — implementation
+ * @see src/scripts/jxa/task_*.js — underlying scripts
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ProjectId, TaskId } from "../../domain/ids.js";
+import { ScriptError } from "../../errors/index.js";
+import { JxaTransport } from "./JxaTransport.js";
+import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function spawnerReturning(payload: unknown): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: JSON.stringify(payload),
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    }),
+  );
+}
+
+function spawnerFailing(stderr: string): ScriptSpawner {
+  return vi.fn(
+    async (): Promise<SpawnResult> => ({
+      stdout: "",
+      stderr,
+      exitCode: 1,
+      timedOut: false,
+    }),
+  );
+}
+
+const BASE_TASK = {
+  id: "task_aaa",
+  name: "Write tests",
+  note: null,
+  noteHtml: null,
+  projectId: null,
+  parentId: null,
+  tagIds: [],
+  deferDate: null,
+  dueDate: null,
+  estimatedMinutes: null,
+  flagged: false,
+  completed: false,
+  completedAt: null,
+  dropped: false,
+  droppedAt: null,
+  available: true,
+  blocked: false,
+  sequential: false,
+  completedByChildren: false,
+  repetition: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  modifiedAt: "2026-01-02T00:00:00.000Z",
+};
+
+// ---------------------------------------------------------------------------
+// listTasks
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — listTasks", () => {
+  it("returns parsed tasks with branded IDs", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ tasks: [BASE_TASK] }) });
+    const tasks = await t.listTasks({});
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.id).toBe("task_aaa");
+    expect(tasks[0]?.name).toBe("Write tests");
+    expect(tasks[0]?.available).toBe(true);
+  });
+
+  it("passes all filter fields to the script", async () => {
+    const spawner = spawnerReturning({ tasks: [] });
+    const t = new JxaTransport({ spawner });
+    await t.listTasks({ flagged: true, completed: false, dueBefore: "2026-12-31T00:00:00Z" });
+    const call = (spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string];
+    const arg = JSON.parse(call[1]) as { flagged: boolean; completed: boolean; dueBefore: string };
+    expect(arg.flagged).toBe(true);
+    expect(arg.completed).toBe(false);
+    expect(arg.dueBefore).toBe("2026-12-31T00:00:00Z");
+  });
+
+  it("returns empty array when no tasks", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ tasks: [] }) });
+    expect(await t.listTasks({})).toEqual([]);
+  });
+
+  it("surfaces ScriptError on script failure", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("OmniFocus got an error") });
+    await expect(t.listTasks({})).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — getTask", () => {
+  it("returns a single task", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ task: BASE_TASK }) });
+    const task = await t.getTask("task_aaa" as TaskId);
+    expect(task.id).toBe("task_aaa");
+    expect(task.name).toBe("Write tests");
+    expect(task.flagged).toBe(false);
+  });
+
+  it("passes the id to the script", async () => {
+    const spawner = spawnerReturning({ task: BASE_TASK });
+    const t = new JxaTransport({ spawner });
+    await t.getTask("task_aaa" as TaskId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string };
+    expect(arg.id).toBe("task_aaa");
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
+    await expect(t.getTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTasksMany
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — getTasksMany", () => {
+  it("returns tasks with branded IDs, nulls for missing", async () => {
+    const t = new JxaTransport({
+      spawner: spawnerReturning({ tasks: [BASE_TASK, null] }),
+    });
+    const tasks = await t.getTasksMany(["task_aaa" as TaskId, "task_missing" as TaskId]);
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0]?.id).toBe("task_aaa");
+    expect(tasks[1]).toBeNull();
+  });
+
+  it("passes ids array to the script", async () => {
+    const spawner = spawnerReturning({ tasks: [BASE_TASK] });
+    const t = new JxaTransport({ spawner });
+    await t.getTasksMany(["task_aaa" as TaskId]);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { ids: string[] };
+    expect(arg.ids).toEqual(["task_aaa"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — createTask", () => {
+  it("returns the new task's branded ID", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ task: BASE_TASK }) });
+    const id = await t.createTask({ name: "Write tests" });
+    expect(id).toBe("task_aaa");
+  });
+
+  it("passes name and defaults to the script", async () => {
+    const spawner = spawnerReturning({ task: BASE_TASK });
+    const t = new JxaTransport({ spawner });
+    await t.createTask({ name: "Write tests" });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { name: string; projectId: null; flagged: boolean; tagIds: string[] };
+    expect(arg.name).toBe("Write tests");
+    expect(arg.projectId).toBeNull();
+    expect(arg.flagged).toBe(false);
+    expect(arg.tagIds).toEqual([]);
+  });
+
+  it("passes projectId when supplied", async () => {
+    const spawner = spawnerReturning({ task: BASE_TASK });
+    const t = new JxaTransport({ spawner });
+    await t.createTask({ name: "Write tests", projectId: "proj_zzz" as ProjectId });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { projectId: string };
+    expect(arg.projectId).toBe("proj_zzz");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — updateTask", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({
+      spawner: spawnerReturning({ task: { ...BASE_TASK, name: "Updated" } }),
+    });
+    await expect(t.updateTask("task_aaa" as TaskId, { name: "Updated" })).resolves.toBeUndefined();
+  });
+
+  it("passes only supplied patch fields to the script", async () => {
+    const spawner = spawnerReturning({ task: BASE_TASK });
+    const t = new JxaTransport({ spawner });
+    await t.updateTask("task_aaa" as TaskId, { flagged: true });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string; flagged: boolean; name?: string };
+    expect(arg.id).toBe("task_aaa");
+    expect(arg.flagged).toBe(true);
+    expect(arg.name).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — completeTask", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "task_aaa" }) });
+    await expect(t.completeTask("task_aaa" as TaskId)).resolves.toBeUndefined();
+  });
+
+  it("passes null completionDate when not supplied", async () => {
+    const spawner = spawnerReturning({ id: "task_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.completeTask("task_aaa" as TaskId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string; completionDate: null };
+    expect(arg.id).toBe("task_aaa");
+    expect(arg.completionDate).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// uncompleteTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — uncompleteTask", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "task_aaa" }) });
+    await expect(t.uncompleteTask("task_aaa" as TaskId)).resolves.toBeUndefined();
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
+    await expect(t.uncompleteTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dropTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — dropTask", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "task_aaa" }) });
+    await expect(t.dropTask("task_aaa" as TaskId)).resolves.toBeUndefined();
+  });
+
+  it("passes null droppedAt when not supplied", async () => {
+    const spawner = spawnerReturning({ id: "task_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.dropTask("task_aaa" as TaskId);
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string; droppedAt: null };
+    expect(arg.id).toBe("task_aaa");
+    expect(arg.droppedAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// undropTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — undropTask", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "task_aaa" }) });
+    await expect(t.undropTask("task_aaa" as TaskId)).resolves.toBeUndefined();
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
+    await expect(t.undropTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — deleteTask", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "task_aaa" }) });
+    await expect(t.deleteTask("task_aaa" as TaskId)).resolves.toBeUndefined();
+  });
+
+  it("surfaces ScriptError on not-found", async () => {
+    const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
+    await expect(t.deleteTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moveTask
+// ---------------------------------------------------------------------------
+
+describe("JxaTransport — moveTask", () => {
+  it("resolves without error on success", async () => {
+    const t = new JxaTransport({ spawner: spawnerReturning({ id: "task_aaa" }) });
+    await expect(
+      t.moveTask("task_aaa" as TaskId, { projectId: "proj_bbb" as ProjectId }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes projectId destination to the script", async () => {
+    const spawner = spawnerReturning({ id: "task_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.moveTask("task_aaa" as TaskId, { projectId: "proj_bbb" as ProjectId });
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { id: string; projectId: string; parentId: null };
+    expect(arg.id).toBe("task_aaa");
+    expect(arg.projectId).toBe("proj_bbb");
+    expect(arg.parentId).toBeNull();
+  });
+
+  it("passes null for unspecified destination fields", async () => {
+    const spawner = spawnerReturning({ id: "task_aaa" });
+    const t = new JxaTransport({ spawner });
+    await t.moveTask("task_aaa" as TaskId, {});
+    const arg = JSON.parse(
+      ((spawner as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string])[1],
+    ) as { projectId: null; parentId: null };
+    expect(arg.projectId).toBeNull();
+    expect(arg.parentId).toBeNull();
+  });
+});

--- a/src/adapter/jxa/JxaTransport.test.ts
+++ b/src/adapter/jxa/JxaTransport.test.ts
@@ -9,7 +9,6 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import type { TaskId } from "../../domain/ids.js";
 import { ScriptError } from "../../errors/index.js";
 import { JxaTransport } from "./JxaTransport.js";
 import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
@@ -72,29 +71,6 @@ describe("JxaTransport — getLastSync (interim)", () => {
   });
 });
 
-describe("JxaTransport — not-yet-wired stubs", () => {
-  const t = new JxaTransport({ spawner: spawnerReturning("{}") });
-
-  // Sample one method per domain group; the per-method shape is uniform.
-  // Note: listTags, getTag, createTag, updateTag, deleteTag, listFolders,
-  // getFolder, createFolder, updateFolder, deleteFolder are now wired and
-  // tested in JxaTransport.tags-folders.test.ts.
-  // listProjects, getProject etc are wired and tested in JxaTransport.projects.test.ts.
-  const cases: Array<readonly [string, () => Promise<unknown>]> = [
-    ["listTasks", () => t.listTasks({})],
-    ["getTask", () => t.getTask("task_000001" as TaskId)],
-    ["createTask", () => t.createTask({ name: "x" })],
-  ];
-
-  for (const [method, call] of cases) {
-    it(`${method} throws ScriptError with reason="not-yet-wired"`, async () => {
-      const err = await call().catch((e) => e);
-      expect(err).toBeInstanceOf(ScriptError);
-      expect((err as ScriptError).details).toMatchObject({
-        transport: "jxa",
-        reason: "not-yet-wired",
-        method,
-      });
-    });
-  }
-});
+// All task, project, tag, and folder methods are now wired.
+// Per-domain unit tests live in JxaTransport.{tasks,projects,tags-folders}.test.ts.
+// No not-yet-wired stubs remain for domain methods.

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -31,6 +31,7 @@ import {
   type TagId,
   TagId as TagIdCtor,
   type TaskId,
+  TaskId as TaskIdCtor,
 } from "../../domain/ids.js";
 import type { Project } from "../../domain/project.js";
 import type { Tag } from "../../domain/tag.js";
@@ -56,6 +57,17 @@ import tagDeleteScript from "../../scripts/jxa/tag_delete.js";
 import tagGetScript from "../../scripts/jxa/tag_get.js";
 import tagListScript from "../../scripts/jxa/tag_list.js";
 import tagUpdateScript from "../../scripts/jxa/tag_update.js";
+import taskCompleteScript from "../../scripts/jxa/task_complete.js";
+import taskCreateScript from "../../scripts/jxa/task_create.js";
+import taskDeleteScript from "../../scripts/jxa/task_delete.js";
+import taskDropScript from "../../scripts/jxa/task_drop.js";
+import taskGetScript from "../../scripts/jxa/task_get.js";
+import taskGetManyScript from "../../scripts/jxa/task_get_many.js";
+import taskListScript from "../../scripts/jxa/task_list.js";
+import taskMoveScript from "../../scripts/jxa/task_move.js";
+import taskUncompleteScript from "../../scripts/jxa/task_uncomplete.js";
+import taskUndropScript from "../../scripts/jxa/task_undrop.js";
+import taskUpdateScript from "../../scripts/jxa/task_update.js";
 import type {
   CreateFolderInput,
   CreateProjectInput,
@@ -112,43 +124,145 @@ export class JxaTransport implements OmniFocusAdapter {
     };
   }
 
-  // -- Tasks ----------------------------------------------------------------
+  // -- Tasks (wired) --------------------------------------------------------
 
-  async listTasks(_filter: TaskFilter): Promise<Task[]> {
-    return notYetWired("listTasks");
+  async listTasks(filter: TaskFilter): Promise<Task[]> {
+    const result = await runJxaScript<{ tasks: Task[] }>(
+      taskListScript,
+      {
+        projectId: filter.projectId ?? null,
+        tagId: filter.tagId ?? null,
+        parentId: filter.parentId ?? null,
+        flagged: filter.flagged ?? null,
+        available: filter.available ?? null,
+        blocked: filter.blocked ?? null,
+        completed: filter.completed ?? null,
+        completedSince: filter.completedSince ?? null,
+        dueBefore: filter.dueBefore ?? null,
+        dueAfter: filter.dueAfter ?? null,
+        deferredBefore: filter.deferredBefore ?? null,
+        deferredAfter: filter.deferredAfter ?? null,
+      },
+      { ...this.runOpts, scriptName: "task_list" },
+    );
+    return result.tasks.map((t) => ({ ...t, id: TaskIdCtor.of(t.id) }));
   }
-  async getTask(_id: TaskId): Promise<Task> {
-    return notYetWired("getTask");
+
+  async getTask(id: TaskId): Promise<Task> {
+    const result = await runJxaScript<{ task: Task }>(
+      taskGetScript,
+      { id },
+      { ...this.runOpts, scriptName: "task_get" },
+    );
+    return { ...result.task, id: TaskIdCtor.of(result.task.id) };
   }
-  async getTasksMany(_ids: TaskId[]): Promise<(Task | null)[]> {
-    return notYetWired("getTasksMany");
+
+  async getTasksMany(ids: TaskId[]): Promise<(Task | null)[]> {
+    const result = await runJxaScript<{ tasks: (Task | null)[] }>(
+      taskGetManyScript,
+      { ids },
+      { ...this.runOpts, scriptName: "task_get_many" },
+    );
+    return result.tasks.map((t) => (t ? { ...t, id: TaskIdCtor.of(t.id) } : null));
   }
-  async createTask(_input: CreateTaskInput): Promise<TaskId> {
-    return notYetWired("createTask");
+
+  async createTask(input: CreateTaskInput): Promise<TaskId> {
+    const result = await runJxaScript<{ task: Task }>(
+      taskCreateScript,
+      {
+        name: input.name,
+        projectId: input.projectId ?? null,
+        parentId: input.parentId ?? null,
+        note: input.note ?? null,
+        flagged: input.flagged ?? false,
+        deferDate: input.deferDate ?? null,
+        dueDate: input.dueDate ?? null,
+        estimatedMinutes: input.estimatedMinutes ?? null,
+        tagIds: input.tagIds ?? [],
+        sequential: input.sequential ?? false,
+        completedByChildren: input.completedByChildren ?? false,
+      },
+      { ...this.runOpts, scriptName: "task_create" },
+    );
+    return TaskIdCtor.of(result.task.id);
   }
-  async updateTask(_id: TaskId, _patch: UpdateTaskInput): Promise<void> {
-    return notYetWired("updateTask");
+
+  async updateTask(id: TaskId, patch: UpdateTaskInput): Promise<void> {
+    await runJxaScript<{ task: Task }>(
+      taskUpdateScript,
+      {
+        id,
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
+        ...(patch.note !== undefined ? { note: patch.note } : {}),
+        ...(patch.flagged !== undefined ? { flagged: patch.flagged } : {}),
+        ...(patch.deferDate !== undefined ? { deferDate: patch.deferDate } : {}),
+        ...(patch.dueDate !== undefined ? { dueDate: patch.dueDate } : {}),
+        ...(patch.estimatedMinutes !== undefined
+          ? { estimatedMinutes: patch.estimatedMinutes }
+          : {}),
+        ...(patch.tagIds !== undefined ? { tagIds: patch.tagIds } : {}),
+        ...(patch.sequential !== undefined ? { sequential: patch.sequential } : {}),
+        ...(patch.completedByChildren !== undefined
+          ? { completedByChildren: patch.completedByChildren }
+          : {}),
+      },
+      { ...this.runOpts, scriptName: "task_update" },
+    );
   }
-  async completeTask(_id: TaskId, _at?: Date): Promise<void> {
-    return notYetWired("completeTask");
+
+  async completeTask(id: TaskId, at?: Date): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      taskCompleteScript,
+      { id, completionDate: at?.toISOString() ?? null },
+      { ...this.runOpts, scriptName: "task_complete" },
+    );
   }
-  async uncompleteTask(_id: TaskId): Promise<void> {
-    return notYetWired("uncompleteTask");
+
+  async uncompleteTask(id: TaskId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      taskUncompleteScript,
+      { id },
+      { ...this.runOpts, scriptName: "task_uncomplete" },
+    );
   }
-  async dropTask(_id: TaskId, _at?: Date): Promise<void> {
-    return notYetWired("dropTask");
+
+  async dropTask(id: TaskId, at?: Date): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      taskDropScript,
+      { id, droppedAt: at?.toISOString() ?? null },
+      { ...this.runOpts, scriptName: "task_drop" },
+    );
   }
-  async undropTask(_id: TaskId): Promise<void> {
-    return notYetWired("undropTask");
+
+  async undropTask(id: TaskId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      taskUndropScript,
+      { id },
+      { ...this.runOpts, scriptName: "task_undrop" },
+    );
   }
-  async deleteTask(_id: TaskId): Promise<void> {
-    return notYetWired("deleteTask");
+
+  async deleteTask(id: TaskId): Promise<void> {
+    await runJxaScript<{ id: string }>(
+      taskDeleteScript,
+      { id },
+      { ...this.runOpts, scriptName: "task_delete" },
+    );
   }
+
   async moveTask(
-    _id: TaskId,
-    _destination: { projectId?: ProjectId; parentId?: TaskId },
+    id: TaskId,
+    destination: { projectId?: ProjectId; parentId?: TaskId },
   ): Promise<void> {
-    return notYetWired("moveTask");
+    await runJxaScript<{ id: string }>(
+      taskMoveScript,
+      {
+        id,
+        projectId: destination.projectId ?? null,
+        parentId: destination.parentId ?? null,
+      },
+      { ...this.runOpts, scriptName: "task_move" },
+    );
   }
 
   // -- Projects (wired) -----------------------------------------------------

--- a/src/scripts/jxa/task_complete.d.ts
+++ b/src/scripts/jxa/task_complete.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_complete.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_complete.js
+++ b/src/scripts/jxa/task_complete.js
@@ -1,0 +1,35 @@
+/**
+ * JXA: mark a task complete.
+ *
+ * Args (argv[0] JSON): { id: string, completionDate?: string|null }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  let found = null;
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      found = allTasks[i];
+      break;
+    }
+  }
+  if (!found) throw new Error(`Task not found: ${args.id}`);
+
+  ofApp.markComplete(found);
+
+  if (args.completionDate) {
+    try {
+      found.completionDate = new Date(args.completionDate);
+    } catch (_e) {}
+  }
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/task_create.d.ts
+++ b/src/scripts/jxa/task_create.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_create.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -1,0 +1,191 @@
+/**
+ * JXA: create a new task.
+ *
+ * Args (argv[0] JSON): {
+ *   name: string, projectId?: string|null, parentId?: string|null,
+ *   note?: string|null, flagged?: boolean, deferDate?: string|null,
+ *   dueDate?: string|null, estimatedMinutes?: number|null,
+ *   tagIds?: string[], sequential?: boolean, completedByChildren?: boolean
+ * }
+ * Returns JSON: { task: Task }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/task.ts — Task domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildRepetition(task) {
+    try {
+      const rr = task.repetitionRule();
+      if (!rr) return null;
+      return {
+        method: rr.method(),
+        unit: rr.unit(),
+        steps: rr.steps(),
+      };
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function buildTask(task) {
+    let projectId = null;
+    try {
+      const cp = task.containingProject();
+      if (cp && cp.class() !== "document") projectId = cp.id();
+    } catch (_e) {}
+
+    let parentId = null;
+    try {
+      const pt = task.parentTask();
+      if (pt) parentId = pt.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = task.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let deferDate = null;
+    try {
+      const dd = task.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = task.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = task.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let dropped = false;
+    try {
+      dropped = task.dropped();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = task.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = task.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (task.noteHtml) noteHtml = task.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = task.flagged();
+    } catch (_e) {}
+
+    let completed = false;
+    try {
+      completed = task.completed();
+    } catch (_e) {}
+
+    let sequential = false;
+    try {
+      sequential = task.sequential();
+    } catch (_e) {}
+
+    let completedByChildren = false;
+    try {
+      completedByChildren = task.containsSingletonActions();
+    } catch (_e) {}
+
+    let available = false;
+    try {
+      available = task.available();
+    } catch (_e) {}
+
+    let blocked = false;
+    try {
+      blocked = task.blocked();
+    } catch (_e) {}
+
+    return {
+      id: task.id(),
+      name: task.name(),
+      note: note,
+      noteHtml: noteHtml,
+      projectId: projectId,
+      parentId: parentId,
+      tagIds: tagIds,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      completed: completed,
+      completedAt: completedAt,
+      dropped: dropped,
+      droppedAt: null,
+      available: available,
+      blocked: blocked,
+      sequential: sequential,
+      completedByChildren: completedByChildren,
+      repetition: buildRepetition(task),
+      createdAt: task.creationDate ? task.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: task.modificationDate
+        ? task.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const props = { name: args.name };
+  if (args.note != null) props.note = args.note;
+  if (args.flagged != null) props.flagged = args.flagged;
+  if (args.deferDate != null) props.deferDate = new Date(args.deferDate);
+  if (args.dueDate != null) props.dueDate = new Date(args.dueDate);
+  if (args.estimatedMinutes != null) props.estimatedMinutes = args.estimatedMinutes;
+  if (args.sequential != null) props.sequential = args.sequential;
+
+  let newTask;
+  if (args.parentId) {
+    const parent = ofApp.defaultDocument.flattenedTasks.byId(args.parentId);
+    if (!parent) throw new Error(`Parent task not found: ${args.parentId}`);
+    newTask = parent.make({ new: "task", withProperties: props });
+  } else if (args.projectId) {
+    const proj = ofApp.defaultDocument.flattenedProjects.byId(args.projectId);
+    if (!proj) throw new Error(`Project not found: ${args.projectId}`);
+    newTask = proj.make({ new: "task", withProperties: props });
+  } else {
+    newTask = ofApp.defaultDocument.make({ new: "inboxTask", withProperties: props });
+  }
+
+  if (args.tagIds) {
+    for (let i = 0; i < args.tagIds.length; i++) {
+      try {
+        const tag = ofApp.defaultDocument.flattenedTags.byId(args.tagIds[i]);
+        newTask.addTag(tag);
+      } catch (_e) {}
+    }
+  }
+
+  if (args.completedByChildren != null) {
+    try {
+      newTask.containsSingletonActions = args.completedByChildren;
+    } catch (_e) {}
+  }
+
+  return JSON.stringify({ task: buildTask(newTask) });
+}

--- a/src/scripts/jxa/task_delete.d.ts
+++ b/src/scripts/jxa/task_delete.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_delete.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_delete.js
+++ b/src/scripts/jxa/task_delete.js
@@ -1,0 +1,29 @@
+/**
+ * JXA: delete a task permanently.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  let found = null;
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      found = allTasks[i];
+      break;
+    }
+  }
+  if (!found) throw new Error(`Task not found: ${args.id}`);
+
+  found.delete();
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/task_drop.d.ts
+++ b/src/scripts/jxa/task_drop.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_drop.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_drop.js
+++ b/src/scripts/jxa/task_drop.js
@@ -1,0 +1,29 @@
+/**
+ * JXA: mark a task as dropped.
+ *
+ * Args (argv[0] JSON): { id: string, droppedAt?: string|null }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  let found = null;
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      found = allTasks[i];
+      break;
+    }
+  }
+  if (!found) throw new Error(`Task not found: ${args.id}`);
+
+  found.dropped = true;
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/task_get.d.ts
+++ b/src/scripts/jxa/task_get.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_get.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_get.js
+++ b/src/scripts/jxa/task_get.js
@@ -1,0 +1,157 @@
+/**
+ * JXA: fetch one task by ID.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { task: Task }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/task.ts — Task domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildRepetition(task) {
+    try {
+      const rr = task.repetitionRule();
+      if (!rr) return null;
+      return {
+        method: rr.method(),
+        unit: rr.unit(),
+        steps: rr.steps(),
+      };
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function buildTask(task) {
+    let projectId = null;
+    try {
+      const cp = task.containingProject();
+      if (cp && cp.class() !== "document") projectId = cp.id();
+    } catch (_e) {}
+
+    let parentId = null;
+    try {
+      const pt = task.parentTask();
+      if (pt) parentId = pt.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = task.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let deferDate = null;
+    try {
+      const dd = task.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = task.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = task.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let dropped = false;
+    try {
+      dropped = task.dropped();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = task.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = task.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (task.noteHtml) noteHtml = task.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = task.flagged();
+    } catch (_e) {}
+
+    let completed = false;
+    try {
+      completed = task.completed();
+    } catch (_e) {}
+
+    let sequential = false;
+    try {
+      sequential = task.sequential();
+    } catch (_e) {}
+
+    let completedByChildren = false;
+    try {
+      completedByChildren = task.containsSingletonActions();
+    } catch (_e) {}
+
+    let available = false;
+    try {
+      available = task.available();
+    } catch (_e) {}
+
+    let blocked = false;
+    try {
+      blocked = task.blocked();
+    } catch (_e) {}
+
+    return {
+      id: task.id(),
+      name: task.name(),
+      note: note,
+      noteHtml: noteHtml,
+      projectId: projectId,
+      parentId: parentId,
+      tagIds: tagIds,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      completed: completed,
+      completedAt: completedAt,
+      dropped: dropped,
+      droppedAt: null,
+      available: available,
+      blocked: blocked,
+      sequential: sequential,
+      completedByChildren: completedByChildren,
+      repetition: buildRepetition(task),
+      createdAt: task.creationDate ? task.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: task.modificationDate
+        ? task.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      return JSON.stringify({ task: buildTask(allTasks[i]) });
+    }
+  }
+
+  throw new Error(`Task not found: ${args.id}`);
+}

--- a/src/scripts/jxa/task_get_many.d.ts
+++ b/src/scripts/jxa/task_get_many.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_get_many.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_get_many.js
+++ b/src/scripts/jxa/task_get_many.js
@@ -1,0 +1,168 @@
+/**
+ * JXA: fetch multiple tasks by IDs.
+ *
+ * Args (argv[0] JSON): { ids: string[] }
+ * Returns JSON: { tasks: (Task | null)[] }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/task.ts — Task domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildRepetition(task) {
+    try {
+      const rr = task.repetitionRule();
+      if (!rr) return null;
+      return {
+        method: rr.method(),
+        unit: rr.unit(),
+        steps: rr.steps(),
+      };
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function buildTask(task) {
+    let projectId = null;
+    try {
+      const cp = task.containingProject();
+      if (cp && cp.class() !== "document") projectId = cp.id();
+    } catch (_e) {}
+
+    let parentId = null;
+    try {
+      const pt = task.parentTask();
+      if (pt) parentId = pt.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = task.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let deferDate = null;
+    try {
+      const dd = task.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = task.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = task.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let dropped = false;
+    try {
+      dropped = task.dropped();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = task.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = task.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (task.noteHtml) noteHtml = task.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = task.flagged();
+    } catch (_e) {}
+
+    let completed = false;
+    try {
+      completed = task.completed();
+    } catch (_e) {}
+
+    let sequential = false;
+    try {
+      sequential = task.sequential();
+    } catch (_e) {}
+
+    let completedByChildren = false;
+    try {
+      completedByChildren = task.containsSingletonActions();
+    } catch (_e) {}
+
+    let available = false;
+    try {
+      available = task.available();
+    } catch (_e) {}
+
+    let blocked = false;
+    try {
+      blocked = task.blocked();
+    } catch (_e) {}
+
+    return {
+      id: task.id(),
+      name: task.name(),
+      note: note,
+      noteHtml: noteHtml,
+      projectId: projectId,
+      parentId: parentId,
+      tagIds: tagIds,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      completed: completed,
+      completedAt: completedAt,
+      dropped: dropped,
+      droppedAt: null,
+      available: available,
+      blocked: blocked,
+      sequential: sequential,
+      completedByChildren: completedByChildren,
+      repetition: buildRepetition(task),
+      createdAt: task.creationDate ? task.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: task.modificationDate
+        ? task.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const idSet = {};
+  for (let i = 0; i < args.ids.length; i++) {
+    idSet[args.ids[i]] = null;
+  }
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  for (let i = 0; i < allTasks.length; i++) {
+    const tid = allTasks[i].id();
+    if (Object.prototype.hasOwnProperty.call(idSet, tid)) {
+      idSet[tid] = buildTask(allTasks[i]);
+    }
+  }
+
+  const results = [];
+  for (let i = 0; i < args.ids.length; i++) {
+    results.push(idSet[args.ids[i]]);
+  }
+
+  return JSON.stringify({ tasks: results });
+}

--- a/src/scripts/jxa/task_list.d.ts
+++ b/src/scripts/jxa/task_list.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_list.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -1,0 +1,223 @@
+/**
+ * JXA: list tasks, optionally filtered.
+ *
+ * Args (argv[0] JSON): {
+ *   projectId?: string|null, tagId?: string|null, parentId?: string|null,
+ *   flagged?: boolean|null, available?: boolean|null, blocked?: boolean|null,
+ *   completed?: boolean|null, completedSince?: string|null,
+ *   dueBefore?: string|null, dueAfter?: string|null,
+ *   deferredBefore?: string|null, deferredAfter?: string|null
+ * }
+ * Returns JSON: { tasks: Task[] }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/task.ts — Task domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildRepetition(task) {
+    try {
+      const rr = task.repetitionRule();
+      if (!rr) return null;
+      return {
+        method: rr.method(),
+        unit: rr.unit(),
+        steps: rr.steps(),
+      };
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function buildTask(task) {
+    let projectId = null;
+    try {
+      const cp = task.containingProject();
+      if (cp && cp.class() !== "document") projectId = cp.id();
+    } catch (_e) {}
+
+    let parentId = null;
+    try {
+      const pt = task.parentTask();
+      if (pt) parentId = pt.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = task.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let deferDate = null;
+    try {
+      const dd = task.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = task.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = task.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    const droppedAt = null;
+    let dropped = false;
+    try {
+      dropped = task.dropped();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = task.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = task.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (task.noteHtml) noteHtml = task.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = task.flagged();
+    } catch (_e) {}
+
+    let completed = false;
+    try {
+      completed = task.completed();
+    } catch (_e) {}
+
+    let sequential = false;
+    try {
+      sequential = task.sequential();
+    } catch (_e) {}
+
+    let completedByChildren = false;
+    try {
+      completedByChildren = task.containsSingletonActions();
+    } catch (_e) {}
+
+    let available = false;
+    try {
+      available = task.available();
+    } catch (_e) {}
+
+    let blocked = false;
+    try {
+      blocked = task.blocked();
+    } catch (_e) {}
+
+    return {
+      id: task.id(),
+      name: task.name(),
+      note: note,
+      noteHtml: noteHtml,
+      projectId: projectId,
+      parentId: parentId,
+      tagIds: tagIds,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      completed: completed,
+      completedAt: completedAt,
+      dropped: dropped,
+      droppedAt: droppedAt,
+      available: available,
+      blocked: blocked,
+      sequential: sequential,
+      completedByChildren: completedByChildren,
+      repetition: buildRepetition(task),
+      createdAt: task.creationDate ? task.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: task.modificationDate
+        ? task.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  let tasks;
+  if (args.projectId) {
+    try {
+      tasks = ofApp.defaultDocument.flattenedProjects.byId(args.projectId).flattenedTasks();
+    } catch (_e) {
+      throw new Error(`Project not found: ${args.projectId}`);
+    }
+  } else if (args.parentId) {
+    try {
+      tasks = ofApp.defaultDocument.flattenedTasks.byId(args.parentId).flattenedTasks();
+    } catch (_e) {
+      throw new Error(`Parent task not found: ${args.parentId}`);
+    }
+  } else {
+    tasks = ofApp.defaultDocument.flattenedTasks();
+  }
+
+  const completedSince = args.completedSince ? new Date(args.completedSince) : null;
+  const dueBefore = args.dueBefore ? new Date(args.dueBefore) : null;
+  const dueAfter = args.dueAfter ? new Date(args.dueAfter) : null;
+  const deferredBefore = args.deferredBefore ? new Date(args.deferredBefore) : null;
+  const deferredAfter = args.deferredAfter ? new Date(args.deferredAfter) : null;
+
+  const result = [];
+  for (let i = 0; i < tasks.length; i++) {
+    const t = tasks[i];
+    const built = buildTask(t);
+
+    if (args.tagId !== null && args.tagId !== undefined) {
+      if (!built.tagIds.includes(args.tagId)) continue;
+    }
+    if (args.flagged !== null && args.flagged !== undefined && built.flagged !== args.flagged)
+      continue;
+    if (
+      args.available !== null &&
+      args.available !== undefined &&
+      built.available !== args.available
+    )
+      continue;
+    if (args.blocked !== null && args.blocked !== undefined && built.blocked !== args.blocked)
+      continue;
+    if (
+      args.completed !== null &&
+      args.completed !== undefined &&
+      built.completed !== args.completed
+    )
+      continue;
+    if (completedSince && built.completedAt) {
+      if (new Date(built.completedAt) < completedSince) continue;
+    }
+    if (dueBefore && built.dueDate) {
+      if (new Date(built.dueDate) >= dueBefore) continue;
+    }
+    if (dueAfter && built.dueDate) {
+      if (new Date(built.dueDate) <= dueAfter) continue;
+    }
+    if (deferredBefore && built.deferDate) {
+      if (new Date(built.deferDate) >= deferredBefore) continue;
+    }
+    if (deferredAfter && built.deferDate) {
+      if (new Date(built.deferDate) <= deferredAfter) continue;
+    }
+
+    result.push(built);
+  }
+
+  return JSON.stringify({ tasks: result });
+}

--- a/src/scripts/jxa/task_move.d.ts
+++ b/src/scripts/jxa/task_move.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_move.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_move.js
+++ b/src/scripts/jxa/task_move.js
@@ -1,0 +1,39 @@
+/**
+ * JXA: move a task to a different project or parent task.
+ *
+ * Args (argv[0] JSON): { id: string, projectId?: string|null, parentId?: string|null }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  let found = null;
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      found = allTasks[i];
+      break;
+    }
+  }
+  if (!found) throw new Error(`Task not found: ${args.id}`);
+
+  if (args.parentId) {
+    const parent = ofApp.defaultDocument.flattenedTasks.byId(args.parentId);
+    if (!parent) throw new Error(`Parent task not found: ${args.parentId}`);
+    found.move({ to: parent });
+  } else if (args.projectId) {
+    const proj = ofApp.defaultDocument.flattenedProjects.byId(args.projectId);
+    if (!proj) throw new Error(`Project not found: ${args.projectId}`);
+    found.move({ to: proj });
+  } else {
+    found.move({ to: ofApp.defaultDocument });
+  }
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/task_uncomplete.d.ts
+++ b/src/scripts/jxa/task_uncomplete.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_uncomplete.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_uncomplete.js
+++ b/src/scripts/jxa/task_uncomplete.js
@@ -1,0 +1,29 @@
+/**
+ * JXA: mark a task incomplete.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  let found = null;
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      found = allTasks[i];
+      break;
+    }
+  }
+  if (!found) throw new Error(`Task not found: ${args.id}`);
+
+  ofApp.markIncomplete(found);
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/task_undrop.d.ts
+++ b/src/scripts/jxa/task_undrop.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_undrop.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_undrop.js
+++ b/src/scripts/jxa/task_undrop.js
@@ -1,0 +1,29 @@
+/**
+ * JXA: remove dropped status from a task.
+ *
+ * Args (argv[0] JSON): { id: string }
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  let found = null;
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      found = allTasks[i];
+      break;
+    }
+  }
+  if (!found) throw new Error(`Task not found: ${args.id}`);
+
+  found.dropped = false;
+
+  return JSON.stringify({ id: args.id });
+}

--- a/src/scripts/jxa/task_update.d.ts
+++ b/src/scripts/jxa/task_update.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_update.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -1,0 +1,202 @@
+/**
+ * JXA: update task fields.
+ *
+ * Args (argv[0] JSON): {
+ *   id: string,
+ *   name?: string, note?: string|null, flagged?: boolean,
+ *   deferDate?: string|null, dueDate?: string|null,
+ *   estimatedMinutes?: number|null, tagIds?: string[],
+ *   sequential?: boolean, completedByChildren?: boolean
+ * }
+ * Returns JSON: { task: Task }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/domain/task.ts — Task domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  function buildRepetition(task) {
+    try {
+      const rr = task.repetitionRule();
+      if (!rr) return null;
+      return {
+        method: rr.method(),
+        unit: rr.unit(),
+        steps: rr.steps(),
+      };
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function buildTask(task) {
+    let projectId = null;
+    try {
+      const cp = task.containingProject();
+      if (cp && cp.class() !== "document") projectId = cp.id();
+    } catch (_e) {}
+
+    let parentId = null;
+    try {
+      const pt = task.parentTask();
+      if (pt) parentId = pt.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = task.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let deferDate = null;
+    try {
+      const dd = task.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = task.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = task.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let dropped = false;
+    try {
+      dropped = task.dropped();
+    } catch (_e) {}
+
+    let estimatedMinutes = null;
+    try {
+      const em = task.estimatedMinutes();
+      if (em != null) estimatedMinutes = em;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      note = task.note() || null;
+    } catch (_e) {}
+
+    let noteHtml = null;
+    try {
+      if (task.noteHtml) noteHtml = task.noteHtml() || null;
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = task.flagged();
+    } catch (_e) {}
+
+    let completed = false;
+    try {
+      completed = task.completed();
+    } catch (_e) {}
+
+    let sequential = false;
+    try {
+      sequential = task.sequential();
+    } catch (_e) {}
+
+    let completedByChildren = false;
+    try {
+      completedByChildren = task.containsSingletonActions();
+    } catch (_e) {}
+
+    let available = false;
+    try {
+      available = task.available();
+    } catch (_e) {}
+
+    let blocked = false;
+    try {
+      blocked = task.blocked();
+    } catch (_e) {}
+
+    return {
+      id: task.id(),
+      name: task.name(),
+      note: note,
+      noteHtml: noteHtml,
+      projectId: projectId,
+      parentId: parentId,
+      tagIds: tagIds,
+      deferDate: deferDate,
+      dueDate: dueDate,
+      estimatedMinutes: estimatedMinutes,
+      flagged: flagged,
+      completed: completed,
+      completedAt: completedAt,
+      dropped: dropped,
+      droppedAt: null,
+      available: available,
+      blocked: blocked,
+      sequential: sequential,
+      completedByChildren: completedByChildren,
+      repetition: buildRepetition(task),
+      createdAt: task.creationDate ? task.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: task.modificationDate
+        ? task.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  let found = null;
+  for (let i = 0; i < allTasks.length; i++) {
+    if (allTasks[i].id() === args.id) {
+      found = allTasks[i];
+      break;
+    }
+  }
+  if (!found) throw new Error(`Task not found: ${args.id}`);
+
+  if (args.name !== undefined) found.name = args.name;
+  if (Object.prototype.hasOwnProperty.call(args, "note")) {
+    found.note = args.note ?? "";
+  }
+  if (args.flagged !== undefined) found.flagged = args.flagged;
+  if (Object.prototype.hasOwnProperty.call(args, "deferDate")) {
+    found.deferDate = args.deferDate ? new Date(args.deferDate) : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(args, "dueDate")) {
+    found.dueDate = args.dueDate ? new Date(args.dueDate) : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(args, "estimatedMinutes")) {
+    found.estimatedMinutes = args.estimatedMinutes;
+  }
+  if (args.sequential !== undefined) found.sequential = args.sequential;
+  if (args.completedByChildren !== undefined) {
+    try {
+      found.containsSingletonActions = args.completedByChildren;
+    } catch (_e) {}
+  }
+
+  if (args.tagIds !== undefined) {
+    try {
+      const currentTags = found.tags();
+      for (let i = 0; i < currentTags.length; i++) {
+        found.removeTag(currentTags[i]);
+      }
+    } catch (_e) {}
+    for (let i = 0; i < args.tagIds.length; i++) {
+      try {
+        const tag = ofApp.defaultDocument.flattenedTags.byId(args.tagIds[i]);
+        found.addTag(tag);
+      } catch (_e) {}
+    }
+  }
+
+  return JSON.stringify({ task: buildTask(found) });
+}


### PR DESCRIPTION
## Summary
- Adds 11 JXA scripts (`task_list/get/get_many/create/update/complete/uncomplete/drop/undrop/delete/move`) under `src/scripts/jxa/` with sibling `.d.ts` shims
- Replaces all `notYetWired()` stubs in `JxaTransport` for task methods with `runJxaScript<>()` calls
- `task_list` passes all 12 `TaskFilter` fields (projectId, tagId, parentId, flagged, available, blocked, completed, completedSince, dueBefore, dueAfter, deferredBefore, deferredAfter)
- Branded ID wrapping via `TaskIdCtor.of()` on all returned task IDs
- 27 unit tests with mocked spawner + integration tests gated behind `OMNIFOCUS_INTEGRATION=1`
- All domain methods in `JxaTransport` are now fully wired (tasks, projects, tags, folders); the not-yet-wired stub describe block is removed

## Design link
Closes #144. Follows ADR-0002 (JXA transport), ADR-0005 (scripts as first-class files), ADR-0008 (branded IDs). Same wiring pattern as #185/#186.

## Breaking change?
- [x] No

## Test plan
- [x] 825 unit tests passing, 29 skipped (integration gated)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (Biome + custom rules)
- [x] No new dependencies