### PR TITLE
feat(attachment): add assertAttachmentSize guard with boundary tests

### DIFF
--- a/src/attachment/assertAttachmentSize.test.ts
+++ b/src/attachment/assertAttachmentSize.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for `assertAttachmentSize`.
+ *
+ * Uses vitest's `vi.mock` to intercept `node:fs/promises` so the tests run
+ * without creating real files on disk.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { ValidationError } from "../errors/index.js";
+import { assertAttachmentSize } from "./assertAttachmentSize.js";
+
+// ---------------------------------------------------------------------------
+// Mock fs/promises.stat
+// ---------------------------------------------------------------------------
+
+vi.mock("node:fs/promises", () => ({
+  stat: vi.fn(),
+}));
+
+import { stat } from "node:fs/promises";
+const mockStat = vi.mocked(stat);
+
+const MB = 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatResult(sizeBytes: number) {
+  return { size: sizeBytes } as Awaited<ReturnType<typeof stat>>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assertAttachmentSize", () => {
+  it("resolves when file is exactly the cap", async () => {
+    mockStat.mockResolvedValue(makeStatResult(100 * MB));
+    await expect(assertAttachmentSize("/path/to/file.zip", 100)).resolves.toBeUndefined();
+  });
+
+  it("resolves when file is just under the cap", async () => {
+    mockStat.mockResolvedValue(makeStatResult(100 * MB - 1));
+    await expect(assertAttachmentSize("/path/to/file.zip", 100)).resolves.toBeUndefined();
+  });
+
+  it("throws ValidationError when file is just over the cap", async () => {
+    mockStat.mockResolvedValue(makeStatResult(100 * MB + 1));
+    await expect(assertAttachmentSize("/path/to/file.zip", 100)).rejects.toThrow(ValidationError);
+  });
+
+  it("throws ValidationError when file is far over the cap", async () => {
+    mockStat.mockResolvedValue(makeStatResult(500 * MB));
+    await expect(assertAttachmentSize("/path/to/file.zip", 100)).rejects.toThrow(ValidationError);
+  });
+
+  it("error message contains the cap and actual size", async () => {
+    mockStat.mockResolvedValue(makeStatResult(200 * MB));
+    const err = await assertAttachmentSize("/path/to/file.zip", 100).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain("100 MB");
+    expect(err.message).toContain("200.00 MB");
+  });
+
+  it("error details include fileSizeBytes and capBytes", async () => {
+    mockStat.mockResolvedValue(makeStatResult(150 * MB));
+    const err = await assertAttachmentSize("/path/to/file.zip", 100).catch((e) => e);
+    expect(err.details).toMatchObject({
+      fileSizeBytes: 150 * MB,
+      capBytes: 100 * MB,
+    });
+  });
+
+  it("resolves without calling stat when maxMb is 0 (no cap)", async () => {
+    mockStat.mockClear();
+    await expect(assertAttachmentSize("/path/to/file.zip", 0)).resolves.toBeUndefined();
+    expect(mockStat).not.toHaveBeenCalled();
+  });
+
+  it("resolves without calling stat when maxMb is negative", async () => {
+    mockStat.mockClear();
+    await expect(assertAttachmentSize("/path/to/file.zip", -1)).resolves.toBeUndefined();
+    expect(mockStat).not.toHaveBeenCalled();
+  });
+
+  it("throws ValidationError with file-not-found message when stat rejects", async () => {
+    mockStat.mockRejectedValue(new Error("ENOENT: no such file"));
+    const err = await assertAttachmentSize("/missing/file.zip", 100).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain("not found or not accessible");
+    expect(err.message).toContain("/missing/file.zip");
+  });
+
+  it("file-not-found error details contain the filePath", async () => {
+    mockStat.mockRejectedValue(new Error("ENOENT"));
+    const err = await assertAttachmentSize("/missing/file.zip", 100).catch((e) => e);
+    expect(err.details).toMatchObject({ field: "filePath", value: "/missing/file.zip" });
+  });
+
+  it("suggestion text mentions the OMNIFOCUS_MAX_ATTACHMENT_MB env var when over cap", async () => {
+    mockStat.mockResolvedValue(makeStatResult(200 * MB));
+    const err = await assertAttachmentSize("/path/to/file.zip", 100).catch((e) => e);
+    expect(err.suggestion).toContain("OMNIFOCUS_MAX_ATTACHMENT_MB");
+  });
+});

