### PR TITLE
test(domain): add fast-check property tests for core codecs and schemas

### DIFF
--- a/src/domain/repetitionRule.property.test.ts
+++ b/src/domain/repetitionRule.property.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Property tests for the RepetitionRule schema.
+ *
+ * `RepetitionRuleSchema` is a Zod discriminated schema. These tests assert:
+ *   1. Valid combinations parse successfully.
+ *   2. Invalid combinations (e.g. `steps <= 0`, unknown unit) are rejected.
+ *   3. The schema is stable: parsing a valid value and re-serializing it
+ *      produces an identical object (no coercion side-effects).
+ */
+
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import type { RepetitionRule, Weekday } from "./task.js";
+import { RepetitionRuleSchema } from "./task.js";
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+const methodArb = fc.constantFrom<RepetitionRule["method"]>("fixed", "start-again", "due-again");
+
+const unitArb = fc.constantFrom<RepetitionRule["unit"]>(
+  "minutes",
+  "hours",
+  "days",
+  "weeks",
+  "months",
+  "years",
+);
+
+const weekdayArb = fc.constantFrom<Weekday>(
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+);
+
+/** A valid positive integer steps value. */
+const stepsArb = fc.integer({ min: 1, max: 999 });
+
+/** Minimal valid RepetitionRule (no optional weekdays/monthlyAnchor). */
+const minimalRuleArb: fc.Arbitrary<RepetitionRule> = fc.record({
+  method: methodArb,
+  unit: unitArb,
+  steps: stepsArb,
+});
+
+/** Rule with optional weekdays. */
+const ruleWithWeekdaysArb: fc.Arbitrary<RepetitionRule> = fc.record({
+  method: methodArb,
+  unit: fc.constantFrom<RepetitionRule["unit"]>("weeks"),
+  steps: stepsArb,
+  weekdays: fc.uniqueArray(weekdayArb, { minLength: 1, maxLength: 7 }),
+});
+
+/** Rule with numeric monthlyAnchor. */
+const ruleWithMonthlyDayArb: fc.Arbitrary<RepetitionRule> = fc.record({
+  method: methodArb,
+  unit: fc.constant<RepetitionRule["unit"]>("months"),
+  steps: stepsArb,
+  monthlyAnchor: fc.record({ day: fc.integer({ min: 1, max: 31 }) }),
+});
+
+/** Rule with weekday-position monthlyAnchor. */
+const ruleWithMonthlyWeekdayArb: fc.Arbitrary<RepetitionRule> = fc.record({
+  method: methodArb,
+  unit: fc.constant<RepetitionRule["unit"]>("months"),
+  steps: stepsArb,
+  monthlyAnchor: fc.record({
+    weekday: weekdayArb,
+    position: fc.constantFrom<1 | 2 | 3 | 4 | "last">(1, 2, 3, 4, "last"),
+  }),
+});
+
+/** Union of all valid rule shapes. */
+const validRuleArb = fc.oneof(
+  minimalRuleArb,
+  ruleWithWeekdaysArb,
+  ruleWithMonthlyDayArb,
+  ruleWithMonthlyWeekdayArb,
+);
+
+// ---------------------------------------------------------------------------
+// Property tests — valid combinations
+// ---------------------------------------------------------------------------
+
+describe("RepetitionRule schema — property tests", () => {
+  it("valid rules parse successfully", () => {
+    fc.assert(
+      fc.property(validRuleArb, (rule) => {
+        const result = RepetitionRuleSchema.safeParse(rule);
+        expect(result.success).toBe(true);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("parsed valid rule equals input (no coercion side-effects on core fields)", () => {
+    fc.assert(
+      fc.property(minimalRuleArb, (rule) => {
+        const parsed = RepetitionRuleSchema.parse(rule);
+        expect(parsed.method).toBe(rule.method);
+        expect(parsed.unit).toBe(rule.unit);
+        expect(parsed.steps).toBe(rule.steps);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("re-parsing an already-parsed rule produces identical output (idempotent)", () => {
+    fc.assert(
+      fc.property(validRuleArb, (rule) => {
+        const first = RepetitionRuleSchema.parse(rule);
+        const second = RepetitionRuleSchema.parse(first);
+        expect(second).toEqual(first);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Invalid combinations
+  // ---------------------------------------------------------------------------
+
+  it("steps <= 0 is rejected", () => {
+    fc.assert(
+      fc.property(methodArb, unitArb, fc.integer({ min: -100, max: 0 }), (method, unit, steps) => {
+        const result = RepetitionRuleSchema.safeParse({ method, unit, steps });
+        expect(result.success).toBe(false);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("unknown method is rejected", () => {
+    fc.assert(
+      fc.property(
+        fc
+          .string({ minLength: 1 })
+          .filter((s) => !["fixed", "start-again", "due-again"].includes(s)),
+        unitArb,
+        stepsArb,
+        (method, unit, steps) => {
+          const result = RepetitionRuleSchema.safeParse({ method, unit, steps });
+          expect(result.success).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("unknown unit is rejected", () => {
+    fc.assert(
+      fc.property(
+        methodArb,
+        fc
+          .string({ minLength: 1 })
+          .filter((s) => !["minutes", "hours", "days", "weeks", "months", "years"].includes(s)),
+        stepsArb,
+        (method, unit, steps) => {
+          const result = RepetitionRuleSchema.safeParse({ method, unit, steps });
+          expect(result.success).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it("missing required fields (method/unit/steps) are rejected", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          method: fc.option(methodArb, { nil: undefined }),
+          unit: fc.option(unitArb, { nil: undefined }),
+          steps: fc.option(stepsArb, { nil: undefined }),
+        }),
+        (partial) => {
+          // At least one field is missing
+          fc.pre(
+            partial.method === undefined ||
+              partial.unit === undefined ||
+              partial.steps === undefined,
+          );
+          const result = RepetitionRuleSchema.safeParse(partial);
+          expect(result.success).toBe(false);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});

--- a/src/pagination/cursor.property.test.ts
+++ b/src/pagination/cursor.property.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Property tests for the cursor codec (encode → decode → encode stability).
+ *
+ * Fast-check generates arbitrary `CursorPayload` values and asserts:
+ *   1. `encodeCursor(payload)` is a valid base64url string (no `+`, `/`, `=`)
+ *   2. `decodeCursor(encodeCursor(payload), payload.filterHash)` returns a
+ *      structurally equivalent payload (round-trip fidelity)
+ *   3. Re-encoding the decoded payload yields the same cursor string (idempotency)
+ *   4. A cursor encoded with hash A always rejects when decoded with hash B ≠ A
+ */
+
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { type CursorPayload, decodeCursor, encodeCursor } from "./cursor.js";
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+/** Generate a valid filterHash (64-char hex, as SHA-256 produces). */
+const filterHashArb = fc.hexaString({ minLength: 64, maxLength: 64 });
+
+/** Generate a CursorPayload with arbitrary string id, sort value, and filterHash. */
+const cursorPayloadArb = fc.record<CursorPayload>({
+  lastId: fc.string({ minLength: 1, maxLength: 64 }),
+  lastSortValue: fc.option(fc.string({ minLength: 1, maxLength: 64 }), { nil: null }),
+  filterHash: filterHashArb,
+});
+
+// ---------------------------------------------------------------------------
+// Property tests
+// ---------------------------------------------------------------------------
+
+describe("cursor codec — property tests", () => {
+  it("encodeCursor produces only base64url-safe characters", () => {
+    fc.assert(
+      fc.property(cursorPayloadArb, (payload) => {
+        const encoded = encodeCursor(payload);
+        // base64url: A-Z a-z 0-9 - _  (no + / =)
+        expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("decode(encode(payload)) round-trips every field", () => {
+    fc.assert(
+      fc.property(cursorPayloadArb, (payload) => {
+        const encoded = encodeCursor(payload);
+        const decoded = decodeCursor(encoded, payload.filterHash);
+        expect(decoded.lastId).toBe(payload.lastId);
+        expect(decoded.lastSortValue).toBe(payload.lastSortValue);
+        expect(decoded.filterHash).toBe(payload.filterHash);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("encode(decode(encode(payload))) is idempotent", () => {
+    fc.assert(
+      fc.property(cursorPayloadArb, (payload) => {
+        const encoded = encodeCursor(payload);
+        const decoded = decodeCursor(encoded, payload.filterHash);
+        const reEncoded = encodeCursor(decoded);
+        expect(reEncoded).toBe(encoded);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("cursor encoded with one filterHash rejects when decoded with a different hash", () => {
+    fc.assert(
+      fc.property(cursorPayloadArb, filterHashArb, (payload, differentHash) => {
+        fc.pre(differentHash !== payload.filterHash);
+        const encoded = encodeCursor(payload);
+        expect(() => decodeCursor(encoded, differentHash)).toThrow();
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("lastSortValue: null round-trips as null (not undefined or empty string)", () => {
+    fc.assert(
+      fc.property(
+        fc.record<CursorPayload>({
+          lastId: fc.string({ minLength: 1, maxLength: 32 }),
+          lastSortValue: fc.constant(null),
+          filterHash: filterHashArb,
+        }),
+        (payload) => {
+          const decoded = decodeCursor(encodeCursor(payload), payload.filterHash);
+          expect(decoded.lastSortValue).toBeNull();
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/src/taskParser/transportText.property.test.ts
+++ b/src/taskParser/transportText.property.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Property tests for the transport-text parser.
+ *
+ * Fast-check generates valid transport-text strings from known tokens and
+ * asserts that the parser returns the expected structure. The "round-trip"
+ * property here means: if we construct a known-valid input, the parser must
+ * extract exactly what we put in (no data loss, no mutation).
+ *
+ * We do NOT do a true encode-then-decode round-trip because the parser is
+ * one-way (it reads DSL, not emits it). Instead we verify:
+ *   1. Name-only tasks: the parsed name matches the input name exactly.
+ *   2. Flag token: `!!` always produces `flagged: true`.
+ *   3. Tag tokens: every `@tagname` in the input appears in `tagNames[]`.
+ *   4. Note token: `//` remainder becomes the `note` field.
+ *   5. Multi-task: N non-empty lines produce N ParsedTask entries.
+ *   6. Project: context: the project name propagates to all following tasks.
+ */
+
+import * as fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { parseTransportText } from "./transportText.js";
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+/**
+ * A "safe" word: letters and digits only, no whitespace or DSL special chars.
+ * Keeps generated inputs unambiguous for the parser.
+ */
+const safeWordArb = fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9]{1,15}$/);
+
+/** A valid tag name (same safe characters). */
+const tagNameArb = safeWordArb;
+
+/** A list of 1–4 unique tag names. */
+const tagNamesArb = fc
+  .uniqueArray(tagNameArb, { minLength: 1, maxLength: 4 })
+  .filter((arr) => arr.length > 0);
+
+// ---------------------------------------------------------------------------
+// Property tests
+// ---------------------------------------------------------------------------
+
+describe("transport-text parser — property tests", () => {
+  it("name-only task: parsed name equals input name (trimmed)", () => {
+    fc.assert(
+      fc.property(safeWordArb, (name) => {
+        const result = parseTransportText(name);
+        expect(result.tasks).toHaveLength(1);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(result.tasks.at(0)!.name).toBe(name);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("!! token always sets flagged: true", () => {
+    fc.assert(
+      fc.property(safeWordArb, (name) => {
+        const result = parseTransportText(`${name} !!`);
+        expect(result.tasks).toHaveLength(1);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(result.tasks.at(0)!.flagged).toBe(true);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("without !! token, flagged is false or undefined (never true)", () => {
+    fc.assert(
+      fc.property(safeWordArb, (name) => {
+        const result = parseTransportText(name);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(result.tasks.at(0)!.flagged).toBeFalsy();
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("every @tagname in input appears in tagNames[]", () => {
+    fc.assert(
+      fc.property(safeWordArb, tagNamesArb, (name, tags) => {
+        const tagTokens = tags.map((t) => `@${t}`).join(" ");
+        const result = parseTransportText(`${name} ${tagTokens}`);
+        expect(result.tasks).toHaveLength(1);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const parsedTags = result.tasks.at(0)!.tagNames ?? [];
+        for (const tag of tags) {
+          expect(parsedTags).toContain(tag);
+        }
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("tagNames[] length matches the number of @tokens provided", () => {
+    fc.assert(
+      fc.property(safeWordArb, tagNamesArb, (name, tags) => {
+        const tagTokens = tags.map((t) => `@${t}`).join(" ");
+        const result = parseTransportText(`${name} ${tagTokens}`);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const parsedTags = result.tasks.at(0)!.tagNames ?? [];
+        expect(parsedTags).toHaveLength(tags.length);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("//note captures everything after the double-slash", () => {
+    fc.assert(
+      fc.property(safeWordArb, safeWordArb, (name, note) => {
+        const result = parseTransportText(`${name} //${note}`);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(result.tasks.at(0)!.note).toBe(note);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("N non-empty task lines produce N parsed tasks", () => {
+    fc.assert(
+      fc.property(fc.array(safeWordArb, { minLength: 1, maxLength: 10 }), (names) => {
+        const input = names.join("\n");
+        const result = parseTransportText(input);
+        expect(result.tasks).toHaveLength(names.length);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("Project: context line propagates projectName to all following tasks", () => {
+    fc.assert(
+      fc.property(
+        safeWordArb,
+        fc.array(safeWordArb, { minLength: 1, maxLength: 5 }),
+        (project, taskNames) => {
+          const lines = [`Project: ${project}`, ...taskNames].join("\n");
+          const result = parseTransportText(lines);
+          expect(result.tasks).toHaveLength(taskNames.length);
+          for (const task of result.tasks) {
+            expect(task.projectName).toBe(project);
+          }
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it("tasks before Project: line have no projectName", () => {
+    fc.assert(
+      fc.property(safeWordArb, safeWordArb, safeWordArb, (task1, project, task2) => {
+        const lines = [task1, `Project: ${project}`, task2].join("\n");
+        const result = parseTransportText(lines);
+        expect(result.tasks).toHaveLength(2);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(result.tasks.at(0)!.projectName).toBeUndefined();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(result.tasks.at(1)!.projectName).toBe(project);
+      }),
+      { numRuns: 200 },
+    );
+  });
+
+  it("parser never throws on arbitrary non-empty single-line input", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (input) => {
+        // Should return a result or warnings, never throw
+        expect(() => parseTransportText(input)).not.toThrow();
+      }),
+      { numRuns: 500 },
+    );
+  });
+
+  it("warnings array is always an array (never undefined)", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (input) => {
+        const result = parseTransportText(input);
+        expect(Array.isArray(result.warnings)).toBe(true);
+      }),
+      { numRuns: 200 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Cursor codec: base64url safety, encode→decode round-trip, idempotency, wrong-hash rejection, null `lastSortValue` preservation (5 tests)
- `RepetitionRule` schema: valid combinations parse, invalid steps/method/unit and missing fields are rejected, re-parsing is idempotent (7 tests)
- Transport-text parser: name/flag/tag/note/multi-task/project propagation properties, never-throw and always-array-warnings safety (10 tests)

Closes #67.

## Issue
Implements [#67 — property tests for cursor codec, RepetitionRule schema, and transport-text parser](https://github.com/torsday/omnifocus-mcp/issues/67).

## Breaking change?
- [x] No

## Test plan
- [x] All 80 test files pass (1157 tests) locally
- [x] No new dependencies (fast-check already installed)
- [x] Self-reviewed