### PR TITLE
feat(task): add task_get — single task read with optional subtask tree

### DIFF
--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -88,6 +88,19 @@ export interface TaskListInput {
   cursor?: string;
 }
 
+export interface TaskGetInput {
+  id: TaskId;
+  /** Default true. When false, subtasks is omitted. */
+  includeSubtasks?: boolean;
+}
+
+export interface TaskGetResult {
+  task: Task;
+  /** Flat list of direct subtasks (parentId === id). Omitted when includeSubtasks=false. */
+  subtasks?: Task[];
+  cacheHit: boolean;
+}
+
 /** Result of {@link TaskService.list} — the service returns the domain payload plus pagination. */
 export interface TaskListResult {
   tasks: Task[];
@@ -166,6 +179,31 @@ export class TaskService {
       hasMore: nextCursor !== null,
       cacheHit,
     };
+  }
+
+  /**
+   * Fetch a single task by ID.
+   *
+   * Optionally attaches the task's flat subtask list (all tasks with `parentId === id`).
+   * The caller rebuilds the tree via `parentId` linkage — the service returns a flat array.
+   * Results are cached under a key that invalidates on any task mutation.
+   *
+   * @throws {NotFound} when the task ID does not exist in OmniFocus
+   * @throws {OmniFocusNotRunning} when OmniFocus is not running
+   */
+  async get(input: TaskGetInput): Promise<TaskGetResult> {
+    const includeSubtasks = input.includeSubtasks ?? true;
+    const cacheKey = `task:${input.id}:${includeSubtasks ? "with-subtasks" : "solo"}`;
+    const cacheHit = this.cache.has(cacheKey);
+
+    const payload = await this.cache.wrap(cacheKey, async () => {
+      const task = await this.adapter.getTask(input.id);
+      if (!includeSubtasks) return { task };
+      const subtasks = await this.adapter.listTasks({ parentId: input.id });
+      return { task, subtasks };
+    });
+
+    return { ...payload, cacheHit };
   }
 
   // -- Internal: page assembly -------------------------------------------

--- a/src/tools/allDescriptions.ts
+++ b/src/tools/allDescriptions.ts
@@ -32,6 +32,7 @@ import { TAG_UPDATE_DESCRIPTION } from "./tag/update.js";
 import { TASK_CLEAR_REPETITION_DESCRIPTION } from "./task/clearRepetition.js";
 import { TASK_DELETE_DESCRIPTION } from "./task/delete.js";
 import { TASK_FIND_BY_NAME_DESCRIPTION } from "./task/findByName.js";
+import { TASK_GET_DESCRIPTION } from "./task/get.js";
 import { TASK_GET_MANY_DESCRIPTION } from "./task/getMany.js";
 import { TASK_LIST_DESCRIPTION } from "./task/list.js";
 import { TASK_SET_REPETITION_DESCRIPTION } from "./task/setRepetition.js";
@@ -65,6 +66,7 @@ export const ALL_TOOL_DESCRIPTIONS: Record<string, string> = {
   task_clear_repetition: TASK_CLEAR_REPETITION_DESCRIPTION,
   task_delete: TASK_DELETE_DESCRIPTION,
   task_find_by_name: TASK_FIND_BY_NAME_DESCRIPTION,
+  task_get: TASK_GET_DESCRIPTION,
   task_get_many: TASK_GET_MANY_DESCRIPTION,
   task_list: TASK_LIST_DESCRIPTION,
   task_set_repetition: TASK_SET_REPETITION_DESCRIPTION,

--- a/src/tools/task/get.test.ts
+++ b/src/tools/task/get.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for task_get tool.
+ *
+ * Covers: happy path, subtasks included/excluded, NotFound for unknown ID,
+ * required id field schema validation.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { TaskId } from "../../domain/ids.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { TaskService } from "../../services/taskService.js";
+import { handleTaskGet, taskGetInputSchema } from "./get.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const cache = {
+    wrap: async <T>(_key: string, factory: () => Promise<T>) => factory(),
+    has: (_key: string) => false,
+  };
+  const taskService = new TaskService({ adapter, cache });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { taskService, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_get — input schema", () => {
+  it("requires id field", () => {
+    expect(() => taskGetInputSchema.parse({})).toThrow();
+  });
+
+  it("accepts a valid id", () => {
+    const parsed = taskGetInputSchema.parse({ id: "task_000001" });
+    expect(parsed.id).toBe("task_000001");
+  });
+
+  it("accepts includeSubtasks boolean", () => {
+    const parsed = taskGetInputSchema.parse({ id: "task_000001", includeSubtasks: false });
+    expect(parsed.includeSubtasks).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("task_get — happy path", () => {
+  it("returns task with subtasks by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Parent task" });
+
+    const envelope = await handleTaskGet({ id }, ctx);
+    expect(envelope.data.task.name).toBe("Parent task");
+    expect(envelope.data.task.id).toBe(id);
+    expect(Array.isArray(envelope.data.subtasks)).toBe(true);
+  });
+
+  it("returns subtasks when child tasks exist", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createTask({ name: "Parent" });
+    await adapter.createTask({ name: "Child 1", parentId });
+    await adapter.createTask({ name: "Child 2", parentId });
+
+    const envelope = await handleTaskGet({ id: parentId, includeSubtasks: true }, ctx);
+    expect(envelope.data.subtasks).toHaveLength(2);
+    const names = envelope.data.subtasks?.map((t) => t.name) ?? [];
+    expect(names).toContain("Child 1");
+    expect(names).toContain("Child 2");
+  });
+
+  it("omits subtasks when includeSubtasks=false", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Solo task" });
+    await adapter.createTask({ name: "Child", parentId: id });
+
+    const envelope = await handleTaskGet({ id, includeSubtasks: false }, ctx);
+    expect(envelope.data.task.name).toBe("Solo task");
+    expect(envelope.data.subtasks).toBeUndefined();
+  });
+
+  it("returns empty subtasks array when task has no children", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Leaf task" });
+
+    const envelope = await handleTaskGet({ id }, ctx);
+    expect(envelope.data.subtasks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NotFound
+// ---------------------------------------------------------------------------
+
+describe("task_get — NotFound", () => {
+  it("rejects with NotFound for unknown ID", async () => {
+    const { ctx } = makeCtx();
+    const ghost = "task_999999" as TaskId;
+
+    await expect(handleTaskGet({ id: ghost }, ctx)).rejects.toThrow();
+  });
+});

--- a/src/tools/task/get.ts
+++ b/src/tools/task/get.ts
@@ -1,0 +1,67 @@
+/**
+ * `task_get` MCP tool — fetch a single OmniFocus task by persistent ID.
+ *
+ * Use when you have a known task ID and need its full detail — optionally
+ * including its direct subtask list. For multiple IDs, prefer task_get_many.
+ * For lookups by name, use task_find_by_name (when it exists).
+ *
+ * @see DESIGN.md §26 — tool pattern
+ * @see src/services/taskService.ts — TaskService.get
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { TaskId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { TaskGetInput, TaskService } from "../../services/taskService.js";
+
+export const TASK_GET_DESCRIPTION =
+  "Fetch a single OmniFocus task by persistent ID. " +
+  "Use when you have a known task ID and need its full detail. " +
+  "Do NOT use for multiple IDs — use task_get_many instead. " +
+  "Returns the Task object plus its direct subtasks (when includeSubtasks=true, the default). " +
+  "Read-only; safe to retry.";
+
+export const taskGetInputSchema = z.object({
+  id: TaskId.schema.describe(
+    "Persistent ID of the task to fetch. Get from task_list or task_get_many.",
+  ),
+  includeSubtasks: z
+    .boolean()
+    .optional()
+    .describe("Include direct subtasks in the response. Default true."),
+});
+
+export type TaskGetToolInput = z.infer<typeof taskGetInputSchema>;
+
+export interface TaskGetContext {
+  taskService: TaskService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for task_get.
+ * @throws {NotFound} when the task ID does not exist
+ * @throws {OmniFocusNotRunning} when OmniFocus is not running
+ */
+export async function handleTaskGet(input: TaskGetToolInput, ctx: TaskGetContext) {
+  const result = await ctx.taskService.get(input as TaskGetInput);
+  return ok(
+    { task: result.task, ...(result.subtasks !== undefined && { subtasks: result.subtasks }) },
+    ctx.makeMeta({ cacheHit: result.cacheHit }),
+  );
+}
+
+export function registerTaskGetTool(server: McpServer, ctx: TaskGetContext) {
+  return server.registerTool(
+    "task_get",
+    { description: TASK_GET_DESCRIPTION, inputSchema: taskGetInputSchema.shape },
+    async (args: TaskGetToolInput) => {
+      const envelope = await handleTaskGet(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `task_get` tool: fetch a single OmniFocus task by persistent ID
- Adds `TaskService.get()` with optional subtask list (flat array, parent reconstructed via parentId)
- Cached under `task:<id>:with-subtasks|solo` key, invalidated on task mutations
- Registers `task_get` in `allDescriptions.ts` for the description-shape lint

## Design link
Closes #37.

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests: happy path, subtasks included/excluded, NotFound, schema validation
- [x] Self-reviewed
- [x] No new dependencies