### PR TITLE
feat(resources): omnifocus://capabilities MCP resource (#141)

### DIFF
--- a/src/resources/capabilities.test.ts
+++ b/src/resources/capabilities.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for `buildCapabilities` and `registerCapabilitiesResource`.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "../config/env.js";
+import {
+  CAPABILITIES_URI,
+  buildCapabilities,
+  registerCapabilitiesResource,
+} from "./capabilities.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    OMNIFOCUS_LOG_LEVEL: "info",
+    OMNIFOCUS_INTEGRATION: false,
+    OMNIFOCUS_E2E: false,
+    OMNIFOCUS_ALLOW_RAW_SCRIPT: false,
+    OMNIFOCUS_CACHE_TTL_MS: 30_000,
+    OMNIFOCUS_CACHE_CAPACITY: 256,
+    OMNIFOCUS_READ_POOL_SIZE: 2,
+    OMNIFOCUS_WRITE_QUEUE_CAP: 50,
+    OMNIFOCUS_JXA_TIMEOUT_MS: 30_000,
+    OMNIFOCUS_OMNIJS_TIMEOUT_MS: 45_000,
+    OMNIFOCUS_ATTACHMENT_PATHS: ["/tmp"],
+    OMNIFOCUS_MAX_ATTACHMENT_MB: 100,
+    OMNIFOCUS_TOOL_RATE_LIMIT: { limit: 120, windowSeconds: 60 },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildCapabilities
+// ---------------------------------------------------------------------------
+
+describe("buildCapabilities", () => {
+  it("defaults ofVersion to 'unknown' and ofEdition to 'standard'", () => {
+    const caps = buildCapabilities(makeConfig());
+    expect(caps.ofVersion).toBe("unknown");
+    expect(caps.ofEdition).toBe("standard");
+  });
+
+  it("accepts ofVersion / ofEdition overrides", () => {
+    const caps = buildCapabilities(makeConfig(), { ofVersion: "4.2.1", ofEdition: "pro" });
+    expect(caps.ofVersion).toBe("4.2.1");
+    expect(caps.ofEdition).toBe("pro");
+  });
+
+  it("exposes jxa timeout from config", () => {
+    const caps = buildCapabilities(makeConfig({ OMNIFOCUS_JXA_TIMEOUT_MS: 15_000 }));
+    expect(caps.transports.jxa.timeoutMs).toBe(15_000);
+    expect(caps.transports.jxa.available).toBe(true);
+  });
+
+  it("exposes omnijs timeout from config", () => {
+    const caps = buildCapabilities(makeConfig({ OMNIFOCUS_OMNIJS_TIMEOUT_MS: 60_000 }));
+    expect(caps.transports.omnijs.timeoutMs).toBe(60_000);
+    expect(caps.transports.omnijs.available).toBe(true);
+  });
+
+  it("all Pro features are false for standard edition", () => {
+    const caps = buildCapabilities(makeConfig());
+    expect(caps.features.customPerspectives).toBe(false);
+    expect(caps.features.forecastTag).toBe(false);
+    expect(caps.features.repetitionRules).toBe(false);
+    expect(caps.features.pluginInvocation).toBe(false);
+  });
+
+  it("all Pro features are true when ofEdition=pro", () => {
+    const caps = buildCapabilities(makeConfig(), { ofEdition: "pro" });
+    expect(caps.features.customPerspectives).toBe(true);
+    expect(caps.features.forecastTag).toBe(true);
+    expect(caps.features.repetitionRules).toBe(true);
+    expect(caps.features.pluginInvocation).toBe(true);
+  });
+
+  it("rawScriptTools reflects OMNIFOCUS_ALLOW_RAW_SCRIPT", () => {
+    expect(
+      buildCapabilities(makeConfig({ OMNIFOCUS_ALLOW_RAW_SCRIPT: false })).features.rawScriptTools,
+    ).toBe(false);
+    expect(
+      buildCapabilities(makeConfig({ OMNIFOCUS_ALLOW_RAW_SCRIPT: true })).features.rawScriptTools,
+    ).toBe(true);
+  });
+
+  it("computes defaultPerToolPerMinute from rate limit config", () => {
+    // 120 calls / 60 seconds = 120 per minute
+    const caps = buildCapabilities(
+      makeConfig({ OMNIFOCUS_TOOL_RATE_LIMIT: { limit: 120, windowSeconds: 60 } }),
+    );
+    expect(caps.rateLimits.defaultPerToolPerMinute).toBe(120);
+  });
+
+  it("computes perMinute correctly for non-60s windows", () => {
+    // 60 calls / 30 seconds = 120 per minute
+    const caps = buildCapabilities(
+      makeConfig({ OMNIFOCUS_TOOL_RATE_LIMIT: { limit: 60, windowSeconds: 30 } }),
+    );
+    expect(caps.rateLimits.defaultPerToolPerMinute).toBe(120);
+  });
+
+  it("sets idempotencyTtlMs to 86_400_000 (24h)", () => {
+    const caps = buildCapabilities(makeConfig());
+    expect(caps.idempotencyTtlMs).toBe(86_400_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CAPABILITIES_URI
+// ---------------------------------------------------------------------------
+
+describe("CAPABILITIES_URI", () => {
+  it("is the expected omnifocus URI", () => {
+    expect(CAPABILITIES_URI).toBe("omnifocus://capabilities");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerCapabilitiesResource
+// ---------------------------------------------------------------------------
+
+describe("registerCapabilitiesResource", () => {
+  it("calls server.registerResource with the correct name and URI", () => {
+    const server = { registerResource: vi.fn() } as unknown as McpServer;
+    const getCapabilities = () => buildCapabilities(makeConfig());
+    registerCapabilitiesResource(server, getCapabilities);
+    expect(server.registerResource).toHaveBeenCalledWith(
+      "omnifocus-capabilities",
+      CAPABILITIES_URI,
+      expect.objectContaining({ mimeType: "application/json" }),
+      expect.any(Function),
+    );
+  });
+
+  it("resource handler returns valid JSON with correct URI", async () => {
+    let capturedCallback: ((uri: URL) => Promise<unknown>) | undefined;
+    const server = {
+      registerResource: (
+        _name: string,
+        _uri: string,
+        _meta: unknown,
+        cb: (uri: URL) => Promise<unknown>,
+      ) => {
+        capturedCallback = cb;
+      },
+    } as unknown as McpServer;
+
+    const caps = buildCapabilities(makeConfig({ OMNIFOCUS_JXA_TIMEOUT_MS: 12_000 }));
+    registerCapabilitiesResource(server, () => caps);
+
+    const result = await capturedCallback?.(new URL(CAPABILITIES_URI));
+    expect(result).toHaveProperty("contents");
+    const contents = (
+      result as { contents: Array<{ uri: string; mimeType: string; text: string }> }
+    ).contents;
+    expect(contents).toHaveLength(1);
+    const first = contents[0] as { uri: string; mimeType: string; text: string };
+    expect(first.uri).toBe(CAPABILITIES_URI);
+    expect(first.mimeType).toBe("application/json");
+    const parsed = JSON.parse(first.text) as { transports: { jxa: { timeoutMs: number } } };
+    expect(parsed.transports.jxa.timeoutMs).toBe(12_000);
+  });
+});

--- a/src/resources/capabilities.ts
+++ b/src/resources/capabilities.ts
@@ -1,0 +1,135 @@
+/**
+ * `omnifocus://capabilities` MCP resource.
+ *
+ * Returns a structured capabilities object so agents can discover feature
+ * availability at session start, avoiding round-trip tool calls that would
+ * trigger `FeatureRequiresPro` or `FeatureRequiresOfVersion` errors.
+ *
+ * **ofVersion / ofEdition** default to `"unknown"` / `"standard"` until the
+ * lazy OF probe (#36) runs. Features that require Pro are `false` until the
+ * edition is confirmed.
+ *
+ * @see DESIGN.md §33 — capabilities resource
+ * @see src/config/env.ts — config values surfaced here
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Config } from "../config/env.js";
+
+// ---------------------------------------------------------------------------
+// Capabilities shape
+// ---------------------------------------------------------------------------
+
+/** Structured capabilities returned by `omnifocus://capabilities`. */
+export interface Capabilities {
+  /** OmniFocus version string, e.g. `"4.2.1"`. `"unknown"` before OF probe. */
+  ofVersion: string;
+  /** OmniFocus edition. `"standard"` before OF probe confirms Pro. */
+  ofEdition: "standard" | "pro";
+  transports: {
+    jxa: { available: boolean; timeoutMs: number };
+    omnijs: { available: boolean; timeoutMs: number };
+  };
+  features: {
+    /** Custom perspectives (OmniFocus Pro only). */
+    customPerspectives: boolean;
+    /** Forecast tag assignment (OmniFocus Pro only). */
+    forecastTag: boolean;
+    /** Repeating task rules (OmniFocus Pro only). */
+    repetitionRules: boolean;
+    /** Plugin / automation invocation (OmniFocus Pro only). */
+    pluginInvocation: boolean;
+    /** Raw JXA / OmniJS escape-hatch tools, enabled via OMNIFOCUS_ALLOW_RAW_SCRIPT=1. */
+    rawScriptTools: boolean;
+  };
+  rateLimits: {
+    /** Tool calls per minute at the default rate limit. */
+    defaultPerToolPerMinute: number;
+  };
+  /** How long idempotency keys are retained (ms). */
+  idempotencyTtlMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/** Default idempotency key TTL: 24 hours. */
+const DEFAULT_IDEMPOTENCY_TTL_MS = 86_400_000;
+
+/**
+ * Build a `Capabilities` object from parsed config.
+ *
+ * Callers may override `ofVersion` and `ofEdition` once the lazy OF probe
+ * completes (see DESIGN §33); until then the defaults signal the unknown state.
+ */
+export function buildCapabilities(
+  config: Config,
+  overrides: { ofVersion?: string; ofEdition?: "standard" | "pro" } = {},
+): Capabilities {
+  const { limit, windowSeconds } = config.OMNIFOCUS_TOOL_RATE_LIMIT;
+  const perMinute = Math.round((limit * 60) / windowSeconds);
+
+  const ofEdition = overrides.ofEdition ?? "standard";
+  const isPro = ofEdition === "pro";
+
+  return {
+    ofVersion: overrides.ofVersion ?? "unknown",
+    ofEdition,
+    transports: {
+      jxa: { available: true, timeoutMs: config.OMNIFOCUS_JXA_TIMEOUT_MS },
+      omnijs: { available: true, timeoutMs: config.OMNIFOCUS_OMNIJS_TIMEOUT_MS },
+    },
+    features: {
+      customPerspectives: isPro,
+      forecastTag: isPro,
+      repetitionRules: isPro,
+      pluginInvocation: isPro,
+      rawScriptTools: config.OMNIFOCUS_ALLOW_RAW_SCRIPT,
+    },
+    rateLimits: {
+      defaultPerToolPerMinute: perMinute,
+    },
+    idempotencyTtlMs: DEFAULT_IDEMPOTENCY_TTL_MS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/** URI at which the resource is exposed. */
+export const CAPABILITIES_URI = "omnifocus://capabilities";
+
+/**
+ * Register the `omnifocus://capabilities` resource with an `McpServer`.
+ *
+ * The `getCapabilities` callback is invoked on each read, allowing the server
+ * to refresh the object after the lazy OF probe (#36) updates edition/version.
+ */
+export function registerCapabilitiesResource(
+  server: McpServer,
+  getCapabilities: () => Capabilities,
+): void {
+  server.registerResource(
+    "omnifocus-capabilities",
+    CAPABILITIES_URI,
+    {
+      description:
+        "Structured capabilities object for this omnifocus-mcp server instance. " +
+        "Read once at session start to discover available features (Pro vs Standard), " +
+        "transport timeouts, rate limits, and whether raw-script tools are enabled. " +
+        "ofVersion and ofEdition are 'unknown'/'standard' until the lazy OF probe runs.",
+      mimeType: "application/json",
+    },
+    async (_uri) => ({
+      contents: [
+        {
+          uri: CAPABILITIES_URI,
+          mimeType: "application/json",
+          text: JSON.stringify(getCapabilities(), null, 2),
+        },
+      ],
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `src/resources/capabilities.ts` with `Capabilities` interface, `buildCapabilities(config)`, and `registerCapabilitiesResource(server, getCapabilities)`
- URI: `omnifocus://capabilities`, MIME: `application/json`
- Config-derived fields: JXA/OmniJS timeouts, raw-script flag, per-minute rate limit
- `ofVersion`/`ofEdition` default to `"unknown"`/`"standard"` until lazy OF probe (#36) runs; all Pro features are `false` until confirmed
- 13 unit tests covering all fields and the registration callback

## Design link
Closes #141.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 852 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Self-reviewed