### PR TITLE
feat(attachment): add path-scope validator with symlink-escape protection

### DIFF
--- a/src/attachment/assertAttachmentPath.test.ts
+++ b/src/attachment/assertAttachmentPath.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for `assertAttachmentPath`.
+ *
+ * Mocks `node:fs/promises` so tests run without touching the real filesystem.
+ * The symlink-escape attack is simulated by having `realpath` return a path
+ * that differs from the input (as it would when resolving a symlink).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { ValidationError } from "../errors/index.js";
+import { assertAttachmentPath } from "./assertAttachmentPath.js";
+
+vi.mock("node:fs/promises", () => ({
+  realpath: vi.fn(),
+}));
+
+import { realpath } from "node:fs/promises";
+const mockRealpath = vi.mocked(realpath);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveAs(path: string) {
+  mockRealpath.mockResolvedValue(path);
+}
+
+function rejectWith(err: Error) {
+  mockRealpath.mockRejectedValue(err);
+}
+
+const HOME = "/Users/alice";
+const ALLOWED = [HOME];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assertAttachmentPath", () => {
+  describe("benign paths", () => {
+    it("resolves for a file directly in home", async () => {
+      resolveAs(`${HOME}/file.pdf`);
+      await expect(assertAttachmentPath(`${HOME}/file.pdf`, ALLOWED)).resolves.toBeUndefined();
+    });
+
+    it("resolves for a file in a subdirectory of home", async () => {
+      resolveAs(`${HOME}/Documents/report.pdf`);
+      await expect(
+        assertAttachmentPath(`${HOME}/Documents/report.pdf`, ALLOWED),
+      ).resolves.toBeUndefined();
+    });
+
+    it("resolves when allowlist has multiple entries and path matches second", async () => {
+      resolveAs("/tmp/scratch/file.txt");
+      await expect(
+        assertAttachmentPath("/tmp/scratch/file.txt", [HOME, "/tmp/scratch"]),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("symlink-escape attack", () => {
+    it("rejects when realpath resolves outside the allowlist", async () => {
+      // Symlink inside HOME points to /etc/passwd
+      resolveAs("/etc/passwd");
+      await expect(assertAttachmentPath(`${HOME}/symlink-to-passwd`, ALLOWED)).rejects.toThrow(
+        ValidationError,
+      );
+    });
+
+    it("rejects when realpath resolves into /System", async () => {
+      resolveAs("/System/Library/Frameworks/something.framework");
+      await expect(assertAttachmentPath(`${HOME}/evil-link`, ALLOWED)).rejects.toThrow(
+        ValidationError,
+      );
+    });
+  });
+
+  describe("hard-blocked prefixes", () => {
+    it("rejects /System/ paths even if they are in the allowlist", async () => {
+      resolveAs("/System/CoreServices/Finder.app");
+      await expect(
+        assertAttachmentPath("/System/CoreServices/Finder.app", ["/System"]),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("rejects /Library/ paths", async () => {
+      resolveAs("/Library/Application Support/something");
+      await expect(
+        assertAttachmentPath("/Library/Application Support/something", ["/Library"]),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("rejects /private/System/ paths", async () => {
+      resolveAs("/private/System/secret");
+      await expect(assertAttachmentPath("/private/System/secret", ["/private"])).rejects.toThrow(
+        ValidationError,
+      );
+    });
+
+    it("does NOT reject /SystemExtensions (not a blocked prefix)", async () => {
+      resolveAs(`${HOME}/SystemExtensions-backup`);
+      await expect(
+        assertAttachmentPath(`${HOME}/SystemExtensions-backup`, ALLOWED),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("prefix-safety (no false positives on similar names)", () => {
+    it("rejects /home/alicebob even when allowlist contains /home/alice", async () => {
+      resolveAs("/home/alicebob/file.txt");
+      await expect(
+        assertAttachmentPath("/home/alicebob/file.txt", ["/home/alice"]),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("file not found", () => {
+    it("throws ValidationError when realpath rejects", async () => {
+      rejectWith(new Error("ENOENT: no such file"));
+      const err = await assertAttachmentPath("/missing/file.pdf", ALLOWED).catch((e) => e);
+      expect(err).toBeInstanceOf(ValidationError);
+      expect(err.message).toContain("cannot be resolved");
+    });
+
+    it("error details contain the original filePath", async () => {
+      rejectWith(new Error("ENOENT"));
+      const err = await assertAttachmentPath("/missing/file.pdf", ALLOWED).catch((e) => e);
+      expect(err.details).toMatchObject({ field: "filePath", value: "/missing/file.pdf" });
+    });
+  });
+
+  describe("error quality", () => {
+    it("out-of-scope error mentions OMNIFOCUS_ATTACHMENT_PATHS in suggestion", async () => {
+      resolveAs("/etc/hosts");
+      const err = await assertAttachmentPath("/etc/hosts", ALLOWED).catch((e) => e);
+      expect(err.suggestion).toContain("OMNIFOCUS_ATTACHMENT_PATHS");
+    });
+
+    it("out-of-scope error details include resolvedPath and allowedPaths", async () => {
+      resolveAs("/etc/hosts");
+      const err = await assertAttachmentPath("/etc/hosts", ALLOWED).catch((e) => e);
+      expect(err.details).toMatchObject({
+        resolvedPath: "/etc/hosts",
+        allowedPaths: ALLOWED,
+      });
+    });
+
+    it("blocked-system-dir error mentions the blocked prefix in the message", async () => {
+      resolveAs("/Library/LaunchDaemons/evil.plist");
+      const err = await assertAttachmentPath("/Library/LaunchDaemons/evil.plist", ALLOWED).catch(
+        (e) => e,
+      );
+      expect(err.message).toContain("blocked system directory");
+    });
+  });
+});

--- a/src/attachment/assertAttachmentPath.ts
+++ b/src/attachment/assertAttachmentPath.ts
@@ -1,0 +1,104 @@
+/**
+ * `assertAttachmentPath` — path-scope guard for attachment operations.
+ *
+ * Resolves symlinks on `filePath` **before** checking the allowlist to
+ * defeat symlink-escape attacks (DESIGN §18). Rejects any resolved path
+ * that is not a strict prefix of at least one entry in `allowedPaths`.
+ *
+ * Hard-blocked prefixes (`/System`, `/private/System`, `/Library`,
+ * `/private/Library`) are always rejected regardless of the allowlist —
+ * writing attachments from system directories has no legitimate use case
+ * and is most likely a path-traversal attempt.
+ *
+ * Default allowlist (when `OMNIFOCUS_ATTACHMENT_PATHS` is unset) is
+ * `[homedir()]`, which restricts operations to files under the user's home
+ * directory.
+ *
+ * @throws ValidationError — resolved path is outside every allowlist entry
+ * @throws ValidationError — file does not exist or cannot be resolved
+ */
+
+import { realpath } from "node:fs/promises";
+import { sep } from "node:path";
+import { ValidationError } from "../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Paths that are always blocked, regardless of the allowlist.
+ * Normalised with a trailing separator so `/System` doesn't block `/SystemExtensions`.
+ */
+const ALWAYS_BLOCKED: readonly string[] = [
+  "/System/",
+  "/private/System/",
+  "/Library/",
+  "/private/Library/",
+];
+
+// ---------------------------------------------------------------------------
+// Guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert that `filePath` (after symlink resolution) is inside at least one
+ * of the `allowedPaths`. Resolves without throwing when the path is in scope.
+ *
+ * @param filePath    - Absolute path to the file to check.
+ * @param allowedPaths - Allowlist of directory prefixes. Entries are resolved
+ *                       against the real filesystem; trailing separators are
+ *                       normalised away.
+ */
+export async function assertAttachmentPath(
+  filePath: string,
+  allowedPaths: readonly string[],
+): Promise<void> {
+  // Resolve symlinks — this is the critical step that defeats traversal.
+  let resolved: string;
+  try {
+    resolved = await realpath(filePath);
+  } catch {
+    throw new ValidationError(`Attachment file not found or cannot be resolved: ${filePath}`, {
+      suggestion: "Verify the file path is correct and the file exists.",
+      details: { field: "filePath", value: filePath },
+    });
+  }
+
+  // Normalise: ensure path comparison is prefix-safe by appending sep.
+  // e.g. /home/alice and /home/alicebob are different prefixes.
+  const resolvedWithSep = resolved.endsWith(sep) ? resolved : resolved + sep;
+
+  // Hard-blocked prefixes — always rejected.
+  for (const blocked of ALWAYS_BLOCKED) {
+    if (resolvedWithSep.startsWith(blocked)) {
+      throw new ValidationError(
+        `Attachment path resolves to a blocked system directory: ${resolved}`,
+        {
+          suggestion:
+            "Attachment files must be under your home directory or an explicitly allowed path (OMNIFOCUS_ATTACHMENT_PATHS).",
+          details: { field: "filePath", value: filePath, resolvedPath: resolved },
+        },
+      );
+    }
+  }
+
+  // Allowlist check — must be under at least one allowed prefix.
+  const allowed = allowedPaths.some((prefix) => {
+    const prefixWithSep = prefix.endsWith(sep) ? prefix : prefix + sep;
+    return resolvedWithSep.startsWith(prefixWithSep);
+  });
+
+  if (!allowed) {
+    throw new ValidationError(`Attachment path is outside the allowed scope: ${resolved}`, {
+      suggestion:
+        "Move the file to your home directory, or add its parent directory to OMNIFOCUS_ATTACHMENT_PATHS (colon-separated list of absolute paths).",
+      details: {
+        field: "filePath",
+        value: filePath,
+        resolvedPath: resolved,
+        allowedPaths: [...allowedPaths],
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/attachment/assertAttachmentPath.ts` — resolves symlinks via `realpath()` before allowlist check to defeat path-traversal attacks (DESIGN §18)
- Hard-blocks `/System`, `/Library`, `/private/System`, `/private/Library` regardless of allowlist
- Default allowlist is `$HOME`; overridable via `OMNIFOCUS_ATTACHMENT_PATHS` colon-separated env var
- Prefix-boundary check prevents `/home/alice` from matching `/home/alicebob`
- 15 unit tests: symlink escape attack, benign paths, blocked prefixes, prefix-false-positive prevention, error message quality

Closes #69.

## Issue
Implements [#69 — Attachment path-scope validator](https://github.com/torsday/omnifocus-mcp/issues/69). The future `attachment_add` tool (#68) will call both this and `assertAttachmentSize` (#70) before writing to OmniFocus.

## Breaking change?
- [x] No — new module only; no existing code changed

## Test plan
- [x] 15 unit tests, all green
- [x] `pnpm typecheck` clean