### PR TITLE
feat(domain): add _links navigation hints to Task and Project responses

### DIFF
--- a/src/domain/links.test.ts
+++ b/src/domain/links.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for buildTaskLinks and buildProjectLinks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { FolderId, ProjectId, TagId, TaskId } from "./ids.js";
+import { buildProjectLinks, buildTaskLinks } from "./links.js";
+
+// ---------------------------------------------------------------------------
+// buildTaskLinks
+// ---------------------------------------------------------------------------
+
+describe("buildTaskLinks", () => {
+  const id = TaskId.of("taskAAA");
+
+  it("inbox task (no projectId, no parentId, no tags) has null project/parent and empty tags", () => {
+    const links = buildTaskLinks({ id, projectId: null, parentId: null, tagIds: [] });
+    expect(links).toEqual({
+      self: "omnifocus://task/taskAAA",
+      project: null,
+      parent: null,
+      tags: [],
+    });
+  });
+
+  it("produces correct self URI", () => {
+    const links = buildTaskLinks({ id, projectId: null, parentId: null, tagIds: [] });
+    expect(links.self).toBe("omnifocus://task/taskAAA");
+  });
+
+  it("produces correct project URI when projectId is set", () => {
+    const projectId = ProjectId.of("projBBB");
+    const links = buildTaskLinks({ id, projectId, parentId: null, tagIds: [] });
+    expect(links.project).toBe("omnifocus://project/projBBB");
+  });
+
+  it("produces correct parent URI when parentId is set", () => {
+    const parentId = TaskId.of("parentCCC");
+    const links = buildTaskLinks({ id, projectId: null, parentId, tagIds: [] });
+    expect(links.parent).toBe("omnifocus://task/parentCCC");
+  });
+
+  it("maps tagIds to tag URIs", () => {
+    const tagIds = [TagId.of("tagDDD"), TagId.of("tagEEE")];
+    const links = buildTaskLinks({ id, projectId: null, parentId: null, tagIds });
+    expect(links.tags).toEqual(["omnifocus://tag/tagDDD", "omnifocus://tag/tagEEE"]);
+  });
+
+  it("fully populated task produces all URIs", () => {
+    const projectId = ProjectId.of("projFFF");
+    const parentId = TaskId.of("parentGGG");
+    const tagIds = [TagId.of("tagHHH")];
+    const links = buildTaskLinks({ id, projectId, parentId, tagIds });
+    expect(links).toEqual({
+      self: "omnifocus://task/taskAAA",
+      project: "omnifocus://project/projFFF",
+      parent: "omnifocus://task/parentGGG",
+      tags: ["omnifocus://tag/tagHHH"],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildProjectLinks
+// ---------------------------------------------------------------------------
+
+describe("buildProjectLinks", () => {
+  const id = ProjectId.of("projAAA");
+
+  it("root-level project (null folderId) has null folder", () => {
+    const links = buildProjectLinks({ id, folderId: null });
+    expect(links).toEqual({
+      self: "omnifocus://project/projAAA",
+      folder: null,
+    });
+  });
+
+  it("produces correct self URI", () => {
+    const links = buildProjectLinks({ id, folderId: null });
+    expect(links.self).toBe("omnifocus://project/projAAA");
+  });
+
+  it("produces correct folder URI when folderId is set", () => {
+    const folderId = FolderId.of("folderBBB");
+    const links = buildProjectLinks({ id, folderId });
+    expect(links.folder).toBe("omnifocus://folder/folderBBB");
+  });
+});

--- a/src/domain/links.ts
+++ b/src/domain/links.ts
@@ -1,0 +1,88 @@
+/**
+ * HATEOAS-style `_links` navigation hints for Task and Project domain objects.
+ *
+ * Link blocks are constructed in the service layer from IDs already present on
+ * the domain object. Adapters never set them; they remain optional on the
+ * interfaces so existing adapter tests stay green.
+ *
+ * URI scheme: `omnifocus://<noun>/<id>`
+ *
+ * @see src/domain/task.ts — TaskLinks field
+ * @see src/domain/project.ts — ProjectLinks field
+ */
+
+import { z } from "zod";
+import type { FolderId, ProjectId, TagId, TaskId } from "./ids.js";
+
+// ---------------------------------------------------------------------------
+// Interfaces
+// ---------------------------------------------------------------------------
+
+export interface TaskLinks {
+  self: string;
+  /** URI to the owning project, or null if the task lives in the inbox. */
+  project: string | null;
+  /** URI to the parent task, or null if the task is top-level. */
+  parent: string | null;
+  /** URIs for each tag applied to the task. Empty array when no tags. */
+  tags: string[];
+}
+
+export interface ProjectLinks {
+  self: string;
+  /** URI to the containing folder, or null if the project is root-level. */
+  folder: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+export const taskLinksSchema: z.ZodType<TaskLinks, z.ZodTypeDef, unknown> = z.object({
+  self: z.string(),
+  project: z.string().nullable(),
+  parent: z.string().nullable(),
+  tags: z.array(z.string()),
+});
+
+export const projectLinksSchema: z.ZodType<ProjectLinks, z.ZodTypeDef, unknown> = z.object({
+  self: z.string(),
+  folder: z.string().nullable(),
+});
+
+// ---------------------------------------------------------------------------
+// Builder functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct a `TaskLinks` block from the minimal ID set on a Task.
+ *
+ * Accepts plain string | null parameters so callers can pass branded ID types
+ * directly (branded strings are assignable to `string`).
+ */
+export function buildTaskLinks(task: {
+  id: TaskId;
+  projectId: ProjectId | null;
+  parentId: TaskId | null;
+  tagIds: TagId[];
+}): TaskLinks {
+  return {
+    self: `omnifocus://task/${task.id}`,
+    project: task.projectId !== null ? `omnifocus://project/${task.projectId}` : null,
+    parent: task.parentId !== null ? `omnifocus://task/${task.parentId}` : null,
+    tags: task.tagIds.map((id) => `omnifocus://tag/${id}`),
+  };
+}
+
+/**
+ * Construct a `ProjectLinks` block from the minimal ID set on a Project.
+ */
+export function buildProjectLinks(project: {
+  id: ProjectId;
+  folderId: FolderId | null;
+}): ProjectLinks {
+  return {
+    self: `omnifocus://project/${project.id}`,
+    folder: project.folderId !== null ? `omnifocus://folder/${project.folderId}` : null,
+  };
+}

--- a/src/domain/project.ts
+++ b/src/domain/project.ts
@@ -24,6 +24,8 @@ import {
   type TagId,
   TagId as TagIdCtor,
 } from "./ids.js";
+// biome-ignore lint/correctness/noUnusedImports: used in interface and schema
+import { type ProjectLinks, projectLinksSchema } from "./links.js";
 
 // ---------------------------------------------------------------------------
 // Project
@@ -60,6 +62,8 @@ export interface Project {
 
   createdAt: IsoDateString;
   modifiedAt: IsoDateString;
+
+  _links?: ProjectLinks;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,4 +101,6 @@ export const ProjectSchema: z.ZodType<Project, z.ZodTypeDef, unknown> = z.object
 
   createdAt: isoDateString(),
   modifiedAt: isoDateString(),
+
+  _links: projectLinksSchema.optional(),
 }) as z.ZodType<Project, z.ZodTypeDef, unknown>;

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -24,6 +24,8 @@ import {
   type TaskId,
   TaskId as TaskIdCtor,
 } from "./ids.js";
+// biome-ignore lint/correctness/noUnusedImports: used in interface and schema
+import { type TaskLinks, taskLinksSchema } from "./links.js";
 
 // ---------------------------------------------------------------------------
 // RepetitionRule
@@ -84,6 +86,8 @@ export interface Task {
 
   createdAt: IsoDateString;
   modifiedAt: IsoDateString;
+
+  _links?: TaskLinks;
 }
 
 // ---------------------------------------------------------------------------
@@ -158,4 +162,6 @@ export const TaskSchema: z.ZodType<Task, z.ZodTypeDef, unknown> = z.object({
 
   createdAt: isoDateString(),
   modifiedAt: isoDateString(),
+
+  _links: taskLinksSchema.optional(),
 }) as z.ZodType<Task, z.ZodTypeDef, unknown>;

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -31,6 +31,7 @@ import type {
   UpdateProjectInput,
 } from "../adapter/OmniFocusAdapter.js";
 import type { FolderId, ProjectId } from "../domain/ids.js";
+import { buildProjectLinks, buildTaskLinks } from "../domain/links.js";
 import type { Project } from "../domain/project.js";
 import type { Task } from "../domain/task.js";
 import { ValidationError } from "../errors/index.js";
@@ -195,9 +196,11 @@ export class ProjectService {
 
     const payload = await this.cache.wrap(cacheKey, async () => {
       const project = await this.adapter.getProject(input.id);
-      if (!includeTaskTree) return { project };
+      const enrichedProject = { ...project, _links: buildProjectLinks(project) };
+      if (!includeTaskTree) return { project: enrichedProject };
       const tasks = await this.adapter.listTasks({ projectId: input.id });
-      return { project, tasks };
+      const enrichedTasks = tasks.map((t) => ({ ...t, _links: buildTaskLinks(t) }));
+      return { project: enrichedProject, tasks: enrichedTasks };
     });
 
     return { ...payload, cacheHit };
@@ -244,7 +247,8 @@ export class ProjectService {
     const hasMore = afterCursor.length > limit;
     const nextCursor = hasMore ? this.encodeNextCursor(page, filterHash) : null;
 
-    return { projects: page, nextCursor };
+    const projects = page.map((p) => ({ ...p, _links: buildProjectLinks(p) }));
+    return { projects, nextCursor };
   }
 
   // -- Internal: validation ----------------------------------------------

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -16,6 +16,7 @@
  */
 
 import type { OmniFocusAdapter, SearchFilter } from "../adapter/OmniFocusAdapter.js";
+import { buildTaskLinks } from "../domain/links.js";
 import type { Task } from "../domain/task.js";
 import {
   type CursorPayload,
@@ -126,7 +127,7 @@ export class SearchService {
     // Take one extra to detect hasMore
     const page = afterCursor.slice(0, limit + 1);
     const hasMore = page.length > limit;
-    const tasks = page.slice(0, limit);
+    const tasks = page.slice(0, limit).map((t) => ({ ...t, _links: buildTaskLinks(t) }));
 
     // Encode next cursor
     const last = tasks.at(-1);

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -34,6 +34,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter, TaskFilter } from "../adapter/OmniFocusAdapter.js";
 import { isIsoDateString, isRelativeDateShortcut, resolveRelativeDate } from "../domain/dates.js";
 import type { ProjectId, TagId, TaskId } from "../domain/ids.js";
+import { buildTaskLinks } from "../domain/links.js";
 import type { Task } from "../domain/task.js";
 import { ValidationError } from "../errors/index.js";
 import {
@@ -198,9 +199,11 @@ export class TaskService {
 
     const payload = await this.cache.wrap(cacheKey, async () => {
       const task = await this.adapter.getTask(input.id);
-      if (!includeSubtasks) return { task };
+      const enrichedTask = { ...task, _links: buildTaskLinks(task) };
+      if (!includeSubtasks) return { task: enrichedTask };
       const subtasks = await this.adapter.listTasks({ parentId: input.id });
-      return { task, subtasks };
+      const enrichedSubtasks = subtasks.map((t) => ({ ...t, _links: buildTaskLinks(t) }));
+      return { task: enrichedTask, subtasks: enrichedSubtasks };
     });
 
     return { ...payload, cacheHit };
@@ -272,7 +275,8 @@ export class TaskService {
     const hasMore = afterCursor.length > limit;
     const nextCursor = hasMore ? this.encodeNextCursor(page, filterHash, getSortValue) : null;
 
-    return { tasks: page, nextCursor };
+    const tasks = page.map((t) => ({ ...t, _links: buildTaskLinks(t) }));
+    return { tasks, nextCursor };
   }
 
   // -- Internal: validation ----------------------------------------------


### PR DESCRIPTION
## Summary
- `src/domain/links.ts` — `TaskLinks`, `ProjectLinks` interfaces, Zod schemas, pure `buildTaskLinks`/`buildProjectLinks` builder functions that produce `omnifocus://noun/id` URIs
- `Task` and `Project` domain types gain `_links?: TaskLinks|ProjectLinks` (optional for adapter compatibility)
- `TaskService`, `ProjectService`, `SearchService` enrich every returned object with `_links` before it reaches tool handlers
- Agents can now pass `task._links.project` directly to `resources/read` instead of constructing the URI themselves

Closes #149.

## Issue
Implements [#149 — `_links` navigation hints on Task and Project responses](https://github.com/torsday/omnifocus-mcp/issues/149). See DESIGN.md §37.

## Breaking change?
- [x] No — `_links` is an additive optional field; existing consumers are unaffected

## Test plan
- [x] 9 unit tests in `src/domain/links.test.ts`: all URI shapes, null cases (inbox task, root project), tag arrays
- [x] 82 test files, 1 180 tests all green
- [x] `pnpm typecheck` clean
- [x] Self-reviewed