### PR TITLE
feat(task): task_create tool (#38)

### DIFF
--- a/src/tools/task/create.test.ts
+++ b/src/tools/task/create.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for task_create tool.
+ *
+ * Covers: schema validation, inbox task creation, project task creation,
+ * mutual-exclusion refine, syncPending meta, and description content.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { TASK_CREATE_DESCRIPTION, handleTaskCreate, taskCreateInputSchema } from "./create.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  const adapter = new InMemoryAdapter();
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { adapter, ctx: { adapter, makeMeta } };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_create — input schema", () => {
+  it("accepts minimal inbox task", () => {
+    expect(taskCreateInputSchema.safeParse({ name: "Test" }).success).toBe(true);
+  });
+
+  it("accepts project task with optional fields", () => {
+    const result = taskCreateInputSchema.safeParse({
+      name: "Test",
+      projectId: "proj-abc123",
+      flagged: true,
+      dueDate: "2025-01-01T00:00:00+00:00",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    const result = taskCreateInputSchema.safeParse({ name: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects both projectId and parentTaskId", () => {
+    const result = taskCreateInputSchema.safeParse({
+      name: "Test",
+      projectId: "proj-abc123",
+      parentTaskId: "task-abc123",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("task_create — handler", () => {
+  it("creates an inbox task and returns an id", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleTaskCreate({ name: "Inbox task" }, ctx);
+    expect(typeof envelope.data.id).toBe("string");
+    expect(envelope.data.id.length).toBeGreaterThan(0);
+  });
+
+  it("creates a project task", async () => {
+    const { adapter, ctx } = makeCtx();
+    const pid = await adapter.createProject({ name: "TestProject" });
+    const envelope = await handleTaskCreate({ name: "Project task", projectId: pid }, ctx);
+    expect(typeof envelope.data.id).toBe("string");
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleTaskCreate({ name: "Task" }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Description
+// ---------------------------------------------------------------------------
+
+describe("task_create — description", () => {
+  it("mentions inbox", () => {
+    expect(TASK_CREATE_DESCRIPTION).toContain("inbox");
+  });
+
+  it("mentions sync_trigger", () => {
+    expect(TASK_CREATE_DESCRIPTION).toContain("sync_trigger");
+  });
+});

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -1,0 +1,138 @@
+/**
+ * `task_create` MCP tool — create a new OmniFocus task.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/task/update.ts — task_update (patch editable fields)
+ * @see docs/domain-reference.md — inbox vs project vs subtask placement
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
+import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_CREATE_DESCRIPTION =
+  "Create a new task in OmniFocus — in the inbox, inside a project, or as a subtask of another task. " +
+  "Supply exactly one of: projectId (project task), parentTaskId (subtask), or neither (inbox). " +
+  "Do not use for bulk creation; prefer task_batch_create for that. " +
+  "Returns the new task's id. " +
+  "Side effects: creates a task in OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need the task to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Base object schema — used for MCP tool registration (.shape is accessible).
+ * The SDK needs individual field descriptors; ZodEffects from .refine() lacks .shape.
+ */
+const taskCreateInputBaseSchema = z.object({
+  name: z.string().min(1).describe("Task name. Required, must be non-empty."),
+
+  // Target: at most one of projectId or parentTaskId; neither = inbox
+  projectId: ProjectId.schema
+    .optional()
+    .describe("Project to add the task to. Omit for inbox or subtask."),
+  parentTaskId: TaskId.schema
+    .optional()
+    .describe("Parent task ID for a subtask. Omit for inbox or project task."),
+
+  // Optional fields
+  note: z.string().optional().describe("Plain-text note."),
+  flagged: z.boolean().optional().describe("Flag the task."),
+  dueDate: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("Due date as ISO-8601 with offset."),
+  deferDate: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("Defer date as ISO-8601 with offset."),
+  estimatedMinutes: z.number().int().min(1).optional().describe("Estimated duration in minutes."),
+  tagIds: z.array(TagId.schema).optional().describe("Tag IDs to apply."),
+  sequential: z.boolean().optional().describe("If true, subtasks must be completed in order."),
+  completedByChildren: z.boolean().optional().describe("Complete when all subtasks complete."),
+});
+
+/**
+ * Full input schema with cross-field refinement.
+ * The base schema's `.shape` is used for MCP tool registration so the SDK
+ * can read individual field descriptors (ZodEffects from `.refine()` lacks `.shape`).
+ */
+export const taskCreateInputSchema = taskCreateInputBaseSchema.refine(
+  (v) => !(v.projectId !== undefined && v.parentTaskId !== undefined),
+  { message: "Supply at most one of projectId or parentTaskId", path: ["projectId"] },
+);
+
+export type TaskCreateToolInput = z.infer<typeof taskCreateInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskCreateContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+/**
+ * Pure handler for `task_create`.
+ *
+ * Creates a task in the inbox, inside a project, or as a subtask. Flushes
+ * the task-mutation scope set after a successful adapter call.
+ *
+ * @throws {NotFound} when projectId or parentTaskId does not exist
+ * @throws {OmniFocusNotRunning} when OmniFocus is not running
+ */
+export async function handleTaskCreate(input: TaskCreateToolInput, ctx: TaskCreateContext) {
+  const taskInput: CreateTaskInput = {
+    name: input.name,
+    ...(input.projectId !== undefined && { projectId: input.projectId }),
+    ...(input.parentTaskId !== undefined && { parentId: input.parentTaskId }),
+    ...(input.note !== undefined && { note: input.note }),
+    ...(input.flagged !== undefined && { flagged: input.flagged }),
+    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
+    ...(input.deferDate !== undefined && { deferDate: input.deferDate }),
+    ...(input.estimatedMinutes !== undefined && { estimatedMinutes: input.estimatedMinutes }),
+    ...(input.tagIds !== undefined && { tagIds: input.tagIds }),
+    ...(input.sequential !== undefined && { sequential: input.sequential }),
+    ...(input.completedByChildren !== undefined && {
+      completedByChildren: input.completedByChildren,
+    }),
+  };
+  const id = await ctx.adapter.createTask(taskInput);
+  if (ctx.cache !== undefined) {
+    invalidateTaskMutation(ctx.cache, {
+      ...(input.projectId !== undefined && { projectId: input.projectId }),
+    });
+  }
+  return ok({ id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskCreateTool(server: McpServer, ctx: TaskCreateContext) {
+  return server.registerTool(
+    "task_create",
+    { description: TASK_CREATE_DESCRIPTION, inputSchema: taskCreateInputBaseSchema.shape },
+    async (args: TaskCreateToolInput) => {
+      const envelope = await handleTaskCreate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `task_create` tool: creates tasks in inbox, in a project, or as subtasks
- Full field coverage: name, projectId/parentTaskId (mutually exclusive), note, flagged, dueDate, deferDate, estimatedMinutes, tagIds, sequential, completedByChildren
- ValidationError when both `projectId` and `parentTaskId` supplied
- Cache-invalidates the target project scope on creation
- 9 unit tests; 962 total passing

## Design link
Closes #38.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 962 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean