### PR TITLE
fix(jxa): inbox task creation + vitest script inlining + integration timeouts

### DIFF
--- a/src/scripts/jxa/task_batch_create.js
+++ b/src/scripts/jxa/task_batch_create.js
@@ -42,7 +42,10 @@ function run(argv) {
         if (!proj) throw new Error(`OF_NOT_FOUND: project ${input.projectId}`);
         newTask = proj.make({ new: "task", withProperties: props });
       } else {
-        newTask = doc.make({ new: "inboxTask", withProperties: props });
+        // Inbox creation: `doc.make({ new: "inboxTask" })` fails with -10024
+        // on OmniFocus 4.x. See issue #275.
+        newTask = ofApp.InboxTask(props);
+        doc.inboxTasks.push(newTask);
       }
 
       if (input.tagIds) {

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -169,7 +169,12 @@ function run(argv) {
     if (!proj) throw new Error(`Project not found: ${args.projectId}`);
     newTask = proj.make({ new: "task", withProperties: props });
   } else {
-    newTask = ofApp.defaultDocument.make({ new: "inboxTask", withProperties: props });
+    // Inbox tasks cannot be created via `doc.make({ new: "inboxTask" })` —
+    // OmniFocus 4.x rejects that with error -10024. Construct an InboxTask
+    // specifier and push it onto `doc.inboxTasks`; the reference stays
+    // usable and exposes `.id()` for the read-back (see issue #275).
+    newTask = ofApp.InboxTask(props);
+    ofApp.defaultDocument.inboxTasks.push(newTask);
   }
 
   if (args.tagIds) {

--- a/src/scripts/jxa/task_duplicate.js
+++ b/src/scripts/jxa/task_duplicate.js
@@ -72,7 +72,11 @@ function run(argv) {
 
   function makeInto(container, props) {
     if (container === doc) {
-      return doc.make({ new: "inboxTask", withProperties: props });
+      // Inbox creation requires `InboxTask + inboxTasks.push` — OmniFocus 4.x
+      // rejects `doc.make({ new: "inboxTask" })` with -10024. See issue #275.
+      const task = Application("OmniFocus").InboxTask(props);
+      doc.inboxTasks.push(task);
+      return task;
     }
     return container.make({ new: "task", withProperties: props });
   }

--- a/src/scripts/scriptLoader.ts
+++ b/src/scripts/scriptLoader.ts
@@ -1,15 +1,21 @@
 /**
- * esbuild plugin that inlines `src/scripts/**\/*.js` files as string exports.
+ * Script inliner — makes `src/scripts/**\/*.js` imports evaluate to a
+ * string of the file's raw contents at both build time (esbuild, for the
+ * production bundle) and test time (vite/vitest, for integration tests).
  *
- * When bundled code does:
+ * When any bundled or test-loaded code does:
  *   import pingScript from './scripts/jxa/ping.js'
  *
- * the plugin intercepts that import and returns the raw file content as a
- * default string export instead of executing the JS file as a module.
+ * the loader intercepts the import and returns the raw file content as
+ * the default export instead of evaluating the JS file as a module. JXA
+ * and OmniJS scripts define a top-level `function run(argv)` without any
+ * exports, so evaluating them as an ES module yields `undefined` — which
+ * is exactly how integration tests broke silently before this loader was
+ * wired into vitest (see issue #276).
  *
- * This keeps JXA and OmniJS scripts as first-class editable source files
- * (ADR-0005) while making the dist bundle self-contained — the server never
- * needs to locate script files on disk at runtime.
+ * Keeping scripts as first-class editable source files (ADR-0005) while
+ * making the dist bundle self-contained — the server never needs to
+ * locate script files on disk at runtime.
  *
  * @see docs/adr/0005-scripts-as-first-class-files.md
  */
@@ -21,23 +27,52 @@ import type { OnLoadArgs, OnLoadResult, Plugin, PluginBuild } from "esbuild";
 /** Matches any path that resolves under `src/scripts/`. */
 const SCRIPTS_RE = /[/\\]src[/\\]scripts[/\\].+\.js$/;
 
+/** Read a script file and wrap its contents as a default string export. */
+function scriptAsDefaultExport(path: string): string {
+  const source = readFileSync(path, "utf8");
+  return `export default ${JSON.stringify(source)};`;
+}
+
 /**
  * Return an esbuild plugin that converts `src/scripts/**\/*.js` imports into
- * string-returning modules.
+ * string-returning modules. Used by `tsup` during `pnpm build`.
  */
 export function scriptInlinerPlugin(): Plugin {
   return {
     name: "omnifocus-script-inliner",
     setup(build: PluginBuild) {
       // Intercept all .js files under src/scripts/.
-      build.onLoad({ filter: SCRIPTS_RE }, (args: OnLoadArgs): OnLoadResult => {
-        const source = readFileSync(resolve(args.path), "utf8");
-        // Emit an ES module whose default export is the raw script source.
-        return {
-          contents: `export default ${JSON.stringify(source)};`,
+      build.onLoad(
+        { filter: SCRIPTS_RE },
+        (args: OnLoadArgs): OnLoadResult => ({
+          contents: scriptAsDefaultExport(resolve(args.path)),
           loader: "js",
-        };
-      });
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * Vite-compatible plugin with the same semantics as {@link scriptInlinerPlugin}.
+ * Used by vitest so integration tests import the script sources as strings,
+ * matching the production build behaviour. Returning a plain object
+ * (typed `unknown`) avoids adding `vite` as a direct dependency — vitest
+ * already bundles a compatible plugin API.
+ */
+export function scriptInlinerVitePlugin(): {
+  name: string;
+  enforce: "pre";
+  load(id: string): string | null;
+} {
+  return {
+    name: "omnifocus-script-inliner",
+    enforce: "pre",
+    load(id: string): string | null {
+      // Strip any query string vite may append (e.g. ?used).
+      const cleanId = id.split("?", 1)[0] ?? id;
+      if (!SCRIPTS_RE.test(cleanId)) return null;
+      return scriptAsDefaultExport(resolve(cleanId));
     },
   };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,23 @@
 import { defineConfig } from "vitest/config";
+import { scriptInlinerVitePlugin } from "./src/scripts/scriptLoader.js";
+
+// Integration tests drive real osascript invocations against live OmniFocus —
+// each JXA round trip is ~200–500ms and cleanup hooks may issue several
+// deletions serially. The 5s default is fine for unit tests (which run in
+// milliseconds) but is routinely too tight for integration. Raise the
+// threshold only when OMNIFOCUS_INTEGRATION=1 so unit-test regressions still
+// surface as clean timeouts.
+const INTEGRATION = process.env.OMNIFOCUS_INTEGRATION === "1";
+const TEST_TIMEOUT = INTEGRATION ? 30_000 : 5_000;
+const HOOK_TIMEOUT = INTEGRATION ? 30_000 : 5_000;
 
 export default defineConfig({
+  // Vite plugin — inlines `src/scripts/**\/*.js` as default string exports,
+  // matching the production build (tsup + scriptInlinerPlugin). Without this,
+  // `import taskCreateScript from "../../scripts/jxa/task_create.js"` imports
+  // the file as an ES module and gets `undefined`, which silently breaks
+  // integration tests (issue #276).
+  plugins: [scriptInlinerVitePlugin()],
   test: {
     include: [
       "tests/unit/**/*.test.ts",
@@ -14,8 +31,8 @@ export default defineConfig({
     environment: "node",
     globals: false,
     reporters: ["default"],
-    testTimeout: 5000,
-    hookTimeout: 5000,
+    testTimeout: TEST_TIMEOUT,
+    hookTimeout: HOOK_TIMEOUT,
     clearMocks: true,
     restoreMocks: true,
     passWithNoTests: true,


### PR DESCRIPTION
## Summary

Three latent bugs were gating integration tests from exercising real OmniFocus at all. All three surfaced together once self-hosted CI started running.

### 1. JXA inbox creation (#275)
\`doc.make({ new: "inboxTask", withProperties: props })\` rejects with error **-10024** on OmniFocus 4.x. Fixed in three scripts with the working pattern: \`ofApp.InboxTask(props); doc.inboxTasks.push(task)\`.

### 2. Vitest doesn't inline JXA/OmniJS scripts (#276)
\`scriptLoader.ts\` was esbuild-only — not wired into vitest. Test-time imports of \`src/scripts/**/*.js\` returned \`undefined\` → empty stdout → misleading \`ScriptError\`. Added \`scriptInlinerVitePlugin\` and registered it in \`vitest.config.ts\`.

### 3. Integration test timeouts
5s default is fine for unit tests but tight for real \`osascript\` round trips + serial cleanup hooks. Bumped to 30s when \`OMNIFOCUS_INTEGRATION=1\`.

Closes #275.
Closes #276.

## Breaking change?
- [x] No

## Net change

+84 / −20 across 5 files.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] Unit suite: 1667 passed (unchanged)
- [x] \`OMNIFOCUS_INTEGRATION=1 pnpm test:integration\`: **6/48 pass** (from 0/48 "empty stdout"). Remaining 42 expose **distinct** unfixed bugs to file as follow-ups: \`project_create\` / \`folder_create\` / \`tag_create\` JXA scripts throwing exit=1 (15, 6, 5 tests respectively), error-classification mismatches (9 tests), plus a few timeouts. None are blocked on the fixes in this PR.

## CI

Run against self-hosted (`mac-local`, macos-omnifocus). Green ci.yml unit run expected; integration.yml will still be red but with far more diagnostic output.