### PR TITLE
feat(observability): emit transport.call events from JXA/OmniJS runners

### DIFF
--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -32,6 +32,7 @@ import {
   Timeout,
   TransportUnavailable,
 } from "../../errors/index.js";
+import { emitTransportCall } from "../../logging/transportCall.js";
 
 // ---------------------------------------------------------------------------
 // Spawner seam (injectable for tests)
@@ -128,7 +129,17 @@ export async function runJxaScript<T = unknown>(
   const jsonArg = JSON.stringify(args ?? {});
   const scriptName = options.scriptName;
 
+  const startedAt = performance.now();
   const result = await spawner(scriptBody, jsonArg, timeoutMs);
+  const durationMs = Math.round(performance.now() - startedAt);
+  const outcome: "ok" | "error" =
+    result.spawnError !== undefined ||
+    result.timedOut ||
+    result.exitCode !== 0 ||
+    result.stdout.trim() === ""
+      ? "error"
+      : "ok";
+  emitTransportCall("jxa", scriptName, args, durationMs, outcome);
 
   // 1. Spawn failure (binary missing) — the transport itself is unavailable.
   if (result.spawnError !== undefined) {

--- a/src/adapter/omnijs/scriptRunner.ts
+++ b/src/adapter/omnijs/scriptRunner.ts
@@ -46,6 +46,7 @@ import {
   Timeout,
   TransportUnavailable,
 } from "../../errors/index.js";
+import { emitTransportCall } from "../../logging/transportCall.js";
 
 // ---------------------------------------------------------------------------
 // Spawner seam (injectable for tests)
@@ -149,7 +150,17 @@ export async function runOmniJsScript<T = unknown>(
   const scriptName = options.scriptName;
 
   const wrapped = wrapOmniJsForJxa(omniJsScriptBody, argsJson);
+  const startedAt = performance.now();
   const result = await spawner(wrapped, argsJson, timeoutMs);
+  const durationMs = Math.round(performance.now() - startedAt);
+  const outcome: "ok" | "error" =
+    result.spawnError !== undefined ||
+    result.timedOut ||
+    result.exitCode !== 0 ||
+    result.stdout.trim() === ""
+      ? "error"
+      : "ok";
+  emitTransportCall("omnijs", scriptName, args, durationMs, outcome);
 
   // 1. Spawn failure (binary missing) — the transport itself is unavailable.
   if (result.spawnError !== undefined) {

--- a/src/logging/transportCall.test.ts
+++ b/src/logging/transportCall.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the `transport.call` event emitted by the JXA + OmniJS script
+ * runners (#313). Goldilocks coverage: hash stability, success path on
+ * each runner, and error path (exitCode !== 0) on the JXA runner — enough
+ * to prove the seam is wired and the outcome classification is correct
+ * without re-testing every error branch in the runner.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runJxaScript } from "../adapter/jxa/scriptRunner.js";
+import { runOmniJsScript } from "../adapter/omnijs/scriptRunner.js";
+import { withCorrelationId } from "./correlation.js";
+import { setLogLevel } from "./logger.js";
+import { hashArgs } from "./transportCall.js";
+
+// `transport.call` is a debug-level event (PII protection per DESIGN §21).
+// Force the singleton logger to debug for the duration of this suite so the
+// events surface; restore to info (the singleton's default) on teardown.
+beforeEach(() => {
+  setLogLevel("debug");
+});
+afterEach(() => {
+  setLogLevel("info");
+});
+
+interface CapturedLine {
+  level: string;
+  event: string;
+  transport?: string;
+  scriptName?: string;
+  argsHash?: string;
+  outcome?: string;
+  durationMs?: number;
+  correlationId?: string;
+}
+
+function captureLogs() {
+  const lines: CapturedLine[] = [];
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    const text = typeof chunk === "string" ? chunk : (chunk as Buffer).toString("utf-8");
+    for (const raw of text.split("\n")) {
+      if (!raw) continue;
+      try {
+        const parsed = JSON.parse(raw) as CapturedLine;
+        if (parsed.event === "transport.call") lines.push(parsed);
+      } catch {
+        /* not JSON — ignore */
+      }
+    }
+    return true;
+  });
+  return { lines, restore: () => spy.mockRestore() };
+}
+
+describe("hashArgs", () => {
+  it("hashes plain objects deterministically regardless of key order", () => {
+    expect(hashArgs({ a: 1, b: 2 })).toBe(hashArgs({ b: 2, a: 1 }));
+  });
+
+  it("distinguishes different values", () => {
+    expect(hashArgs({ a: 1 })).not.toBe(hashArgs({ a: 2 }));
+  });
+});
+
+describe("runJxaScript transport.call event", () => {
+  let cap: ReturnType<typeof captureLogs>;
+
+  beforeEach(() => {
+    cap = captureLogs();
+  });
+  afterEach(() => {
+    cap.restore();
+  });
+
+  it("emits exactly one transport.call event with outcome ok on a clean exit", async () => {
+    await withCorrelationId(
+      () =>
+        runJxaScript(
+          "function run(){return JSON.stringify({ok:true});}",
+          { foo: 1 },
+          {
+            scriptName: "test_script",
+            spawner: async () => ({
+              stdout: '{"ok":true}',
+              stderr: "",
+              exitCode: 0,
+              timedOut: false,
+            }),
+          },
+        ),
+      "01J0000000000000000000ABCD",
+    );
+
+    expect(cap.lines).toHaveLength(1);
+    const [evt] = cap.lines;
+    expect(evt?.transport).toBe("jxa");
+    expect(evt?.scriptName).toBe("test_script");
+    expect(evt?.outcome).toBe("ok");
+    expect(evt?.argsHash).toBe(hashArgs({ foo: 1 }));
+    expect(evt?.correlationId).toBe("01J0000000000000000000ABCD");
+    expect(typeof evt?.durationMs).toBe("number");
+  });
+
+  it("emits outcome=error when the script exits non-zero", async () => {
+    await expect(
+      runJxaScript(
+        "function run(){throw 'boom';}",
+        { x: 1 },
+        {
+          scriptName: "broken",
+          spawner: async () => ({
+            stdout: "",
+            stderr: "execution error",
+            exitCode: 1,
+            timedOut: false,
+          }),
+        },
+      ),
+    ).rejects.toThrow();
+
+    const evt = cap.lines.find((l) => l.scriptName === "broken");
+    expect(evt?.transport).toBe("jxa");
+    expect(evt?.outcome).toBe("error");
+  });
+});
+
+describe("runOmniJsScript transport.call event", () => {
+  let cap: ReturnType<typeof captureLogs>;
+
+  beforeEach(() => {
+    cap = captureLogs();
+  });
+  afterEach(() => {
+    cap.restore();
+  });
+
+  it("emits exactly one transport.call event with transport=omnijs on a clean exit", async () => {
+    await runOmniJsScript(
+      "(()=>JSON.stringify({ok:true}))()",
+      { y: 2 },
+      {
+        scriptName: "omnijs_test",
+        spawner: async () => ({
+          stdout: '{"ok":true}',
+          stderr: "",
+          exitCode: 0,
+          timedOut: false,
+        }),
+      },
+    );
+
+    expect(cap.lines).toHaveLength(1);
+    const [evt] = cap.lines;
+    expect(evt?.transport).toBe("omnijs");
+    expect(evt?.scriptName).toBe("omnijs_test");
+    expect(evt?.outcome).toBe("ok");
+    expect(evt?.argsHash).toBe(hashArgs({ y: 2 }));
+  });
+});

--- a/src/logging/transportCall.ts
+++ b/src/logging/transportCall.ts
@@ -1,0 +1,64 @@
+/**
+ * `transport.call` event helper (#313).
+ *
+ * Emits one structured event per JXA / OmniJS script invocation at `debug`
+ * level. Fired by `runJxaScript` and `runOmniJsScript` after the spawner
+ * resolves (success or failure) so the duration captures the real spawn-and-
+ * exec cost, not just the side of the call that succeeded.
+ *
+ * Event shape:
+ *   {
+ *     event: "transport.call",
+ *     transport: "jxa" | "omnijs",
+ *     scriptName: string | undefined,
+ *     argsHash: string,        // sha1 prefix of stable JSON
+ *     durationMs: number,
+ *     outcome: "ok" | "error",
+ *     correlationId?: string,  // from the surrounding withCorrelationId scope
+ *   }
+ *
+ * `argsHash` lets operators correlate identical calls without leaking the
+ * args themselves — task names and notes stay out of the high-level log
+ * channel per DESIGN §21 (PII redaction at info+).
+ *
+ * @see DESIGN.md §21 — observability contract (transport.call)
+ * @see src/loopDetector/LoopDetector.ts — same hashing convention
+ */
+
+import { createHash } from "node:crypto";
+import { getCorrelationId } from "./correlation.js";
+import { logger } from "./logger.js";
+
+/** Stable sha1-prefix hash of any JSON-serialisable args object. */
+export function hashArgs(args: unknown): string {
+  // Sort top-level keys when args is a plain object so `{a:1,b:2}` and
+  // `{b:2,a:1}` collapse to the same hash. Non-objects (primitives, arrays,
+  // null) serialize as-is.
+  const isPlainObject = typeof args === "object" && args !== null && !Array.isArray(args);
+  const serialized = isPlainObject
+    ? JSON.stringify(args, Object.keys(args as object).sort())
+    : JSON.stringify(args ?? null);
+  return createHash("sha1").update(serialized).digest("hex").slice(0, 16);
+}
+
+/** Emit a single `transport.call` event at debug level. */
+export function emitTransportCall(
+  transport: "jxa" | "omnijs",
+  scriptName: string | undefined,
+  args: unknown,
+  durationMs: number,
+  outcome: "ok" | "error",
+): void {
+  logger.debug(
+    {
+      event: "transport.call",
+      transport,
+      scriptName,
+      argsHash: hashArgs(args),
+      durationMs,
+      outcome,
+      correlationId: getCorrelationId(),
+    },
+    "transport call",
+  );
+}


### PR DESCRIPTION
## Summary
- Both script runners now emit one `transport.call` debug event per invocation: `{ event, transport, scriptName, argsHash, durationMs, outcome, correlationId }`.
- `argsHash` reuses the sorted-JSON sha1-prefix convention from LoopDetector — operators can correlate identical calls without args content leaking on the wire.
- `correlationId` flows from the per-tool `withCorrelationId` scope (#283) so transport hops link back to the originating tool call.

Closes #313.

## Issue
Implements [#313](https://github.com/torsday/omnifocus-mcp/issues/313) — third item on the DESIGN §21 observability contract after #283 (tool.invoked/tool.error). Cache-invalidated events live in #314.

## Breaking change?
- [x] No — additive; existing event taxonomy unchanged.

## Test plan
- [x] `pnpm test src/logging/transportCall.test.ts` — 5/5 (hash stability, JXA ok+error, OmniJS ok)
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` — green; bundle 398.07 KB
- [x] `OMNIFOCUS_E2E=1 pnpm test tests/e2e/smoke.test.ts` — 4/4 (envelope round-trip unchanged)
- [x] Self-reviewed via /review-pr
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)