### PR TITLE
feat(export): add export_opml tool

### DIFF
--- a/src/services/exportService.test.ts
+++ b/src/services/exportService.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for `ExportService.exportOpml` — OPML generation using InMemoryAdapter.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import type { ProjectId } from "../domain/ids.js";
+import { ExportService } from "./exportService.js";
+
+function makeService() {
+  const adapter = new InMemoryAdapter({
+    now: () => new Date("2026-04-23T12:00:00.000Z"),
+  });
+  const service = new ExportService({ adapter });
+  return { adapter, service };
+}
+
+describe("ExportService.exportOpml — scope: all", () => {
+  it("returns empty body when no active projects exist", async () => {
+    const { service } = makeService();
+    const result = await service.exportOpml({ kind: "all" });
+    expect(result.projectCount).toBe(0);
+    expect(result.taskCount).toBe(0);
+    expect(result.opml).toContain("<?xml version=");
+    expect(result.opml).toContain("<opml");
+    expect(result.opml).toContain("</opml>");
+  });
+
+  it("includes active projects", async () => {
+    const { adapter, service } = makeService();
+    await adapter.createProject({ name: "Work" });
+    await adapter.createProject({ name: "Personal" });
+    const result = await service.exportOpml({ kind: "all" });
+    expect(result.projectCount).toBe(2);
+    expect(result.opml).toContain('text="Work"');
+    expect(result.opml).toContain('text="Personal"');
+  });
+
+  it("excludes dropped projects", async () => {
+    const { adapter, service } = makeService();
+    const id = await adapter.createProject({ name: "Dropped proj" });
+    await adapter.dropProject(id);
+    const result = await service.exportOpml({ kind: "all" });
+    expect(result.opml).not.toContain("Dropped proj");
+  });
+});
+
+describe("ExportService.exportOpml — scope: project", () => {
+  it("exports a single project with its tasks", async () => {
+    const { adapter, service } = makeService();
+    const projectId = await adapter.createProject({ name: "My Project" });
+    await adapter.createTask({ name: "Task A", projectId });
+    await adapter.createTask({ name: "Task B", projectId });
+
+    const result = await service.exportOpml({ kind: "project", id: projectId });
+    expect(result.projectCount).toBe(1);
+    expect(result.taskCount).toBe(2);
+    expect(result.opml).toContain('text="My Project"');
+    expect(result.opml).toContain('text="Task A"');
+    expect(result.opml).toContain('text="Task B"');
+    expect(result.opml).toContain('type="omnifocus:project"');
+    expect(result.opml).toContain('type="omnifocus:task"');
+  });
+
+  it("renders multiple tasks in document order", async () => {
+    const { adapter, service } = makeService();
+    const projectId = await adapter.createProject({ name: "Multi-task" });
+    await adapter.createTask({ name: "Alpha", projectId });
+    await adapter.createTask({ name: "Beta", projectId });
+    await adapter.createTask({ name: "Gamma", projectId });
+
+    const result = await service.exportOpml({ kind: "project", id: projectId });
+    expect(result.taskCount).toBe(3);
+    expect(result.opml).toContain('text="Alpha"');
+    expect(result.opml).toContain('text="Beta"');
+    expect(result.opml).toContain('text="Gamma"');
+  });
+
+  it("includes task attributes when present", async () => {
+    const { adapter, service } = makeService();
+    const projectId = await adapter.createProject({ name: "Proj" });
+    await adapter.createTask({
+      name: "Due task",
+      projectId,
+      dueDate: "2026-05-01T00:00:00.000Z",
+      flagged: true,
+    });
+
+    const result = await service.exportOpml({ kind: "project", id: projectId });
+    expect(result.opml).toContain('due="2026-05-01T00:00:00.000Z"');
+    expect(result.opml).toContain('flagged="true"');
+  });
+
+  it("throws NotFound for an unknown project ID", async () => {
+    const { service } = makeService();
+    const fakeId = "proj_unknown" as ProjectId;
+    await expect(service.exportOpml({ kind: "project", id: fakeId })).rejects.toThrow();
+  });
+
+  it("produces well-formed OPML with xml declaration and opml root", async () => {
+    const { adapter, service } = makeService();
+    await adapter.createProject({ name: "P" });
+    const result = await service.exportOpml({ kind: "all" });
+    expect(result.opml).toMatch(/^<\?xml version="1\.0"/);
+    expect(result.opml).toContain('<opml version="2.0">');
+    expect(result.opml).toContain("<head>");
+    expect(result.opml).toContain("<body>");
+    expect(result.opml).toContain("</body>");
+    expect(result.opml).toContain("</opml>");
+  });
+
+  it("escapes XML special characters in task names", async () => {
+    const { adapter, service } = makeService();
+    const projectId = await adapter.createProject({ name: 'Special <chars> & "quotes"' });
+    await adapter.createTask({ name: "Task with <tag> & 'quotes'", projectId });
+
+    const result = await service.exportOpml({ kind: "project", id: projectId });
+    expect(result.opml).toContain("Special &lt;chars&gt; &amp; &quot;quotes&quot;");
+    // Single quotes don't need escaping inside double-quoted XML attributes
+    expect(result.opml).toContain("Task with &lt;tag&gt; &amp; 'quotes'");
+  });
+});
+
+describe("ExportService.exportOpml — scope: folder", () => {
+  it("exports all projects in a folder", async () => {
+    const { adapter, service } = makeService();
+    const folderId = await adapter.createFolder({ name: "Work folder" });
+    await adapter.createProject({ name: "Proj A", folderId });
+    await adapter.createProject({ name: "Proj B", folderId });
+    await adapter.createProject({ name: "Unrelated proj" }); // root, not in folder
+
+    const result = await service.exportOpml({ kind: "folder", id: folderId });
+    expect(result.projectCount).toBe(2);
+    expect(result.opml).toContain('text="Proj A"');
+    expect(result.opml).toContain('text="Proj B"');
+    expect(result.opml).not.toContain('text="Unrelated proj"');
+  });
+});

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,0 +1,221 @@
+/**
+ * `ExportService` — structured export operations (OPML, TaskPaper, etc.).
+ *
+ * Composes existing adapter primitives into export formats. No new adapter
+ * methods required — the service fetches domain objects and serialises them.
+ *
+ * @see DESIGN.md §6.5 — service layer principles
+ * @see docs/domain-reference.md — canonical domain schemas
+ */
+
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import type { FolderId, ProjectId } from "../domain/ids.js";
+import type { Project } from "../domain/project.js";
+import type { Task } from "../domain/task.js";
+import { NotFound } from "../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Public shapes
+// ---------------------------------------------------------------------------
+
+/** Which slice of the OmniFocus database to export. */
+export type ExportScope =
+  | { kind: "project"; id: ProjectId }
+  | { kind: "folder"; id: FolderId }
+  | { kind: "all" };
+
+export interface ExportOpmlResult {
+  /** Complete, well-formed OPML XML string. */
+  opml: string;
+  /** Number of projects included in the export. */
+  projectCount: number;
+  /** Number of tasks (all levels) included in the export. */
+  taskCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// OPML serialisation helpers
+// ---------------------------------------------------------------------------
+
+/** Escape XML special characters in attribute values. */
+function xmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Build an `<outline>` element for a task, recursively rendering children.
+ *
+ * Attributes follow OmniFocus's own OPML conventions:
+ * - `text` — task name (required by OPML spec)
+ * - `type` — `"omnifocus:task"` to allow round-trip import
+ * - `id` — persistent OmniFocus ID
+ * - `due` — ISO-8601 due date, omitted if null
+ * - `defer` — ISO-8601 defer date, omitted if null
+ * - `flagged` — `"true"` if flagged, omitted if false
+ * - `completed` — `"true"` if completed, omitted if false
+ * - `dropped` — `"true"` if dropped, omitted if false
+ * - `note` — plain-text note, omitted if null/empty
+ */
+function renderTaskOutline(
+  task: Task,
+  childrenByParent: Map<string, Task[]>,
+  indent: string,
+): string {
+  const attrs: string[] = [
+    `text="${xmlAttr(task.name)}"`,
+    `type="omnifocus:task"`,
+    `id="${xmlAttr(String(task.id))}"`,
+  ];
+  if (task.dueDate) attrs.push(`due="${xmlAttr(task.dueDate)}"`);
+  if (task.deferDate) attrs.push(`defer="${xmlAttr(task.deferDate)}"`);
+  if (task.flagged) attrs.push(`flagged="true"`);
+  if (task.completed) attrs.push(`completed="true"`);
+  if (task.dropped) attrs.push(`dropped="true"`);
+  if (task.note) attrs.push(`note="${xmlAttr(task.note)}"`);
+
+  const children = childrenByParent.get(String(task.id)) ?? [];
+  if (children.length === 0) {
+    return `${indent}<outline ${attrs.join(" ")} />`;
+  }
+
+  const childIndent = `${indent}  `;
+  const childLines = children
+    .map((c) => renderTaskOutline(c, childrenByParent, childIndent))
+    .join("\n");
+  return `${indent}<outline ${attrs.join(" ")}>\n${childLines}\n${indent}</outline>`;
+}
+
+/**
+ * Build an `<outline>` element for a project with its task tree.
+ */
+function renderProjectOutline(project: Project, tasks: Task[], indent: string): string {
+  // Build parent → children map for tasks in this project
+  const byParent = new Map<string, Task[]>();
+  const rootTasks: Task[] = [];
+
+  for (const task of tasks) {
+    if (task.parentId === null) {
+      rootTasks.push(task);
+    } else {
+      const key = String(task.parentId);
+      const existing = byParent.get(key);
+      if (existing) {
+        existing.push(task);
+      } else {
+        byParent.set(key, [task]);
+      }
+    }
+  }
+
+  const attrs: string[] = [
+    `text="${xmlAttr(project.name)}"`,
+    `type="omnifocus:project"`,
+    `id="${xmlAttr(String(project.id))}"`,
+    `status="${xmlAttr(project.status)}"`,
+  ];
+  if (project.dueDate) attrs.push(`due="${xmlAttr(project.dueDate)}"`);
+  if (project.deferDate) attrs.push(`defer="${xmlAttr(project.deferDate)}"`);
+  if (project.flagged) attrs.push(`flagged="true"`);
+  if (project.note) attrs.push(`note="${xmlAttr(project.note)}"`);
+
+  const childIndent = `${indent}  `;
+  if (rootTasks.length === 0) {
+    return `${indent}<outline ${attrs.join(" ")} />`;
+  }
+
+  const childLines = rootTasks.map((t) => renderTaskOutline(t, byParent, childIndent)).join("\n");
+  return `${indent}<outline ${attrs.join(" ")}>\n${childLines}\n${indent}</outline>`;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class ExportService {
+  private readonly adapter: OmniFocusAdapter;
+
+  constructor(deps: { adapter: OmniFocusAdapter }) {
+    this.adapter = deps.adapter;
+  }
+
+  /**
+   * Export OmniFocus data as OPML XML.
+   *
+   * Scope controls the slice exported:
+   * - `{ kind: "project", id }` — one project and its task tree
+   * - `{ kind: "folder", id }` — all projects in a folder (flat; no
+   *   sub-folder recursion in v1)
+   * - `{ kind: "all" }` — all active projects (status = active)
+   *
+   * The returned OPML is a complete, well-formed XML document following
+   * OmniFocus's own OPML conventions so that it can be round-tripped back
+   * into OmniFocus via File → Import.
+   *
+   * @throws {NotFound} when the requested project or folder ID does not exist.
+   */
+  async exportOpml(scope: ExportScope): Promise<ExportOpmlResult> {
+    const projects = await this.resolveProjects(scope);
+
+    // Fetch tasks per project in parallel reads (adapter contract: reads are safe to parallelise)
+    const tasksByProject = await Promise.all(
+      projects.map((p) =>
+        this.adapter.listTasks({ projectId: p.id }).then((tasks) => ({ project: p, tasks })),
+      ),
+    );
+
+    const projectOutlines = tasksByProject
+      .map(({ project, tasks }) => renderProjectOutline(project, tasks, "    "))
+      .join("\n");
+
+    const totalTasks = tasksByProject.reduce((sum, { tasks }) => sum + tasks.length, 0);
+
+    const opml = [
+      `<?xml version="1.0" encoding="UTF-8"?>`,
+      `<opml version="2.0">`,
+      `  <head>`,
+      `    <title>OmniFocus Export</title>`,
+      `  </head>`,
+      `  <body>`,
+      projectOutlines,
+      `  </body>`,
+      `</opml>`,
+    ].join("\n");
+
+    return {
+      opml,
+      projectCount: projects.length,
+      taskCount: totalTasks,
+    };
+  }
+
+  /** Resolve the correct project list based on scope. */
+  private async resolveProjects(scope: ExportScope): Promise<Project[]> {
+    if (scope.kind === "all") {
+      return this.adapter.listProjects({ status: "active" });
+    }
+    if (scope.kind === "folder") {
+      const projects = await this.adapter.listProjects({ folderId: scope.id });
+      // Verify folder existence: if no projects returned, check that the folder
+      // actually exists (listProjects returns [] for unknown folderIds too).
+      if (projects.length === 0) {
+        // Best-effort check — getFolder may not exist on all adapters yet;
+        // skip the existence check when the method isn't available.
+        try {
+          await this.adapter.getFolder(scope.id);
+        } catch {
+          throw new NotFound(`Folder not found: ${String(scope.id)}`, {
+            details: { resource: "folder", id: String(scope.id) },
+          });
+        }
+      }
+      return projects;
+    }
+    // kind === "project"
+    const project = await this.adapter.getProject(scope.id);
+    return [project];
+  }
+}

--- a/src/tools/__snapshots__/descriptions.snapshot.test.ts.snap
+++ b/src/tools/__snapshots__/descriptions.snapshot.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`tool descriptions — snapshot > all descriptions match their committed snapshots 1`] = `
 {
+  "export_opml": "Export OmniFocus data as OPML XML — a structured outline format OmniFocus can import. Do NOT use to export a single task; OPML scope is project-level or broader. Three scopes: 'project' (one project + its tasks), 'folder' (all projects in a folder), or 'all' (all active projects). Returns { opml, projectCount, taskCount } where opml is a complete XML string. Safe to call repeatedly; no side effects.",
   "folder_create": "Create a new folder in OmniFocus. Optionally nest it inside an existing parent folder (get IDs from folder_list). Do not use to move an existing folder; prefer folder_move instead. Returns the new folder's persistent ID. Triggers a sync; call sync_trigger after to propagate to other devices.",
   "folder_delete": "Delete a folder from OmniFocus. By default returns ValidationError when the folder contains projects or subfolders. Pass cascade=true to orphan all direct projects (move to no folder) and recursively delete subfolders before deleting. IRREVERSIBLE — do not use to archive; prefer folder_update to rename instead. Get the folder ID from folder_list. Triggers a sync; call sync_trigger after to propagate to other devices.",
   "folder_get": "Fetch a single folder by its persistent ID, including project and subfolder counts. Do not use to list multiple folders; prefer folder_list instead. Returns folder details including name, parentId, projectCount, and subfolderCount. Safe to call repeatedly; no side effects.",
@@ -40,6 +41,8 @@ exports[`tool descriptions — snapshot > all descriptions match their committed
   "task_update": "Partially update mutable fields on an OmniFocus task. Only supplied fields are changed; omit a field to leave it unchanged. Do not use to complete or delete a task; prefer task_complete or task_delete instead. Two tag-update modes: (1) supply tagIds to replace the full tag set; (2) supply addTags and/or removeTags to apply a diff without reading first. Supplying tagIds together with addTags/removeTags is a ValidationError. setFlagged is a convenience alias for flagged. Returns the updated task. Side effects: writes to OmniFocus, sets meta.syncPending = true. Call sync_trigger when you need changes to appear on other devices.",
 }
 `;
+
+exports[`tool descriptions — snapshot > export_opml description matches snapshot 1`] = `"Export OmniFocus data as OPML XML — a structured outline format OmniFocus can import. Do NOT use to export a single task; OPML scope is project-level or broader. Three scopes: 'project' (one project + its tasks), 'folder' (all projects in a folder), or 'all' (all active projects). Returns { opml, projectCount, taskCount } where opml is a complete XML string. Safe to call repeatedly; no side effects."`;
 
 exports[`tool descriptions — snapshot > folder_create description matches snapshot 1`] = `"Create a new folder in OmniFocus. Optionally nest it inside an existing parent folder (get IDs from folder_list). Do not use to move an existing folder; prefer folder_move instead. Returns the new folder's persistent ID. Triggers a sync; call sync_trigger after to propagate to other devices."`;
 

--- a/src/tools/allDescriptions.ts
+++ b/src/tools/allDescriptions.ts
@@ -1,5 +1,5 @@
+import { EXPORT_OPML_DESCRIPTION } from "./export/opml.js";
 import { FOLDER_CREATE_DESCRIPTION } from "./folder/create.js";
-import { INTERNAL_STATUS_DESCRIPTION } from "./observability/internalStatus.js";
 import { FOLDER_DELETE_DESCRIPTION } from "./folder/delete.js";
 import { FOLDER_GET_DESCRIPTION } from "./folder/get.js";
 import { FOLDER_LIST_DESCRIPTION } from "./folder/list.js";
@@ -11,6 +11,7 @@ import { NOTE_GET_DESCRIPTION } from "./note/get.js";
 import { NOTE_GET_HTML_DESCRIPTION } from "./note/get_html.js";
 import { NOTE_SET_DESCRIPTION } from "./note/set.js";
 import { NOTE_SET_HTML_DESCRIPTION } from "./note/set_html.js";
+import { INTERNAL_STATUS_DESCRIPTION } from "./observability/internalStatus.js";
 import { PROJECT_DELETE_DESCRIPTION } from "./project/delete.js";
 import { SEARCH_QUERY_DESCRIPTION } from "./search/query.js";
 import { SYNC_STATUS_DESCRIPTION } from "./sync/status.js";
@@ -36,14 +37,15 @@ import { TASK_SET_REPETITION_DESCRIPTION } from "./task/setRepetition.js";
 import { TASK_UPDATE_DESCRIPTION } from "./task/update.js";
 
 export const ALL_TOOL_DESCRIPTIONS: Record<string, string> = {
+  export_opml: EXPORT_OPML_DESCRIPTION,
   forecast_get: FORECAST_GET_DESCRIPTION,
   folder_create: FOLDER_CREATE_DESCRIPTION,
-  internal_status: INTERNAL_STATUS_DESCRIPTION,
   folder_delete: FOLDER_DELETE_DESCRIPTION,
   folder_get: FOLDER_GET_DESCRIPTION,
   folder_list: FOLDER_LIST_DESCRIPTION,
   folder_move: FOLDER_MOVE_DESCRIPTION,
   folder_update: FOLDER_UPDATE_DESCRIPTION,
+  internal_status: INTERNAL_STATUS_DESCRIPTION,
   note_append: NOTE_APPEND_DESCRIPTION,
   note_get: NOTE_GET_DESCRIPTION,
   note_get_html: NOTE_GET_HTML_DESCRIPTION,
@@ -64,12 +66,12 @@ export const ALL_TOOL_DESCRIPTIONS: Record<string, string> = {
   tag_set_status: TAG_SET_STATUS_DESCRIPTION,
   tag_update: TAG_UPDATE_DESCRIPTION,
   task_clear_repetition: TASK_CLEAR_REPETITION_DESCRIPTION,
-  task_parse_transport_text: TASK_PARSE_TRANSPORT_TEXT_DESCRIPTION,
   task_delete: TASK_DELETE_DESCRIPTION,
   task_find_by_name: TASK_FIND_BY_NAME_DESCRIPTION,
   task_get: TASK_GET_DESCRIPTION,
   task_get_many: TASK_GET_MANY_DESCRIPTION,
   task_list: TASK_LIST_DESCRIPTION,
+  task_parse_transport_text: TASK_PARSE_TRANSPORT_TEXT_DESCRIPTION,
   task_set_repetition: TASK_SET_REPETITION_DESCRIPTION,
   task_update: TASK_UPDATE_DESCRIPTION,
 };

--- a/src/tools/export/opml.test.ts
+++ b/src/tools/export/opml.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the `export_opml` tool — schema, description, handler envelope.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { ExportService } from "../../services/exportService.js";
+import { EXPORT_OPML_DESCRIPTION, exportOpmlInputSchema, handleExportOpml } from "./opml.js";
+
+function makeCtx() {
+  const adapter = new InMemoryAdapter({
+    now: () => new Date("2026-04-23T12:00:00.000Z"),
+  });
+  const exportService = new ExportService({ adapter });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { exportService, makeMeta }, adapter };
+}
+
+describe("export_opml — input schema", () => {
+  it("accepts scope='all' without id", () => {
+    expect(() => exportOpmlInputSchema.parse({ scope: "all" })).not.toThrow();
+  });
+
+  it("accepts scope='project' with an id", () => {
+    const result = exportOpmlInputSchema.parse({ scope: "project", id: "proj_abc" });
+    expect(result.scope).toBe("project");
+    expect(result.id).toBe("proj_abc");
+  });
+
+  it("accepts scope='folder' with an id", () => {
+    const result = exportOpmlInputSchema.parse({ scope: "folder", id: "folder_xyz" });
+    expect(result.scope).toBe("folder");
+  });
+
+  it("rejects an unknown scope value", () => {
+    expect(() => exportOpmlInputSchema.parse({ scope: "task" })).toThrow();
+  });
+});
+
+describe("export_opml — description", () => {
+  it("mentions OPML", () => {
+    expect(EXPORT_OPML_DESCRIPTION).toMatch(/OPML/i);
+  });
+
+  it("has a when-not clause", () => {
+    expect(EXPORT_OPML_DESCRIPTION).toMatch(/Do NOT/i);
+  });
+
+  it("is read-only (no side effects)", () => {
+    expect(EXPORT_OPML_DESCRIPTION).toMatch(/no side effects/i);
+  });
+});
+
+describe("export_opml — handler", () => {
+  it("returns an ok envelope with opml string and counts", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createProject({ name: "Test Project" });
+
+    const envelope = await handleExportOpml({ scope: "all" }, ctx);
+    expect(typeof envelope.data.opml).toBe("string");
+    expect(envelope.data.opml).toContain("<opml");
+    expect(envelope.data.projectCount).toBe(1);
+    expect(typeof envelope.data.taskCount).toBe("number");
+  });
+
+  it("handler throws for scope='project' without id", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleExportOpml({ scope: "project" }, ctx)).rejects.toThrow(/requires an id/);
+  });
+
+  it("returns empty OPML for scope='all' with no projects", async () => {
+    const { ctx } = makeCtx();
+    const envelope = await handleExportOpml({ scope: "all" }, ctx);
+    expect(envelope.data.projectCount).toBe(0);
+    expect(envelope.data.opml).toContain("</opml>");
+  });
+});

--- a/src/tools/export/opml.ts
+++ b/src/tools/export/opml.ts
@@ -1,0 +1,111 @@
+/**
+ * `export_opml` MCP tool — export OmniFocus data as OPML XML.
+ *
+ * Supports three scopes: a single project, all projects in a folder, or
+ * all active projects. Returns a complete OPML document following
+ * OmniFocus conventions for round-trip import.
+ *
+ * @see src/services/exportService.ts
+ * @see DESIGN.md §12 — response envelope
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { FolderId, ProjectId } from "../../domain/ids.js";
+import { type ResponseMeta, ok } from "../../envelope/index.js";
+import type { ExportScope, ExportService } from "../../services/exportService.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const EXPORT_OPML_DESCRIPTION =
+  "Export OmniFocus data as OPML XML — a structured outline format OmniFocus can import. " +
+  "Do NOT use to export a single task; OPML scope is project-level or broader. " +
+  "Three scopes: 'project' (one project + its tasks), 'folder' (all projects in a folder), " +
+  "or 'all' (all active projects). " +
+  "Returns { opml, projectCount, taskCount } where opml is a complete XML string. " +
+  "Safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const exportOpmlInputSchema = z.object({
+  scope: z
+    .enum(["project", "folder", "all"])
+    .describe(
+      "What to export: 'project' (one project), 'folder' (all projects in a folder), or 'all' (all active projects).",
+    ),
+  id: z
+    .string()
+    .optional()
+    .describe(
+      "Required when scope='project' (project ID from project_list) or scope='folder' (folder ID from folder_list). Omit for scope='all'.",
+    ),
+});
+
+export type ExportOpmlToolInput = z.infer<typeof exportOpmlInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export interface ExportOpmlContext {
+  exportService: ExportService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Resolve the tool input into a typed `ExportScope`.
+ *
+ * @throws {Error} when scope requires an id but none is supplied — the Zod
+ *   schema accepts `id` as optional; the handler validates the combination.
+ */
+function resolveScope(input: ExportOpmlToolInput): ExportScope {
+  if (input.scope === "all") {
+    return { kind: "all" };
+  }
+  if (!input.id) {
+    throw new Error(`scope='${input.scope}' requires an id`);
+  }
+  if (input.scope === "project") {
+    return { kind: "project", id: input.id as ProjectId };
+  }
+  return { kind: "folder", id: input.id as FolderId };
+}
+
+export async function handleExportOpml(input: ExportOpmlToolInput, ctx: ExportOpmlContext) {
+  const scope = resolveScope(input);
+  const result = await ctx.exportService.exportOpml(scope);
+  const meta = ctx.makeMeta();
+  return ok(
+    {
+      opml: result.opml,
+      projectCount: result.projectCount,
+      taskCount: result.taskCount,
+    },
+    meta,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerExportOpmlTool(server: McpServer, ctx: ExportOpmlContext) {
+  return server.registerTool(
+    "export_opml",
+    {
+      description: EXPORT_OPML_DESCRIPTION,
+      inputSchema: exportOpmlInputSchema.shape,
+    },
+    async (args: ExportOpmlToolInput) => {
+      const envelope = await handleExportOpml(args, ctx);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(envelope) }],
+        structuredContent: envelope as unknown as Record<string, unknown>,
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- New `ExportService` with `exportOpml(scope)` — composes existing adapter primitives, no new adapter methods
- Three export scopes: `project` (one project + tasks), `folder` (all projects in a folder), `all` (all active projects)
- OPML follows OmniFocus import conventions: `type="omnifocus:project"` / `"omnifocus:task"`, task attributes (due, defer, flagged, note), XML-escaped values
- `export_opml` registered in tool description registry

Closes #72.

## Issue
Implements [#72 — OPML export](https://github.com/torsday/omnifocus-mcp/issues/72).

## Breaking change?
- [x] No

## Test plan
- [x] 20 unit tests: service (all three scopes, XML escaping, dropped-project exclusion, NotFound) + tool handler (schema, description lint, envelope)
- [x] Full suite green: 1222 pass
- [x] typecheck clean
- [x] Self-reviewed
- [x] No new dependencies