### PR TITLE
docs(troubleshooting): add Permission Denied recovery runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ npm install -g @torsday/omnifocus-mcp
 omnifocus-mcp
 ```
 
-On first run, macOS asks permission for Claude to automate OmniFocus. Click **OK**. If you denied it by mistake: **System Settings → Privacy & Security → Automation → [app] → OmniFocus** ✓. See the per-client guides in [`docs/clients/`](./docs/clients/) for full troubleshooting steps.
+On first run, macOS asks permission for Claude to automate OmniFocus. Click **OK**. If you denied it by mistake: **System Settings → Privacy & Security → Automation → [app] → OmniFocus** ✓. See the [troubleshooting guide](./docs/troubleshooting.md) and the per-client guides in [`docs/clients/`](./docs/clients/) for step-by-step recovery.
 
 ### Environment variables
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,61 @@
+# Troubleshooting
+
+Common issues and step-by-step recovery procedures for omnifocus-mcp.
+
+---
+
+## Permission Denied — macOS Automation access
+
+**Error code:** `OF_PERMISSION_DENIED`
+
+**When it happens:** The first time any MCP tool calls OmniFocus, macOS shows an Automation permission prompt. If you click **Don't Allow** (or the prompt is dismissed automatically), subsequent calls will fail with a `PermissionDenied` error.
+
+### Symptom
+
+The MCP client surfaces an error whose `suggestion` field reads:
+
+> Open System Settings → Privacy & Security → Automation; grant this terminal or client access to OmniFocus.
+
+### Recovery (macOS Ventura / Sonoma / Sequoia)
+
+1. **Open System Settings** (Apple menu → System Settings).
+2. Go to **Privacy & Security** → **Automation**.
+3. Find the application that runs your MCP client — typically **Terminal**, **iTerm**, **Claude**, or the specific app launcher you use.
+4. Make sure the **OmniFocus** toggle under that app is **enabled** (blue).
+5. If OmniFocus does not appear in the list at all: run any `osascript` command targeting OmniFocus from that app first — macOS will re-prompt for permission.
+
+   ```bash
+   osascript -e 'tell application "OmniFocus" to name'
+   ```
+
+   Click **OK** when the dialog appears.
+
+6. Retry the MCP tool call that failed.
+
+### Recovery (macOS Monterey and earlier)
+
+1. Open **System Preferences** → **Security & Privacy** → **Privacy** tab → **Automation**.
+2. Locate your MCP client app; check the **OmniFocus** box.
+3. Click the lock icon and authenticate if the list is greyed out.
+
+### Notes
+
+- Automation permissions are **per-app**. If you run the server from a different terminal emulator or launch wrapper, that app needs its own permission grant.
+- `tccutil reset Automation com.apple.Terminal` resets all Terminal Automation permissions — use only as a last resort since it removes _all_ app grants for that launcher.
+- Some managed (MDM-enrolled) Macs restrict Automation via configuration profiles. Contact your IT department if the toggle is greyed out and you cannot change it.
+
+---
+
+## OmniFocus not running
+
+**Error code:** `OF_NOT_RUNNING`
+
+**Recovery:** Launch OmniFocus.app normally, then retry. The server does not auto-launch OmniFocus to avoid surprise windows.
+
+---
+
+## Additional resources
+
+- [README — Quickstart](../README.md#quickstart)
+- [Per-client setup guides](./clients/)
+- [Domain reference](./domain-reference.md)

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -150,7 +150,7 @@ export class PermissionDenied extends OmniFocusError {
     super("OF_PERMISSION_DENIED", "Automation permission for OmniFocus is denied.", {
       remediationClass: "environment",
       suggestion:
-        "Open System Settings → Privacy & Security → Automation; grant this terminal or client access to OmniFocus.",
+        "Open System Settings → Privacy & Security → Automation; grant this terminal or client access to OmniFocus. See docs/troubleshooting.md for step-by-step recovery.",
       ...options,
     });
   }


### PR DESCRIPTION
## Summary
- Adds `docs/troubleshooting.md` with step-by-step macOS Automation permission recovery for Ventura/Sonoma/Sequoia and Monterey
- Links the doc from README (permission paragraph) and from `PermissionDenied` error suggestion text
- Also includes basic `OF_NOT_RUNNING` entry and links to per-client guides

Closes #88.

## Issue
Implements [#88 — Permission-prompt recovery runbook](https://github.com/torsday/omnifocus-mcp/issues/88). See SPEC cold-start key flow and DESIGN §17.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm typecheck` clean
- [x] Docs-only change; no logic paths added