### PR TITLE
feat(observability): add loop-detection middleware (DESIGN §6.11)

### DIFF
--- a/src/envelope/index.ts
+++ b/src/envelope/index.ts
@@ -36,13 +36,15 @@ import type { OmniFocusError, SerializedError } from "../errors/index.js";
  * | `WARN_SYNC_PENDING`    | Mutation saved locally; OF hasn't synced             | —                                 |
  * | `WARN_DEPRECATED_FIELD`| Caller used a deprecated input field                 | `{ field: string, replacement: string }` |
  * | `WARN_DRY_RUN`         | Response is hypothetical; no write occurred          | —                                 |
+ * | `WARN_LOOP_DETECTED`   | Same tool+args called ≥5× within 60s                | `{ tool: string, count: number, windowSeconds: number }` |
  */
 export type WarningCode =
   | "WARN_IDS_NOT_FOUND"
   | "WARN_RESULT_TRUNCATED"
   | "WARN_SYNC_PENDING"
   | "WARN_DEPRECATED_FIELD"
-  | "WARN_DRY_RUN";
+  | "WARN_DRY_RUN"
+  | "WARN_LOOP_DETECTED";
 
 /**
  * Structured non-fatal issue that the agent should see inline.

--- a/src/loopDetector/LoopDetector.test.ts
+++ b/src/loopDetector/LoopDetector.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for LoopDetector and withLoopDetection middleware.
+ *
+ * Acceptance criteria from #76:
+ *   - Identical args → warning fires after threshold (default 5)
+ *   - Different args for the same tool → never fires
+ *   - Calls outside the window are not counted
+ *   - withLoopDetection appends warning to meta.warnings
+ *   - withLoopDetection is transparent when no loop is detected
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { ok } from "../envelope/index.js";
+import type { ResponseMeta } from "../envelope/index.js";
+import { LoopDetector, buildCallKey } from "./LoopDetector.js";
+import { withLoopDetection } from "./withLoopDetection.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const fakeMeta: ResponseMeta = {
+  correlationId: "test-corr",
+  durationMs: 1,
+  cacheHit: false,
+  transport: "memory",
+  ofVersion: "test",
+};
+
+function makeHandler<T>(data: T) {
+  return () => Promise.resolve(ok(data, fakeMeta));
+}
+
+// ---------------------------------------------------------------------------
+// LoopDetector
+// ---------------------------------------------------------------------------
+
+describe("LoopDetector", () => {
+  it("returns undefined for the first N-1 identical calls (below threshold)", () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    for (let i = 0; i < 4; i++) {
+      expect(detector.record("task_list", { flagged: true })).toBeUndefined();
+    }
+  });
+
+  it("returns WARN_LOOP_DETECTED on the 5th identical call", () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = { projectId: "abc" };
+    for (let i = 0; i < 4; i++) detector.record("task_list", args);
+    const warning = detector.record("task_list", args);
+    expect(warning).toBeDefined();
+    expect(warning?.code).toBe("WARN_LOOP_DETECTED");
+    expect(warning?.details).toMatchObject({ tool: "task_list", count: 5 });
+  });
+
+  it("continues to return the warning on subsequent identical calls", () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = { projectId: "abc" };
+    for (let i = 0; i < 5; i++) detector.record("task_list", args);
+    expect(detector.record("task_list", args)?.code).toBe("WARN_LOOP_DETECTED");
+    expect(detector.record("task_list", args)?.details?.count).toBe(7);
+  });
+
+  it("different args for the same tool never trigger the warning", () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    for (let i = 0; i < 10; i++) {
+      expect(detector.record("task_list", { projectId: `proj-${i}` })).toBeUndefined();
+    }
+  });
+
+  it("different tools with the same args are tracked independently", () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = { id: "x" };
+    for (let i = 0; i < 4; i++) detector.record("task_get", args);
+    // 4 calls to task_get, 0 to project_get → neither fires
+    expect(detector.record("project_get", args)).toBeUndefined();
+  });
+
+  it("calls outside the window are pruned and not counted", () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = { id: "y" };
+
+    // Simulate 4 old calls by mocking Date.now
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now - 61_000); // 61s in the past
+    for (let i = 0; i < 4; i++) detector.record("task_get", args);
+
+    // Restore to "now" — old calls should be pruned
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    expect(detector.record("task_get", args)).toBeUndefined(); // count=1 after prune
+
+    vi.restoreAllMocks();
+  });
+
+  it("reset() clears all tracking state", () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = { id: "z" };
+    for (let i = 0; i < 5; i++) detector.record("task_get", args);
+    detector.reset();
+    // After reset, first call should not warn
+    expect(detector.record("task_get", args)).toBeUndefined();
+  });
+
+  it("respects a custom threshold", () => {
+    const detector = new LoopDetector({ threshold: 3, windowSeconds: 60 });
+    const args = {};
+    detector.record("sync_status", args);
+    detector.record("sync_status", args);
+    expect(detector.record("sync_status", args)?.code).toBe("WARN_LOOP_DETECTED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCallKey
+// ---------------------------------------------------------------------------
+
+describe("buildCallKey", () => {
+  it("is stable regardless of key order in args object", () => {
+    const key1 = buildCallKey("task_list", { b: 2, a: 1 });
+    const key2 = buildCallKey("task_list", { a: 1, b: 2 });
+    expect(key1).toBe(key2);
+  });
+
+  it("differs for different tool names with same args", () => {
+    expect(buildCallKey("task_list", { id: "x" })).not.toBe(buildCallKey("task_get", { id: "x" }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withLoopDetection
+// ---------------------------------------------------------------------------
+
+describe("withLoopDetection", () => {
+  it("is transparent when no loop is detected (returns handler result unchanged)", async () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const result = await withLoopDetection("task_list", {}, detector, makeHandler({ tasks: [] }));
+    expect(result.data).toEqual({ tasks: [] });
+    expect(result.meta.warnings).toBeUndefined();
+  });
+
+  it("appends WARN_LOOP_DETECTED to meta.warnings after threshold", async () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = { flagged: true };
+    for (let i = 0; i < 4; i++) {
+      await withLoopDetection("task_list", args, detector, makeHandler({ tasks: [] }));
+    }
+    const result = await withLoopDetection("task_list", args, detector, makeHandler({ tasks: [] }));
+    expect(result.meta.warnings).toHaveLength(1);
+    expect(result.meta.warnings?.[0]?.code).toBe("WARN_LOOP_DETECTED");
+  });
+
+  it("preserves existing warnings when appending loop warning", async () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = {};
+    const existingWarning = {
+      code: "WARN_SYNC_PENDING" as const,
+      message: "pending",
+    };
+    const handlerWithWarning = () =>
+      Promise.resolve(ok({ id: "x" }, { ...fakeMeta, warnings: [existingWarning] }));
+
+    for (let i = 0; i < 4; i++) detector.record("task_update", args);
+    const result = await withLoopDetection("task_update", args, detector, handlerWithWarning);
+
+    expect(result.meta.warnings).toHaveLength(2);
+    expect(result.meta.warnings?.[0]?.code).toBe("WARN_SYNC_PENDING");
+    expect(result.meta.warnings?.[1]?.code).toBe("WARN_LOOP_DETECTED");
+  });
+
+  it("does not mutate the original meta.warnings array", async () => {
+    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const args = {};
+    const original = [{ code: "WARN_SYNC_PENDING" as const, message: "x" }];
+    const handlerWithWarning = () =>
+      Promise.resolve(ok({ id: "x" }, { ...fakeMeta, warnings: original }));
+
+    for (let i = 0; i < 4; i++) detector.record("task_update", args);
+    await withLoopDetection("task_update", args, detector, handlerWithWarning);
+
+    expect(original).toHaveLength(1); // original untouched
+  });
+});

--- a/src/loopDetector/LoopDetector.ts
+++ b/src/loopDetector/LoopDetector.ts
@@ -1,0 +1,111 @@
+/**
+ * `LoopDetector` — tracks recent (tool, args-hash) invocations to surface
+ * agent loops early.
+ *
+ * Per DESIGN §6.11: if the same `(tool, serialized-args)` invocation occurs
+ * ≥5 times within 60s, `record()` returns a `WARN_LOOP_DETECTED` warning so
+ * the handler can include it in `meta.warnings`.
+ *
+ * The args hash is a simple stable-stringify checksum — not cryptographic,
+ * just a compact dedup key. Different arg values → different key → no warning.
+ *
+ * Thread-safety: JavaScript is single-threaded; no locking needed.
+ *
+ * @see DESIGN.md §6.11 — loop detection
+ */
+
+import { createHash } from "node:crypto";
+import type { Warning } from "../envelope/index.js";
+
+export interface LoopDetectorConfig {
+  /** Number of identical calls before the warning fires. Default 5. */
+  threshold: number;
+  /** Sliding window in seconds. Default 60. */
+  windowSeconds: number;
+}
+
+const DEFAULT_CONFIG: LoopDetectorConfig = {
+  threshold: 5,
+  windowSeconds: 60,
+};
+
+/**
+ * Build a stable dedup key from a tool name and its raw arguments object.
+ *
+ * Uses deterministic JSON serialization (keys sorted) so that
+ * `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` hash to the same value.
+ */
+export function buildCallKey(toolName: string, args: unknown): string {
+  const serialized = JSON.stringify(args, Object.keys(args as object).sort());
+  const hash = createHash("sha1").update(serialized).digest("hex").slice(0, 16);
+  return `${toolName}:${hash}`;
+}
+
+export class LoopDetector {
+  private readonly config: LoopDetectorConfig;
+  /** Maps call key → sorted list of invocation timestamps (ms). */
+  private readonly windows: Map<string, number[]> = new Map();
+
+  constructor(config: Partial<LoopDetectorConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Record an invocation and return a warning if the threshold is met.
+   *
+   * @param toolName - MCP tool name (e.g. `"task_list"`)
+   * @param args - Raw input arguments passed to the tool
+   * @returns A `WARN_LOOP_DETECTED` `Warning` when the threshold is reached,
+   *          or `undefined` otherwise.
+   */
+  record(toolName: string, args: unknown): Warning | undefined {
+    const key = buildCallKey(toolName, args);
+    const now = Date.now();
+    const cutoff = now - this.config.windowSeconds * 1000;
+
+    const timestamps = this.getAndPrune(key, cutoff);
+    timestamps.push(now);
+
+    const count = timestamps.length;
+    if (count >= this.config.threshold) {
+      return {
+        code: "WARN_LOOP_DETECTED",
+        message: `Tool "${toolName}" has been called ${count} time(s) with identical arguments within ${this.config.windowSeconds}s.`,
+        suggestion:
+          "The agent may be stuck in a loop. Verify that the previous response was acted on before repeating this call.",
+        details: { tool: toolName, count, windowSeconds: this.config.windowSeconds },
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Reset the tracking state for a call key (useful in tests).
+   * If `key` is omitted, clears all state.
+   */
+  reset(key?: string): void {
+    if (key === undefined) {
+      this.windows.clear();
+    } else {
+      this.windows.delete(key);
+    }
+  }
+
+  /** Get the timestamp array for a key, pruning stale entries in place. */
+  private getAndPrune(key: string, cutoff: number): number[] {
+    if (!this.windows.has(key)) {
+      this.windows.set(key, []);
+    }
+    const timestamps = this.windows.get(key) as number[];
+
+    // Prune oldest-first (timestamps are appended in order, so oldest is at [0])
+    let i = 0;
+    while (i < timestamps.length && (timestamps[i] as number) <= cutoff) {
+      i++;
+    }
+    if (i > 0) timestamps.splice(0, i);
+
+    return timestamps;
+  }
+}

--- a/src/loopDetector/withLoopDetection.ts
+++ b/src/loopDetector/withLoopDetection.ts
@@ -1,0 +1,49 @@
+/**
+ * `withLoopDetection` — loop-detection middleware for MCP tool handlers.
+ *
+ * Wraps a tool handler to:
+ * 1. Record the `(tool, args)` invocation via `LoopDetector.record()`.
+ * 2. If a `WARN_LOOP_DETECTED` warning is returned, append it to the
+ *    `meta.warnings` array of the response.
+ *
+ * The wrapper is transparent — it preserves the envelope shape and type
+ * parameter of the wrapped handler. It never blocks or throws on loop
+ * detection; the warning is advisory only.
+ *
+ * @see src/loopDetector/LoopDetector.ts
+ * @see DESIGN.md §6.11 — loop detection
+ * @see src/envelope/index.ts — ResponseMeta.warnings
+ */
+
+import type { ResponseMeta, ToolSuccess } from "../envelope/index.js";
+import type { LoopDetector } from "./LoopDetector.js";
+
+/**
+ * Wrap a tool handler with loop-detection.
+ *
+ * @param toolName - MCP tool name (e.g. `"task_list"`)
+ * @param args - Raw input arguments passed to the tool (from the MCP request)
+ * @param detector - Shared `LoopDetector` instance (typically a singleton)
+ * @param handler - The actual tool handler to invoke
+ */
+export function withLoopDetection<T>(
+  toolName: string,
+  args: unknown,
+  detector: LoopDetector,
+  handler: () => Promise<ToolSuccess<T>>,
+): Promise<ToolSuccess<T>> {
+  const warning = detector.record(toolName, args);
+
+  return handler().then((envelope) => {
+    if (warning === undefined) return envelope;
+
+    const existingWarnings = envelope.meta.warnings ?? [];
+    return {
+      ...envelope,
+      meta: {
+        ...envelope.meta,
+        warnings: [...existingWarnings, warning],
+      } satisfies ResponseMeta,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- `LoopDetector` tracks `(tool, args-hash)` invocations in a configurable sliding window (default 60s / threshold 5)
- `withLoopDetection` wraps any tool handler transparently, appending `WARN_LOOP_DETECTED` to `meta.warnings` after threshold — never blocks or throws
- `WARN_LOOP_DETECTED` added to the `WarningCode` union in `src/envelope/index.ts`
- 14 unit tests covering threshold, window expiry, key stability, multi-tool isolation, warning accumulation, and immutability

Closes #76.

## Issue
Implements [#76 — Loop-detection middleware](https://github.com/torsday/omnifocus-mcp/issues/76). See [DESIGN.md §6.11](https://github.com/torsday/omnifocus-mcp/blob/main/DESIGN.md#611-loop-detection).

## Breaking change?
- [x] No — `WARN_LOOP_DETECTED` is an additive WarningCode value per ADR-0011

## Test plan
- [x] 14 unit tests, all green
- [x] Full suite: 81 test files, 1171 tests passing
- [x] `pnpm typecheck` clean
- [x] Self-reviewed