### PR TITLE
feat(project): project_complete, project_drop, project_move (#44)

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -154,6 +154,21 @@ export class ProjectService {
     };
   }
 
+  /** Complete a project (sets completionDate, removes from active view). */
+  async completeProject(id: ProjectId): Promise<void> {
+    await this.adapter.completeProject(id);
+  }
+
+  /** Drop a project (removes from active view without completing). */
+  async dropProject(id: ProjectId): Promise<void> {
+    await this.adapter.dropProject(id);
+  }
+
+  /** Move a project to a folder (or to the root if folderId is null). */
+  async moveProject(id: ProjectId, destination: { folderId: FolderId | null }): Promise<void> {
+    await this.adapter.moveProject(id, destination);
+  }
+
   /**
    * Fetch a single project by ID, optionally attaching its task tree.
    *

--- a/src/tools/project/complete.test.ts
+++ b/src/tools/project/complete.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for project_complete tool.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { ProjectService } from "../../services/projectService.js";
+import {
+  PROJECT_COMPLETE_DESCRIPTION,
+  handleProjectComplete,
+  projectCompleteInputSchema,
+} from "./complete.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = { wrap: <T>(_k: string, f: () => Promise<T>) => f(), has: () => false };
+  const projectService = new ProjectService({ adapter, cache });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { projectService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("project_complete — input schema", () => {
+  it("requires id", () => {
+    expect(() => projectCompleteInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid project ID", () => {
+    const parsed = projectCompleteInputSchema.parse({ id: "project_000001" });
+    expect(parsed.id).toBe("project_000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("project_complete — handler", () => {
+  it("returns { completed: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "Finish me" });
+    const envelope = await handleProjectComplete({ id }, ctx);
+    expect(envelope.data.completed).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    const envelope = await handleProjectComplete({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("project status is done after completing", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    await handleProjectComplete({ id }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.status).toBe("done");
+  });
+
+  it("throws for unknown project ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleProjectComplete(
+        { id: "project_999999" as import("../../domain/ids.js").ProjectId },
+        ctx,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("tool description mentions 'complete'", () => {
+    expect(PROJECT_COMPLETE_DESCRIPTION.toLowerCase()).toContain("complete");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("project_complete — cache invalidation", () => {
+  it("emits project:${id}, forecast:*, perspective:*, search:*", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const lruCache = new OmniFocusLruCache();
+    const scopes = recordScopes(lruCache);
+    const id = await adapter.createProject({ name: "P" });
+
+    await handleProjectComplete({ id }, { ...base, cache: lruCache });
+
+    expect(scopes).toEqual([`project:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("does not invalidate when complete fails", async () => {
+    const { ctx: base } = makeCtx();
+    const lruCache = new OmniFocusLruCache();
+    const scopes = recordScopes(lruCache);
+    await expect(
+      handleProjectComplete(
+        { id: "project_999999" as import("../../domain/ids.js").ProjectId },
+        { ...base, cache: lruCache },
+      ),
+    ).rejects.toThrow();
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/project/complete.ts
+++ b/src/tools/project/complete.ts
@@ -1,0 +1,73 @@
+/**
+ * `project_complete` MCP tool — mark an OmniFocus project as done.
+ *
+ * @see src/tools/project/drop.ts — project_drop (status change without completing)
+ * @see src/tools/project/delete.ts — project_delete (hard removal)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { ProjectId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { ProjectService } from "../../services/projectService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_COMPLETE_DESCRIPTION =
+  "Complete an OmniFocus project — marks it done with today's date and moves it out of the active view. " +
+  "Use when a project is finished. " +
+  "Do not use to archive or hide a project without completing it; prefer project_drop for that. " +
+  "Returns { completed: true, id }. " +
+  "Side effects: sets completionDate, removes from active projects, sets meta.syncPending = true.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectCompleteInputSchema = z.object({
+  id: ProjectId.schema.describe("Persistent ID of the project to complete."),
+});
+
+export type ProjectCompleteToolInput = z.infer<typeof projectCompleteInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectCompleteContext {
+  projectService: ProjectService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+export async function handleProjectComplete(
+  input: ProjectCompleteToolInput,
+  ctx: ProjectCompleteContext,
+) {
+  await ctx.projectService.completeProject(input.id);
+  if (ctx.cache !== undefined) {
+    invalidateProjectMutation(ctx.cache, { projectId: input.id });
+  }
+  return ok({ completed: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectCompleteTool(server: McpServer, ctx: ProjectCompleteContext) {
+  return server.registerTool(
+    "project_complete",
+    { description: PROJECT_COMPLETE_DESCRIPTION, inputSchema: projectCompleteInputSchema.shape },
+    async (args: ProjectCompleteToolInput) => {
+      const envelope = await handleProjectComplete(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/project/drop.test.ts
+++ b/src/tools/project/drop.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for project_drop tool.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { ProjectService } from "../../services/projectService.js";
+import { PROJECT_DROP_DESCRIPTION, handleProjectDrop, projectDropInputSchema } from "./drop.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = { wrap: <T>(_k: string, f: () => Promise<T>) => f(), has: () => false };
+  const projectService = new ProjectService({ adapter, cache });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { projectService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("project_drop — input schema", () => {
+  it("requires id", () => {
+    expect(() => projectDropInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid project ID", () => {
+    const parsed = projectDropInputSchema.parse({ id: "project_000001" });
+    expect(parsed.id).toBe("project_000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("project_drop — handler", () => {
+  it("returns { dropped: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "Abandon me" });
+    const envelope = await handleProjectDrop({ id }, ctx);
+    expect(envelope.data.dropped).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    const envelope = await handleProjectDrop({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("project status is dropped after dropping", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    await handleProjectDrop({ id }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.status).toBe("dropped");
+  });
+
+  it("throws for unknown project ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleProjectDrop({ id: "project_999999" as import("../../domain/ids.js").ProjectId }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it("tool description mentions 'drop'", () => {
+    expect(PROJECT_DROP_DESCRIPTION.toLowerCase()).toContain("drop");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("project_drop — cache invalidation", () => {
+  it("emits project:${id}, forecast:*, perspective:*, search:*", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const lruCache = new OmniFocusLruCache();
+    const scopes = recordScopes(lruCache);
+    const id = await adapter.createProject({ name: "P" });
+
+    await handleProjectDrop({ id }, { ...base, cache: lruCache });
+
+    expect(scopes).toEqual([`project:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("does not invalidate when drop fails", async () => {
+    const { ctx: base } = makeCtx();
+    const lruCache = new OmniFocusLruCache();
+    const scopes = recordScopes(lruCache);
+    await expect(
+      handleProjectDrop(
+        { id: "project_999999" as import("../../domain/ids.js").ProjectId },
+        { ...base, cache: lruCache },
+      ),
+    ).rejects.toThrow();
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/project/drop.ts
+++ b/src/tools/project/drop.ts
@@ -1,0 +1,70 @@
+/**
+ * `project_drop` MCP tool — mark an OmniFocus project as dropped (on-hold/abandoned).
+ *
+ * @see src/tools/project/complete.ts — project_complete (marks project done)
+ * @see src/tools/project/delete.ts — project_delete (hard removal)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { ProjectId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { ProjectService } from "../../services/projectService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_DROP_DESCRIPTION =
+  "Drop an OmniFocus project — marks it as on-hold/dropped and removes it from the active view without completing it. " +
+  "Use to defer or abandon a project while keeping it recoverable. " +
+  "Do not use if the project is actually done; prefer project_complete for that. " +
+  "Returns { dropped: true, id }. " +
+  "Side effects: changes project status, sets meta.syncPending = true.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectDropInputSchema = z.object({
+  id: ProjectId.schema.describe("Persistent ID of the project to drop."),
+});
+
+export type ProjectDropToolInput = z.infer<typeof projectDropInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectDropContext {
+  projectService: ProjectService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+export async function handleProjectDrop(input: ProjectDropToolInput, ctx: ProjectDropContext) {
+  await ctx.projectService.dropProject(input.id);
+  if (ctx.cache !== undefined) {
+    invalidateProjectMutation(ctx.cache, { projectId: input.id });
+  }
+  return ok({ dropped: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectDropTool(server: McpServer, ctx: ProjectDropContext) {
+  return server.registerTool(
+    "project_drop",
+    { description: PROJECT_DROP_DESCRIPTION, inputSchema: projectDropInputSchema.shape },
+    async (args: ProjectDropToolInput) => {
+      const envelope = await handleProjectDrop(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/project/move.test.ts
+++ b/src/tools/project/move.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for project_move tool.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { FolderId } from "../../domain/ids.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { ProjectService } from "../../services/projectService.js";
+import { handleProjectMove, projectMoveInputSchema } from "./move.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = { wrap: <T>(_k: string, f: () => Promise<T>) => f(), has: () => false };
+  const projectService = new ProjectService({ adapter, cache });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { projectService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("project_move — input schema", () => {
+  it("requires id", () => {
+    expect(() => projectMoveInputSchema.parse({ folderId: null })).toThrow();
+  });
+
+  it("accepts id with a folderId", () => {
+    const parsed = projectMoveInputSchema.parse({ id: "project_000001", folderId: "folder_abc" });
+    expect(parsed.id).toBe("project_000001");
+    expect(parsed.folderId).toBe("folder_abc");
+  });
+
+  it("accepts id with folderId null (move to root)", () => {
+    const parsed = projectMoveInputSchema.parse({ id: "project_000001", folderId: null });
+    expect(parsed.folderId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("project_move — handler", () => {
+  it("returns { moved: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const folderId = await adapter.createFolder({ name: "Target" });
+    const id = await adapter.createProject({ name: "Roaming project" });
+    const envelope = await handleProjectMove({ id, folderId }, ctx);
+    expect(envelope.data.moved).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const folderId = await adapter.createFolder({ name: "F" });
+    const id = await adapter.createProject({ name: "P" });
+    const envelope = await handleProjectMove({ id, folderId }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("project is in the target folder after move", async () => {
+    const { ctx, adapter } = makeCtx();
+    const folderId = await adapter.createFolder({ name: "F" });
+    const id = await adapter.createProject({ name: "P" });
+    await handleProjectMove({ id, folderId }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.folderId).toBe(folderId);
+  });
+
+  it("moves to root when folderId is null", async () => {
+    const { ctx, adapter } = makeCtx();
+    const folderId = await adapter.createFolder({ name: "F" });
+    const id = await adapter.createProject({ name: "P", folderId });
+    await handleProjectMove({ id, folderId: null }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.folderId).toBeNull();
+  });
+
+  it("throws for unknown project ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleProjectMove(
+        { id: "project_999999" as import("../../domain/ids.js").ProjectId, folderId: null },
+        ctx,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("project_move — cache invalidation", () => {
+  it("emits project:${id}, forecast:*, perspective:*, search:*", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const lruCache = new OmniFocusLruCache();
+    const scopes = recordScopes(lruCache);
+    const folderId = await adapter.createFolder({ name: "F" });
+    const id = await adapter.createProject({ name: "P" });
+
+    await handleProjectMove({ id, folderId }, { ...base, cache: lruCache });
+
+    expect(scopes).toEqual([`project:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("does not invalidate when move fails", async () => {
+    const { ctx: base } = makeCtx();
+    const lruCache = new OmniFocusLruCache();
+    const scopes = recordScopes(lruCache);
+    await expect(
+      handleProjectMove(
+        {
+          id: "project_999999" as import("../../domain/ids.js").ProjectId,
+          folderId: "folder_abc" as FolderId,
+        },
+        { ...base, cache: lruCache },
+      ),
+    ).rejects.toThrow();
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/project/move.ts
+++ b/src/tools/project/move.ts
@@ -1,0 +1,72 @@
+/**
+ * `project_move` MCP tool — move an OmniFocus project to a different folder.
+ *
+ * @see src/tools/project/complete.ts — project_complete
+ * @see src/tools/project/drop.ts — project_drop
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { FolderId, ProjectId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { ProjectService } from "../../services/projectService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_MOVE_DESCRIPTION =
+  "Move an OmniFocus project to a different folder. " +
+  "Pass folderId to move into a folder, or null to move to the root (no folder). " +
+  "Use when reorganizing projects. " +
+  "Do not use to complete or drop a project. " +
+  "Returns { moved: true, id }. " +
+  "Side effects: changes the project's folder, sets meta.syncPending = true.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectMoveInputSchema = z.object({
+  id: ProjectId.schema.describe("Persistent ID of the project to move."),
+  folderId: FolderId.schema.nullable().describe("Target folder ID, or null to move to root."),
+});
+
+export type ProjectMoveToolInput = z.infer<typeof projectMoveInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectMoveContext {
+  projectService: ProjectService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+export async function handleProjectMove(input: ProjectMoveToolInput, ctx: ProjectMoveContext) {
+  await ctx.projectService.moveProject(input.id, { folderId: input.folderId });
+  if (ctx.cache !== undefined) {
+    invalidateProjectMutation(ctx.cache, { projectId: input.id });
+  }
+  return ok({ moved: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectMoveTool(server: McpServer, ctx: ProjectMoveContext) {
+  return server.registerTool(
+    "project_move",
+    { description: PROJECT_MOVE_DESCRIPTION, inputSchema: projectMoveInputSchema.shape },
+    async (args: ProjectMoveToolInput) => {
+      const envelope = await handleProjectMove(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `project_complete` — marks project done with today's date, cache-invalidated
- `project_drop` — soft removal from active view (recoverable), cache-invalidated
- `project_move` — relocates project to folder or root (`folderId: null`), cache-invalidated
- `ProjectService` extended with `completeProject`, `dropProject`, `moveProject`
- 24 unit tests (8 per tool) — 911 total passing

## Design link
Closes #44. Note: `project_delete` was already shipped separately; AC for that item was already met.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 911 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean