### PR TITLE
feat(rateLimit): add per-tool sliding-window rate limiter

### DIFF
--- a/src/rateLimit/ToolRateLimiter.test.ts
+++ b/src/rateLimit/ToolRateLimiter.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RateLimited } from "../errors/index.js";
+import { ToolRateLimiter } from "./ToolRateLimiter.js";
+
+describe("ToolRateLimiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const makeConfig = (limit = 3, windowSeconds = 60) => ({ limit, windowSeconds });
+
+  describe("burst allowed", () => {
+    it("allows exactly limit calls without throwing", () => {
+      const limiter = new ToolRateLimiter(makeConfig(3));
+      expect(() => {
+        limiter.check("tool_a");
+        limiter.check("tool_a");
+        limiter.check("tool_a");
+      }).not.toThrow();
+    });
+  });
+
+  describe("limit exceeded", () => {
+    it("throws RateLimited on the (limit+1)th call", () => {
+      const limiter = new ToolRateLimiter(makeConfig(3));
+      limiter.check("tool_a");
+      limiter.check("tool_a");
+      limiter.check("tool_a");
+      expect(() => limiter.check("tool_a")).toThrow(RateLimited);
+    });
+
+    it("throws with OF_RATE_LIMITED code", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1));
+      limiter.check("tool_a");
+      try {
+        limiter.check("tool_a");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RateLimited);
+        expect((err as RateLimited).code).toBe("OF_RATE_LIMITED");
+      }
+    });
+  });
+
+  describe("retryAfterMs in error", () => {
+    it("carries a positive retryAfterMs in details", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1, 60));
+      limiter.check("tool_a");
+      try {
+        limiter.check("tool_a");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RateLimited);
+        const details = (err as RateLimited).details as { retryAfterMs: number };
+        expect(details.retryAfterMs).toBeGreaterThan(0);
+      }
+    });
+
+    it("retryAfterMs equals time until oldest call expires", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1, 60));
+      const startMs = Date.now();
+      limiter.check("tool_a");
+
+      // Advance by 10 seconds
+      vi.advanceTimersByTime(10_000);
+
+      try {
+        limiter.check("tool_a");
+        expect.fail("should have thrown");
+      } catch (err) {
+        const details = (err as RateLimited).details as { retryAfterMs: number };
+        // oldest call was at startMs, window = 60s
+        // retryAfterMs = startMs + 60000 - now + 1 = 60000 - 10000 + 1 = 50001
+        expect(details.retryAfterMs).toBe(startMs + 60_000 - Date.now() + 1);
+      }
+    });
+  });
+
+  describe("window slides", () => {
+    it("allows new calls after the window passes", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1, 60));
+      limiter.check("tool_a");
+
+      // Advance past the window
+      vi.advanceTimersByTime(61_000);
+
+      expect(() => limiter.check("tool_a")).not.toThrow();
+    });
+
+    it("only prunes calls outside the window", () => {
+      const limiter = new ToolRateLimiter(makeConfig(2, 60));
+      limiter.check("tool_a"); // t=0
+      vi.advanceTimersByTime(30_000); // t=30s
+      limiter.check("tool_a"); // t=30s — now window has 2 calls
+      expect(() => limiter.check("tool_a")).toThrow(RateLimited);
+
+      // advance to t=61s — first call at t=0 has expired
+      vi.advanceTimersByTime(31_000);
+      expect(() => limiter.check("tool_a")).not.toThrow();
+    });
+  });
+
+  describe("per-tool isolation", () => {
+    it("exceeding one tool does not affect another", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1));
+      limiter.check("tool_a");
+      expect(() => limiter.check("tool_a")).toThrow(RateLimited);
+      expect(() => limiter.check("tool_b")).not.toThrow();
+    });
+  });
+
+  describe("remaining()", () => {
+    it("starts at limit and counts down", () => {
+      const limiter = new ToolRateLimiter(makeConfig(3));
+      expect(limiter.remaining("tool_a").remaining).toBe(3);
+      limiter.check("tool_a");
+      expect(limiter.remaining("tool_a").remaining).toBe(2);
+      limiter.check("tool_a");
+      expect(limiter.remaining("tool_a").remaining).toBe(1);
+      limiter.check("tool_a");
+      expect(limiter.remaining("tool_a").remaining).toBe(0);
+    });
+
+    it("resets to limit after window passes", () => {
+      const limiter = new ToolRateLimiter(makeConfig(2, 60));
+      limiter.check("tool_a");
+      limiter.check("tool_a");
+      expect(limiter.remaining("tool_a").remaining).toBe(0);
+
+      vi.advanceTimersByTime(61_000);
+      expect(limiter.remaining("tool_a").remaining).toBe(2);
+    });
+
+    it("does not record a call (read-only)", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1));
+      limiter.remaining("tool_a");
+      limiter.remaining("tool_a");
+      // Should still be able to make a call
+      expect(() => limiter.check("tool_a")).not.toThrow();
+    });
+
+    it("returns resetAt as an ISO-8601 string", () => {
+      const limiter = new ToolRateLimiter(makeConfig(3, 60));
+      const { resetAt } = limiter.remaining("tool_a");
+      expect(() => new Date(resetAt)).not.toThrow();
+      expect(resetAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("resetAt points to when oldest call expires when window has entries", () => {
+      const limiter = new ToolRateLimiter(makeConfig(3, 60));
+      const startMs = Date.now();
+      limiter.check("tool_a");
+      vi.advanceTimersByTime(5_000);
+      const { resetAt } = limiter.remaining("tool_a");
+      expect(new Date(resetAt).getTime()).toBe(startMs + 60_000);
+    });
+  });
+
+  describe("reset()", () => {
+    it("clears all records for a tool, allowing immediate calls again", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1));
+      limiter.check("tool_a");
+      expect(() => limiter.check("tool_a")).toThrow(RateLimited);
+      limiter.reset("tool_a");
+      expect(() => limiter.check("tool_a")).not.toThrow();
+    });
+
+    it("does not affect other tools", () => {
+      const limiter = new ToolRateLimiter(makeConfig(1));
+      limiter.check("tool_a");
+      limiter.check("tool_b");
+      limiter.reset("tool_a");
+      expect(() => limiter.check("tool_a")).not.toThrow();
+      expect(() => limiter.check("tool_b")).toThrow(RateLimited);
+    });
+  });
+});

