### PR TITLE
refactor(adapter): extract task state-transition helpers for complete/drop pairs

### DIFF
--- a/src/adapter/inMemory/InMemoryAdapter.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.ts
@@ -267,15 +267,59 @@ export class InMemoryAdapter implements OmniFocusAdapter {
   }
 
   async completeTask(id: TaskId, at?: Date): Promise<void> {
+    return this.applyTaskCompletion(id, true, at);
+  }
+
+  async uncompleteTask(id: TaskId): Promise<void> {
+    return this.applyTaskCompletion(id, false);
+  }
+
+  async dropTask(id: TaskId, at?: Date): Promise<void> {
+    return this.applyTaskDropState(id, true, at);
+  }
+
+  async undropTask(id: TaskId): Promise<void> {
+    return this.applyTaskDropState(id, false);
+  }
+
+  /**
+   * Toggle a task's completion state. Drives both `completeTask` and
+   * `uncompleteTask` from the single boolean pivot.
+   *
+   * Asymmetric idempotency — load-bearing: **uncomplete** short-circuits
+   * if already uncompleted; **complete** does NOT short-circuit. The batch
+   * tool's contract (`task_batch_complete` description) explicitly states
+   * "Already-completed tasks are not treated specially". Changing this is
+   * a behaviour change and belongs in its own issue, not a refactor.
+   */
+  private async applyTaskCompletion(id: TaskId, completed: boolean, at?: Date): Promise<void> {
     const task = await this.getTask(id);
-    const completedAt = isoOf(at ?? this.now()) as Task["completedAt"];
+    if (!completed && !task.completed) return;
+    const stamp = completed ? (isoOf(at ?? this.now()) as Task["completedAt"]) : null;
     this.tasks.set(id, {
       ...task,
-      completed: true,
-      completedAt,
-      modifiedAt: completedAt as unknown as Task["modifiedAt"],
+      completed,
+      completedAt: stamp,
+      modifiedAt: (stamp ?? isoOf(this.now())) as unknown as Task["modifiedAt"],
     });
-    this.bumpProjectCompletedCount(task.projectId, +1);
+    this.bumpProjectCompletedCount(task.projectId, completed ? +1 : -1);
+  }
+
+  /**
+   * Toggle a task's dropped state. Drives both `dropTask` and `undropTask`
+   * from the single boolean pivot. Same idempotency asymmetry as
+   * {@link applyTaskCompletion} — drop re-stamps, undrop short-circuits.
+   */
+  private async applyTaskDropState(id: TaskId, dropped: boolean, at?: Date): Promise<void> {
+    const task = await this.getTask(id);
+    if (!dropped && !task.dropped) return;
+    const stamp = dropped ? (isoOf(at ?? this.now()) as Task["droppedAt"]) : null;
+    this.tasks.set(id, {
+      ...task,
+      dropped,
+      droppedAt: stamp,
+      modifiedAt: (stamp ?? isoOf(this.now())) as unknown as Task["modifiedAt"],
+    });
   }
 
   async batchCreateTasks(
@@ -299,40 +343,6 @@ export class InMemoryAdapter implements OmniFocusAdapter {
     return processBatch(items, async ({ id, at }) => {
       await this.completeTask(id, at);
       return id;
-    });
-  }
-
-  async uncompleteTask(id: TaskId): Promise<void> {
-    const task = await this.getTask(id);
-    if (!task.completed) return;
-    this.tasks.set(id, {
-      ...task,
-      completed: false,
-      completedAt: null,
-      modifiedAt: isoOf(this.now()) as Task["modifiedAt"],
-    });
-    this.bumpProjectCompletedCount(task.projectId, -1);
-  }
-
-  async dropTask(id: TaskId, at?: Date): Promise<void> {
-    const task = await this.getTask(id);
-    const droppedAt = isoOf(at ?? this.now()) as Task["droppedAt"];
-    this.tasks.set(id, {
-      ...task,
-      dropped: true,
-      droppedAt,
-      modifiedAt: droppedAt as unknown as Task["modifiedAt"],
-    });
-  }
-
-  async undropTask(id: TaskId): Promise<void> {
-    const task = await this.getTask(id);
-    if (!task.dropped) return;
-    this.tasks.set(id, {
-      ...task,
-      dropped: false,
-      droppedAt: null,
-      modifiedAt: isoOf(this.now()) as Task["modifiedAt"],
     });
   }
 


### PR DESCRIPTION
## Summary

- \`completeTask\`/\`uncompleteTask\` and \`dropTask\`/\`undropTask\` form symmetric pairs — wrote them longhand, inverse relationship invisible.
- Two helpers — \`applyTaskCompletion\` and \`applyTaskDropState\` — drive both directions from a boolean pivot. Public methods become 3-line dispatchers.
- **Behaviour-preserving:** the asymmetric idempotency that \`task_batch_complete\`'s contract documents (complete/drop re-stamp, uncomplete/undrop short-circuit) is kept verbatim. Inline comments in both helpers flag this so future readers don't "fix" it without opening a separate behaviour-change issue.

Closes #271.

## Issue

Implements [#271](https://github.com/torsday/omnifocus-mcp/issues/271).

## Breaking change?
- [x] No

## Net change

+49 / −39 lines in 1 file (+10 net — the two helper docstrings cost lines but encode the load-bearing asymmetry so it survives future code reviews).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (biome + custom + docs)
- [x] \`pnpm test\` — 1667 passed, 43 skipped, unchanged (this is the safety net for behaviour preservation)

## CI note

GitHub Actions billing still blocks CI; verified green locally before push.