### PR TITLE
feat(observability): per-tool invocation logging + real correlation IDs

### DIFF
--- a/src/logging/withInvocationLogging.test.ts
+++ b/src/logging/withInvocationLogging.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for {@link withInvocationLogging} — the per-tool invocation event
+ * middleware (#283). Goldilocks coverage: success path emits exactly one
+ * `tool.invoked`, error path emits exactly one `tool.error` with the typed
+ * code, and the correlationId on the event matches the surrounding scope.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OmniFocusError } from "../errors/index.js";
+import { withCorrelationId } from "./correlation.js";
+import { withInvocationLogging } from "./withInvocationLogging.js";
+
+interface CapturedLine {
+  level: string;
+  event: string;
+  tool: string;
+  correlationId?: string;
+  durationMs: number;
+  transport?: string;
+  cacheHit?: boolean;
+  code?: string;
+}
+
+/**
+ * Capture pino output by spying on `process.stderr.write`. Filters to lines
+ * carrying an `event` field so unrelated debug noise doesn't pollute the
+ * assertions.
+ */
+function captureLogs(): { lines: CapturedLine[]; restore: () => void } {
+  const lines: CapturedLine[] = [];
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    const text = typeof chunk === "string" ? chunk : (chunk as Buffer).toString("utf-8");
+    for (const raw of text.split("\n")) {
+      if (!raw) continue;
+      try {
+        const parsed = JSON.parse(raw) as CapturedLine;
+        if (parsed.event) lines.push(parsed);
+      } catch {
+        /* not a structured event line — ignore */
+      }
+    }
+    return true;
+  });
+  return {
+    lines,
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+}
+
+const okEnvelope = {
+  data: { value: 1 },
+  meta: {
+    correlationId: "01J0000000000000000000TEST",
+    durationMs: 0,
+    cacheHit: true,
+    transport: "memory" as const,
+    ofVersion: "unknown",
+  },
+};
+
+describe("withInvocationLogging", () => {
+  let cap: { lines: CapturedLine[]; restore: () => void };
+
+  beforeEach(() => {
+    cap = captureLogs();
+  });
+
+  afterEach(() => {
+    cap.restore();
+  });
+
+  it("emits exactly one tool.invoked on success with the surrounding correlationId", async () => {
+    const result = await withCorrelationId(
+      () =>
+        withInvocationLogging("tool_x", async () => {
+          // capture inside scope so we can compare to the log line
+          return okEnvelope;
+        }),
+      "01J0000000000000000000FIXED",
+    );
+
+    expect(result).toBe(okEnvelope);
+
+    const events = cap.lines.filter((l) => l.tool === "tool_x");
+    expect(events).toHaveLength(1);
+    const [evt] = events;
+    expect(evt?.event).toBe("tool.invoked");
+    expect(evt?.level).toBe("info");
+    expect(evt?.transport).toBe("memory");
+    expect(evt?.cacheHit).toBe(true);
+    expect(typeof evt?.durationMs).toBe("number");
+    expect(evt?.correlationId).toBe("01J0000000000000000000FIXED");
+  });
+
+  it("emits exactly one tool.error with the typed error code on a thrown OmniFocusError", async () => {
+    const boom = new OmniFocusError("OF_VALIDATION", "bad input");
+
+    await expect(
+      withCorrelationId(
+        () =>
+          withInvocationLogging("tool_y", async () => {
+            throw boom;
+          }),
+        "01J0000000000000000000ERR0",
+      ),
+    ).rejects.toBe(boom);
+
+    const events = cap.lines.filter((l) => l.tool === "tool_y");
+    expect(events).toHaveLength(1);
+    const [evt] = events;
+    expect(evt?.event).toBe("tool.error");
+    expect(evt?.code).toBe("OF_VALIDATION");
+    expect(evt?.correlationId).toBe("01J0000000000000000000ERR0");
+  });
+
+  it("falls back to code UNKNOWN on an untyped throw", async () => {
+    await expect(
+      withCorrelationId(() =>
+        withInvocationLogging("tool_z", async () => {
+          throw new Error("ouch");
+        }),
+      ),
+    ).rejects.toThrow("ouch");
+
+    const evt = cap.lines.find((l) => l.tool === "tool_z");
+    expect(evt?.event).toBe("tool.error");
+    expect(evt?.code).toBe("UNKNOWN");
+  });
+});

