### PR TITLE
feat(server): register the 10 MCP resources in startServer

### DIFF
--- a/src/server/composition.test.ts
+++ b/src/server/composition.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from "vitest";
 import { JxaTransport } from "../adapter/jxa/JxaTransport.js";
 import { OmniJsTransport } from "../adapter/omnijs/OmniJsTransport.js";
 import { ROUTING_TABLE, TransportRouter } from "../adapter/router.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
 import type { Config } from "../config/env.js";
-import { composeAdapter, makeMeta } from "./composition.js";
+import { ForecastService } from "../services/forecastService.js";
+import { PerspectiveService } from "../services/perspectiveService.js";
+import { ProjectService } from "../services/projectService.js";
+import { ReviewService } from "../services/reviewService.js";
+import { composeAdapter, composeResourceServices, makeMeta } from "./composition.js";
 
 const baseConfig: Config = {
   OMNIFOCUS_LOG_LEVEL: "info",
@@ -53,6 +58,36 @@ describe("composeAdapter", () => {
   it("uses the same options shape that the transports accept directly", () => {
     expect(() => new JxaTransport({ timeoutMs: 30000 })).not.toThrow();
     expect(() => new OmniJsTransport({ timeoutMs: 45000 })).not.toThrow();
+  });
+});
+
+describe("composeResourceServices", () => {
+  it("instantiates the four services + cache the resources need", () => {
+    const adapter = composeAdapter(baseConfig);
+    const services = composeResourceServices(adapter, baseConfig);
+
+    expect(services.cache).toBeInstanceOf(OmniFocusLruCache);
+    expect(services.projectService).toBeInstanceOf(ProjectService);
+    expect(services.reviewService).toBeInstanceOf(ReviewService);
+    expect(services.forecastService).toBeInstanceOf(ForecastService);
+    expect(services.perspectiveService).toBeInstanceOf(PerspectiveService);
+  });
+
+  it("propagates cache sizing from config", () => {
+    // Two distinct configs should produce two distinct caches; confirms
+    // the factory honours capacity/ttl rather than ignoring them.
+    const adapter = composeAdapter(baseConfig);
+    const a = composeResourceServices(adapter, { ...baseConfig, OMNIFOCUS_CACHE_CAPACITY: 64 });
+    const b = composeResourceServices(adapter, { ...baseConfig, OMNIFOCUS_CACHE_CAPACITY: 512 });
+    expect(a.cache).not.toBe(b.cache);
+  });
+
+  it("returns fresh service instances per call (no shared global state)", () => {
+    const adapter = composeAdapter(baseConfig);
+    const a = composeResourceServices(adapter, baseConfig);
+    const b = composeResourceServices(adapter, baseConfig);
+    expect(a.projectService).not.toBe(b.projectService);
+    expect(a.cache).not.toBe(b.cache);
   });
 });
 

--- a/src/server/composition.ts
+++ b/src/server/composition.ts
@@ -1,27 +1,34 @@
 /**
  * Server composition primitives — the seam where individual primitives
- * (transports, router, response-meta defaults) are wired into the runtime
- * shape that `startServer` consumes.
+ * (transports, router, cache, services, response-meta defaults) are wired
+ * into the runtime shape that `startServer` consumes.
  *
  * Splitting this out of `mcpServer.ts` keeps the bootstrap file readable
  * once #289 (49 tool registrations) and #290 (10 resource registrations)
  * land — both call into the factories defined here so they don't re-do the
  * adapter chain plumbing.
  *
- * Cache wrapping (#22) and service composition (`TaskService`, etc. for #289)
- * arrive in follow-ups and will likely also live in this file.
+ * Service composition for tools (`TaskService`, etc.) arrives with #289 and
+ * will likely also live in this file.
  *
  * @see DESIGN.md §17 — lifecycle
  * @see ADR-0002 — JXA + OmniJS dual transport
+ * @see ADR-0006 — read-cache strategy
  * @see ADR-0009 — read pool + write queue + OmniJS queue
  */
 
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import { JxaTransport } from "../adapter/jxa/JxaTransport.js";
 import { OmniJsTransport } from "../adapter/omnijs/OmniJsTransport.js";
 import { TransportRouter } from "../adapter/router.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
 import type { Config } from "../config/env.js";
 import type { ResponseMeta, Transport } from "../envelope/index.js";
 import { generateCorrelationId } from "../logging/correlation.js";
+import { ForecastService } from "../services/forecastService.js";
+import { PerspectiveService } from "../services/perspectiveService.js";
+import { ProjectService } from "../services/projectService.js";
+import { ReviewService } from "../services/reviewService.js";
 
 // ---------------------------------------------------------------------------
 // Adapter chain
@@ -44,6 +51,53 @@ export function composeAdapter(config: Config): TransportRouter {
   const jxa = new JxaTransport({ timeoutMs: config.OMNIFOCUS_JXA_TIMEOUT_MS });
   const omnijs = new OmniJsTransport({ timeoutMs: config.OMNIFOCUS_OMNIJS_TIMEOUT_MS });
   return TransportRouter.fromTransports(jxa, omnijs);
+}
+
+// ---------------------------------------------------------------------------
+// Resource service chain
+// ---------------------------------------------------------------------------
+
+/**
+ * The four services consumed by `registerOmniFocusResources` (#290), plus
+ * the LRU cache they share. Returned as a bundle so `startServer` can both
+ * pass them into the resource registrar and reuse the same instances when
+ * #289 lands the tool registrations (every service singleton — by design).
+ */
+export interface ResourceServiceChain {
+  cache: OmniFocusLruCache;
+  projectService: ProjectService;
+  reviewService: ReviewService;
+  forecastService: ForecastService;
+  perspectiveService: PerspectiveService;
+}
+
+/**
+ * Build the read-cache and the four services that the OmniFocus data
+ * resources consume.
+ *
+ * The cache is sized from `OMNIFOCUS_CACHE_CAPACITY` /
+ * `OMNIFOCUS_CACHE_TTL_MS` and shared across services so cross-service
+ * mutations invalidate consistently per ADR-0006. The full set of services
+ * (TaskService, TagService, FolderService, AttachmentService, ExportService,
+ * PluginService, SearchService) is composed in #289 alongside the tool
+ * wiring; this slice only instantiates what `registerOmniFocusResources`
+ * needs.
+ */
+export function composeResourceServices(
+  adapter: OmniFocusAdapter,
+  config: Config,
+): ResourceServiceChain {
+  const cache = new OmniFocusLruCache({
+    capacity: config.OMNIFOCUS_CACHE_CAPACITY,
+    ttlMs: config.OMNIFOCUS_CACHE_TTL_MS,
+  });
+  return {
+    cache,
+    projectService: new ProjectService({ adapter, cache }),
+    reviewService: new ReviewService({ adapter }),
+    forecastService: new ForecastService({ adapter }),
+    perspectiveService: new PerspectiveService({ adapter }),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -3,9 +3,10 @@
  *
  * Stands up the server over stdio (ADR-0010) using the high-level McpServer
  * API from @modelcontextprotocol/sdk. Currently registers the
- * `internal_status` tool and the four OmniFocus workflow prompts; the full
- * tool surface, MCP resources, and per-tool middleware composition arrive in
- * follow-ups under #278.
+ * `internal_status` tool, the four OmniFocus workflow prompts, and the ten
+ * MCP resources (`omnifocus://capabilities` + nine data URIs). The full
+ * tool surface and per-tool middleware composition arrive in follow-ups
+ * under #278.
  *
  * Signal handlers for SIGINT/SIGTERM delegate to `shutdownController` (#26),
  * which drains in-flight calls, flushes logs, and exits 0.
@@ -13,6 +14,7 @@
  * Cold-start target: < 500ms on a warm macOS (DESIGN §17).
  *
  * @see DESIGN.md §17 — lifecycle
+ * @see DESIGN.md §28 — MCP resources
  * @see docs/adr/0010-stdio-as-sole-transport.md
  */
 
@@ -27,9 +29,26 @@ import {
   WEEKLY_REVIEW_PROMPT,
   registerOmniFocusPrompts,
 } from "../prompts/omnifocus.js";
+import {
+  CAPABILITIES_URI,
+  buildCapabilities,
+  registerCapabilitiesResource,
+} from "../resources/capabilities.js";
+import {
+  FLAGGED_URI,
+  FORECAST_TODAY_URI,
+  INBOX_URI,
+  OVERDUE_URI,
+  PERSPECTIVE_URI_TEMPLATE,
+  PROJECT_URI_TEMPLATE,
+  REVIEW_DUE_URI,
+  SNAPSHOT_URI,
+  TAG_URI_TEMPLATE,
+  registerOmniFocusResources,
+} from "../resources/omnifocus.js";
 import { registerInternalStatusTool } from "../tools/observability/internalStatus.js";
 import { circuitBreakerRegistry } from "./circuitBreaker.js";
-import { composeAdapter, makeMeta } from "./composition.js";
+import { composeAdapter, composeResourceServices, makeMeta } from "./composition.js";
 import { shutdownController } from "./shutdown.js";
 import { installStdoutGuard } from "./stdoutGuard.js";
 
@@ -73,10 +92,11 @@ export async function startServer(): Promise<void> {
   const transport = new StdioServerTransport();
 
   // Compose the live adapter chain (JxaTransport + OmniJsTransport →
-  // TransportRouter). Cache wrapping (#22) and service composition (#289)
-  // arrive in follow-ups; the raw chain is enough for `internal_status` and
-  // for downstream registration helpers to start consuming via shared deps.
+  // TransportRouter). Cache wrapping (#22) and the rest of the service
+  // chain (#289) arrive in follow-ups; the resource-side services land
+  // here so #290's resources can resolve.
   const adapter = composeAdapter(config);
+  const services = composeResourceServices(adapter, config);
 
   // Register internal_status tool.
   registerInternalStatusTool(server, {
@@ -91,6 +111,22 @@ export async function startServer(): Promise<void> {
   // templates with no runtime dependencies, so they wire in without an
   // adapter or service chain.
   registerOmniFocusPrompts(server);
+
+  // Register the ten MCP resources (DESIGN §28) — capabilities plus nine
+  // data URIs (snapshot, inbox, forecast/today, overdue, flagged,
+  // review-due, project/{id}, tag/{id}, perspective/{id}).
+  //
+  // `buildCapabilities` reads from config on every resource fetch so a
+  // future lazy OF probe (#36) can update edition / version without a
+  // restart by mutating a shared cell read inside the closure.
+  registerCapabilitiesResource(server, () => buildCapabilities(config));
+  registerOmniFocusResources(server, {
+    adapter,
+    projectService: services.projectService,
+    reviewService: services.reviewService,
+    forecastService: services.forecastService,
+    perspectiveService: services.perspectiveService,
+  });
 
   // Graceful shutdown — delegate to shutdownController so tool handlers can
   // call assertNotShuttingDown() and in-flight queues drain cleanly.
@@ -126,6 +162,18 @@ export async function startServer(): Promise<void> {
         WEEKLY_REVIEW_PROMPT,
         CAPTURE_MEETING_PROMPT,
         PROJECT_PLANNING_PROMPT,
+      ],
+      resources: [
+        CAPABILITIES_URI,
+        SNAPSHOT_URI,
+        INBOX_URI,
+        FORECAST_TODAY_URI,
+        OVERDUE_URI,
+        FLAGGED_URI,
+        REVIEW_DUE_URI,
+        PROJECT_URI_TEMPLATE,
+        TAG_URI_TEMPLATE,
+        PERSPECTIVE_URI_TEMPLATE,
       ],
     },
     "server started",

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -63,4 +63,41 @@ describe.skipIf(!E2E)("E2E — smoke", () => {
     expect(daily.messages.length).toBeGreaterThan(0);
     expect(daily.messages[0]?.role).toBe("user");
   });
+
+  it("lists the ten MCP resources and reads omnifocus://capabilities", async () => {
+    try {
+      await server.start();
+    } catch (err) {
+      throw new Error(
+        `E2EServer.start() failed: ${String(err)}\n` + `stderr: ${server.stderrBuffer}`,
+      );
+    }
+
+    const resources = await server.client.listResources();
+    const uris = resources.resources.map((r) => r.uri).sort();
+    expect(uris).toContain("omnifocus://capabilities");
+    expect(uris).toContain("omnifocus://snapshot");
+    expect(uris).toContain("omnifocus://inbox");
+    expect(uris).toContain("omnifocus://forecast/today");
+    expect(uris).toContain("omnifocus://overdue");
+    expect(uris).toContain("omnifocus://flagged");
+    expect(uris).toContain("omnifocus://review-due");
+    // Static-URI resources only — the three template URIs surface via
+    // resources/templates/list, not resources/list.
+    expect(uris.length).toBeGreaterThanOrEqual(7);
+
+    const capabilities = await server.client.readResource({
+      uri: "omnifocus://capabilities",
+    });
+    expect(capabilities.contents.length).toBeGreaterThan(0);
+    const first = capabilities.contents[0] as { mimeType?: string; text?: string };
+    expect(first?.mimeType).toBe("application/json");
+    const parsed = JSON.parse(first?.text ?? "") as {
+      ofVersion: string;
+      ofEdition: string;
+      transports: { jxa: { available: boolean } };
+    };
+    expect(parsed.ofVersion).toBeTypeOf("string");
+    expect(parsed.transports.jxa.available).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- `startServer` now calls `registerCapabilitiesResource` + `registerOmniFocusResources`, so `resources/list` returns all ten URIs and `resources/read` flows through the live adapter chain composed in #293
- New `composeResourceServices(adapter, config)` factory in `src/server/composition.ts` instantiates the shared `OmniFocusLruCache` and the four services the resources consume (Project, Review, Forecast, Perspective)
- E2E smoke gains a third test asserting `resources/list` includes the seven static URIs and `resources/read("omnifocus://capabilities")` returns a parseable JSON payload with the expected shape
- Server-started log gains a `resources` array listing all ten URIs
- Bundle: 180 KB → 204 KB

Closes #290.

## Issue
Implements [#290](https://github.com/torsday/omnifocus-mcp/issues/290), the resources slice of #278. See DESIGN.md §28.

Builds on #293 / PR #294 (`composeAdapter` + `makeMeta` foundation). Remaining services (Task, Tag, Folder, Attachment, Export, Plugin, Search) compose in #289 alongside the tool wiring.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1678 passed, 45 skipped
- [x] `pnpm lint` — clean (biome + custom + docs:check)
- [x] `pnpm build` — 204 KB
- [x] `OMNIFOCUS_E2E=1 pnpm test tests/e2e/smoke.test.ts` — 3/3 passed
- [x] Self-reviewed via /review-pr