### PR TITLE
feat(envelope): add rateLimit state to ResponseMeta and withRateLimitMeta helper

### DIFF
--- a/src/envelope/index.ts
+++ b/src/envelope/index.ts
@@ -150,6 +150,17 @@ export interface ResponseMeta {
    * Each entry has a stable `code` agents can switch on — see `Warning`.
    */
   warnings?: Warning[];
+  /**
+   * Current rate-limit window state for this tool. Absent on cached responses
+   * (no rate check was performed). Present on live calls and on RateLimited errors
+   * (remaining: 0). Agents: if remaining < 10, add a short delay between calls.
+   */
+  rateLimit?: {
+    /** Calls remaining in the current window for this tool. */
+    remaining: number;
+    /** ISO-8601 timestamp when the current window resets. */
+    resetAt: string;
+  };
 }
 
 /**

--- a/src/rateLimit/withRateLimitMeta.test.ts
+++ b/src/rateLimit/withRateLimitMeta.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { ResponseMeta, ToolSuccess } from "../envelope/index.js";
+import { RateLimited } from "../errors/index.js";
+import { ToolRateLimiter } from "./ToolRateLimiter.js";
+import { withRateLimitMeta } from "./withRateLimitMeta.js";
+
+const TOOL = "test_tool";
+
+function makeBaseMeta(): ResponseMeta {
+  return {
+    correlationId: "test-correlation-id",
+    durationMs: 10,
+    cacheHit: false,
+    transport: "jxa",
+    ofVersion: "4.5.2",
+  };
+}
+
+function makeHandler<T>(data: T): () => Promise<ToolSuccess<T>> {
+  return () => Promise.resolve({ data, meta: makeBaseMeta() });
+}
+
+describe("withRateLimitMeta", () => {
+  it("success path: injects rateLimit into meta", async () => {
+    const limiter = new ToolRateLimiter({ limit: 3, windowSeconds: 60 });
+    const result = await withRateLimitMeta(TOOL, limiter, makeHandler({ ok: true }));
+
+    expect(result.meta.rateLimit).toBeDefined();
+    const rl = result.meta.rateLimit;
+    expect(rl).toBeDefined();
+    if (!rl) return;
+    expect(typeof rl.remaining).toBe("number");
+    expect(typeof rl.resetAt).toBe("string");
+    // One call was recorded, so remaining should be limit - 1 = 2
+    expect(rl.remaining).toBe(2);
+  });
+
+  it("limit exceeded: propagates RateLimited throw", async () => {
+    const limiter = new ToolRateLimiter({ limit: 1, windowSeconds: 60 });
+    // Exhaust the limit
+    await withRateLimitMeta(TOOL, limiter, makeHandler(null));
+
+    // Second call should throw synchronously (check() throws before returning a promise)
+    expect(() => withRateLimitMeta(TOOL, limiter, makeHandler(null))).toThrow(RateLimited);
+  });
+
+  it("remaining counts down: second call has lower remaining than first", async () => {
+    const limiter = new ToolRateLimiter({ limit: 3, windowSeconds: 60 });
+
+    const first = await withRateLimitMeta(TOOL, limiter, makeHandler(null));
+    const second = await withRateLimitMeta(TOOL, limiter, makeHandler(null));
+
+    const firstRemaining = first.meta.rateLimit?.remaining;
+    const secondRemaining = second.meta.rateLimit?.remaining;
+    expect(firstRemaining).toBeDefined();
+    expect(secondRemaining).toBeDefined();
+    expect(secondRemaining).toBeLessThan(firstRemaining as number);
+  });
+
+  it("no mutation of original meta: spread creates a new object", async () => {
+    const limiter = new ToolRateLimiter({ limit: 3, windowSeconds: 60 });
+    const originalMeta = makeBaseMeta();
+    const handler = (): Promise<ToolSuccess<null>> =>
+      Promise.resolve({ data: null, meta: originalMeta });
+
+    const result = await withRateLimitMeta(TOOL, limiter, handler);
+
+    // The result meta is a new object
+    expect(result.meta).not.toBe(originalMeta);
+    // The original is not mutated
+    expect(originalMeta.rateLimit).toBeUndefined();
+    // The result has the injected field
+    expect(result.meta.rateLimit).toBeDefined();
+  });
+});

--- a/src/rateLimit/withRateLimitMeta.ts
+++ b/src/rateLimit/withRateLimitMeta.ts
@@ -1,0 +1,36 @@
+/**
+ * `withRateLimitMeta` — rate-limit middleware for MCP tool handlers.
+ *
+ * Wraps a tool handler to:
+ * 1. Call `limiter.check(toolName)` — throws `RateLimited` if exceeded.
+ * 2. On success: inject `meta.rateLimit = limiter.remaining(toolName)` into
+ *    the returned envelope.
+ * 3. On `RateLimited` error: pass through (the server's error handler will
+ *    build the error envelope with `remaining: 0, resetAt`).
+ *
+ * The wrapper is transparent — it preserves the exact envelope shape and
+ * type parameter of the wrapped handler. Cached responses (where the tool
+ * handler returns without calling the limiter) should NOT use this wrapper;
+ * calling it opts the response in to rate-limit tracking.
+ *
+ * @see src/rateLimit/ToolRateLimiter.ts
+ * @see src/envelope/index.ts — ResponseMeta.rateLimit
+ */
+
+import type { ResponseMeta, ToolSuccess } from "../envelope/index.js";
+import type { ToolRateLimiter } from "./ToolRateLimiter.js";
+
+export function withRateLimitMeta<T>(
+  toolName: string,
+  limiter: ToolRateLimiter,
+  handler: () => Promise<ToolSuccess<T>>,
+): Promise<ToolSuccess<T>> {
+  limiter.check(toolName); // throws RateLimited if exceeded
+  return handler().then((envelope) => {
+    const rl = limiter.remaining(toolName);
+    return {
+      ...envelope,
+      meta: { ...envelope.meta, rateLimit: rl } satisfies ResponseMeta,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `rateLimit?: { remaining, resetAt }` to `ResponseMeta` (absent on cached responses)
- Adds `withRateLimitMeta(toolName, limiter, handler)` middleware: checks limiter, injects rate-limit state into meta on success
- Agents can now self-throttle proactively instead of discovering limits by hitting them

## Design link
Closes #148. Implements DESIGN §35.

## Breaking change?
- [x] No — `rateLimit` is optional; existing callers are unaffected

## Test plan
- [x] Unit tests: success path populates rateLimit, limit exceeded propagates throw, remaining counts down, no meta mutation
- [x] Self-reviewed
- [x] No new dependencies