--- a/src/logging/withInvocationLogging.ts
+++ b/src/logging/withInvocationLogging.ts
@@ -1,0 +1,72 @@
+/**
+ * `withInvocationLogging` — per-tool invocation event middleware (#283).
+ *
+ * Wraps an MCP tool handler so every call emits exactly one log event:
+ *
+ *   - `tool.invoked` on success — `{ tool, durationMs, transport, cacheHit, correlationId }`
+ *   - `tool.error` on a thrown error — `{ tool, durationMs, code?, correlationId, err }`
+ *
+ * Sits at the bottom of the middleware stack so `durationMs` measures the
+ * handler's actual wall-clock cost (excluding rate-limit / circuit-breaker
+ * bookkeeping, which already have their own dedicated events). The
+ * correlationId is read from the surrounding `withCorrelationId` scope so it
+ * matches the value that ends up in `ResponseMeta.correlationId`.
+ *
+ * Failure handling: typed `OmniFocusError`s log `tool.error` with their stable
+ * `code` and re-throw so the SDK builds the error envelope. Untyped throws
+ * still emit `tool.error` (with `code: "UNKNOWN"`) and re-throw — they will
+ * surface to the unhandled-exception path.
+ *
+ * @see DESIGN.md §21 — observability contract
+ * @see SPEC.md NFR — Observability
+ */
+
+import type { ToolSuccess } from "../envelope/index.js";
+import { isOmniFocusError } from "../errors/index.js";
+import { getCorrelationId } from "./correlation.js";
+import { logger } from "./logger.js";
+
+/**
+ * Wrap a tool handler with invocation logging. The wrapper is transparent —
+ * it returns the handler's envelope unchanged.
+ *
+ * @param toolName - MCP tool name (e.g. `"task_list"`)
+ * @param handler - Inner envelope-returning handler to invoke
+ */
+export async function withInvocationLogging<T>(
+  toolName: string,
+  handler: () => Promise<ToolSuccess<T>>,
+): Promise<ToolSuccess<T>> {
+  const startedAt = performance.now();
+  try {
+    const envelope = await handler();
+    const durationMs = Math.round(performance.now() - startedAt);
+    logger.info(
+      {
+        event: "tool.invoked",
+        tool: toolName,
+        correlationId: getCorrelationId(),
+        durationMs,
+        transport: envelope.meta.transport,
+        cacheHit: envelope.meta.cacheHit,
+      },
+      "tool invoked",
+    );
+    return envelope;
+  } catch (err) {
+    const durationMs = Math.round(performance.now() - startedAt);
+    const code = isOmniFocusError(err) ? err.code : "UNKNOWN";
+    logger.warn(
+      {
+        event: "tool.error",
+        tool: toolName,
+        correlationId: getCorrelationId(),
+        durationMs,
+        code,
+        err,
+      },
+      "tool error",
+    );
+    throw err;
+  }
+}

--- a/src/server/composition.ts
+++ b/src/server/composition.ts
@@ -20,7 +20,7 @@ import { TransportRouter } from "../adapter/router.js";
 import { OmniFocusLruCache } from "../cache/lruCache.js";
 import type { Config } from "../config/env.js";
 import type { ResponseMeta, Transport } from "../envelope/index.js";
-import { generateCorrelationId } from "../logging/correlation.js";
+import { generateCorrelationId, getCorrelationId } from "../logging/correlation.js";
 import { AttachmentService } from "../services/attachmentService.js";
 import { ExportService } from "../services/exportService.js";
 import { FolderService } from "../services/folderService.js";
