### PR TITLE
feat(concurrency): add ReadPool + WriteQueue primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - `LifecycleManager` — lazy OmniFocus detection + version gate (DESIGN §17). Single-flight probe that caches `{ ofVersion, ofEdition }` on first success, emits one `of.detected` log event, and exposes `checkMinimumVersion(minimum, featureName)` that throws `FeatureRequiresOfVersion` (`OF_FEATURE_REQUIRES_VERSION`) when detected OmniFocus is older than required. Does not poison the cache on probe failure. ([#25](https://github.com/torsday/omnifocus-mcp/issues/25))
+- `ReadPool` / `WriteQueue` — concurrency primitives per ADR-0009 / DESIGN §16. `ReadPool` is a FIFO-fair bounded-concurrency semaphore (`OMNIFOCUS_READ_POOL_SIZE`, default 2). `WriteQueue` is a single-slot strictly-serial queue with soft-cap backpressure (`OMNIFOCUS_WRITE_QUEUE_CAP`, default 50) that throws `QueueFull` (`OF_QUEUE_FULL`) synchronously when saturated; the same class backs the separate OmniJS queue. Both implement `DrainableQueue` so the shutdown controller can drain them. ([#20](https://github.com/torsday/omnifocus-mcp/issues/20))
 
 See [GitHub Issues](https://github.com/torsday/omnifocus-mcp/issues) and [Project #4](https://github.com/users/torsday/projects/4) for the live backlog and status.
 

--- a/src/concurrency/ReadPool.test.ts
+++ b/src/concurrency/ReadPool.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for `ReadPool`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ReadPool } from "./ReadPool.js";
+
+/** A promise plus resolvers — the deferred-promise pattern used to control timing in tests. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("ReadPool", () => {
+  it("rejects invalid sizes at construction", () => {
+    expect(() => new ReadPool({ size: 0 })).toThrow(RangeError);
+    expect(() => new ReadPool({ size: -1 })).toThrow(RangeError);
+    expect(() => new ReadPool({ size: 1.5 })).toThrow(RangeError);
+  });
+
+  it("runs fn and returns its value", async () => {
+    const pool = new ReadPool({ size: 2 });
+    await expect(pool.run(async () => 42)).resolves.toBe(42);
+  });
+
+  it("never exceeds the configured concurrency", async () => {
+    const pool = new ReadPool({ size: 2 });
+    const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const runs = gates.map((g, i) =>
+      pool.run(async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await g.promise;
+        concurrent--;
+        return i;
+      }),
+    );
+
+    // Let the event loop turn so the first two start.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(pool.inFlightCount()).toBe(2);
+    expect(pool.waitingCount()).toBe(1);
+
+    gates[0]?.resolve();
+    await runs[0];
+    gates[1]?.resolve();
+    gates[2]?.resolve();
+    await Promise.all(runs);
+
+    expect(maxConcurrent).toBe(2);
+    expect(pool.pendingCount()).toBe(0);
+  });
+
+  it("dispatches waiters in FIFO order as slots free", async () => {
+    const pool = new ReadPool({ size: 1 });
+    const order: number[] = [];
+    const gate = deferred<void>();
+
+    const p1 = pool.run(async () => {
+      order.push(1);
+      await gate.promise;
+    });
+    const p2 = pool.run(async () => {
+      order.push(2);
+    });
+    const p3 = pool.run(async () => {
+      order.push(3);
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual([1]);
+    gate.resolve();
+    await Promise.all([p1, p2, p3]);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("releases the slot when fn throws, so the next waiter proceeds", async () => {
+    const pool = new ReadPool({ size: 1 });
+    const ran: string[] = [];
+
+    const failing = pool.run(async () => {
+      ran.push("fail");
+      throw new Error("boom");
+    });
+    const after = pool.run(async () => {
+      ran.push("after");
+    });
+
+    await expect(failing).rejects.toThrow("boom");
+    await after;
+    expect(ran).toEqual(["fail", "after"]);
+    expect(pool.pendingCount()).toBe(0);
+  });
+
+  it("exposes pendingCount = inFlight + waiting", async () => {
+    const pool = new ReadPool({ size: 1 });
+    const g1 = deferred<void>();
+    const g2 = deferred<void>();
+
+    const r1 = pool.run(() => g1.promise);
+    const r2 = pool.run(() => g2.promise);
+
+    await Promise.resolve();
+    expect(pool.inFlightCount()).toBe(1);
+    expect(pool.waitingCount()).toBe(1);
+    expect(pool.pendingCount()).toBe(2);
+
+    g1.resolve();
+    await r1;
+    g2.resolve();
+    await r2;
+    expect(pool.pendingCount()).toBe(0);
+  });
+
+  it("uses the configured name on the DrainableQueue contract", () => {
+    expect(new ReadPool({ size: 2 }).name).toBe("read-pool");
+    expect(new ReadPool({ size: 2, name: "jxa-reads" }).name).toBe("jxa-reads");
+  });
+});

--- a/src/concurrency/ReadPool.ts
+++ b/src/concurrency/ReadPool.ts
@@ -1,0 +1,106 @@
+/**
+ * `ReadPool` — bounded-concurrency semaphore for OmniFocus reads.
+ *
+ * Per ADR-0009 / DESIGN §16, reads are gated at `OMNIFOCUS_READ_POOL_SIZE`
+ * (default 2) so we don't stampede `osascript`. Writes use `WriteQueue`;
+ * OmniJS traffic uses a separate `WriteQueue` instance because URL-scheme
+ * callbacks contend on the filesystem.
+ *
+ * Semantics:
+ * - `run(fn)` acquires a slot, runs `fn`, releases the slot.
+ * - Callers that arrive when all slots are busy queue FIFO.
+ * - A slot is always released, even if `fn` throws.
+ * - `pendingCount()` returns in-flight + waiting, enabling the shutdown
+ *   controller and `internal_status` to drain deterministically.
+ *
+ * @see DESIGN.md §16 — concurrency model
+ * @see ADR-0009 — read pool + write queue + OmniJS queue
+ * @see src/server/shutdown.ts — DrainableQueue contract
+ */
+
+import type { DrainableQueue } from "../server/shutdown.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Waiter = () => void;
+
+export interface ReadPoolOptions {
+  /** Maximum concurrent runs. Must be a positive integer. */
+  size: number;
+  /** Human-readable name surfaced in shutdown logs and status. */
+  name?: string;
+}
+
+// ---------------------------------------------------------------------------
+// ReadPool
+// ---------------------------------------------------------------------------
+
+/**
+ * FIFO-fair bounded-concurrency pool. Creates no slot objects — just a
+ * counter + waiter queue.
+ */
+export class ReadPool implements DrainableQueue {
+  readonly name: string;
+  private readonly size: number;
+  private inFlight = 0;
+  private readonly waiters: Waiter[] = [];
+
+  constructor(options: ReadPoolOptions) {
+    if (!Number.isInteger(options.size) || options.size < 1) {
+      throw new RangeError(
+        `ReadPool.size must be a positive integer (got ${String(options.size)})`,
+      );
+    }
+    this.size = options.size;
+    this.name = options.name ?? "read-pool";
+  }
+
+  /**
+   * Run `fn` as soon as a slot is free. Preserves FIFO among waiters.
+   * Always releases the slot, even when `fn` rejects.
+   */
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+
+  /** Slots currently occupied by in-flight work. */
+  inFlightCount(): number {
+    return this.inFlight;
+  }
+
+  /** Callers waiting for a free slot. */
+  waitingCount(): number {
+    return this.waiters.length;
+  }
+
+  /** In-flight plus waiting — the total `DrainableQueue` depth. */
+  pendingCount(): number {
+    return this.inFlight + this.waiters.length;
+  }
+
+  private acquire(): Promise<void> {
+    if (this.inFlight < this.size) {
+      this.inFlight++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(() => {
+        this.inFlight++;
+        resolve();
+      });
+    });
+  }
+
+  private release(): void {
+    this.inFlight--;
+    const next = this.waiters.shift();
+    if (next !== undefined) next();
+  }
+}

--- a/src/concurrency/WriteQueue.test.ts
+++ b/src/concurrency/WriteQueue.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for `WriteQueue`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { QueueFull } from "../errors/index.js";
+import { WriteQueue } from "./WriteQueue.js";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+} {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("WriteQueue", () => {
+  it("rejects invalid caps at construction", () => {
+    expect(() => new WriteQueue({ cap: 0 })).toThrow(RangeError);
+    expect(() => new WriteQueue({ cap: -1 })).toThrow(RangeError);
+    expect(() => new WriteQueue({ cap: 2.5 })).toThrow(RangeError);
+  });
+
+  it("runs a single call and returns its value", async () => {
+    const q = new WriteQueue({ cap: 10 });
+    await expect(q.run(async () => "ok")).resolves.toBe("ok");
+  });
+
+  it("runs calls strictly serially", async () => {
+    const q = new WriteQueue({ cap: 10 });
+    const order: string[] = [];
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+
+    const runs = gates.map((g, i) =>
+      q.run(async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        order.push(`start-${i}`);
+        await g.promise;
+        order.push(`end-${i}`);
+        concurrent--;
+      }),
+    );
+
+    await Promise.resolve();
+    expect(q.inFlightCount()).toBe(1);
+    expect(q.waitingCount()).toBe(2);
+
+    gates[0]?.resolve();
+    gates[1]?.resolve();
+    gates[2]?.resolve();
+    await Promise.all(runs);
+
+    expect(maxConcurrent).toBe(1);
+    expect(order).toEqual(["start-0", "end-0", "start-1", "end-1", "start-2", "end-2"]);
+  });
+
+  it("throws QueueFull synchronously when pending reaches the cap", () => {
+    const q = new WriteQueue({ cap: 2, name: "jxa-writes" });
+    const g1 = deferred<void>();
+    const g2 = deferred<void>();
+
+    void q.run(() => g1.promise);
+    void q.run(() => g2.promise);
+
+    expect(() => q.run(async () => undefined)).toThrow(QueueFull);
+
+    // Confirm details payload carries queue name, cap, pending for the agent.
+    try {
+      q.run(async () => undefined);
+    } catch (err) {
+      expect(err).toBeInstanceOf(QueueFull);
+      expect((err as QueueFull).code).toBe("OF_QUEUE_FULL");
+      expect((err as QueueFull).details).toEqual({ queue: "jxa-writes", cap: 2, pending: 2 });
+    }
+
+    g1.resolve();
+    g2.resolve();
+  });
+
+  it("accepts a new call after an in-flight one completes and frees a slot", async () => {
+    const q = new WriteQueue({ cap: 2 });
+    const g1 = deferred<void>();
+    const g2 = deferred<void>();
+
+    const r1 = q.run(() => g1.promise);
+    const r2 = q.run(() => g2.promise);
+    expect(() => q.run(async () => undefined)).toThrow(QueueFull);
+
+    g1.resolve();
+    await r1;
+    // One slot free — this call must not throw.
+    const r3 = q.run(async () => "ok");
+    g2.resolve();
+    await r2;
+    await expect(r3).resolves.toBe("ok");
+  });
+
+  it("does not stall the queue when a call rejects", async () => {
+    const q = new WriteQueue({ cap: 10 });
+    const ran: string[] = [];
+
+    const failing = q.run(async () => {
+      ran.push("fail");
+      throw new Error("boom");
+    });
+    const after = q.run(async () => {
+      ran.push("after");
+    });
+
+    await expect(failing).rejects.toThrow("boom");
+    await after;
+    expect(ran).toEqual(["fail", "after"]);
+    expect(q.pendingCount()).toBe(0);
+  });
+
+  it("exposes pendingCount = inFlight + waiting", async () => {
+    const q = new WriteQueue({ cap: 10 });
+    const g1 = deferred<void>();
+    const g2 = deferred<void>();
+
+    const r1 = q.run(() => g1.promise);
+    const r2 = q.run(() => g2.promise);
+
+    await Promise.resolve();
+    expect(q.inFlightCount()).toBe(1);
+    expect(q.waitingCount()).toBe(1);
+    expect(q.pendingCount()).toBe(2);
+
+    g1.resolve();
+    await r1;
+    g2.resolve();
+    await r2;
+    expect(q.pendingCount()).toBe(0);
+  });
+
+  it("uses the configured name on the DrainableQueue contract", () => {
+    expect(new WriteQueue({ cap: 10 }).name).toBe("write-queue");
+    expect(new WriteQueue({ cap: 10, name: "omnijs-writes" }).name).toBe("omnijs-writes");
+  });
+});

--- a/src/concurrency/WriteQueue.ts
+++ b/src/concurrency/WriteQueue.ts
@@ -1,0 +1,125 @@
+/**
+ * `WriteQueue` — strictly serial, capped queue for OmniFocus writes.
+ *
+ * Per ADR-0009 / DESIGN §16, OmniFocus writes must be serialized (the JXA
+ * runtime is single-threaded relative to OF's main thread) and bounded
+ * (unbounded queueing masks upstream pressure). Each transport owns its own
+ * `WriteQueue` — JXA writes are one queue, OmniJS is a separate one, because
+ * the two channels contend on different kernel resources.
+ *
+ * Semantics:
+ * - Single slot: at most one call runs at a time.
+ * - Soft cap on pending (`OMNIFOCUS_WRITE_QUEUE_CAP`, default 50). Arrivals
+ *   when `pendingCount() >= cap` reject synchronously with `QueueFull`.
+ * - FIFO ordering among queued callers.
+ * - A failing call does not block the queue: the next caller runs as soon
+ *   as the failing promise settles.
+ *
+ * @see DESIGN.md §16 — concurrency model
+ * @see ADR-0009 — read pool + write queue + OmniJS queue
+ * @see src/errors/index.ts — QueueFull (`OF_QUEUE_FULL`)
+ * @see src/server/shutdown.ts — DrainableQueue contract
+ */
+
+import { QueueFull } from "../errors/index.js";
+import type { DrainableQueue } from "../server/shutdown.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WriteQueueOptions {
+  /** Maximum number of pending calls (in-flight + queued). Must be positive. */
+  cap: number;
+  /** Human-readable name surfaced in shutdown logs, `QueueFull` messages, and `internal_status`. */
+  name?: string;
+}
+
+type Job<T> = {
+  fn: () => Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+};
+
+// ---------------------------------------------------------------------------
+// WriteQueue
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-slot FIFO queue with soft-cap backpressure.
+ */
+export class WriteQueue implements DrainableQueue {
+  readonly name: string;
+  private readonly cap: number;
+  private inFlight = 0;
+  private readonly queue: Job<unknown>[] = [];
+
+  constructor(options: WriteQueueOptions) {
+    if (!Number.isInteger(options.cap) || options.cap < 1) {
+      throw new RangeError(
+        `WriteQueue.cap must be a positive integer (got ${String(options.cap)})`,
+      );
+    }
+    this.cap = options.cap;
+    this.name = options.name ?? "write-queue";
+  }
+
+  /**
+   * Enqueue `fn`. Returns a promise that settles with its result. Throws
+   * `QueueFull` synchronously when the queue is saturated — callers may
+   * surface `error.details.retryAfterMs` to agents.
+   */
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.pendingCount() >= this.cap) {
+      throw new QueueFull(
+        `${this.name} is full (cap ${this.cap}); ${this.pendingCount()} pending`,
+        { details: { queue: this.name, cap: this.cap, pending: this.pendingCount() } },
+      );
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        fn: fn as () => Promise<unknown>,
+        resolve: resolve as (v: unknown) => void,
+        reject,
+      });
+      this.pump();
+    });
+  }
+
+  /** Calls currently executing. 0 or 1 for a single-slot queue. */
+  inFlightCount(): number {
+    return this.inFlight;
+  }
+
+  /** Calls queued but not yet started. */
+  waitingCount(): number {
+    return this.queue.length;
+  }
+
+  /** In-flight plus waiting — the total `DrainableQueue` depth. */
+  pendingCount(): number {
+    return this.inFlight + this.queue.length;
+  }
+
+  private pump(): void {
+    if (this.inFlight > 0) return;
+    const next = this.queue.shift();
+    if (next === undefined) return;
+
+    this.inFlight++;
+    // Detach from the synchronous enqueue path so `run()` resolves/throws
+    // only via the returned promise.
+    void (async () => {
+      try {
+        const value = await next.fn();
+        next.resolve(value);
+      } catch (err) {
+        next.reject(err);
+      } finally {
+        this.inFlight--;
+        this.pump();
+      }
+    })();
+  }
+}

