### PR TITLE
feat(project): add project_create and project_update tools

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -25,7 +25,11 @@
  * @see src/services/taskService.ts — sibling service for tasks
  */
 
-import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import type {
+  CreateProjectInput,
+  OmniFocusAdapter,
+  UpdateProjectInput,
+} from "../adapter/OmniFocusAdapter.js";
 import type { FolderId, ProjectId } from "../domain/ids.js";
 import type { Project } from "../domain/project.js";
 import type { Task } from "../domain/task.js";
@@ -167,6 +171,16 @@ export class ProjectService {
   /** Move a project to a folder (or to the root if folderId is null). */
   async moveProject(id: ProjectId, destination: { folderId: FolderId | null }): Promise<void> {
     await this.adapter.moveProject(id, destination);
+  }
+
+  /** Create a new project with the given fields. Returns the new project's ID. */
+  async createProject(input: CreateProjectInput): Promise<ProjectId> {
+    return this.adapter.createProject(input);
+  }
+
+  /** Partially update mutable fields on an existing project. */
+  async updateProject(id: ProjectId, patch: UpdateProjectInput): Promise<void> {
+    return this.adapter.updateProject(id, patch);
   }
 
   /**

--- a/src/tools/project/create.test.ts
+++ b/src/tools/project/create.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for project_create tool.
+ *
+ * Covers: schema validation, successful creation, optional fields,
+ * cache invalidation, and response shape.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleProjectCreate, projectCreateInputSchema } from "./create.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("project_create — input schema", () => {
+  it("requires name", () => {
+    expect(() => projectCreateInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() => projectCreateInputSchema.parse({ name: "" })).toThrow();
+  });
+
+  it("accepts minimal input (name only)", () => {
+    const parsed = projectCreateInputSchema.parse({ name: "My Project" });
+    expect(parsed.name).toBe("My Project");
+  });
+
+  it("accepts full optional fields", () => {
+    const parsed = projectCreateInputSchema.parse({
+      name: "Full Project",
+      status: "on-hold",
+      completionCriterion: "sequential",
+      flagged: true,
+      estimatedMinutes: 60,
+      reviewIntervalDays: 7,
+      deferDate: "2026-01-01T00:00:00+00:00",
+      dueDate: "2026-02-01T00:00:00+00:00",
+    });
+    expect(parsed.status).toBe("on-hold");
+    expect(parsed.completionCriterion).toBe("sequential");
+    expect(parsed.flagged).toBe(true);
+    expect(parsed.estimatedMinutes).toBe(60);
+    expect(parsed.reviewIntervalDays).toBe(7);
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => projectCreateInputSchema.parse({ name: "P", status: "completed" })).toThrow();
+  });
+
+  it("rejects estimatedMinutes < 1", () => {
+    expect(() => projectCreateInputSchema.parse({ name: "P", estimatedMinutes: 0 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("project_create — handler", () => {
+  it("creates a project and returns { created: true, id }", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleProjectCreate({ name: "New Project" }, ctx);
+
+    expect(envelope.data.created).toBe(true);
+    expect(typeof envelope.data.id).toBe("string");
+    expect(envelope.data.id.length).toBeGreaterThan(0);
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleProjectCreate({ name: "P" }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("project is retrievable from adapter after creation", async () => {
+    const { ctx, adapter } = makeCtx();
+    const envelope = await handleProjectCreate({ name: "Retrievable" }, ctx);
+    const project = await adapter.getProject(envelope.data.id);
+    expect(project.name).toBe("Retrievable");
+  });
+
+  it("creates with status on-hold", async () => {
+    const { ctx, adapter } = makeCtx();
+    const envelope = await handleProjectCreate({ name: "On Hold", status: "on-hold" }, ctx);
+    const project = await adapter.getProject(envelope.data.id);
+    expect(project.status).toBe("on-hold");
+  });
+
+  it("creates with flagged=true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const envelope = await handleProjectCreate({ name: "Flagged", flagged: true }, ctx);
+    const project = await adapter.getProject(envelope.data.id);
+    expect(project.flagged).toBe(true);
+  });
+
+  it("creates without optional fields (minimal path)", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleProjectCreate({ name: "Minimal" }, ctx);
+    expect(envelope.data.created).toBe(true);
+  });
+
+  it("multiple creates return distinct IDs", async () => {
+    const { ctx } = makeCtx();
+    const a = await handleProjectCreate({ name: "A" }, ctx);
+    const b = await handleProjectCreate({ name: "B" }, ctx);
+    expect(a.data.id).not.toBe(b.data.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("project_create — cache invalidation", () => {
+  it("emits project:${id}, forecast:*, perspective:*, search:*", async () => {
+    const { ctx: base } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+
+    const envelope = await handleProjectCreate({ name: "Cache Test" }, { ...base, cache });
+    const id = envelope.data.id;
+
+    expect(scopes).toEqual([`project:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("does not invalidate when no cache is provided", async () => {
+    const { ctx } = makeCtx();
+    // No error, just no cache side-effects
+    const envelope = await handleProjectCreate({ name: "No Cache" }, ctx);
+    expect(envelope.data.created).toBe(true);
+  });
+});

--- a/src/tools/project/create.ts
+++ b/src/tools/project/create.ts
@@ -1,0 +1,140 @@
+/**
+ * `project_create` MCP tool — create a new OmniFocus project.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/project/update.ts — project_update (patch editable fields)
+ * @see docs/domain-reference.md — project schema
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { CreateProjectInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { FolderId, TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_CREATE_DESCRIPTION =
+  "Create a new OmniFocus project. " +
+  "Optionally place it in a folder, assign tags, set completion criterion, status, defer/due dates, " +
+  "estimated minutes, flagged state, and review interval. " +
+  "Returns { created: true, id }. " +
+  "Side effects: creates a project in OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need the project to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectCreateInputSchema = z.object({
+  name: z.string().min(1).describe("Project name. Required, must be non-empty."),
+  folderId: FolderId.schema
+    .optional()
+    .describe("Folder ID to place the project in. Omit for root."),
+  note: z.string().optional().describe("Plain-text note for the project."),
+  status: z
+    .enum(["active", "on-hold"])
+    .optional()
+    .describe("Initial project status. Default: active."),
+  completionCriterion: z
+    .enum(["parallel", "sequential", "singleActions"])
+    .optional()
+    .describe(
+      "How the project's tasks are completed: parallel (any order), sequential (in order), or singleActions.",
+    ),
+  deferDate: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("Defer date as ISO-8601 with UTC offset."),
+  dueDate: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("Due date as ISO-8601 with UTC offset."),
+  estimatedMinutes: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Estimated total duration in minutes."),
+  flagged: z.boolean().optional().describe("Flag the project."),
+  tagIds: z.array(TagId.schema).optional().describe("Tag IDs to apply to the project."),
+  reviewIntervalDays: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Review interval in days. Omit to use OmniFocus default."),
+});
+
+export type ProjectCreateToolInput = z.infer<typeof projectCreateInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectCreateContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+}
+
+/**
+ * Pure handler for `project_create`.
+ *
+ * Delegates to `adapter.createProject`, then flushes the project-mutation
+ * cache scopes. Returns the new project's ID.
+ *
+ * @throws {NotFound} when folderId or any tagId does not exist
+ * @throws {OmniFocusNotRunning} when OmniFocus is not running
+ */
+export async function handleProjectCreate(
+  input: ProjectCreateToolInput,
+  ctx: ProjectCreateContext,
+) {
+  const projectInput: CreateProjectInput = {
+    name: input.name,
+    ...(input.folderId !== undefined && { folderId: input.folderId }),
+    ...(input.note !== undefined && { note: input.note }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.completionCriterion !== undefined && {
+      completionCriterion: input.completionCriterion,
+    }),
+    ...(input.deferDate !== undefined && { deferDate: input.deferDate }),
+    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
+    ...(input.estimatedMinutes !== undefined && { estimatedMinutes: input.estimatedMinutes }),
+    ...(input.flagged !== undefined && { flagged: input.flagged }),
+    ...(input.tagIds !== undefined && { tagIds: input.tagIds }),
+    ...(input.reviewIntervalDays !== undefined && { reviewIntervalDays: input.reviewIntervalDays }),
+  };
+
+  const id = await ctx.adapter.createProject(projectInput);
+
+  if (ctx.cache !== undefined) {
+    invalidateProjectMutation(ctx.cache, { projectId: id });
+  }
+
+  return ok({ created: true as const, id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectCreateTool(server: McpServer, ctx: ProjectCreateContext) {
+  return server.registerTool(
+    "project_create",
+    { description: PROJECT_CREATE_DESCRIPTION, inputSchema: projectCreateInputSchema.shape },
+    async (args: ProjectCreateToolInput) => {
+      const envelope = await handleProjectCreate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}

--- a/src/tools/project/update.test.ts
+++ b/src/tools/project/update.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for project_update tool.
+ *
+ * Covers: schema validation, successful update, nullable field clearing,
+ * cache invalidation, and response shape.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleProjectUpdate, projectUpdateInputSchema } from "./update.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
+    scopes.push(e.scope);
+  });
+  return scopes;
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("project_update — input schema", () => {
+  it("requires id", () => {
+    expect(() => projectUpdateInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts id only (no-op patch)", () => {
+    const parsed = projectUpdateInputSchema.parse({ id: "project_000001" });
+    expect(parsed.id).toBe("project_000001");
+  });
+
+  it("accepts nullable note (null = clear)", () => {
+    const parsed = projectUpdateInputSchema.parse({ id: "project_000001", note: null });
+    expect(parsed.note).toBeNull();
+  });
+
+  it("rejects empty name", () => {
+    expect(() => projectUpdateInputSchema.parse({ id: "project_000001", name: "" })).toThrow();
+  });
+
+  it("rejects invalid status", () => {
+    expect(() =>
+      projectUpdateInputSchema.parse({ id: "project_000001", status: "dropped" }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("project_update — handler", () => {
+  it("updates a project and returns { updated: true, id }", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "Original" });
+
+    const envelope = await handleProjectUpdate({ id, name: "Updated" }, ctx);
+
+    expect(envelope.data.updated).toBe(true);
+    expect(envelope.data.id).toBe(id);
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P" });
+    const envelope = await handleProjectUpdate({ id }, ctx);
+    expect(envelope.meta.syncPending).toBe(true);
+  });
+
+  it("adapter receives the name patch", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "Before" });
+    await handleProjectUpdate({ id, name: "After" }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.name).toBe("After");
+  });
+
+  it("adapter receives the flagged patch", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P", flagged: false });
+    await handleProjectUpdate({ id, flagged: true }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.flagged).toBe(true);
+  });
+
+  it("adapter receives the status patch", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "P", status: "active" });
+    await handleProjectUpdate({ id, status: "on-hold" }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.status).toBe("on-hold");
+  });
+
+  it("omitted fields are not changed", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createProject({ name: "Keep Me", flagged: true });
+    await handleProjectUpdate({ id, status: "on-hold" }, ctx);
+    const project = await adapter.getProject(id);
+    expect(project.name).toBe("Keep Me");
+    expect(project.flagged).toBe(true);
+  });
+
+  it("throws NotFound for unknown project ID", async () => {
+    const { ctx } = makeCtx();
+    await expect(
+      handleProjectUpdate(
+        { id: "project_999999" as import("../../domain/ids.js").ProjectId, name: "X" },
+        ctx,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("project_update — cache invalidation", () => {
+  it("emits project:${id}, forecast:*, perspective:*, search:*", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    const id = await adapter.createProject({ name: "P" });
+
+    await handleProjectUpdate({ id }, { ...base, cache });
+
+    expect(scopes).toEqual([`project:${id}`, "forecast:*", "perspective:*", "search:*"]);
+  });
+
+  it("does not invalidate when update fails (NotFound)", async () => {
+    const { ctx: base } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    await expect(
+      handleProjectUpdate(
+        { id: "project_999999" as import("../../domain/ids.js").ProjectId },
+        { ...base, cache },
+      ),
+    ).rejects.toThrow();
+    expect(scopes).toEqual([]);
+  });
+});

--- a/src/tools/project/update.ts
+++ b/src/tools/project/update.ts
@@ -1,0 +1,156 @@
+/**
+ * `project_update` MCP tool — partial-patch update for OmniFocus projects.
+ *
+ * Only supplied fields are changed; omit a field to leave it unchanged.
+ * Pass null for nullable fields (note, deferDate, dueDate, estimatedMinutes,
+ * reviewIntervalDays) to clear them.
+ *
+ * @see DESIGN.md §26 — reference tool pattern
+ * @see src/tools/project/create.ts — project_create (initial creation)
+ * @see docs/domain-reference.md — project schema
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter, UpdateProjectInput } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { ProjectId, TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_UPDATE_DESCRIPTION =
+  "Partially update mutable fields on an OmniFocus project. " +
+  "Only supplied fields are changed; omit a field to leave it unchanged. " +
+  "Pass null for note, deferDate, dueDate, estimatedMinutes, or reviewIntervalDays to clear those fields. " +
+  "Returns { updated: true, id }. " +
+  "Side effects: writes to OmniFocus, sets meta.syncPending = true. " +
+  "Call sync_trigger when you need changes to appear on other devices.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectUpdateInputSchema = z.object({
+  id: ProjectId.schema.describe("Persistent project ID. Get from project_list or project_get."),
+  name: z.string().min(1).optional().describe("New project name. Must be non-empty if supplied."),
+  note: z.string().nullable().optional().describe("Plain-text note. Pass null to clear."),
+  noteHtml: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("HTML note. Pass null to clear. Prefer note for plain-text edits."),
+  status: z
+    .enum(["active", "on-hold"])
+    .optional()
+    .describe("Project status. Use project_complete or project_drop to close a project."),
+  completionCriterion: z
+    .enum(["parallel", "sequential", "singleActions"])
+    .optional()
+    .describe("How the project's tasks are completed."),
+  deferDate: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("ISO-8601 defer date with UTC offset. Pass null to clear."),
+  dueDate: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("ISO-8601 due date with UTC offset. Pass null to clear."),
+  estimatedMinutes: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe("Estimated total duration in minutes. Pass null to clear."),
+  flagged: z.boolean().optional().describe("Flag or unflag the project."),
+  tagIds: z
+    .array(TagId.schema)
+    .optional()
+    .describe("Full-replacement tag list. Replaces all existing tags."),
+  reviewIntervalDays: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe("Review interval in days. Pass null to clear."),
+});
+
+export type ProjectUpdateToolInput = z.infer<typeof projectUpdateInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface ProjectUpdateContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  /**
+   * Optional cache; when supplied, `invalidateProjectMutation` flushes the
+   * scopes in the per-mutation matrix after the adapter call succeeds.
+   */
+  cache?: InvalidatingCache;
+}
+
+/**
+ * Pure handler for `project_update`.
+ *
+ * Delegates to `adapter.updateProject` with only the supplied patch fields.
+ * Flushes the project-mutation cache scopes on success.
+ *
+ * @throws {NotFound} when the project ID or any tag ID does not exist
+ * @throws {OmniFocusNotRunning} when OmniFocus is not running
+ */
+export async function handleProjectUpdate(
+  input: ProjectUpdateToolInput,
+  ctx: ProjectUpdateContext,
+) {
+  const { id, ...rest } = input;
+
+  const patch: UpdateProjectInput = {
+    ...(rest.name !== undefined && { name: rest.name }),
+    ...(rest.note !== undefined && { note: rest.note }),
+    ...(rest.noteHtml !== undefined && { noteHtml: rest.noteHtml }),
+    ...(rest.status !== undefined && { status: rest.status }),
+    ...(rest.completionCriterion !== undefined && {
+      completionCriterion: rest.completionCriterion,
+    }),
+    ...(rest.deferDate !== undefined && { deferDate: rest.deferDate }),
+    ...(rest.dueDate !== undefined && { dueDate: rest.dueDate }),
+    ...(rest.estimatedMinutes !== undefined && { estimatedMinutes: rest.estimatedMinutes }),
+    ...(rest.flagged !== undefined && { flagged: rest.flagged }),
+    ...(rest.tagIds !== undefined && { tagIds: rest.tagIds }),
+    ...(rest.reviewIntervalDays !== undefined && { reviewIntervalDays: rest.reviewIntervalDays }),
+  };
+
+  await ctx.adapter.updateProject(id, patch);
+
+  if (ctx.cache !== undefined) {
+    invalidateProjectMutation(ctx.cache, { projectId: id });
+  }
+
+  return ok({ updated: true as const, id }, ctx.makeMeta({ syncPending: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectUpdateTool(server: McpServer, ctx: ProjectUpdateContext) {
+  return server.registerTool(
+    "project_update",
+    { description: PROJECT_UPDATE_DESCRIPTION, inputSchema: projectUpdateInputSchema.shape },
+    async (args: ProjectUpdateToolInput) => {
+      const envelope = await handleProjectUpdate(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `project_create` tool: create a new OmniFocus project with completion criteria, review interval, folder placement, and initial fields
- Adds `project_update` tool: partial patch over all editable project fields (name, note, noteHtml, status, completionCriterion, dates, estimatedMinutes, flagged, tagIds, reviewIntervalDays)
- Adds `createProject`/`updateProject` methods to `ProjectService`
- Cache invalidation for project + wildcard scopes on both operations

## Design link
Closes #43.

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests for create and update handlers (happy path + edge cases)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (991 tests)
- [x] No new dependencies