### PR TITLE
test(jxa): add moveTask, moveProject, completeProject integration tests

### DIFF
--- a/src/adapter/jxa/JxaTransport.projects.integration.test.ts
+++ b/src/adapter/jxa/JxaTransport.projects.integration.test.ts
@@ -62,6 +62,30 @@ describe.skipIf(!INTEGRATION)("JxaTransport — project integration", () => {
     await expect(t.markProjectReviewed(createdProjectId)).resolves.toBeUndefined();
   });
 
+  it("moveProject to null folderId (root) does not throw", async () => {
+    // Pass folderId: null to place the project at the root (no containing folder).
+    // Idempotent when the project is already at root — safe for any OF state.
+    await expect(t.moveProject(createdProjectId, { folderId: null })).resolves.toBeUndefined();
+  });
+
+  it("completeProject marks the project as completed", async () => {
+    // Use a separate short-lived fixture so this does not interfere with the
+    // drop/delete tests that follow (completed and dropped are exclusive states).
+    let tmpId: ProjectId | undefined;
+    try {
+      tmpId = await t.createProject({ name: "__mcp_test_complete_project__" });
+      await t.completeProject(tmpId);
+      const project = await t.getProject(tmpId);
+      expect(project.status).toBe("completed");
+    } finally {
+      if (tmpId !== undefined) {
+        await t.deleteProject(tmpId).catch(() => {
+          /* best-effort cleanup */
+        });
+      }
+    }
+  });
+
   it("dropProject drops the project", async () => {
     await t.dropProject(createdProjectId);
     const project = await t.getProject(createdProjectId);

--- a/src/adapter/jxa/JxaTransport.tasks.integration.test.ts
+++ b/src/adapter/jxa/JxaTransport.tasks.integration.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { TaskId } from "../../domain/ids.js";
+import type { ProjectId, TaskId } from "../../domain/ids.js";
 import { JxaTransport } from "./JxaTransport.js";
 
 const INTEGRATION = process.env.OMNIFOCUS_INTEGRATION === "1";
@@ -92,6 +92,23 @@ describe.skipIf(!INTEGRATION)("JxaTransport — task integration", () => {
     await t.uncompleteTask(createdTaskId);
     const task = await t.getTask(createdTaskId);
     expect(task.completed).toBe(false);
+  });
+
+  it("moveTask moves the task into a target project", async () => {
+    // Create a short-lived target project, move the task into it, then clean up.
+    let targetProjectId: ProjectId | undefined;
+    try {
+      targetProjectId = await t.createProject({ name: "__mcp_test_move_target__" });
+      await t.moveTask(createdTaskId, { projectId: targetProjectId });
+      const task = await t.getTask(createdTaskId);
+      expect(task.projectId).toBe(targetProjectId);
+    } finally {
+      if (targetProjectId !== undefined) {
+        await t.deleteProject(targetProjectId).catch(() => {
+          /* best-effort cleanup */
+        });
+      }
+    }
   });
 
   it("deleteTask removes the task", async () => {


### PR DESCRIPTION
## Summary
- Adds `moveTask` integration test: creates a short-lived target project, moves the task into it, asserts `task.projectId` matches, then cleans up
- Adds `moveProject` integration test: passes `folderId: null` (root placement), verifies no throw — idempotent against any OF state
- Adds `completeProject` integration test: uses a separate short-lived fixture (completed/dropped are exclusive states — sharing the fixture would break the drop/delete tests that follow), asserts `status === "completed"`

All other M1 scripts (task_list/create/update/complete/drop/undrop/uncomplete, project_list/create/update/markReviewed/drop/delete) were already covered by the existing integration test suite shipped with #36–#44.

Closes #47.

## Issue
Implements [#47 — M1 script-tier tests (each JXA script in isolation)](https://github.com/torsday/omnifocus-mcp/issues/47). See DESIGN.md §19 for the script-tier coverage requirement.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm test` — 1418 tests pass (32 correctly skipped under `OMNIFOCUS_INTEGRATION=0`), 3.3s
- [x] `pnpm typecheck` — clean
- [x] Self-reviewed: fixture isolation prevents test order contamination; `afterAll` + inline `finally` both clean up test data
- [x] No new dependencies