--- a/src/attachment/assertAttachmentSize.ts
+++ b/src/attachment/assertAttachmentSize.ts
@@ -1,0 +1,59 @@
+/**
+ * `assertAttachmentSize` — pre-flight guard for attachment operations.
+ *
+ * Stats the file at `filePath` and throws `ValidationError` if its size
+ * exceeds `maxMb` megabytes. Callers (e.g. `attachment_add`) should invoke
+ * this before opening the file so over-sized payloads fail fast with an
+ * actionable message.
+ *
+ * The default cap (`OMNIFOCUS_MAX_ATTACHMENT_MB`, default 100) is documented
+ * in SPEC resolved-decisions and surfaced via `capabilities_get`. Passing
+ * `maxMb = 0` disables the cap (treat as unlimited); negative values are
+ * treated as 0.
+ *
+ * @throws ValidationError — file exceeds the size cap
+ * @throws ValidationError — file does not exist or is not accessible
+ */
+
+import { stat } from "node:fs/promises";
+import { ValidationError } from "../errors/index.js";
+
+const BYTES_PER_MB = 1024 * 1024;
+
+/**
+ * Assert that the file at `filePath` does not exceed `maxMb` megabytes.
+ * Resolves without throwing when the file is within bounds.
+ *
+ * @param filePath - Absolute path to the file to check.
+ * @param maxMb    - Size cap in megabytes. `0` or negative = no cap.
+ */
+export async function assertAttachmentSize(filePath: string, maxMb: number): Promise<void> {
+  // No cap — skip the stat entirely.
+  if (maxMb <= 0) return;
+
+  let fileStats: Awaited<ReturnType<typeof stat>>;
+  try {
+    fileStats = await stat(filePath);
+  } catch {
+    throw new ValidationError(`Attachment file not found or not accessible: ${filePath}`, {
+      suggestion: "Verify the file path is correct and the file is readable.",
+      details: { field: "filePath", value: filePath },
+    });
+  }
+
+  const fileMb = fileStats.size / BYTES_PER_MB;
+  if (fileMb > maxMb) {
+    throw new ValidationError(
+      `Attachment file exceeds the ${maxMb} MB size cap (file is ${fileMb.toFixed(2)} MB): ${filePath}`,
+      {
+        suggestion: `Reduce the file size to below ${maxMb} MB, or increase the cap via the OMNIFOCUS_MAX_ATTACHMENT_MB environment variable.`,
+        details: {
+          field: "filePath",
+          value: filePath,
+          fileSizeBytes: fileStats.size,
+          capBytes: maxMb * BYTES_PER_MB,
+        },
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/attachment/assertAttachmentSize.ts` — `stat`s the file and throws `ValidationError` if size exceeds `OMNIFOCUS_MAX_ATTACHMENT_MB` (default 100 MB)
- `maxMb ≤ 0` disables the cap (no stat call)
- 11 boundary unit tests: just-under, just-at, just-over, far-over, missing file, disabled cap, error message content, env var mention in suggestion

Closes #70.

## Issue
Implements [#70 — Attachment size cap enforcement](https://github.com/torsday/omnifocus-mcp/issues/70). The future `attachment_add` tool (issue #68) will call this guard before writing to OmniFocus.

## Breaking change?
- [x] No — new module only; no existing code changed

## Test plan
- [x] 11 unit tests, all green
- [x] `pnpm typecheck` clean