--- a/src/concurrency/index.ts
+++ b/src/concurrency/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Barrel for the concurrency module.
+ *
+ * @see src/concurrency/ReadPool.ts
+ * @see src/concurrency/WriteQueue.ts
+ */
+
+export { ReadPool, type ReadPoolOptions } from "./ReadPool.js";
+export { WriteQueue, type WriteQueueOptions } from "./WriteQueue.js";


### PR DESCRIPTION
## Summary

- New `src/concurrency/` module: `ReadPool` (FIFO-fair bounded-concurrency semaphore) and `WriteQueue` (single-slot serial queue with soft-cap backpressure).
- `WriteQueue` throws `QueueFull` (`OF_QUEUE_FULL`) synchronously at saturation, with `{ queue, cap, pending }` in `details` so agents can retry with `retryAfterMs`.
- Same `WriteQueue` class backs the separate OmniJS queue per ADR-0009 / DESIGN §16.
- Both implement the existing `DrainableQueue` interface, so the shutdown controller drains them automatically.
- Config keys `OMNIFOCUS_READ_POOL_SIZE` (default 2) and `OMNIFOCUS_WRITE_QUEUE_CAP` (default 50) already defined in `env.ts`.

Closes #20.

## Issue

Implements [#20 — Read pool + write queue + OmniJS queue](https://github.com/torsday/omnifocus-mcp/issues/20). See ADR-0009 and DESIGN §16.

## Breaking change?

- [x] No — additive module; no existing call sites modified.

## Test plan

- [x] 15 new unit tests across `ReadPool.test.ts` and `WriteQueue.test.ts` — concurrency bounds, FIFO ordering, saturation throws `QueueFull` synchronously with full `details` payload, slot release after both success and rejection, `pendingCount = inFlight + waiting`, construction guards.
- [x] Full suite green (`pnpm test`).
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean.
- [x] `pnpm exec biome check src/concurrency` clean.
- [x] Self-reviewed per `/review-pr`.
- [x] No new dependencies.

## Follow-ups (not in this PR)

- Wiring `ReadPool` / `WriteQueue` into `JxaTransport` and `OmniJsTransport`.
- Surfacing queue depths in `internal_status` (#77).