### PR TITLE
refactor(export): extract shared task-tree helpers into export/tree.ts

### DIFF
--- a/src/services/export/opml.ts
+++ b/src/services/export/opml.ts
@@ -15,6 +15,7 @@
 
 import type { Project } from "../../domain/project.js";
 import type { Task } from "../../domain/task.js";
+import { partitionTasksByParent } from "./tree.js";
 
 /** Escape XML special characters in attribute values. */
 export function xmlAttr(value: string): string {
@@ -72,23 +73,7 @@ export function renderTaskOutline(
  * Build an `<outline>` element for a project with its task tree.
  */
 export function renderProjectOutline(project: Project, tasks: Task[], indent: string): string {
-  // Build parent → children map for tasks in this project
-  const byParent = new Map<string, Task[]>();
-  const rootTasks: Task[] = [];
-
-  for (const task of tasks) {
-    if (task.parentId === null) {
-      rootTasks.push(task);
-    } else {
-      const key = String(task.parentId);
-      const existing = byParent.get(key);
-      if (existing) {
-        existing.push(task);
-      } else {
-        byParent.set(key, [task]);
-      }
-    }
-  }
+  const { rootTasks, byParent } = partitionTasksByParent(tasks);
 
   const attrs: string[] = [
     `text="${xmlAttr(project.name)}"`,

--- a/src/services/export/tree.ts
+++ b/src/services/export/tree.ts
@@ -1,0 +1,79 @@
+/**
+ * Task-tree helpers shared by the export formats.
+ *
+ * Both OPML and TaskPaper rendering walk a project's tasks as a parent/child
+ * tree. The two operations needed — fetching the full descendant set from the
+ * adapter and partitioning a flat list into root/children — are format-
+ * agnostic and belong here rather than duplicated in each format module.
+ *
+ * @see src/services/export/opml.ts
+ * @see src/services/export/taskpaper.ts
+ */
+
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import type { ProjectId } from "../../domain/ids.js";
+import type { Task } from "../../domain/task.js";
+
+/**
+ * Fetch ALL tasks belonging to a project, including subtasks at every depth.
+ *
+ * `adapter.listTasks({ projectId })` only returns tasks whose `projectId`
+ * field equals the given ID — subtasks (which carry `parentId` but have
+ * `projectId: null`) are excluded. This helper does a BFS expansion to
+ * collect every descendant.
+ */
+export async function fetchProjectTaskTree(
+  adapter: OmniFocusAdapter,
+  projectId: ProjectId,
+): Promise<Task[]> {
+  // Fetch root-level tasks (directly in the project)
+  const direct = await adapter.listTasks({ projectId });
+  const all: Task[] = [...direct];
+
+  // BFS: for each task, fetch its children. `for (;;)` with break-on-empty
+  // keeps `current` narrowed to Task without needing a non-null assertion
+  // on `queue.shift()`.
+  const queue: Task[] = [...direct];
+  for (;;) {
+    const current = queue.shift();
+    if (current === undefined) break;
+    const children = await adapter.listTasks({ parentId: current.id });
+    for (const child of children) {
+      all.push(child);
+      queue.push(child);
+    }
+  }
+
+  return all;
+}
+
+/**
+ * Partition a flat task list into root tasks and a `parentId → children` map.
+ *
+ * Root tasks are those with `parentId === null` (directly under their project
+ * or inbox). The map indexes children by their stringified parent ID, so
+ * recursive renderers can look up a given task's children in O(1).
+ */
+export function partitionTasksByParent(tasks: Task[]): {
+  rootTasks: Task[];
+  byParent: Map<string, Task[]>;
+} {
+  const rootTasks: Task[] = [];
+  const byParent = new Map<string, Task[]>();
+
+  for (const task of tasks) {
+    if (task.parentId === null) {
+      rootTasks.push(task);
+    } else {
+      const key = String(task.parentId);
+      const existing = byParent.get(key);
+      if (existing) {
+        existing.push(task);
+      } else {
+        byParent.set(key, [task]);
+      }
+    }
+  }
+
+  return { rootTasks, byParent };
+}

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -11,10 +11,10 @@
 import type { CreateTaskInput, OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import type { FolderId, ProjectId, TagId, TaskId } from "../domain/ids.js";
 import type { Project } from "../domain/project.js";
-import type { Task } from "../domain/task.js";
 import { NotFound, ValidationError } from "../errors/index.js";
 import { renderProjectOutline } from "./export/opml.js";
 import { countLeadingTabs, parseTaskPaperLine, renderTaskPaper } from "./export/taskpaper.js";
+import { fetchProjectTaskTree, partitionTasksByParent } from "./export/tree.js";
 
 // ---------------------------------------------------------------------------
 // Public shapes
@@ -57,43 +57,6 @@ export interface ImportTaskPaperResult {
    * could not be resolved.
    */
   warnings: string[];
-}
-
-// ---------------------------------------------------------------------------
-// Shared tree-fetch helper
-// ---------------------------------------------------------------------------
-
-/**
- * Fetch ALL tasks belonging to a project, including subtasks at every depth.
- *
- * `adapter.listTasks({ projectId })` only returns tasks whose `projectId`
- * field equals the given ID — subtasks (which carry `parentId` but have
- * `projectId: null`) are excluded. This helper does a BFS expansion to
- * collect every descendant.
- */
-async function fetchProjectTaskTree(
-  adapter: OmniFocusAdapter,
-  projectId: ProjectId,
-): Promise<Task[]> {
-  // Fetch root-level tasks (directly in the project)
-  const direct = await adapter.listTasks({ projectId });
-  const all: Task[] = [...direct];
-
-  // BFS: for each task, fetch its children. `for (;;)` with break-on-empty
-  // keeps `current` narrowed to Task without needing a non-null assertion
-  // on `queue.shift()`.
-  const queue: Task[] = [...direct];
-  for (;;) {
-    const current = queue.shift();
-    if (current === undefined) break;
-    const children = await adapter.listTasks({ parentId: current.id });
-    for (const child of children) {
-      all.push(child);
-      queue.push(child);
-    }
-  }
-
-  return all;
 }
 
 // ---------------------------------------------------------------------------
@@ -215,19 +178,7 @@ export class ExportService {
         fetchProjectTaskTree(this.adapter, p.id).then((tasks) => ({ project: p, tasks })),
       ),
     )) {
-      // Build parent → children map
-      const byParent = new Map<string, Task[]>();
-      const rootTasks: Task[] = [];
-      for (const task of tasks) {
-        if (task.parentId === null) {
-          rootTasks.push(task);
-        } else {
-          const key = String(task.parentId);
-          const arr = byParent.get(key) ?? [];
-          arr.push(task);
-          byParent.set(key, arr);
-        }
-      }
+      const { rootTasks, byParent } = partitionTasksByParent(tasks);
 
       // Project heading
       lines.push(`${project.name}:`);


### PR DESCRIPTION
## Summary

- "Partition task list into root + parentId→children map" was independently reimplemented at two call sites (OPML \`renderProjectOutline\`, TaskPaper \`exportTaskPaper\`) — consolidated as \`partitionTasksByParent\`.
- \`fetchProjectTaskTree\` (adapter-agnostic BFS helper) moves alongside to the new \`src/services/export/tree.ts\` module. It was format-agnostic but lived in the service file.

Closes #269.

## Issue

Implements [#269](https://github.com/torsday/omnifocus-mcp/issues/269).

## Breaking change?
- [x] No

## Net change

+83 / −68 across 3 files (+15 net — new-module docstring cost; same tradeoff as #265/#267). Duplication eliminated; drift risk removed.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (biome + custom + docs)
- [x] \`pnpm test\` — 1667 passed, 43 skipped, unchanged

## CI note

GitHub Actions billing still blocks CI; verified green locally before push.