### PR TITLE
feat(task): task_complete, task_uncomplete, task_drop, task_undrop (#40)

### DIFF
--- a/src/tools/task/complete.test.ts
+++ b/src/tools/task/complete.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for task_complete tool.
+ *
+ * Covers: schema validation, successful completion, idempotency (noChange),
+ * syncPending flag, and cache invalidation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskComplete, taskCompleteInputSchema } from "./complete.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_complete — input schema", () => {
+  it("requires id", () => {
+    expect(() => taskCompleteInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts id only", () => {
+    const parsed = taskCompleteInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+
+  it("accepts id + at with offset", () => {
+    const parsed = taskCompleteInputSchema.parse({
+      id: "task_000001",
+      at: "2026-01-01T12:00:00+00:00",
+    });
+    expect(parsed.at).toBe("2026-01-01T12:00:00+00:00");
+  });
+
+  it("rejects at without timezone offset", () => {
+    expect(() =>
+      taskCompleteInputSchema.parse({ id: "task_000001", at: "2026-01-01T12:00:00" }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("task_complete — handler", () => {
+  it("returns { done: true, id } for an incomplete task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskComplete({ id }, ctx);
+    expect("done" in envelope.data && envelope.data.done).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true when completing", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskComplete({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("returns { noChange: true, id } for an already-completed task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.completeTask(id);
+    const envelope = await handleTaskComplete({ id }, ctx);
+    expect("noChange" in envelope.data && envelope.data.noChange).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("meta.syncPending is falsy when noChange", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.completeTask(id);
+    const envelope = await handleTaskComplete({ id }, ctx);
+    expect(envelope.meta.syncPending).toBeFalsy();
+  });
+
+  it("marks the task as completed in the adapter", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await handleTaskComplete({ id }, ctx);
+    const task = await adapter.getTask(id);
+    expect(task.completed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("task_complete — cache invalidation", () => {
+  it("emits task:${id}, forecast:*, perspective:*, search:* for inbox task", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "Inbox" });
+
+    await handleTaskComplete({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([`task:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("emits project:${projectId} for a project task", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const projectId = await adapter.createProject({ name: "P" });
+    const id = await adapter.createTask({ name: "T", projectId });
+
+    await handleTaskComplete({ id }, { ...base, cache });
+
+    expect(scopes).toContain(`project:${projectId}`);
+  });
+
+  it("does not invalidate on noChange", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "T" });
+    await adapter.completeTask(id);
+
+    await handleTaskComplete({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/task/complete.ts
+++ b/src/tools/task/complete.ts
@@ -1,0 +1,82 @@
+/**
+ * `task_complete` MCP tool — mark an OmniFocus task as done.
+ *
+ * @see src/tools/task/uncomplete.ts — reverse operation
+ * @see src/tools/task/drop.ts — task_drop (deferred without completing)
+ * @see src/tools/task/delete.ts — task_delete (irreversible hard removal)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_COMPLETE_DESCRIPTION =
+  "Complete an OmniFocus task — marks it done with a completion timestamp. " +
+  "Accepts an optional ISO-8601 date for the completion time; defaults to now. " +
+  "Idempotent: returns noChange: true if the task is already completed. " +
+  "Do not use to drop or delete a task. " +
+  "Returns { done: true, id } or { noChange: true, id }. " +
+  "Side effects: sets completedAt, sets meta.syncPending = true.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskCompleteInputSchema = z.object({
+  id: TaskId.schema.describe("Persistent task ID."),
+  at: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("ISO-8601 completion time. Defaults to now."),
+});
+
+export type TaskCompleteToolInput = z.infer<typeof taskCompleteInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskCompleteContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+export async function handleTaskComplete(input: TaskCompleteToolInput, ctx: TaskCompleteContext) {
+  const task = await ctx.adapter.getTask(input.id);
+  if (task.completed) {
+    return ok({ noChange: true as const, id: input.id }, ctx.makeMeta());
+  }
+  const at = input.at !== undefined ? new Date(input.at) : undefined;
+  await ctx.adapter.completeTask(input.id, at);
+  if (ctx.cache !== undefined) {
+    invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
+  }
+  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskCompleteTool(server: McpServer, ctx: TaskCompleteContext) {
+  return server.registerTool(
+    "task_complete",
+    { description: TASK_COMPLETE_DESCRIPTION, inputSchema: taskCompleteInputSchema.shape },
+    async (args: TaskCompleteToolInput) => {
+      const envelope = await handleTaskComplete(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/task/drop.test.ts
+++ b/src/tools/task/drop.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for task_drop tool.
+ *
+ * Covers: schema validation, successful drop, idempotency (noChange),
+ * syncPending flag, and cache invalidation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskDrop, taskDropInputSchema } from "./drop.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_drop — input schema", () => {
+  it("requires id", () => {
+    expect(() => taskDropInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts id only", () => {
+    const parsed = taskDropInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+
+  it("accepts id + at with offset", () => {
+    const parsed = taskDropInputSchema.parse({
+      id: "task_000001",
+      at: "2026-01-01T12:00:00+00:00",
+    });
+    expect(parsed.at).toBe("2026-01-01T12:00:00+00:00");
+  });
+
+  it("rejects at without timezone offset", () => {
+    expect(() =>
+      taskDropInputSchema.parse({ id: "task_000001", at: "2026-01-01T12:00:00" }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("task_drop — handler", () => {
+  it("returns { done: true, id } for an active task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskDrop({ id }, ctx);
+    expect("done" in envelope.data && envelope.data.done).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true when dropping", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskDrop({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("returns { noChange: true, id } for an already-dropped task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.dropTask(id);
+    const envelope = await handleTaskDrop({ id }, ctx);
+    expect("noChange" in envelope.data && envelope.data.noChange).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("meta.syncPending is falsy when noChange", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.dropTask(id);
+    const envelope = await handleTaskDrop({ id }, ctx);
+    expect(envelope.meta.syncPending).toBeFalsy();
+  });
+
+  it("marks the task as dropped in the adapter", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await handleTaskDrop({ id }, ctx);
+    const task = await adapter.getTask(id);
+    expect(task.dropped).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("task_drop — cache invalidation", () => {
+  it("emits task:${id}, forecast:*, perspective:*, search:* for inbox task", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "Inbox" });
+
+    await handleTaskDrop({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([`task:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("emits project:${projectId} for a project task", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const projectId = await adapter.createProject({ name: "P" });
+    const id = await adapter.createTask({ name: "T", projectId });
+
+    await handleTaskDrop({ id }, { ...base, cache });
+
+    expect(scopes).toContain(`project:${projectId}`);
+  });
+
+  it("does not invalidate on noChange", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "T" });
+    await adapter.dropTask(id);
+
+    await handleTaskDrop({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/task/drop.ts
+++ b/src/tools/task/drop.ts
@@ -1,0 +1,83 @@
+/**
+ * `task_drop` MCP tool — drop an OmniFocus task (reversible status change).
+ *
+ * @see src/tools/task/undrop.ts — reverse operation
+ * @see src/tools/task/complete.ts — task_complete (marks done, not dropped)
+ * @see src/tools/task/delete.ts — task_delete (irreversible hard removal)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_DROP_DESCRIPTION =
+  "Drop an OmniFocus task — marks it as dropped/deferred and removes it from active view. " +
+  "Reversible via task_undrop. " +
+  "Accepts an optional ISO-8601 date. " +
+  "Idempotent: returns noChange: true if already dropped. " +
+  "Do not use to complete or delete a task. " +
+  "Returns { done: true, id } or { noChange: true, id }. " +
+  "Side effects: sets droppedAt, sets meta.syncPending = true.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskDropInputSchema = z.object({
+  id: TaskId.schema.describe("Persistent task ID."),
+  at: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("ISO-8601 drop time. Defaults to now."),
+});
+
+export type TaskDropToolInput = z.infer<typeof taskDropInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskDropContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+export async function handleTaskDrop(input: TaskDropToolInput, ctx: TaskDropContext) {
+  const task = await ctx.adapter.getTask(input.id);
+  if (task.dropped) {
+    return ok({ noChange: true as const, id: input.id }, ctx.makeMeta());
+  }
+  const at = input.at !== undefined ? new Date(input.at) : undefined;
+  await ctx.adapter.dropTask(input.id, at);
+  if (ctx.cache !== undefined) {
+    invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
+  }
+  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskDropTool(server: McpServer, ctx: TaskDropContext) {
+  return server.registerTool(
+    "task_drop",
+    { description: TASK_DROP_DESCRIPTION, inputSchema: taskDropInputSchema.shape },
+    async (args: TaskDropToolInput) => {
+      const envelope = await handleTaskDrop(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/task/uncomplete.test.ts
+++ b/src/tools/task/uncomplete.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for task_uncomplete tool.
+ *
+ * Covers: schema validation, successful uncomplete, idempotency (noChange),
+ * syncPending flag, and cache invalidation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskUncomplete, taskUncompleteInputSchema } from "./uncomplete.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_uncomplete — input schema", () => {
+  it("requires id", () => {
+    expect(() => taskUncompleteInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid task ID", () => {
+    const parsed = taskUncompleteInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("task_uncomplete — handler", () => {
+  it("returns { done: true, id } for a completed task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.completeTask(id);
+    const envelope = await handleTaskUncomplete({ id }, ctx);
+    expect("done" in envelope.data && envelope.data.done).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true when uncompleting", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.completeTask(id);
+    const envelope = await handleTaskUncomplete({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("returns { noChange: true, id } for an already-incomplete task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskUncomplete({ id }, ctx);
+    expect("noChange" in envelope.data && envelope.data.noChange).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("meta.syncPending is falsy when noChange", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskUncomplete({ id }, ctx);
+    expect(envelope.meta.syncPending).toBeFalsy();
+  });
+
+  it("marks the task as incomplete in the adapter", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.completeTask(id);
+    await handleTaskUncomplete({ id }, ctx);
+    const task = await adapter.getTask(id);
+    expect(task.completed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("task_uncomplete — cache invalidation", () => {
+  it("emits task:${id}, forecast:*, perspective:*, search:* for inbox task", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "Inbox" });
+    await adapter.completeTask(id);
+
+    await handleTaskUncomplete({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([`task:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("does not invalidate on noChange", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "T" });
+
+    await handleTaskUncomplete({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/task/uncomplete.ts
+++ b/src/tools/task/uncomplete.ts
@@ -1,0 +1,77 @@
+/**
+ * `task_uncomplete` MCP tool — mark an OmniFocus task as incomplete.
+ *
+ * @see src/tools/task/complete.ts — reverse operation
+ * @see src/tools/task/undrop.ts — task_undrop (restore a dropped task)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_UNCOMPLETE_DESCRIPTION =
+  "Mark an OmniFocus task as incomplete — removes its completion timestamp. " +
+  "Idempotent: returns noChange: true if the task is already incomplete. " +
+  "Do not use to drop or delete a task. " +
+  "Returns { done: true, id } or { noChange: true, id }. " +
+  "Side effects: clears completedAt, sets meta.syncPending = true.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskUncompleteInputSchema = z.object({
+  id: TaskId.schema.describe("Persistent task ID."),
+});
+
+export type TaskUncompleteToolInput = z.infer<typeof taskUncompleteInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskUncompleteContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+export async function handleTaskUncomplete(
+  input: TaskUncompleteToolInput,
+  ctx: TaskUncompleteContext,
+) {
+  const task = await ctx.adapter.getTask(input.id);
+  if (task.completed === false) {
+    return ok({ noChange: true as const, id: input.id }, ctx.makeMeta());
+  }
+  await ctx.adapter.uncompleteTask(input.id);
+  if (ctx.cache !== undefined) {
+    invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
+  }
+  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskUncompleteTool(server: McpServer, ctx: TaskUncompleteContext) {
+  return server.registerTool(
+    "task_uncomplete",
+    { description: TASK_UNCOMPLETE_DESCRIPTION, inputSchema: taskUncompleteInputSchema.shape },
+    async (args: TaskUncompleteToolInput) => {
+      const envelope = await handleTaskUncomplete(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/task/undrop.test.ts
+++ b/src/tools/task/undrop.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for task_undrop tool.
+ *
+ * Covers: schema validation, successful undrop, idempotency (noChange),
+ * syncPending flag, and cache invalidation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskUndrop, taskUndropInputSchema } from "./undrop.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_undrop — input schema", () => {
+  it("requires id", () => {
+    expect(() => taskUndropInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid task ID", () => {
+    const parsed = taskUndropInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("task_undrop — handler", () => {
+  it("returns { done: true, id } for a dropped task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.dropTask(id);
+    const envelope = await handleTaskUndrop({ id }, ctx);
+    expect("done" in envelope.data && envelope.data.done).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true when undropping", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.dropTask(id);
+    const envelope = await handleTaskUndrop({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("returns { noChange: true, id } for an already-active (not dropped) task", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskUndrop({ id }, ctx);
+    expect("noChange" in envelope.data && envelope.data.noChange).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("meta.syncPending is falsy when noChange", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    const envelope = await handleTaskUndrop({ id }, ctx);
+    expect(envelope.meta.syncPending).toBeFalsy();
+  });
+
+  it("marks the task as active in the adapter", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Test" });
+    await adapter.dropTask(id);
+    await handleTaskUndrop({ id }, ctx);
+    const task = await adapter.getTask(id);
+    expect(task.dropped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("task_undrop — cache invalidation", () => {
+  it("emits task:${id}, forecast:*, perspective:*, search:* for inbox task", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "Inbox" });
+    await adapter.dropTask(id);
+
+    await handleTaskUndrop({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([`task:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("does not invalidate on noChange", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createTask({ name: "T" });
+
+    await handleTaskUndrop({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/task/undrop.ts
+++ b/src/tools/task/undrop.ts
@@ -1,0 +1,74 @@
+/**
+ * `task_undrop` MCP tool — restore a dropped OmniFocus task to active view.
+ *
+ * @see src/tools/task/drop.ts — reverse operation
+ * @see src/tools/task/uncomplete.ts — task_uncomplete (undo completion)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_UNDROP_DESCRIPTION =
+  "Restore a dropped OmniFocus task — clears its dropped status and returns it to the active view. " +
+  "Idempotent: returns noChange: true if the task is not dropped. " +
+  "Do not use to complete a task. " +
+  "Returns { done: true, id } or { noChange: true, id }. " +
+  "Side effects: clears droppedAt, sets meta.syncPending = true.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskUndropInputSchema = z.object({
+  id: TaskId.schema.describe("Persistent task ID."),
+});
+
+export type TaskUndropToolInput = z.infer<typeof taskUndropInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskUndropContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+export async function handleTaskUndrop(input: TaskUndropToolInput, ctx: TaskUndropContext) {
+  const task = await ctx.adapter.getTask(input.id);
+  if (task.dropped === false) {
+    return ok({ noChange: true as const, id: input.id }, ctx.makeMeta());
+  }
+  await ctx.adapter.undropTask(input.id);
+  if (ctx.cache !== undefined) {
+    invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
+  }
+  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskUndropTool(server: McpServer, ctx: TaskUndropContext) {
+  return server.registerTool(
+    "task_undrop",
+    { description: TASK_UNDROP_DESCRIPTION, inputSchema: taskUndropInputSchema.shape },
+    async (args: TaskUndropToolInput) => {
+      const envelope = await handleTaskUndrop(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `task_complete` — marks done with optional ISO-8601 timestamp; idempotent
- `task_uncomplete` — clears completion; idempotent
- `task_drop` — soft-remove from active view with optional timestamp; idempotent
- `task_undrop` — restores dropped task; idempotent
- All four return `{ noChange: true, id }` when already in target state (no write, no syncPending)
- Cache invalidation: task + project + forecast + perspective + search scopes
- 42 unit tests (≥10 per tool); 953 total passing

## Design link
Closes #40.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 953 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean