### PR TITLE
feat(sync): add sync_trigger and sync_status tools

### DIFF
--- a/src/tools/allDescriptions.ts
+++ b/src/tools/allDescriptions.ts
@@ -18,6 +18,7 @@ import { NOTE_SET_DESCRIPTION } from "./note/set.js";
 import { NOTE_SET_HTML_DESCRIPTION } from "./note/set_html.js";
 import { PROJECT_DELETE_DESCRIPTION } from "./project/delete.js";
 import { SEARCH_QUERY_DESCRIPTION } from "./search/query.js";
+import { SYNC_STATUS_DESCRIPTION } from "./sync/status.js";
 import { SYNC_TRIGGER_DESCRIPTION } from "./sync/trigger.js";
 import { TAG_CREATE_DESCRIPTION } from "./tag/create.js";
 import { TAG_DELETE_DESCRIPTION } from "./tag/delete.js";
@@ -51,6 +52,7 @@ export const ALL_TOOL_DESCRIPTIONS: Record<string, string> = {
   note_set_html: NOTE_SET_HTML_DESCRIPTION,
   project_delete: PROJECT_DELETE_DESCRIPTION,
   search_query: SEARCH_QUERY_DESCRIPTION,
+  sync_status: SYNC_STATUS_DESCRIPTION,
   sync_trigger: SYNC_TRIGGER_DESCRIPTION,
   tag_create: TAG_CREATE_DESCRIPTION,
   tag_delete: TAG_DELETE_DESCRIPTION,

--- a/src/tools/sync/status.test.ts
+++ b/src/tools/sync/status.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for sync_status tool.
+ *
+ * Covers: schema validation, handler returns lastSyncAt + inFlight,
+ * read-only (no side effects on adapter state).
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleSyncStatus, syncStatusInputSchema } from "./status.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { adapter, makeMeta };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("sync_status — input schema", () => {
+  it("accepts an empty object", () => {
+    expect(syncStatusInputSchema.parse({})).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("sync_status — handler", () => {
+  it("returns envelope with lastSyncAt and inFlight", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    const envelope = await handleSyncStatus({}, { adapter, makeMeta });
+    expect("lastSyncAt" in envelope.data).toBe(true);
+    expect("inFlight" in envelope.data).toBe(true);
+  });
+
+  it("returns inFlight=false when no sync is running", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    const envelope = await handleSyncStatus({}, { adapter, makeMeta });
+    expect(envelope.data.inFlight).toBe(false);
+  });
+
+  it("returns lastSyncAt=null before any sync has run", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    const envelope = await handleSyncStatus({}, { adapter, makeMeta });
+    // InMemoryAdapter initializes lastSyncAt to null until syncTrigger is called
+    expect(envelope.data.lastSyncAt).toBeNull();
+  });
+
+  it("returns lastSyncAt as ISO string after a sync has run", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    // Trigger a sync first to set lastSyncAt
+    await adapter.syncTrigger();
+    const envelope = await handleSyncStatus({}, { adapter, makeMeta });
+    expect(typeof envelope.data.lastSyncAt).toBe("string");
+  });
+
+  it("does not mutate adapter state (read-only)", async () => {
+    const { adapter, makeMeta } = makeCtx();
+    const before = await adapter.getLastSync();
+    await handleSyncStatus({}, { adapter, makeMeta });
+    const after = await adapter.getLastSync();
+    expect(after.lastSyncAt).toBe(before.lastSyncAt);
+    expect(after.inFlight).toBe(before.inFlight);
+  });
+});

--- a/src/tools/sync/status.ts
+++ b/src/tools/sync/status.ts
@@ -1,0 +1,68 @@
+/**
+ * `sync_status` MCP tool — return the last OmniFocus sync state without triggering a new sync.
+ *
+ * Use this to check whether a previous sync completed before querying
+ * cross-device data. Read-only; no side effects.
+ *
+ * @see src/adapter/OmniFocusAdapter.ts — SyncStatus
+ * @see src/tools/sync/trigger.ts — sync_trigger (triggers a new sync)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const SYNC_STATUS_DESCRIPTION =
+  "Return the last OmniFocus sync state without triggering a new sync. " +
+  "Do NOT call this to initiate a sync — use sync_trigger instead. " +
+  "Use to check whether a previous sync completed before querying cross-device data. " +
+  "Returns { lastSyncAt, inFlight }. " +
+  "lastSyncAt is null if OmniFocus has never synced in this session. " +
+  "Read-only; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const syncStatusInputSchema = z.object({});
+export type SyncStatusInput = z.infer<typeof syncStatusInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface SyncStatusContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler — callable directly in unit tests.
+ */
+export async function handleSyncStatus(_input: SyncStatusInput, ctx: SyncStatusContext) {
+  const status = await ctx.adapter.getLastSync();
+  return ok({ lastSyncAt: status.lastSyncAt, inFlight: status.inFlight }, ctx.makeMeta());
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerSyncStatusTool(server: McpServer, ctx: SyncStatusContext) {
+  return server.registerTool(
+    "sync_status",
+    { description: SYNC_STATUS_DESCRIPTION, inputSchema: syncStatusInputSchema.shape },
+    async (args: SyncStatusInput) => {
+      const envelope = await handleSyncStatus(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `sync_trigger` tool: asks OmniFocus to sync with its server (already existed on the branch)
- Adds `sync_status` tool: returns last sync state without triggering a sync
- Both tools delegate directly to the adapter (no service layer needed — no cache, no pagination)
- Registers both descriptions in `allDescriptions.ts` for description-shape lint coverage

## Design link
Closes #73.

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests for sync_status handler (schema, envelope shape, read-only invariant)
- [x] Existing unit tests for sync_trigger pass (lifecycle, cache invalidation, syncPending)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` all pass (1012 tests)
- [x] Self-reviewed
- [x] No new dependencies