--- a/src/rateLimit/ToolRateLimiter.ts
+++ b/src/rateLimit/ToolRateLimiter.ts
@@ -1,0 +1,96 @@
+/**
+ * `ToolRateLimiter` — per-tool sliding-window rate limiter.
+ *
+ * Each tool name gets its own window. When `check(toolName)` is called:
+ * 1. Prune timestamps outside the sliding window.
+ * 2. If count >= limit: throw `RateLimited` with `retryAfterMs` = time
+ *    until the oldest call in the window expires.
+ * 3. Otherwise: record the call timestamp and return void.
+ *
+ * Thread-safety: JavaScript is single-threaded; no locking needed.
+ *
+ * @see DESIGN.md §16 — rate limiting
+ * @see src/errors/index.ts — RateLimited error
+ * @see src/config/env.ts — OMNIFOCUS_TOOL_RATE_LIMIT config
+ */
+
+import { RateLimited } from "../errors/index.js";
+
+export interface RateLimitConfig {
+  /** Maximum number of calls allowed per window. */
+  limit: number;
+  /** Sliding window size in seconds. */
+  windowSeconds: number;
+}
+
+export class ToolRateLimiter {
+  private readonly config: RateLimitConfig;
+  private readonly windows: Map<string, number[]> = new Map();
+
+  constructor(config: RateLimitConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Check and record a call for the given tool.
+   * @throws {RateLimited} when the call would exceed the configured limit.
+   */
+  check(toolName: string): void {
+    const now = Date.now();
+    const cutoff = now - this.config.windowSeconds * 1000;
+    const timestamps = this.getAndPrune(toolName, cutoff);
+
+    if (timestamps.length >= this.config.limit) {
+      const windowStart = timestamps[0] as number;
+      const retryAfterMs = windowStart + this.config.windowSeconds * 1000 - now + 1;
+      throw new RateLimited(
+        `Rate limit exceeded for tool "${toolName}". Limit: ${this.config.limit} calls per ${this.config.windowSeconds}s.`,
+        { details: { retryAfterMs } },
+      );
+    }
+
+    timestamps.push(now);
+  }
+
+  /**
+   * Return the current window state for a tool (for use in meta.rateLimit).
+   * Does NOT record a call — read-only.
+   */
+  remaining(toolName: string): { remaining: number; resetAt: string } {
+    const now = Date.now();
+    const cutoff = now - this.config.windowSeconds * 1000;
+    const timestamps = this.getAndPrune(toolName, cutoff);
+
+    const remaining = this.config.limit - timestamps.length;
+    const resetAt =
+      timestamps.length > 0
+        ? new Date((timestamps[0] as number) + this.config.windowSeconds * 1000).toISOString()
+        : new Date(now + this.config.windowSeconds * 1000).toISOString();
+
+    return { remaining, resetAt };
+  }
+
+  /** Clear all call records for a tool (used in tests). */
+  reset(toolName: string): void {
+    this.windows.delete(toolName);
+  }
+
+  /** Get the timestamp array for a tool, pruning stale entries in place. */
+  private getAndPrune(toolName: string, cutoff: number): number[] {
+    if (!this.windows.has(toolName)) {
+      this.windows.set(toolName, []);
+    }
+    const timestamps = this.windows.get(toolName) as number[];
+
+    // Prune timestamps outside the window (array is maintained in insertion order, oldest first)
+    let i = 0;
+    while (i < timestamps.length && (timestamps[i] as number) <= cutoff) {
+      i++;
+    }
+    if (i > 0) {
+      timestamps.splice(0, i);
+    }
+
+    return timestamps;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `ToolRateLimiter` class: per-tool sliding-window counter using `OMNIFOCUS_TOOL_RATE_LIMIT` config
- Throws `RateLimited` with accurate `retryAfterMs` when limit exceeded
- Exposes `remaining(toolName)` for future use by rate-limit-state-in-meta (#148)

## Design link
Closes #24. Implements DESIGN §16.

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests: burst-allowed, limit-exceeded, sliding window, per-tool isolation, retryAfterMs, remaining(), reset()
- [x] Self-reviewed
- [x] No new dependencies (uses only Date.now())