@@ -177,8 +177,12 @@ const DEFAULT_OF_VERSION = "unknown";
  * shared cell that subsequent calls read from.
  */
 export function makeMeta(partial: Partial<ResponseMeta> = {}): ResponseMeta {
+  // Read from the request-scoped `withCorrelationId` AsyncLocalStorage when
+  // available so the envelope's correlationId matches the value emitted on
+  // the corresponding `tool.invoked` / `tool.error` log event (#283). Outside
+  // a scope (test fixtures, internal callers) we fall back to a fresh ULID.
   return {
-    correlationId: generateCorrelationId(),
+    correlationId: getCorrelationId() ?? generateCorrelationId(),
     durationMs: 0,
     cacheHit: false,
     transport: DEFAULT_TRANSPORT,

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -5,11 +5,13 @@
  * each tool handler — old and future — gets reliability and observability
  * primitives without per-tool wiring:
  *
- *     assertNotShuttingDown
- *       → withCircuitBreaker (per-tool registry)
- *         → withRateLimitMeta
- *           → withLoopDetection
- *             → handler
+ *     withCorrelationId  (AsyncLocalStorage scope — #283)
+ *       → assertNotShuttingDown
+ *         → withCircuitBreaker (per-tool registry)
+ *           → withRateLimitMeta
+ *             → withLoopDetection
+ *               → withInvocationLogging  (#283 — emits tool.invoked / tool.error)
+ *                 → handler
  *
  * **Why monkey-patch `registerTool`?** The alternative — threading a
  * `composeToolHandler` through ~30 register* helpers — adds a parameter to
@@ -45,6 +47,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { type ToolEnvelope, type ToolSuccess, toolResponse } from "../envelope/index.js";
+import { withCorrelationId } from "../logging/correlation.js";
+import { withInvocationLogging } from "../logging/withInvocationLogging.js";
 import type { LoopDetector } from "../loopDetector/LoopDetector.js";
 import { withLoopDetection } from "../loopDetector/withLoopDetection.js";
 import type { ToolRateLimiter } from "../rateLimit/ToolRateLimiter.js";
@@ -74,26 +78,36 @@ export function composeToolCallback(
   callback: ToolCallback,
   deps: ToolMiddlewareDeps,
 ): ToolCallback {
-  return async (args, extra) => {
-    deps.shutdown.assertNotShuttingDown();
+  return (args, extra) => {
+    // Open a request-scoped correlationId scope as the *outermost* layer so
+    // every downstream `getCorrelationId()` (logger events, makeMeta in the
+    // envelope) sees the same ULID. AsyncLocalStorage propagates through
+    // every awaited promise inside `fn`.
+    return withCorrelationId(async () => {
+      deps.shutdown.assertNotShuttingDown();
 
-    const breaker = deps.circuitRegistry.get(toolName);
+      const breaker = deps.circuitRegistry.get(toolName);
 
-    return breaker.call(async () => {
-      // Inner handler returns the envelope unwrapped from the SDK shape.
-      // Casting to `ToolSuccess<unknown>` matches what every handler in this
-      // codebase produces today — error envelopes are not returned (handlers
-      // throw typed errors, which propagate to the SDK error path).
-      const innerEnvelope = async (): Promise<ToolSuccess<unknown>> => {
-        const result = await callback(args, extra);
-        return result.structuredContent as unknown as ToolSuccess<unknown>;
-      };
+      return breaker.call(async () => {
+        // Inner handler returns the envelope unwrapped from the SDK shape.
+        // Casting to `ToolSuccess<unknown>` matches what every handler in this
+        // codebase produces today — error envelopes are not returned (handlers
+        // throw typed errors, which propagate to the SDK error path).
+        const innerEnvelope = async (): Promise<ToolSuccess<unknown>> => {
+          const result = await callback(args, extra);
+          return result.structuredContent as unknown as ToolSuccess<unknown>;
+        };
 
-      const enveloped = await withRateLimitMeta(toolName, deps.rateLimiter, () =>
-        withLoopDetection(toolName, args, deps.loopDetector, innerEnvelope),
-      );
+        const enveloped = await withRateLimitMeta(toolName, deps.rateLimiter, () =>
+          withLoopDetection(toolName, args, deps.loopDetector, () =>
+            // `withInvocationLogging` is the innermost layer so `durationMs`
+            // measures the handler's actual wall-clock cost (#283).
+            withInvocationLogging(toolName, innerEnvelope),
+          ),
+        );
 
-      return toolResponse(enveloped as ToolEnvelope<unknown>);
+        return toolResponse(enveloped as ToolEnvelope<unknown>);
+      });
     });
   };
 }


### PR DESCRIPTION
## Summary
- Adds `withInvocationLogging` as the innermost layer of the middleware stack — every tool call emits exactly one `tool.invoked` (info) or `tool.error` (warn) structured event.
- Wraps the whole stack in a `withCorrelationId(...)` AsyncLocalStorage scope; `makeMeta` reads it so `ResponseMeta.correlationId` matches the event's `correlationId` for grep-friendly correlation across the transcript.
- Typed `OmniFocusError`s log their stable `code`; untyped throws log `code: "UNKNOWN"`. Re-throws preserved so SDK error envelopes are unchanged.

Closes #283.

## Issue
Implements [#283 — feat(observability): per-tool invocation logging middleware + real correlation IDs](https://github.com/torsday/omnifocus-mcp/issues/283). Closes the SPEC NFR Observability gap that #278 left after #291's reliability stack landed.

Out of scope — to be filed as follow-ups so the diff stays atomic:
- `transport.call` events at debug level (JXA/OmniJS adapter-layer surgery)
- `cache.invalidated` events (cache-layer hooks)
- content-redaction guarantees at debug level (PII redaction is already wired in `logger.ts`; the per-event audit belongs in its own ticket)

## Breaking change?
- [x] No — additive; all existing events and envelopes unchanged.

## Test plan
- [x] `pnpm test src/logging/withInvocationLogging.test.ts` — 3/3 (success, typed error, untyped error)
- [x] `OMNIFOCUS_E2E=1 pnpm test tests/e2e/smoke.test.ts` — 4/4 (envelope still round-trips through the new layer)
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` — all green; bundle 396.79 KB
- [x] Self-reviewed via /review-pr
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)