### PR TITLE
feat(server): wire 20 task tool registrations into startServer

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -3,10 +3,10 @@
  *
  * Stands up the server over stdio (ADR-0010) using the high-level McpServer
  * API from @modelcontextprotocol/sdk. Currently registers `internal_status`,
- * the four OmniFocus workflow prompts, the ten MCP resources, and 44 domain
+ * the four OmniFocus workflow prompts, the ten MCP resources, and 65 domain
  * tools across folder, tag, note, search, forecast, perspective, plugin,
- * sync, review, export, app, and project surfaces. Task tools and per-tool
- * middleware (#291) arrive in follow-ups under #289.
+ * sync, review, export, app, project, and task surfaces. Attachment tools
+ * and per-tool middleware (#291) arrive in follow-ups under #289.
  *
  * Signal handlers for SIGINT/SIGTERM delegate to `shutdownController` (#26),
  * which drains in-flight calls, flushes logs, and exits 0.
@@ -90,6 +90,26 @@ import { registerTagSetAllowsNextActionTool } from "../tools/tag/setAllowsNextAc
 import { registerTagSetLocationTool } from "../tools/tag/setLocation.js";
 import { registerTagSetStatusTool } from "../tools/tag/setStatus.js";
 import { registerTagUpdateTool } from "../tools/tag/update.js";
+import { registerTaskBatchCompleteTool } from "../tools/task/batchComplete.js";
+import { registerTaskBatchCreateTool } from "../tools/task/batchCreate.js";
+import { registerTaskBatchUpdateTool } from "../tools/task/batchUpdate.js";
+import { registerTaskClearRepetitionTool } from "../tools/task/clearRepetition.js";
+import { registerTaskCompleteTool } from "../tools/task/complete.js";
+import { registerTaskCreateTool } from "../tools/task/create.js";
+import { registerTaskDeleteTool } from "../tools/task/delete.js";
+import { registerTaskDropTool } from "../tools/task/drop.js";
+import { registerTaskDuplicateTool } from "../tools/task/duplicate.js";
+import { registerTaskFindByNameTool } from "../tools/task/findByName.js";
+import { registerTaskGetTool } from "../tools/task/get.js";
+import { registerTaskGetManyTool } from "../tools/task/getMany.js";
+import { registerTaskListTool } from "../tools/task/list.js";
+import { registerTaskMoveTool } from "../tools/task/move.js";
+import { registerTaskParseTransportTextTool } from "../tools/task/parseTransportText.js";
+import { registerTaskReorderTool } from "../tools/task/reorder.js";
+import { registerTaskSetRepetitionTool } from "../tools/task/setRepetition.js";
+import { registerTaskUncompleteTool } from "../tools/task/uncomplete.js";
+import { registerTaskUndropTool } from "../tools/task/undrop.js";
+import { registerTaskUpdateTool } from "../tools/task/update.js";
 import { circuitBreakerRegistry } from "./circuitBreaker.js";
 import { composeAdapter, composeServices, makeMeta } from "./composition.js";
 import { shutdownController } from "./shutdown.js";
@@ -248,6 +268,37 @@ export async function startServer(): Promise<void> {
   registerProjectMoveTool(server, projectServiceCtx);
   registerProjectUpdateTool(server, projectAdapterCtx);
 
+  // Task tools — twenty registrations across four context shapes.
+  // Service-backed reads use `{taskService, makeMeta}`; raw adapter reads
+  // (find_by_name, get_many, parse_transport_text) use `{adapter, makeMeta}`;
+  // mutations use `{adapter, makeMeta, cache?}` so invalidate-on-write
+  // (ADR-0006 / docs/cache-invalidation.md) sees the shared cache; and the
+  // three idempotent mutations (create, delete, update) additionally fall
+  // back to the module-singleton idempotency store.
+  const taskServiceCtx = { taskService: services.taskService, makeMeta };
+  const taskAdapterCtx = { adapter, makeMeta };
+  const taskMutationCtx = { adapter, makeMeta, cache: services.cache };
+  registerTaskGetTool(server, taskServiceCtx);
+  registerTaskListTool(server, taskServiceCtx);
+  registerTaskFindByNameTool(server, taskAdapterCtx);
+  registerTaskGetManyTool(server, taskAdapterCtx);
+  registerTaskParseTransportTextTool(server, { makeMeta });
+  registerTaskBatchCompleteTool(server, taskMutationCtx);
+  registerTaskBatchCreateTool(server, taskMutationCtx);
+  registerTaskBatchUpdateTool(server, taskMutationCtx);
+  registerTaskClearRepetitionTool(server, taskMutationCtx);
+  registerTaskCompleteTool(server, taskMutationCtx);
+  registerTaskDropTool(server, taskMutationCtx);
+  registerTaskDuplicateTool(server, taskMutationCtx);
+  registerTaskMoveTool(server, taskMutationCtx);
+  registerTaskReorderTool(server, taskMutationCtx);
+  registerTaskSetRepetitionTool(server, taskMutationCtx);
+  registerTaskUncompleteTool(server, taskMutationCtx);
+  registerTaskUndropTool(server, taskMutationCtx);
+  registerTaskCreateTool(server, taskMutationCtx);
+  registerTaskDeleteTool(server, taskMutationCtx);
+  registerTaskUpdateTool(server, taskMutationCtx);
+
   // Graceful shutdown — delegate to shutdownController so tool handlers can
   // call assertNotShuttingDown() and in-flight queues drain cleanly.
   process.on("SIGINT", () => {
@@ -322,6 +373,26 @@ export async function startServer(): Promise<void> {
         "project_list",
         "project_move",
         "project_update",
+        "task_get",
+        "task_list",
+        "task_find_by_name",
+        "task_get_many",
+        "task_parse_transport_text",
+        "task_batch_complete",
+        "task_batch_create",
+        "task_batch_update",
+        "task_clear_repetition",
+        "task_complete",
+        "task_drop",
+        "task_duplicate",
+        "task_move",
+        "task_reorder",
+        "task_set_repetition",
+        "task_uncomplete",
+        "task_undrop",
+        "task_create",
+        "task_delete",
+        "task_update",
       ],
       prompts: [
         DAILY_REVIEW_PROMPT,

--- a/tests/e2e/smoke.test.ts
+++ b/tests/e2e/smoke.test.ts
@@ -73,7 +73,28 @@ describe.skipIf(!E2E)("E2E — smoke", () => {
     expect(names).toContain("project_list");
     expect(names).toContain("project_move");
     expect(names).toContain("project_update");
-    expect(tools.tools.length).toBeGreaterThanOrEqual(45);
+    // Task tools (#305): twenty register* helpers wired in startServer.
+    expect(names).toContain("task_get");
+    expect(names).toContain("task_list");
+    expect(names).toContain("task_find_by_name");
+    expect(names).toContain("task_get_many");
+    expect(names).toContain("task_parse_transport_text");
+    expect(names).toContain("task_create");
+    expect(names).toContain("task_update");
+    expect(names).toContain("task_delete");
+    expect(names).toContain("task_complete");
+    expect(names).toContain("task_uncomplete");
+    expect(names).toContain("task_drop");
+    expect(names).toContain("task_undrop");
+    expect(names).toContain("task_move");
+    expect(names).toContain("task_reorder");
+    expect(names).toContain("task_duplicate");
+    expect(names).toContain("task_set_repetition");
+    expect(names).toContain("task_clear_repetition");
+    expect(names).toContain("task_batch_complete");
+    expect(names).toContain("task_batch_create");
+    expect(names).toContain("task_batch_update");
+    expect(tools.tools.length).toBeGreaterThanOrEqual(65);
 
     const result = await server.client.callTool({ name: "internal_status", arguments: {} });
     const structured = result.structuredContent as { data?: { uptimeMs?: number } } | undefined;


### PR DESCRIPTION
## Summary
- Wires twenty `task_*` register* calls in `startServer` — the largest single domain in the wire-up sequence — bringing the wired surface to 65 tools.
- Four context shapes: service `{taskService, makeMeta}` (2); adapter-only `{adapter, makeMeta}` (3); adapter+cache `{adapter, makeMeta, cache?}` (12 mutations); adapter+cache+idempotency `{adapter, makeMeta, cache?, idempotencyStore?}` (3 — `create`/`delete`/`update`, fall back to the module singleton).
- Shared cache flows in so every mutation invalidates per ADR-0006 / docs/cache-invalidation.md.
- Extends `tests/e2e/smoke.test.ts` to assert all twenty task names and ≥65 total tools.

Closes #305.
Refs #289.

## Issue
Implements [#305 — wire 20 task tool registrations](https://github.com/torsday/omnifocus-mcp/issues/305), the next slice in the #289 / #278 wire-up series after #303.

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1681 passed
- [x] `pnpm lint` — clean
- [x] `pnpm build` — 378 KB
- [x] `OMNIFOCUS_E2E=1 pnpm test tests/e2e/smoke.test.ts` — 3 passed
- [x] Self-reviewed via /review-pr
- [x] No new dependencies