### PR TITLE
feat(server): compose per-tool middleware stack

### DIFF
--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -8,8 +8,10 @@
  * sync, review, export, app, project, task, and attachment surfaces. Two
  * additional raw-script escape-hatch tools (`run_jxa_script`,
  * `run_omnijs_script`) register only when `OMNIFOCUS_ALLOW_RAW_SCRIPT=1`
- * (ADR-0004), bringing the wired surface to 71. Per-tool middleware (#291)
- * arrives in a follow-up under #289.
+ * (ADR-0004), bringing the wired surface to 71. Every registered tool is
+ * wrapped in `assertNotShuttingDown → withCircuitBreaker → withRateLimitMeta
+ * → withLoopDetection` via `installToolMiddleware` (#291), which runs once
+ * before any `register*Tool` helper.
  *
  * Signal handlers for SIGINT/SIGTERM delegate to `shutdownController` (#26),
  * which drains in-flight calls, flushes logs, and exits 0.
@@ -25,6 +27,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { parseConfig, redactConfig } from "../config/env.js";
 import { logger } from "../logging/logger.js";
+import { LoopDetector } from "../loopDetector/LoopDetector.js";
 import {
   CAPTURE_MEETING_PROMPT,
   DAILY_REVIEW_PROMPT,
@@ -32,6 +35,7 @@ import {
   WEEKLY_REVIEW_PROMPT,
   registerOmniFocusPrompts,
 } from "../prompts/omnifocus.js";
+import { ToolRateLimiter } from "../rateLimit/ToolRateLimiter.js";
 import {
   CAPABILITIES_URI,
   buildCapabilities,
@@ -118,6 +122,7 @@ import { registerTaskUndropTool } from "../tools/task/undrop.js";
 import { registerTaskUpdateTool } from "../tools/task/update.js";
 import { circuitBreakerRegistry } from "./circuitBreaker.js";
 import { composeAdapter, composeServices, makeMeta } from "./composition.js";
+import { installToolMiddleware } from "./middleware.js";
 import { shutdownController } from "./shutdown.js";
 import { installStdoutGuard } from "./stdoutGuard.js";
 
@@ -158,12 +163,27 @@ export async function startServer(): Promise<void> {
   logger.level = config.OMNIFOCUS_LOG_LEVEL;
 
   const server = createMcpServer();
+
+  // Install per-tool middleware (#291) BEFORE any register* helper runs so
+  // every tool gets wrapped through:
+  //   assertNotShuttingDown → withCircuitBreaker → withRateLimitMeta → withLoopDetection
+  // Singletons live for the lifetime of the server: the rate limiter shares
+  // its sliding window across calls, the loop detector its dedup keys, and
+  // the circuit-breaker registry already holds per-tool state.
+  const rateLimiter = new ToolRateLimiter(config.OMNIFOCUS_TOOL_RATE_LIMIT);
+  const loopDetector = new LoopDetector();
+  installToolMiddleware(server, {
+    rateLimiter,
+    loopDetector,
+    circuitRegistry: circuitBreakerRegistry,
+    shutdown: shutdownController,
+  });
+
   const transport = new StdioServerTransport();
 
   // Compose the live adapter chain (JxaTransport + OmniJsTransport →
   // TransportRouter) and the full service bundle. Cache wrapping at the
-  // adapter layer (#22) arrives in a follow-up; per-tool middleware
-  // composition (#291) wraps individual handlers.
+  // adapter layer (#22) arrives in a follow-up.
   const adapter = composeAdapter(config);
   const services = composeServices(adapter, config);
 

--- a/src/server/middleware.test.ts
+++ b/src/server/middleware.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for {@link composeToolCallback} — the per-tool middleware stack
+ * (#291). Goldilocks coverage: one path per protective layer, plus the happy
+ * path that proves composition order works end to end. Heavy state-machine
+ * branches live in each middleware's own unit test (see
+ * `src/rateLimit/withRateLimitMeta.test.ts`, `src/loopDetector/...`,
+ * `src/server/circuitBreaker.test.ts`); we don't restate them here.
+ */
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import type { ToolSuccess } from "../envelope/index.js";
+import { LoopDetector } from "../loopDetector/LoopDetector.js";
+import { ToolRateLimiter } from "../rateLimit/ToolRateLimiter.js";
+import { CircuitBreakerRegistry } from "./circuitBreaker.js";
+import { composeToolCallback } from "./middleware.js";
+import { ShutdownController } from "./shutdown.js";
+
+function makeDeps(overrides: { rateLimit?: { limit: number; windowSeconds: number } } = {}) {
+  return {
+    rateLimiter: new ToolRateLimiter(overrides.rateLimit ?? { limit: 120, windowSeconds: 60 }),
+    loopDetector: new LoopDetector({ threshold: 5, windowSeconds: 60 }),
+    circuitRegistry: new CircuitBreakerRegistry(),
+    shutdown: new ShutdownController(),
+  };
+}
+
+/** Build a fake SDK callback that returns a fixed envelope wrapped per `toolResponse`. */
+function makeOkCallback(): (args: unknown, extra: unknown) => Promise<CallToolResult> {
+  return async () => {
+    const envelope: ToolSuccess<{ value: number }> = {
+      data: { value: 1 },
+      meta: {
+        correlationId: "01J0000000000000000000TEST",
+        durationMs: 0,
+        cacheHit: false,
+        transport: "memory",
+        ofVersion: "unknown",
+      },
+    };
+    return {
+      content: [{ type: "text", text: JSON.stringify(envelope) }],
+      structuredContent: envelope as unknown as Record<string, unknown>,
+    };
+  };
+}
+
+describe("composeToolCallback", () => {
+  it("threads success through the stack and injects rateLimit meta", async () => {
+    const deps = makeDeps();
+    const wrapped = composeToolCallback("tool_a", makeOkCallback(), deps);
+
+    const result = await wrapped({ x: 1 }, {});
+    const env = result.structuredContent as unknown as ToolSuccess<{ value: number }>;
+    expect(env.data.value).toBe(1);
+    expect(env.meta.rateLimit?.remaining).toBe(119); // 120 - this call
+    expect(env.meta.warnings ?? []).toHaveLength(0);
+  });
+
+  it("appends WARN_LOOP_DETECTED once the threshold is crossed", async () => {
+    const deps = makeDeps();
+    const wrapped = composeToolCallback("tool_b", makeOkCallback(), deps);
+
+    // Five identical calls — the 5th crosses the loop-detector threshold.
+    let last: CallToolResult | undefined;
+    for (let i = 0; i < 5; i++) {
+      last = await wrapped({ same: "args" }, {});
+    }
+    const env = last?.structuredContent as unknown as ToolSuccess<unknown>;
+    const warnings = env.meta.warnings ?? [];
+    expect(warnings.some((w) => w.code === "WARN_LOOP_DETECTED")).toBe(true);
+  });
+
+  it("throws RateLimited when the per-tool window is full", async () => {
+    const deps = makeDeps({ rateLimit: { limit: 2, windowSeconds: 60 } });
+    const wrapped = composeToolCallback("tool_c", makeOkCallback(), deps);
+
+    await wrapped({ i: 1 }, {});
+    await wrapped({ i: 2 }, {});
+    await expect(wrapped({ i: 3 }, {})).rejects.toMatchObject({ code: "OF_RATE_LIMITED" });
+  });
+
+  it("opens the circuit after consecutive failures and fast-fails", async () => {
+    const deps = makeDeps();
+    const failingCb = async (): Promise<CallToolResult> => {
+      throw new Error("boom");
+    };
+    const wrapped = composeToolCallback("tool_d", failingCb, deps);
+
+    // Default failureThreshold is 3 — three failures must open the circuit.
+    for (let i = 0; i < 3; i++) {
+      await expect(wrapped({}, {})).rejects.toThrow();
+    }
+    // Next call must short-circuit with CircuitOpen rather than re-invoke.
+    await expect(wrapped({}, {})).rejects.toMatchObject({ code: "OF_CIRCUIT_OPEN" });
+  });
+
+  it("rejects with ServerShuttingDown once the controller flips", async () => {
+    const deps = makeDeps();
+    const wrapped = composeToolCallback("tool_e", makeOkCallback(), deps);
+
+    // First call goes through.
+    await wrapped({}, {});
+
+    // Flip the flag directly — initiate() would call process.exit; we only
+    // need `isShuttingDown=true` to exercise assertNotShuttingDown.
+    (deps.shutdown as unknown as { _shuttingDown: boolean })._shuttingDown = true;
+
+    await expect(wrapped({}, {})).rejects.toMatchObject({ code: "OF_SHUTTING_DOWN" });
+  });
+});

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -1,0 +1,132 @@
+/**
+ * Per-tool middleware composition for omnifocus-mcp (#291).
+ *
+ * Wraps every `server.registerTool` callback in the same uniform stack so
+ * each tool handler — old and future — gets reliability and observability
+ * primitives without per-tool wiring:
+ *
+ *     assertNotShuttingDown
+ *       → withCircuitBreaker (per-tool registry)
+ *         → withRateLimitMeta
+ *           → withLoopDetection
+ *             → handler
+ *
+ * **Why monkey-patch `registerTool`?** The alternative — threading a
+ * `composeToolHandler` through ~30 register* helpers — adds a parameter to
+ * every tool file for zero behavioural benefit. Patching once at server
+ * construction guarantees the stack wraps every current and future
+ * registration with no diff in the tool layer.
+ *
+ * **Order rationale.**
+ *
+ * 1. `assertNotShuttingDown` first: cheapest check, lets SIGINT win
+ *    immediately without paying for breaker bookkeeping.
+ * 2. `withCircuitBreaker` next: when a tool is consistently failing, we want
+ *    fast-fail to short-circuit *before* burning rate-limit slots.
+ * 3. `withRateLimitMeta` next: throws `RateLimited` before we touch the
+ *    inner handler when the window is full; otherwise injects
+ *    `meta.rateLimit` on success.
+ * 4. `withLoopDetection` last: it never throws — only appends a warning to
+ *    `meta.warnings` — so it sits closest to the handler where the meta it
+ *    augments is freshest.
+ *
+ * **Envelope ↔ SDK shape.** The `registerTool` callback returns the SDK's
+ * `{ content, structuredContent }` pair, while the middleware utilities
+ * mutate the inner `ToolEnvelope` (under `structuredContent`). This patch
+ * unwraps once before the middleware runs and re-packs once after, keeping
+ * the inner middleware contract pure (`() => Promise<ToolSuccess<T>>`).
+ *
+ * @see DESIGN.md §6.10 — circuit breaker
+ * @see DESIGN.md §6.11 — loop detection
+ * @see DESIGN.md §16 — rate limiting
+ * @see DESIGN.md §17 — graceful shutdown
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { type ToolEnvelope, type ToolSuccess, toolResponse } from "../envelope/index.js";
+import type { LoopDetector } from "../loopDetector/LoopDetector.js";
+import { withLoopDetection } from "../loopDetector/withLoopDetection.js";
+import type { ToolRateLimiter } from "../rateLimit/ToolRateLimiter.js";
+import { withRateLimitMeta } from "../rateLimit/withRateLimitMeta.js";
+import type { CircuitBreakerRegistry } from "./circuitBreaker.js";
+import type { ShutdownController } from "./shutdown.js";
+
+/** Dependency bundle threaded into the patch. All required. */
+export interface ToolMiddlewareDeps {
+  rateLimiter: ToolRateLimiter;
+  loopDetector: LoopDetector;
+  circuitRegistry: CircuitBreakerRegistry;
+  shutdown: ShutdownController;
+}
+
+/** Loose shape for the SDK tool callback — `(args, extra) => Promise<CallToolResult>`. */
+type ToolCallback = (args: unknown, extra: unknown) => Promise<CallToolResult>;
+
+/**
+ * Wrap a single SDK tool callback in the full middleware stack.
+ *
+ * Exported for unit tests; production code should call
+ * {@link installToolMiddleware} which patches `registerTool` once.
+ */
+export function composeToolCallback(
+  toolName: string,
+  callback: ToolCallback,
+  deps: ToolMiddlewareDeps,
+): ToolCallback {
+  return async (args, extra) => {
+    deps.shutdown.assertNotShuttingDown();
+
+    const breaker = deps.circuitRegistry.get(toolName);
+
+    return breaker.call(async () => {
+      // Inner handler returns the envelope unwrapped from the SDK shape.
+      // Casting to `ToolSuccess<unknown>` matches what every handler in this
+      // codebase produces today — error envelopes are not returned (handlers
+      // throw typed errors, which propagate to the SDK error path).
+      const innerEnvelope = async (): Promise<ToolSuccess<unknown>> => {
+        const result = await callback(args, extra);
+        return result.structuredContent as unknown as ToolSuccess<unknown>;
+      };
+
+      const enveloped = await withRateLimitMeta(toolName, deps.rateLimiter, () =>
+        withLoopDetection(toolName, args, deps.loopDetector, innerEnvelope),
+      );
+
+      return toolResponse(enveloped as ToolEnvelope<unknown>);
+    });
+  };
+}
+
+/**
+ * Patch `server.registerTool` so every subsequent registration goes through
+ * {@link composeToolCallback}. Idempotent — calling twice on the same server
+ * is a no-op (subsequent calls would double-wrap, so we guard with a brand).
+ *
+ * Call this immediately after `createMcpServer()` and before any
+ * `register*Tool` helper.
+ */
+export function installToolMiddleware(server: McpServer, deps: ToolMiddlewareDeps): void {
+  type Branded = McpServer & { __omnifocusMiddlewareInstalled?: true };
+  const branded = server as Branded;
+  if (branded.__omnifocusMiddlewareInstalled === true) return;
+
+  const original = server.registerTool.bind(server);
+
+  // The SDK overload is fully generic; we preserve its surface but wrap the
+  // callback. The function is invoked as `(name, config, cb)` for the only
+  // overload our register* helpers use; widen to `unknown[]` so TS doesn't
+  // collapse the parameter tuple to `never` under generic resolution.
+  const patched = (...args: unknown[]): ReturnType<typeof original> => {
+    const [name, config, cb] = args as [string, Parameters<typeof original>[1], ToolCallback];
+    const wrapped = composeToolCallback(name, cb, deps);
+    return (original as unknown as (...a: unknown[]) => ReturnType<typeof original>)(
+      name,
+      config,
+      wrapped,
+    );
+  };
+
+  (server as unknown as { registerTool: typeof patched }).registerTool = patched;
+  branded.__omnifocusMiddlewareInstalled = true;
+}


### PR DESCRIPTION
## Summary
- Monkey-patches `server.registerTool` once via `installToolMiddleware` so every registered tool is wrapped through `assertNotShuttingDown → withCircuitBreaker → withRateLimitMeta → withLoopDetection → handler` with no per-tool diff.
- Singleton `ToolRateLimiter` (configured from `OMNIFOCUS_TOOL_RATE_LIMIT`, default 120/60s) and `LoopDetector` are created once per server and live for its lifetime.
- Five Goldilocks tests in `src/server/middleware.test.ts` cover happy path, loop warning, rate-limit ceiling, circuit-breaker open, and shutdown rejection — leaving each middleware's own state-machine branches in its existing unit test.

Closes #291.

## Issue
Implements [#291 — feat(server): compose per-tool middleware](https://github.com/torsday/omnifocus-mcp/issues/291). Closes the SPEC NFR Reliability + Observability gap noted in #278; unblocks #283 (per-tool invocation logging) which can now slot in as the next middleware layer.

## Breaking change?
- [x] No — additive; existing handlers unchanged.

## Test plan
- [x] `pnpm test src/server/middleware.test.ts` — 5/5
- [x] `OMNIFOCUS_E2E=1 pnpm test tests/e2e/smoke.test.ts` — 4/4 (registered tools still answer through the wrapped seam)
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` — all green; bundle 395.29 KB
- [x] Self-reviewed via /review-pr
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)