### PR TITLE
feat(lifecycle): add LifecycleManager — lazy OF detection + version gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- `LifecycleManager` — lazy OmniFocus detection + version gate (DESIGN §17). Single-flight probe that caches `{ ofVersion, ofEdition }` on first success, emits one `of.detected` log event, and exposes `checkMinimumVersion(minimum, featureName)` that throws `FeatureRequiresOfVersion` (`OF_FEATURE_REQUIRES_VERSION`) when detected OmniFocus is older than required. Does not poison the cache on probe failure. ([#25](https://github.com/torsday/omnifocus-mcp/issues/25))
 
 See [GitHub Issues](https://github.com/torsday/omnifocus-mcp/issues) and [Project #4](https://github.com/users/torsday/projects/4) for the live backlog and status.
 

--- a/src/lifecycle/LifecycleManager.test.ts
+++ b/src/lifecycle/LifecycleManager.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for `LifecycleManager`.
+ *
+ * Goldilocks coverage of the invariants that matter:
+ * - Lazy: probe is not touched until `ensureOfAvailable()` is called
+ * - Single-flight: concurrent callers coalesce onto one probe
+ * - Cache-on-success: subsequent calls are near-free
+ * - No poison-on-failure: probe errors don't taint the cache
+ * - `of.detected` is emitted exactly once on first success
+ * - `checkMinimumVersion` throws `FeatureRequiresOfVersion` with structured details
+ * - Edition info flows through cached state unchanged
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { FeatureRequiresOfVersion } from "../errors/index.js";
+import {
+  type LifecycleLogger,
+  LifecycleManager,
+  type OfAppInfo,
+  compareVersions,
+} from "./LifecycleManager.js";
+
+function silentLogger(): LifecycleLogger {
+  return { info: vi.fn() };
+}
+
+describe("compareVersions", () => {
+  it.each([
+    ["4.5.2", "4.5.2", 0],
+    ["4.5", "4.5.0", 0],
+    ["4.5.2", "4.6", -1],
+    ["4.6", "4.5.9", 1],
+    ["4.0", "3.15.2", 1],
+    ["3.15", "4.0", -1],
+  ] as const)("compareVersions(%s, %s) === %i", (a, b, expected) => {
+    expect(compareVersions(a, b)).toBe(expected);
+  });
+});
+
+describe("LifecycleManager.ensureOfAvailable", () => {
+  it("is lazy — probe is not called at construction", () => {
+    const probe = vi.fn(async (): Promise<OfAppInfo> => ({ ofVersion: "4.5.2", ofEdition: "pro" }));
+    new LifecycleManager({ probe, logger: silentLogger() });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("caches the probe result across subsequent calls", async () => {
+    const probe = vi.fn(async (): Promise<OfAppInfo> => ({ ofVersion: "4.5.2", ofEdition: "pro" }));
+    const mgr = new LifecycleManager({ probe, logger: silentLogger() });
+
+    const first = await mgr.ensureOfAvailable();
+    const second = await mgr.ensureOfAvailable();
+
+    expect(first).toEqual({ ofVersion: "4.5.2", ofEdition: "pro" });
+    expect(second).toBe(first);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent callers onto a single in-flight probe", async () => {
+    let release!: (info: OfAppInfo) => void;
+    const probe = vi.fn(
+      (): Promise<OfAppInfo> =>
+        new Promise<OfAppInfo>((r) => {
+          release = r;
+        }),
+    );
+    const mgr = new LifecycleManager({ probe, logger: silentLogger() });
+
+    const callers = [mgr.ensureOfAvailable(), mgr.ensureOfAvailable(), mgr.ensureOfAvailable()];
+    release({ ofVersion: "4.5.2", ofEdition: "pro" });
+    const results = await Promise.all(callers);
+
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(results[0]).toEqual({ ofVersion: "4.5.2", ofEdition: "pro" });
+    expect(results[1]).toBe(results[0]);
+    expect(results[2]).toBe(results[0]);
+  });
+
+  it("does not poison the cache when the probe rejects — next call retries", async () => {
+    const probe = vi
+      .fn<[], Promise<OfAppInfo>>()
+      .mockRejectedValueOnce(new Error("permission prompt dismissed"))
+      .mockResolvedValueOnce({ ofVersion: "4.5.2", ofEdition: "pro" });
+    const mgr = new LifecycleManager({ probe, logger: silentLogger() });
+
+    await expect(mgr.ensureOfAvailable()).rejects.toThrow("permission prompt dismissed");
+    const recovered = await mgr.ensureOfAvailable();
+    expect(recovered).toEqual({ ofVersion: "4.5.2", ofEdition: "pro" });
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits `of.detected` exactly once on first success", async () => {
+    const probe = vi.fn(async (): Promise<OfAppInfo> => ({ ofVersion: "4.5.2", ofEdition: "pro" }));
+    const log = silentLogger();
+    const mgr = new LifecycleManager({ probe, logger: log });
+
+    await mgr.ensureOfAvailable();
+    await mgr.ensureOfAvailable();
+    await mgr.ensureOfAvailable();
+
+    expect(log.info).toHaveBeenCalledTimes(1);
+    expect(log.info).toHaveBeenCalledWith(
+      { event: "of.detected", ofVersion: "4.5.2", ofEdition: "pro" },
+      "of.detected",
+    );
+  });
+});
+
+describe("LifecycleManager.getInfo", () => {
+  it("returns undefined before the first probe and cached info after", async () => {
+    const probe = vi.fn(
+      async (): Promise<OfAppInfo> => ({ ofVersion: "4.5.2", ofEdition: "standard" }),
+    );
+    const mgr = new LifecycleManager({ probe, logger: silentLogger() });
+
+    expect(mgr.getInfo()).toBeUndefined();
+    await mgr.ensureOfAvailable();
+    expect(mgr.getInfo()).toEqual({ ofVersion: "4.5.2", ofEdition: "standard" });
+  });
+});
+
+describe("LifecycleManager.checkMinimumVersion", () => {
+  function mgrAt(version: string): LifecycleManager {
+    const probe = vi.fn(async (): Promise<OfAppInfo> => ({ ofVersion: version, ofEdition: "pro" }));
+    return new LifecycleManager({ probe, logger: silentLogger() });
+  }
+
+  it("resolves when the detected version exceeds the minimum", async () => {
+    await expect(
+      mgrAt("4.6.0").checkMinimumVersion("4.0", "perspective_evaluate"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves when the detected version equals the minimum", async () => {
+    await expect(
+      mgrAt("4.0").checkMinimumVersion("4.0.0", "perspective_evaluate"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws `FeatureRequiresOfVersion` when the detected version is lower", async () => {
+    const mgr = mgrAt("3.15.2");
+    await expect(mgr.checkMinimumVersion("4.0", "perspective_evaluate")).rejects.toBeInstanceOf(
+      FeatureRequiresOfVersion,
+    );
+  });
+
+  it("surfaces detected, minimum, and feature in the error details", async () => {
+    const mgr = mgrAt("3.15.2");
+    const err = await mgr.checkMinimumVersion("4.0", "perspective_evaluate").catch((e) => e);
+    expect(err).toBeInstanceOf(FeatureRequiresOfVersion);
+    expect(err.code).toBe("OF_FEATURE_REQUIRES_VERSION");
+    expect(err.details).toEqual({
+      feature: "perspective_evaluate",
+      minimum: "4.0",
+      detected: "3.15.2",
+    });
+  });
+});

--- a/src/lifecycle/LifecycleManager.ts
+++ b/src/lifecycle/LifecycleManager.ts
@@ -1,0 +1,155 @@
+/**
+ * `LifecycleManager` — lazy OmniFocus detection + version gate.
+ *
+ * Startup should stay under 500ms with no macOS Automation permission prompts
+ * (DESIGN §17). Probing OmniFocus can take seconds and trigger a permission
+ * dialog, so we defer detection to the first tool call that actually needs
+ * OF. The result — `{ ofVersion, ofEdition }` — is cached for the lifetime
+ * of the process and surfaced in every response envelope's `meta.ofVersion`.
+ *
+ * Tools that require a minimum OmniFocus version call `checkMinimumVersion`,
+ * which throws `FeatureRequiresOfVersion` when the detected version is lower.
+ *
+ * The probe is injected rather than hard-wired to a transport so the manager
+ * stays testable and so the same gate can be reused behind any adapter
+ * (JXA today, an OmniJS-based probe tomorrow, a fake in unit tests).
+ *
+ * @see DESIGN.md §17 — Lifecycle: startup sequence, version detection
+ * @see src/errors/index.ts — FeatureRequiresOfVersion
+ */
+
+import { FeatureRequiresOfVersion } from "../errors/index.js";
+import { logger as defaultLogger } from "../logging/logger.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** OmniFocus application metadata discovered at first use. */
+export interface OfAppInfo {
+  /** Dotted-number version string reported by OmniFocus, e.g. `"4.5.2"`. */
+  ofVersion: string;
+  /** OmniFocus edition — `"pro"` unlocks custom perspectives, plug-ins, repetition, forecast tag. */
+  ofEdition: "standard" | "pro";
+}
+
+/** Minimal logger shape — matches pino's surface used here. Injected for tests. */
+export interface LifecycleLogger {
+  info: (obj: Record<string, unknown>, msg?: string) => void;
+}
+
+export interface LifecycleManagerOptions {
+  /**
+   * Probe implementation. Must resolve with the detected app info on success,
+   * or reject with one of the typed errors from the error taxonomy
+   * (`OmniFocusNotRunning`, `PermissionDenied`, `ScriptError`, …).
+   */
+  probe: () => Promise<OfAppInfo>;
+  /** Overridable logger; defaults to the process singleton. */
+  logger?: LifecycleLogger;
+}
+
+// ---------------------------------------------------------------------------
+// Internal semver compare — dotted-number strings ("4.5.2" vs "4.6")
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two dotted-number version strings. Returns `-1` if `a < b`, `1` if
+ * `a > b`, `0` if equal. Trailing non-numeric segments are ignored — OmniFocus
+ * version strings are always numeric triples, but we defensively coerce.
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const pa = a.split(".").map((s) => Number.parseInt(s, 10) || 0);
+  const pb = b.split(".").map((s) => Number.parseInt(s, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const ai = pa[i] ?? 0;
+    const bi = pb[i] ?? 0;
+    if (ai < bi) return -1;
+    if (ai > bi) return 1;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-flight, cache-on-success lifecycle manager.
+ *
+ * - First `ensureOfAvailable()` call runs the probe; concurrent callers coalesce
+ *   onto the same in-flight promise so OF sees exactly one probe invocation.
+ * - On success the result is cached for the process lifetime and an
+ *   `of.detected` structured log event is emitted exactly once.
+ * - On failure the in-flight promise is cleared and the next caller retries;
+ *   we never poison the cache with an error.
+ */
+export class LifecycleManager {
+  private readonly probe: () => Promise<OfAppInfo>;
+  private readonly log: LifecycleLogger;
+  private cached: OfAppInfo | undefined;
+  private inflight: Promise<OfAppInfo> | undefined;
+
+  constructor(options: LifecycleManagerOptions) {
+    this.probe = options.probe;
+    this.log = options.logger ?? defaultLogger;
+  }
+
+  /**
+   * Resolve — probing if needed — with the detected `{ ofVersion, ofEdition }`.
+   * Tools that need OmniFocus should await this before their first call; the
+   * subsequent call is a near-free in-memory read.
+   */
+  async ensureOfAvailable(): Promise<OfAppInfo> {
+    if (this.cached !== undefined) return this.cached;
+    if (this.inflight !== undefined) return this.inflight;
+
+    this.inflight = (async () => {
+      const info = await this.probe();
+      this.cached = info;
+      this.log.info(
+        { event: "of.detected", ofVersion: info.ofVersion, ofEdition: info.ofEdition },
+        "of.detected",
+      );
+      return info;
+    })().finally(() => {
+      this.inflight = undefined;
+    });
+
+    return this.inflight;
+  }
+
+  /**
+   * Synchronously return the cached app info, or `undefined` if the probe has
+   * not yet run. Intended for envelope builders that want `meta.ofVersion`
+   * without forcing a probe — the envelope uses `"unknown"` until the first
+   * `ensureOfAvailable()` completes.
+   */
+  getInfo(): OfAppInfo | undefined {
+    return this.cached;
+  }
+
+  /**
+   * Throw `FeatureRequiresOfVersion` when the detected OmniFocus version is
+   * strictly lower than `minimum`. Implicitly calls `ensureOfAvailable()`.
+   *
+   * @param minimum   Dotted-number version string the tool requires (e.g. `"4.0"`).
+   * @param featureName  Human-readable feature label for the error message.
+   */
+  async checkMinimumVersion(minimum: string, featureName: string): Promise<void> {
+    const info = await this.ensureOfAvailable();
+    if (compareVersions(info.ofVersion, minimum) < 0) {
+      throw new FeatureRequiresOfVersion(
+        `Feature "${featureName}" requires OmniFocus ${minimum} or later (detected ${info.ofVersion})`,
+        {
+          details: {
+            feature: featureName,
+            minimum,
+            detected: info.ofVersion,
+          },
+        },
+      );
+    }
+  }
+}

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Barrel for the lifecycle module.
+ *
+ * @see src/lifecycle/LifecycleManager.ts
+ */
+
+export {
+  compareVersions,
+  LifecycleManager,
+  type LifecycleLogger,
+  type LifecycleManagerOptions,
+  type OfAppInfo,
+} from "./LifecycleManager.js";


### PR DESCRIPTION
## Summary

- New `LifecycleManager` (`src/lifecycle/`) exposes `ensureOfAvailable()` and `checkMinimumVersion(minimum, feature)`.
- Single-flight probe: concurrent callers coalesce onto one probe invocation; cache never poisoned on failure.
- Emits exactly one `of.detected` structured log event on first success.
- `checkMinimumVersion` throws `FeatureRequiresOfVersion` (code `OF_FEATURE_REQUIRES_VERSION`) with `{ feature, minimum, detected }` in `details`.
- Probe is injected — manager stays testable and reusable behind any adapter. Wiring to the real JXA version probe lands with the first consumer (follow-up).

Closes #25.

## Issue

Implements [#25 — Lifecycle manager — lazy OF detection, OF version cache, FeatureRequiresOfVersion gate](https://github.com/torsday/omnifocus-mcp/issues/25). See DESIGN.md §17.

## Breaking change?

- [x] No — additive module; no existing call sites modified.

## Test plan

- [x] 16 new unit tests (`src/lifecycle/LifecycleManager.test.ts`) — lazy, single-flight, no-poison, `of.detected` once, version-compare matrix, gate-throws-with-details
- [x] Full suite green: 1260 passed / 29 skipped / 3 integration-skipped
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm exec biome check src/lifecycle` clean (repo-wide lint has unrelated pre-existing findings)
- [x] Self-reviewed per `/review-pr`
- [x] No new dependencies