### PR TITLE
feat(resources): add nine OmniFocus MCP data resources (DESIGN §28)

### DIFF
--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for `registerOmniFocusResources`.
+ *
+ * Verifies:
+ * - All nine resources are registered with the correct name and URI/template
+ * - Each handler returns valid `application/json` contents
+ * - Snapshot counts are accurate
+ * - Inbox filtering (no projectId + no parentId)
+ * - Overdue is sorted by dueDate ascending
+ * - Review-due is sorted by nextReviewDate ascending
+ * - Dynamic resources extract the {id} variable from the URI
+ *
+ * Uses `InMemoryAdapter` seeded with predictable fixtures. No mocks beyond
+ * the McpServer stub — service instances are real.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
+import type { ProjectId, TagId } from "../domain/ids.js";
+import { ForecastService } from "../services/forecastService.js";
+import { PerspectiveService } from "../services/perspectiveService.js";
+import { ProjectService } from "../services/projectService.js";
+import { ReviewService } from "../services/reviewService.js";
+import {
+  FLAGGED_URI,
+  FORECAST_TODAY_URI,
+  INBOX_URI,
+  OVERDUE_URI,
+  PERSPECTIVE_URI_TEMPLATE,
+  PROJECT_URI_TEMPLATE,
+  REVIEW_DUE_URI,
+  SNAPSHOT_URI,
+  TAG_URI_TEMPLATE,
+  registerOmniFocusResources,
+} from "./omnifocus.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+type CapturedResource = {
+  name: string;
+  uriOrTemplate: unknown;
+  config: { mimeType: string; description: string };
+  callback: (uri: URL, variables?: Record<string, string>) => Promise<unknown>;
+};
+
+function makeHarness() {
+  const adapter = new InMemoryAdapter();
+  const cache = new OmniFocusLruCache({ ttlMs: 30_000 });
+  const projectService = new ProjectService({ adapter, cache });
+  const reviewService = new ReviewService({ adapter });
+  const forecastService = new ForecastService({ adapter });
+  const perspectiveService = new PerspectiveService({ adapter });
+
+  const registered: CapturedResource[] = [];
+  const server = {
+    registerResource: vi.fn(
+      (
+        name: string,
+        uriOrTemplate: unknown,
+        config: { mimeType: string; description: string },
+        callback: (uri: URL, variables?: Record<string, string>) => Promise<unknown>,
+      ) => {
+        registered.push({ name, uriOrTemplate, config, callback });
+      },
+    ),
+  } as unknown as McpServer;
+
+  registerOmniFocusResources(server, {
+    adapter,
+    projectService,
+    reviewService,
+    forecastService,
+    perspectiveService,
+  });
+
+  function find(name: string): CapturedResource {
+    const r = registered.find((x) => x.name === name);
+    if (!r) throw new Error(`Resource "${name}" was not registered`);
+    return r;
+  }
+
+  async function read(name: string, uriStr?: string, vars?: Record<string, string>) {
+    const r = find(name);
+    // For template resources, uriStr must be provided (or we build one from vars).
+    const resolvedUri =
+      uriStr ??
+      (typeof r.uriOrTemplate === "string"
+        ? r.uriOrTemplate
+        : vars
+          ? Object.entries(vars).reduce(
+              (tpl, [k, v]) => tpl.replace(`{${k}}`, v),
+              (r.uriOrTemplate as { uriTemplate: { toString(): string } }).uriTemplate.toString(),
+            )
+          : SNAPSHOT_URI); // fallback; should never reach here
+    const uri = new URL(resolvedUri);
+    const raw = await r.callback(uri, vars);
+    const result = raw as { contents: Array<{ uri: string; mimeType: string; text: string }> };
+    const first = result.contents[0];
+    if (!first) throw new Error("No contents returned");
+    return JSON.parse(first.text) as unknown;
+  }
+
+  return { adapter, server, registered, find, read };
+}
+
+// ---------------------------------------------------------------------------
+// Registration surface
+// ---------------------------------------------------------------------------
+
+describe("registerOmniFocusResources — registration", () => {
+  it("registers exactly 9 resources", () => {
+    const { registered } = makeHarness();
+    expect(registered).toHaveLength(9);
+  });
+
+  it("registers omnifocus-snapshot with the correct URI", () => {
+    const { find } = makeHarness();
+    const r = find("omnifocus-snapshot");
+    expect(r.uriOrTemplate).toBe(SNAPSHOT_URI);
+    expect(r.config.mimeType).toBe("application/json");
+  });
+
+  it("registers omnifocus-inbox with the correct URI", () => {
+    const { find } = makeHarness();
+    expect(find("omnifocus-inbox").uriOrTemplate).toBe(INBOX_URI);
+  });
+
+  it("registers omnifocus-forecast-today with the correct URI", () => {
+    const { find } = makeHarness();
+    expect(find("omnifocus-forecast-today").uriOrTemplate).toBe(FORECAST_TODAY_URI);
+  });
+
+  it("registers omnifocus-overdue with the correct URI", () => {
+    const { find } = makeHarness();
+    expect(find("omnifocus-overdue").uriOrTemplate).toBe(OVERDUE_URI);
+  });
+
+  it("registers omnifocus-flagged with the correct URI", () => {
+    const { find } = makeHarness();
+    expect(find("omnifocus-flagged").uriOrTemplate).toBe(FLAGGED_URI);
+  });
+
+  it("registers omnifocus-review-due with the correct URI", () => {
+    const { find } = makeHarness();
+    expect(find("omnifocus-review-due").uriOrTemplate).toBe(REVIEW_DUE_URI);
+  });
+
+  it("registers omnifocus-project as a ResourceTemplate", () => {
+    const { find } = makeHarness();
+    const r = find("omnifocus-project");
+    expect(typeof r.uriOrTemplate).toBe("object"); // ResourceTemplate instance
+  });
+
+  it("registers omnifocus-tag as a ResourceTemplate", () => {
+    const { find } = makeHarness();
+    expect(typeof find("omnifocus-tag").uriOrTemplate).toBe("object");
+  });
+
+  it("registers omnifocus-perspective as a ResourceTemplate", () => {
+    const { find } = makeHarness();
+    expect(typeof find("omnifocus-perspective").uriOrTemplate).toBe("object");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshot
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://snapshot", () => {
+  it("returns all five counts as 0 on an empty adapter", async () => {
+    const { read } = makeHarness();
+    const data = (await read("omnifocus-snapshot")) as Record<string, number>;
+    expect(data.inboxCount).toBe(0);
+    expect(data.overdueCount).toBe(0);
+    expect(data.dueTodayCount).toBe(0);
+    expect(data.flaggedCount).toBe(0);
+    expect(data.reviewDueCount).toBe(0);
+  });
+
+  it("counts inbox tasks (no project, no parent)", async () => {
+    const { adapter, read } = makeHarness();
+    await adapter.createTask({ name: "Inbox A" });
+    await adapter.createTask({ name: "Inbox B" });
+    const projId = await adapter.createProject({ name: "P" });
+    await adapter.createTask({ name: "Project task", projectId: projId as ProjectId });
+
+    const data = (await read("omnifocus-snapshot")) as Record<string, number>;
+    expect(data.inboxCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inbox
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://inbox", () => {
+  it("returns an empty array when no inbox tasks exist", async () => {
+    const { read } = makeHarness();
+    const tasks = (await read("omnifocus-inbox")) as unknown[];
+    expect(tasks).toEqual([]);
+  });
+
+  it("returns only tasks with no projectId and no parentId", async () => {
+    const { adapter, read } = makeHarness();
+    const projId = await adapter.createProject({ name: "P" });
+    await adapter.createTask({ name: "Inbox task" });
+    await adapter.createTask({ name: "Project task", projectId: projId as ProjectId });
+
+    const tasks = (await read("omnifocus-inbox")) as Array<{ name: string }>;
+    expect(tasks.map((t) => t.name)).toEqual(["Inbox task"]);
+  });
+
+  it("excludes completed tasks", async () => {
+    const { adapter, read } = makeHarness();
+    const id = await adapter.createTask({ name: "Done" });
+    await adapter.completeTask(id);
+    await adapter.createTask({ name: "Active" });
+
+    const tasks = (await read("omnifocus-inbox")) as Array<{ name: string }>;
+    expect(tasks.map((t) => t.name)).toEqual(["Active"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forecast/today
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://forecast/today", () => {
+  it("returns the four forecast categories", async () => {
+    const { read } = makeHarness();
+    const data = (await read("omnifocus-forecast-today")) as Record<string, unknown[]>;
+    expect(Array.isArray(data.overdue)).toBe(true);
+    expect(Array.isArray(data.dueToday)).toBe(true);
+    expect(Array.isArray(data.deferredToday)).toBe(true);
+    expect(Array.isArray(data.flagged)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// overdue
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://overdue", () => {
+  it("returns an empty array when no overdue tasks exist", async () => {
+    const { read } = makeHarness();
+    const tasks = (await read("omnifocus-overdue")) as unknown[];
+    expect(tasks).toEqual([]);
+  });
+
+  it("sorts overdue tasks by dueDate ascending", async () => {
+    const { adapter, read } = makeHarness();
+    await adapter.createTask({ name: "Late B", dueDate: "2020-06-01T00:00:00Z" });
+    await adapter.createTask({ name: "Late A", dueDate: "2020-01-01T00:00:00Z" });
+
+    const tasks = (await read("omnifocus-overdue")) as Array<{ name: string }>;
+    expect(tasks.map((t) => t.name)).toEqual(["Late A", "Late B"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flagged
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://flagged", () => {
+  it("returns an empty array when no flagged tasks exist", async () => {
+    const { read } = makeHarness();
+    expect((await read("omnifocus-flagged")) as unknown[]).toEqual([]);
+  });
+
+  it("returns only flagged incomplete tasks", async () => {
+    const { adapter, read } = makeHarness();
+    await adapter.createTask({ name: "Flagged", flagged: true });
+    await adapter.createTask({ name: "Plain" });
+
+    const tasks = (await read("omnifocus-flagged")) as Array<{ name: string }>;
+    expect(tasks.map((t) => t.name)).toEqual(["Flagged"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// review-due
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://review-due", () => {
+  it("returns an empty array when no projects are due for review", async () => {
+    const { read } = makeHarness();
+    expect((await read("omnifocus-review-due")) as unknown[]).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project/{id}
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://project/{id}", () => {
+  it("returns project and its tasks", async () => {
+    const { adapter, read } = makeHarness();
+    const projId = await adapter.createProject({ name: "My Project" });
+    await adapter.createTask({ name: "Task 1", projectId: projId as ProjectId });
+    await adapter.createTask({ name: "Task 2", projectId: projId as ProjectId });
+
+    const data = (await read("omnifocus-project", undefined, { id: projId })) as {
+      project: { name: string };
+      tasks: Array<{ name: string }>;
+    };
+    expect(data.project.name).toBe("My Project");
+    expect(data.tasks.map((t) => t.name)).toContain("Task 1");
+    expect(data.tasks.map((t) => t.name)).toContain("Task 2");
+  });
+
+  it("returns empty tasks array for a project with no tasks", async () => {
+    const { adapter, read } = makeHarness();
+    const projId = await adapter.createProject({ name: "Empty" });
+
+    const data = (await read("omnifocus-project", undefined, { id: projId })) as {
+      tasks: unknown[];
+    };
+    expect(data.tasks).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag/{id}
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://tag/{id}", () => {
+  it("returns tag and its tasks", async () => {
+    const { adapter, read } = makeHarness();
+    const tagId = await adapter.createTag({ name: "Work" });
+    await adapter.createTask({ name: "Work task", tagIds: [tagId as TagId] });
+    await adapter.createTask({ name: "Other task" });
+
+    const data = (await read("omnifocus-tag", undefined, { id: tagId })) as {
+      tag: { name: string };
+      tasks: Array<{ name: string }>;
+    };
+    expect(data.tag.name).toBe("Work");
+    expect(data.tasks.map((t) => t.name)).toEqual(["Work task"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// perspective/{id}
+// ---------------------------------------------------------------------------
+
+describe("omnifocus://perspective/{id}", () => {
+  it("returns perspectiveId and tasks array", async () => {
+    const { read } = makeHarness();
+    const data = (await read("omnifocus-perspective", undefined, { id: "flagged" })) as {
+      perspectiveId: string;
+      tasks: unknown[];
+    };
+    expect(data.perspectiveId).toBe("flagged");
+    expect(Array.isArray(data.tasks)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URI template constants
+// ---------------------------------------------------------------------------
+
+describe("URI template constants", () => {
+  it("PROJECT_URI_TEMPLATE has the correct pattern", () => {
+    expect(PROJECT_URI_TEMPLATE).toBe("omnifocus://project/{id}");
+  });
+  it("TAG_URI_TEMPLATE has the correct pattern", () => {
+    expect(TAG_URI_TEMPLATE).toBe("omnifocus://tag/{id}");
+  });
+  it("PERSPECTIVE_URI_TEMPLATE has the correct pattern", () => {
+    expect(PERSPECTIVE_URI_TEMPLATE).toBe("omnifocus://perspective/{id}");
+  });
+});

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -1,0 +1,314 @@
+/**
+ * OmniFocus MCP data resources — all nine URIs from DESIGN §28.
+ *
+ * Resources are read-only, URI-addressable, enumerable via `resources/list`.
+ * They let an agent load structured context without spending a tool call.
+ *
+ * Static URIs:
+ *   omnifocus://snapshot       — five-count orientation object
+ *   omnifocus://inbox          — inbox tasks as Task[]
+ *   omnifocus://forecast/today — today's forecast grouped by category
+ *   omnifocus://overdue        — overdue tasks sorted by dueDate ASC
+ *   omnifocus://flagged        — all flagged available tasks
+ *   omnifocus://review-due     — projects with nextReviewDate ≤ today
+ *
+ * Dynamic URIs (ResourceTemplate):
+ *   omnifocus://project/{id}      — single project + full task tree
+ *   omnifocus://tag/{id}          — single tag + its tasks
+ *   omnifocus://perspective/{id}  — perspective evaluation result
+ *
+ * Every resource returns `application/json` and carries the equivalent
+ * tool's `data` payload directly (no envelope wrapper, per §28 AC2).
+ *
+ * Cache invalidation follows the same scope matrix as tools (ADR-0006):
+ * where a service exists, resource handlers delegate to it so write-side
+ * invalidation paths apply automatically.
+ *
+ * @see DESIGN.md §28 — MCP resources spec
+ * @see src/resources/capabilities.ts — omnifocus://capabilities resource
+ * @see docs/adr/0006-read-cache-strategy.md
+ */
+
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import type { ProjectId, TagId } from "../domain/ids.js";
+import type { BuiltinPerspectiveId } from "../domain/perspective.js";
+import type { ForecastService } from "../services/forecastService.js";
+import type { PerspectiveService } from "../services/perspectiveService.js";
+import type { ProjectService } from "../services/projectService.js";
+import type { ReviewService } from "../services/reviewService.js";
+
+// ---------------------------------------------------------------------------
+// Dependency bundle
+// ---------------------------------------------------------------------------
+
+/** Services and adapter required to serve the nine data resources. */
+export interface OmniFocusResourceDeps {
+  /** Raw adapter — used for queries that have no dedicated service (inbox, overdue, flagged, tag). */
+  adapter: OmniFocusAdapter;
+  projectService: ProjectService;
+  reviewService: ReviewService;
+  forecastService: ForecastService;
+  perspectiveService: PerspectiveService;
+}
+
+// ---------------------------------------------------------------------------
+// URI constants
+// ---------------------------------------------------------------------------
+
+export const SNAPSHOT_URI = "omnifocus://snapshot";
+export const INBOX_URI = "omnifocus://inbox";
+export const FORECAST_TODAY_URI = "omnifocus://forecast/today";
+export const OVERDUE_URI = "omnifocus://overdue";
+export const FLAGGED_URI = "omnifocus://flagged";
+export const REVIEW_DUE_URI = "omnifocus://review-due";
+export const PROJECT_URI_TEMPLATE = "omnifocus://project/{id}";
+export const TAG_URI_TEMPLATE = "omnifocus://tag/{id}";
+export const PERSPECTIVE_URI_TEMPLATE = "omnifocus://perspective/{id}";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** ISO-8601 strings for start and end of today (local time). */
+function todayRange(): { from: string; to: string } {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+  return { from: start.toISOString(), to: end.toISOString() };
+}
+
+/** Wrap a JSON payload in the MCP resource contents envelope. */
+function jsonContents(uri: string, data: unknown) {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register all nine OmniFocus data resources with the given McpServer.
+ *
+ * Each resource handler delegates to the relevant service or adapter method.
+ * No business logic lives here — the service / adapter layer owns filtering,
+ * caching, and validation (DESIGN §26 / ADR-0006).
+ */
+export function registerOmniFocusResources(server: McpServer, deps: OmniFocusResourceDeps): void {
+  const { adapter, projectService, reviewService, forecastService, perspectiveService } = deps;
+
+  // ── omnifocus://snapshot ─────────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-snapshot",
+    SNAPSHOT_URI,
+    {
+      description:
+        "Five-count snapshot of the current OmniFocus state: " +
+        "inboxCount, overdueCount, dueTodayCount, flaggedCount, reviewDueCount. " +
+        "Read at session start to orient before calling task_list or forecast_get.",
+      mimeType: "application/json",
+    },
+    async (_uri) => {
+      const { from, to } = todayRange();
+      const [inboxTasks, forecast, reviewProjects] = await Promise.all([
+        adapter.listTasks({ completed: false }),
+        adapter.getForecast({ from, to, includeOverdue: true, includeFlagged: true }),
+        adapter.listProjectsDueForReview(),
+      ]);
+
+      const inboxCount = inboxTasks.filter(
+        (t) => t.projectId === null && t.parentId === null,
+      ).length;
+
+      return jsonContents(SNAPSHOT_URI, {
+        inboxCount,
+        overdueCount: forecast.overdue.length,
+        dueTodayCount: forecast.dueToday.length,
+        flaggedCount: forecast.flagged.length,
+        reviewDueCount: reviewProjects.length,
+      });
+    },
+  );
+
+  // ── omnifocus://inbox ────────────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-inbox",
+    INBOX_URI,
+    {
+      description:
+        "Inbox tasks as Task[]. Incomplete tasks not assigned to any project or parent task. " +
+        "Use to triage the inbox without calling task_list.",
+      mimeType: "application/json",
+    },
+    async (_uri) => {
+      const tasks = await adapter.listTasks({ completed: false });
+      const inbox = tasks.filter((t) => t.projectId === null && t.parentId === null);
+      return jsonContents(INBOX_URI, inbox);
+    },
+  );
+
+  // ── omnifocus://forecast/today ───────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-forecast-today",
+    FORECAST_TODAY_URI,
+    {
+      description:
+        "Today's forecast tasks grouped by category: overdue[], dueToday[], deferredToday[], flagged[]. " +
+        "Equivalent to forecast_get with from/to=today. " +
+        "Use for 'what's on my plate today' without a tool call.",
+      mimeType: "application/json",
+    },
+    async (_uri) => {
+      const { from, to } = todayRange();
+      const result = await forecastService.get({ from, to });
+      return jsonContents(FORECAST_TODAY_URI, {
+        overdue: result.overdue,
+        dueToday: result.dueToday,
+        deferredToday: result.deferredToday,
+        flagged: result.flagged,
+      });
+    },
+  );
+
+  // ── omnifocus://overdue ──────────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-overdue",
+    OVERDUE_URI,
+    {
+      description:
+        "All overdue tasks as Task[], sorted by dueDate ascending. " +
+        "Tasks whose dueDate is in the past and are not completed/dropped.",
+      mimeType: "application/json",
+    },
+    async (_uri) => {
+      const { from } = todayRange();
+      const result = await adapter.getForecast({
+        from,
+        to: from,
+        includeOverdue: true,
+        includeFlagged: false,
+        includeDeferred: false,
+      });
+      const sorted = [...result.overdue].sort((a, b) => {
+        if (!a.dueDate) return 1;
+        if (!b.dueDate) return -1;
+        return a.dueDate < b.dueDate ? -1 : a.dueDate > b.dueDate ? 1 : 0;
+      });
+      return jsonContents(OVERDUE_URI, sorted);
+    },
+  );
+
+  // ── omnifocus://flagged ──────────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-flagged",
+    FLAGGED_URI,
+    {
+      description:
+        "All flagged available tasks as Task[]. " +
+        "Equivalent to task_list with flagged=true. " +
+        "Use to review the flagged list without a tool call.",
+      mimeType: "application/json",
+    },
+    async (_uri) => {
+      const tasks = await adapter.listTasks({ flagged: true, completed: false });
+      return jsonContents(FLAGGED_URI, tasks);
+    },
+  );
+
+  // ── omnifocus://review-due ───────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-review-due",
+    REVIEW_DUE_URI,
+    {
+      description:
+        "Projects due for review as Project[], sorted by nextReviewDate ascending. " +
+        "Equivalent to review_list_due. " +
+        "Use to start a review session without a tool call.",
+      mimeType: "application/json",
+    },
+    async (_uri) => {
+      const result = await reviewService.listDue();
+      const sorted = [...result.projects].sort((a, b) => {
+        if (!a.nextReviewDate) return 1;
+        if (!b.nextReviewDate) return -1;
+        return a.nextReviewDate < b.nextReviewDate
+          ? -1
+          : a.nextReviewDate > b.nextReviewDate
+            ? 1
+            : 0;
+      });
+      return jsonContents(REVIEW_DUE_URI, sorted);
+    },
+  );
+
+  // ── omnifocus://project/{id} ─────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-project",
+    new ResourceTemplate(PROJECT_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Single project with its full task tree as { project: Project, tasks: Task[] }. " +
+        "Get the project ID from project_list. " +
+        "Tasks are a flat array; rebuild the tree via task.parentId.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const id = (variables as { id: string }).id as ProjectId;
+      const result = await projectService.get({ id, includeTaskTree: true });
+      return jsonContents(`omnifocus://project/${id}`, {
+        project: result.project,
+        tasks: result.tasks ?? [],
+      });
+    },
+  );
+
+  // ── omnifocus://tag/{id} ─────────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-tag",
+    new ResourceTemplate(TAG_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Single tag with its tasks as { tag: Tag, tasks: Task[] }. " +
+        "Get the tag ID from tag_list.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const id = (variables as { id: string }).id as TagId;
+      const [tag, tasks] = await Promise.all([
+        adapter.getTag(id),
+        adapter.listTasks({ tagId: id, completed: false }),
+      ]);
+      return jsonContents(`omnifocus://tag/${id}`, { tag, tasks });
+    },
+  );
+
+  // ── omnifocus://perspective/{id} ─────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-perspective",
+    new ResourceTemplate(PERSPECTIVE_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Perspective evaluation result as { perspectiveId: string, tasks: Task[] }. " +
+        "Get perspective IDs from perspective_list. " +
+        "Built-in IDs: inbox, projects, tags, forecast, flagged, nearby, review.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const id = (variables as { id: string }).id as BuiltinPerspectiveId;
+      const result = await perspectiveService.evaluate(id);
+      return jsonContents(`omnifocus://perspective/${id}`, {
+        perspectiveId: id,
+        tasks: result.tasks,
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Implements all nine read-only MCP resources from DESIGN §28
- **Static:** `omnifocus://snapshot`, `omnifocus://inbox`, `omnifocus://forecast/today`, `omnifocus://overdue`, `omnifocus://flagged`, `omnifocus://review-due`
- **Dynamic (ResourceTemplate):** `omnifocus://project/{id}`, `omnifocus://tag/{id}`, `omnifocus://perspective/{id}`
- Each resource returns `application/json` with the equivalent tool's `data` payload (no envelope wrapper, AC2)
- Handlers delegate to service layer so write-side cache invalidation applies automatically (ADR-0006)
- 36 unit tests covering registration surface, handler correctness, inbox filtering, overdue sorting, and template variable extraction

Closes #58.

## Issue
Implements [#58 — MCP resources](https://github.com/torsday/omnifocus-mcp/issues/58). See DESIGN.md §28.

## Breaking change?
- [x] No — additive only; new resource URIs are part of the public contract (ADR-0011)

## Test plan
- [x] `pnpm test` — 1462 passed, 32 skipped, typecheck clean
- [x] Self-reviewed via /review-pr
- [x] No new dependencies