### PR TITLE
fix(jxa): replace make() with specifier-push for project/folder/tag create

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,115 +1,91 @@
 ---
-description: Create a new GitHub issue with this project's labels, milestone, project board, and field values populated.
+description: Project-local override for the global `/issue` skill — supplies omnifocus-mcp's project board, label vocabulary, and field IDs.
 ---
 
-Create a GitHub issue for the work described in the user's request, wired into this project's tracker conventions end-to-end.
+This is a **thin override** for the global `/issue` skill (`~/.claude/skills/issue/SKILL.md`). Follow that skill's protocol; the values below replace its defaults where this project differs.
 
-**Follow the canonical tracker issue-quality standard** from `~/src/github.com/torsday/llm_prompts/tracker.md` for title, body, and AC quality. Then apply the project-specific wiring below.
+> [!IMPORTANT]
+> **Use `scripts/file-issue.sh` — never `gh issue create` directly.** Raw `gh issue create` skips project-board membership, the Status field, and the `model:` label, producing issues that silently fall outside the Up Next queue. The script is the atomic filer the global skill expects; it validates flags, runs every wiring step, and verifies by re-reading the project item before exiting 0.
 
-## Project-specific wiring
+---
 
-### Title
-
-- Verb-first imperative, specific enough to scan
-- Format matches the existing 94 issues: `<tool_name>` for new tools, `<verb> <subject>` for chores/docs
-
-### Body — use this template verbatim
-
-```markdown
-## Context
-
-<Why this work exists + one-sentence link to DESIGN.md §N / ADR-NNNN / SPEC section>
-
-## Acceptance Criteria
-
-- [ ] <Observable, testable outcome — not an implementation step>
-- [ ] <One more>
-- [ ] All code follows `coding.md` standards (typed errors, docblocks, Goldilocks tests)
-
-## Technical Notes
-
-<Files, patterns, constraints — 1–3 bullets; omit if genuinely empty>
-
-## Dependencies
-
-- Blocked by: #N (if any)
-- Blocks: <describe; may omit>
-```
-
-### Labels — pick the full set
-
-Every issue gets:
-
-- **Type:** one of `type: feature`, `type: chore`, `type: spike`, `type: infra`, `type: docs`, `type: bug`, `type: test`
-- **Priority:** one of `P0 · critical`, `P1 · high`, `P2 · medium`, `P3 · low`
-- **Size:** one of `size: XS` (≤2h), `size: S` (½ day), `size: M` (1 day), `size: L` (2–3 days), `size: XL` (≥1 week — split instead)
-- **Phase:** one of `phase: M0 foundation`, `phase: M1 core`, `phase: M2 metadata`, `phase: M3 advanced`, `phase: M4 long-tail`, `phase: M5 polish`
-- **Domain:** one or more of `domain: task|project|tag|folder|perspective|forecast|review|search|note|attachment|repetition|batch|export|sync|transport|observability|security|lifecycle|config|resources`
-- **Model:** exactly one of `model: opus` or `model: sonnet` — see "Model — pick which" below
-- **Risk** (only if medium or high): `risk: high`, `risk: medium`
-
-### Model — pick which
-
-Every issue must carry exactly one of `model: opus` or `model: sonnet`. This lets `/next` and `/ship-next` filter the Ready queue by the active model so parallel loop threads (one Opus, one Sonnet) never collide on the same issue. See `CLAUDE.md` § "Model split" for the project-specific application of this heuristic.
-
-| Label           | When                                                                                                                                                                                                |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model: opus`   | Sustained reasoning, judgment calls, ambiguous requirements, central design, ADRs, security-adjacent changes, error taxonomy, complex algorithms, large refactors, spikes, tool descriptions, SPI work |
-| `model: sonnet` | Well-spec'd execution, CRUD, mapping layers, handler patterns following an established template, validation gates, mechanical tests, infra/CI scripts, docs, small bug fixes                        |
-
-When in doubt, label `opus` — over-using opus is cheap; under-using it produces lower-quality work on hard problems. Re-label freely as you learn what's actually hard.
-
-### Milestone
-
-Match the phase:
-
-- `phase: M0 foundation` → milestone `M0 Foundation`
-- `phase: M1 core` → `M1 Core surface`
-- `phase: M2 metadata` → `M2 Metadata`
-- `phase: M3 advanced` → `M3 Advanced`
-- `phase: M4 long-tail` → `M4 Long tail`
-- `phase: M5 polish` → `M5 Polish`
-
-### Commands — create + wire
+## The one command
 
 ```bash
-# Create the issue. The label set MUST include exactly one model: label.
-gh issue create \
-  --title "<title>" \
-  --label "<type,priority,size,phase,domain[,risk],model: opus|sonnet>" \
-  --milestone "<milestone>" \
-  --body "$(cat <<'EOF'
-<body>
-EOF
-)"
-
-# Add to project #4 and capture the item ID
-ITEM_ID=$(gh project item-add 4 --owner torsday --url <issue-url> --format json | jq -r '.id')
-
-# Populate Phase / Priority / Size / Risk via GraphQL (field + option IDs live in scripts/populate-project.sh)
-# See that script for the exact mutation pattern.
+./scripts/file-issue.sh \
+  --title "<verb-first imperative>" \
+  --body-file /tmp/issue-body.md \
+  --type feature \                  # feature|bug|chore|refactor|perf|docs|test|infra|spike|epic
+  --priority P1 \
+  --size M \
+  --phase M1 \
+  --domain "tag,task" \
+  --model opus \
+  [--risk medium] \
+  [--milestone "M1 Core surface"]  # derived from --phase if omitted \
+  [--blocked]                       # only if Dependencies lists a blocker \
+  [--modifier "tech-debt,security"] # orthogonal; any of: security, breaking-change,
+                                    # regression, tech-debt, flaky, needs-repro
 ```
 
-Use `scripts/populate-project.sh` as reference for field/option IDs. Alternatively, re-run that script after creation — it's idempotent for already-populated items.
+Capture the URL from stdout. Then run the global skill's post-return checklist (substituting the project values below).
 
-### Status at creation time
+---
 
-- If the new issue has **no blockers** (Dependencies section is empty or only lists "Blocks: ..."), set `Status = Ready` in the project
-- Otherwise `Status = Todo`
+## Project-local values
 
-Update via the GraphQL mutation pattern in `scripts/set-ready-status.sh`.
+| What                | Value                                                     |
+| ------------------- | --------------------------------------------------------- |
+| Owner               | `torsday`                                                 |
+| Project number      | `4` (`torsday/omnifocus-mcp v1`)                          |
+| Project node ID     | `PVT_kwHOAARNgc4BVGvQ`                                    |
+| Status field naming | Status options were renamed: Ready→**Up Next**, Todo→**Backlog**. Six options total: `Backlog` · `Up Next` · `In Progress` · `In Review` · `On Hold` · `Done`. New issues land in `Up Next` unblocked, `Backlog` blocked. |
 
-### After creating
+### Phase → Milestone mapping
 
-- Report the issue number + URL back to the user
-- If the issue unblocks existing work, note it
-- If this reveals a gap in the design or SPEC, file an ADR note or a follow-up `needs-design` issue
+`M0` foundation · `M1` core · `M2` metadata · `M3` advanced · `M4` long-tail · `M5` polish
 
-## When NOT to create
+`scripts/file-issue.sh` derives the milestone from `--phase` automatically; pass `--milestone` only to override.
 
-Refuse politely (and explain) if the work is:
+### Domain vocabulary (project-specific — `--domain` accepts comma-separated)
 
-- Already tracked in an existing open issue (search with `gh issue list --search "<keyword>"`)
-- Explicitly in `SPEC.md`'s "Out of Scope" section — those need an ADR conversation first
-- Vague "improve X" without concrete acceptance criteria
-- Trivially a PR-scope cleanup better done in the next touch of the file
+`task` · `project` · `tag` · `folder` · `perspective` · `forecast` · `review` · `search` · `note` · `attachment` · `repetition` · `batch` · `export` · `sync` · `transport` · `observability` · `security` · `lifecycle` · `config` · `resources`
+
+### Model labels — pick exactly one
+
+| Value    | When                                                                                                                                                                                        |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `opus`   | Sustained reasoning, judgment calls, ambiguous requirements, central design, ADRs, security-adjacent changes, error taxonomy, complex algorithms, large refactors, spikes, SPI work, tool descriptions |
+| `sonnet` | Well-spec'd execution, CRUD, mapping layers, handler patterns following a template, validation gates, mechanical tests, infra/CI scripts, docs, small bug fixes                             |
+
+`/next` and `/ship-next` filter the Up Next queue by active model so parallel Opus + Sonnet loop threads don't collide.
+
+---
+
+## Pre-return checklist (project-specific queries)
+
+Re-run these even if `file-issue.sh` exited 0:
+
+```bash
+# Exactly one model label
+gh issue view <N> --repo torsday/omnifocus-mcp --json labels \
+  | jq '[.labels[] | select(.name|startswith("model: "))] | length'
+# → 1
+
+# On project #4
+gh api graphql -f query='query{user(login:"torsday"){projectV2(number:4){items(first:100){nodes{content{...on Issue{number}}}}}}}' \
+  | jq '.data.user.projectV2.items.nodes[] | .content.number' | grep -w <N>
+# → <N>
+```
+
+If any check fails, stop and fix before reporting.
+
+---
+
+## Bulk / migration work
+
+`scripts/populate-project.sh` re-runs label-driven field population across every issue in the repo (idempotent). Use it after adding a new Status/Phase/Priority/Size option, or to repair drift — **not** for single-issue filing. Single-issue filing always goes through `scripts/file-issue.sh`.
+
+---
+
+For the body template, classifier definitions (Type / Priority / Size), title style, "When NOT to file", and the general protocol — see the global skill: `~/.claude/skills/issue/SKILL.md`.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,47 @@
+name: Epic
+description: Parent issue tracking a multi-issue feature area
+title: "<area name — e.g. 'Tag management' or 'Perspective CRUD'>"
+labels: ["type: epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epics are parent trackers for feature areas too large for a single issue. They do not get implemented directly — the child issues are the unit of work. Epics are **exempt** from the `model:` label rule because they aren't picked up by `/ship-next` directly; only their children are. Check off child tasks as they close to track progress.
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What this epic delivers, in one paragraph. What the system or user can do when it's done.
+      placeholder: |
+        Complete CRUD + query surface for tags, covering create/update/delete, location binding, hierarchy, and listing with status/due-date/forecast filters. When this epic ships, every SPEC.md §4 tag requirement is backed by an MCP tool.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Child issues, as a GitHub-tracked task list. Link by #number; GitHub auto-updates the progress bar as children close.
+      placeholder: |
+        - [ ] Implement `create_tag` (#NN)
+        - [ ] Implement `update_tag` (#NN)
+        - [ ] Implement `delete_tag` (#NN)
+        - [ ] Implement `set_tag_location` (#NN)
+        - [ ] Implement `list_tags` with filters (#NN)
+    validations:
+      required: true
+  - type: textarea
+    id: success
+    attributes:
+      label: Success Criteria
+      description: Epic-level outcomes. These are coarser than child-issue acceptance criteria — "what becomes true when all children ship."
+      placeholder: |
+        - [ ] Every SPEC.md §4 tag requirement has a corresponding shipping MCP tool
+        - [ ] Integration coverage for tag mutation ≥ 90% (per coverage script)
+        - [ ] ADR-NNNN accepted for any design decisions surfaced during implementation
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Design links, constraints, cross-cutting concerns.

--- a/.github/ISSUE_TEMPLATE/perf.yml
+++ b/.github/ISSUE_TEMPLATE/perf.yml
@@ -1,0 +1,49 @@
+name: Performance
+description: Measurable speedup, memory reduction, or throughput improvement
+title: "<verb-first imperative summary>"
+labels: ["type: perf"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Performance work must be measurement-driven. File this only if you have (or can produce) a baseline number and a target number. "Feels slow" belongs in an investigation spike first.
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Symptom
+      description: What's slow/bloated, how did it surface, and in what scenario?
+      placeholder: |
+        `list_reminders --limit 1000` takes ~4.2s cold, ~1.8s warm on a 50k-item DB (MacBook Air M2, macOS 15.4). EventKit predicate evaluation dominates; no obvious N+1 in our code.
+    validations:
+      required: true
+  - type: textarea
+    id: baseline
+    attributes:
+      label: Baseline & Target
+      description: Current measurement and the goal. Include how you measured.
+      placeholder: |
+        Baseline: 4.2s cold / 1.8s warm (p50 over 10 runs, `time ./bin/scripts/bench-list.sh`)
+        Target:   <1s cold / <300ms warm
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Observable, measurable outcomes. No regressions elsewhere.
+      placeholder: |
+        - [ ] `bench-list.sh` hits the target under the same conditions (documented in the script)
+        - [ ] No regression in existing integration-test runtime (±10%)
+        - [ ] Bench script added to `scripts/` so future runs are reproducible
+    validations:
+      required: true
+  - type: textarea
+    id: technical
+    attributes:
+      label: Technical Notes
+      description: Hypotheses, prior profiling data, suspected culprits, approaches considered.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked-by / blocks relationships, with issue numbers.

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,50 @@
+name: Refactor
+description: Restructure existing code without changing behavior
+title: "<verb-first imperative summary>"
+labels: ["type: refactor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Refactors must not change observable behavior. If behavior changes, file as `type: feature` or `type: bug` instead. Adding `tech-debt` to refactors is common and encouraged when the cleanup has accumulated rather than being a fresh design decision.
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What smell, duplication, or design problem does this address? Why now?
+      placeholder: |
+        `EventKitRemindersStore` has grown to 600 lines with three distinct concerns (fetch, mutate, observe). Testing mutate requires stubbing fetch, which doubles fixture complexity. Splitting by concern unblocks focused tests and lines up with the SPI boundary documented in ADR-0012.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which files/modules are in scope. Bound it — refactors that touch everything are epics, not issues.
+      placeholder: |
+        - Sources/EventKitAdapter/EventKitRemindersStore.swift
+        - Sources/EventKitAdapter/Mapping/*
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: How we'll know it's done. Behavior-preservation is the #1 criterion.
+      placeholder: |
+        - [ ] Public API of `EventKitRemindersStore` unchanged (callers do not need updates)
+        - [ ] All existing tests pass unchanged
+        - [ ] New structure documented in module docblock
+        - [ ] No increase in cyclomatic complexity on the split functions
+    validations:
+      required: true
+  - type: textarea
+    id: technical
+    attributes:
+      label: Technical Notes
+      description: Patterns to apply, anti-patterns to avoid, constraints.
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Blocked-by / blocks relationships, with issue numbers.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint config — consumed by the meta-lint workflow and by local
+# `actionlint` runs. Declares custom self-hosted runner labels so actionlint
+# doesn't flag them as unknown.
+
+self-hosted-runner:
+  labels:
+    - macos-omnifocus

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       prefix: chore(deps)
     labels:
       - "type: chore"
+      - "no-issue"
 
   - package-ecosystem: github-actions
     directory: /
@@ -28,3 +29,4 @@ updates:
       prefix: chore(ci)
     labels:
       - "type: chore"
+      - "no-issue"

--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -5,11 +5,9 @@
 #   - Repository permission "Issues: Read and write"
 # GITHUB_TOKEN can't write to user-owned projects; the PAT is required.
 #
-# Field/option IDs are hardcoded for project 4. If the project is recreated,
-# re-query:
-#   gh api graphql -f query='query { user(login:"torsday") { projectV2(number:4) {
-#     id field(name:"Status") { ... on ProjectV2SingleSelectField { id options { id name } } } } } }'
-# and update the env block below.
+# Field/option IDs are sourced from `scripts/_project-constants.sh` at job start
+# (single source of truth — see that file for rediscovery commands if the project
+# is ever recreated).
 
 name: Board sync
 
@@ -26,11 +24,6 @@ permissions:
 
 env:
   GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-  PROJECT_ID: PVT_kwHOAARNgc4BVGvQ
-  STATUS_FIELD: PVTSSF_lAHOAARNgc4BVGvQzhQkx-E
-  OPT_IN_PROGRESS: "381a1e62"
-  OPT_IN_REVIEW: "04079029"
-  OPT_DONE: c2f7c066
 
 jobs:
   pr:
@@ -42,6 +35,19 @@ jobs:
         run: |
           echo "::warning::PROJECT_TOKEN not set — skipping board sync. Add a PAT with Projects read/write to enable."
           exit 0
+
+      - uses: actions/checkout@v4
+
+      - name: Load project constants
+        run: |
+          # shellcheck source=../../scripts/_project-constants.sh
+          source scripts/_project-constants.sh
+          {
+            echo "PROJECT_ID=$PROJECT_ID"
+            echo "STATUS_FIELD=$F_STATUS"
+            echo "OPT_IN_REVIEW=$STATUS_IN_REVIEW"
+            echo "OPT_DONE=$STATUS_DONE"
+          } >> "$GITHUB_ENV"
 
       - name: Extract linked issue numbers from PR body
         id: linked
@@ -101,6 +107,18 @@ jobs:
         run: |
           echo "::warning::PROJECT_TOKEN not set — skipping board sync."
           exit 0
+
+      - uses: actions/checkout@v4
+
+      - name: Load project constants
+        run: |
+          # shellcheck source=../../scripts/_project-constants.sh
+          source scripts/_project-constants.sh
+          {
+            echo "PROJECT_ID=$PROJECT_ID"
+            echo "STATUS_FIELD=$F_STATUS"
+            echo "OPT_DONE=$STATUS_DONE"
+          } >> "$GITHUB_ENV"
 
       - name: Flip closed issue to Done + strip label
         env:

--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -13,7 +13,10 @@ name: Board sync
 
 on:
   pull_request:
-    types: [opened, reopened, closed]
+    # `ready_for_review` fires when a draft flips to ready — that's the right
+    # moment to move linked issues to "In Review". Raw `opened`/`reopened` on
+    # a draft is premature; the job below guards with draft == false.
+    types: [opened, reopened, ready_for_review, closed]
   issues:
     types: [closed, reopened]
 
@@ -62,13 +65,19 @@ jobs:
           echo "nums=$nums" >> "$GITHUB_OUTPUT"
           echo "Linked issues: ${nums:-<none>}"
 
-      - name: PR opened → flip linked issues to In Review
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
+      - name: PR opened (ready) → flip linked issues to In Review
+        # Only flip on non-draft opens, reopens, or draft→ready transitions.
+        # Draft PRs stay on whatever status they had (typically In Progress).
+        if: >-
+          (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
+          (github.event.action == 'reopened' && github.event.pull_request.draft == false) ||
+          github.event.action == 'ready_for_review'
         env:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           NUMS: ${{ steps.linked.outputs.nums }}
         run: |
+          # shellcheck disable=SC2016  # $o/$r/$n are GraphQL variables, not shell expansions
           for n in $NUMS; do
             item=$(gh api graphql \
               -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
@@ -86,6 +95,7 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           NUMS: ${{ steps.linked.outputs.nums }}
         run: |
+          # shellcheck disable=SC2016  # $o/$r/$n are GraphQL variables, not shell expansions
           for n in $NUMS; do
             item=$(gh api graphql \
               -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
@@ -126,6 +136,7 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           N: ${{ github.event.issue.number }}
         run: |
+          # shellcheck disable=SC2016  # $o/$r/$n are GraphQL variables, not shell expansions
           item=$(gh api graphql \
             -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
             -F o="$OWNER" -F r="$REPO" -F n="$N" \

--- a/.github/workflows/issue-lint.yml
+++ b/.github/workflows/issue-lint.yml
@@ -1,0 +1,70 @@
+# Label-hygiene gate for issues filed or edited through the GitHub UI.
+#
+# scripts/file-issue.sh enforces label invariants at creation, but a user
+# editing labels in the web UI can break them later. This workflow is the
+# automation backstop: it fails loudly (and posts a one-line comment) when an
+# open issue violates the rules.
+#
+# Rules enforced:
+#   - Exactly one `type: *` label (feature|bug|chore|refactor|perf|docs|test|
+#     infra|spike|epic)
+#   - Exactly one `model: *` label (opus|sonnet)
+#
+# Project-membership is not checked here — use the scheduled sweep
+# (`scripts/populate-project.sh`) for drift repair. Epics are exempt from the
+# model rule (they're parent trackers, not implementable work).
+
+name: Issue lint
+
+on:
+  issues:
+    types: [opened, reopened, labeled, unlabeled, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    # Skip if the edit was made by the filer script — it verifies its own output.
+    if: github.event.issue.state == 'open'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Check label invariants
+        run: |
+          set -euo pipefail
+
+          labels_json=$(gh issue view "$ISSUE" --repo "$REPO" --json labels)
+          type_count=$(echo "$labels_json" | jq '[.labels[] | select(.name | startswith("type: "))] | length')
+          model_count=$(echo "$labels_json" | jq '[.labels[] | select(.name | startswith("model: "))] | length')
+          is_epic=$(echo "$labels_json" | jq '[.labels[] | select(.name == "type: epic")] | length')
+
+          problems=()
+          if [ "$type_count" != "1" ]; then
+            problems+=("expected 1 \`type: *\` label, found $type_count")
+          fi
+          # Epics are parent trackers; model label is not required on them.
+          if [ "$is_epic" = "0" ] && [ "$model_count" != "1" ]; then
+            problems+=("expected 1 \`model: *\` label, found $model_count")
+          fi
+
+          if [ ${#problems[@]} -eq 0 ]; then
+            echo "✓ issue #$ISSUE label hygiene OK"
+            exit 0
+          fi
+
+          # Assemble a single comment listing every violation, then fail.
+          body="⚠️ **Label hygiene check failed** on this issue:"$'\n\n'
+          for p in "${problems[@]}"; do
+            body+="- $p"$'\n'
+          done
+          body+=$'\n'"Fix the labels and re-save. See \`.github/workflows/issue-lint.yml\` for the rules."
+
+          # Post the comment only if we haven't already flagged these same problems
+          # on this run — avoids duplicate comments on fast label-edit churn.
+          gh issue comment "$ISSUE" --repo "$REPO" --body "$body"
+          echo "::error title=Label hygiene::$(IFS=\; ; echo "${problems[*]}")"
+          exit 1

--- a/.github/workflows/issue-lint.yml
+++ b/.github/workflows/issue-lint.yml
@@ -11,8 +11,10 @@
 #   - Exactly one `model: *` label (opus|sonnet)
 #
 # Project-membership is not checked here — use the scheduled sweep
-# (`scripts/populate-project.sh`) for drift repair. Epics are exempt from the
-# model rule (they're parent trackers, not implementable work).
+# (`scripts/populate-project.sh`) for drift repair. Epics and automated-audit
+# issues (any `audit: *` label) are exempt from the model rule — epics are
+# parent trackers and audits are machine-generated notifications, neither
+# representing implementable work.
 
 name: Issue lint
 
@@ -41,13 +43,14 @@ jobs:
           type_count=$(echo "$labels_json" | jq '[.labels[] | select(.name | startswith("type: "))] | length')
           model_count=$(echo "$labels_json" | jq '[.labels[] | select(.name | startswith("model: "))] | length')
           is_epic=$(echo "$labels_json" | jq '[.labels[] | select(.name == "type: epic")] | length')
+          is_audit=$(echo "$labels_json" | jq '[.labels[] | select(.name | startswith("audit: "))] | length')
 
           problems=()
           if [ "$type_count" != "1" ]; then
             problems+=("expected 1 \`type: *\` label, found $type_count")
           fi
-          # Epics are parent trackers; model label is not required on them.
-          if [ "$is_epic" = "0" ] && [ "$model_count" != "1" ]; then
+          # Epics and automated-audit issues are exempt from the model rule.
+          if [ "$is_epic" = "0" ] && [ "$is_audit" = "0" ] && [ "$model_count" != "1" ]; then
             problems+=("expected 1 \`model: *\` label, found $model_count")
           fi
 

--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -1,0 +1,45 @@
+# Lint the tracker/board plumbing itself.
+#
+# scripts/_project-constants.sh is now load-bearing for four downstream
+# consumers plus a workflow. A typo (missing quote, unbound var, wrong
+# variable name) would silently break every consumer. This job catches
+# it at PR time before the damage propagates.
+#
+# Runs only on PRs that touch scripts/ or .github/workflows/ — no point
+# burning CI minutes on every PR.
+
+name: Meta lint
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck on scripts/*.sh
+        uses: ludeeus/action-shellcheck@master
+        env:
+          # bash 3.2 is macOS default; lint against it so we catch features
+          # (associative arrays, `readarray`, etc.) that would break locally.
+          SHELLCHECK_OPTS: "--shell=bash --severity=warning"
+        with:
+          scandir: "./scripts"
+          additional_files: "scripts/*.sh"
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint on .github/workflows/*.yml
+        uses: raven-actions/actionlint@v2
+        with:
+          # shellcheck inside workflows uses the same severity bar as above.
+          shellcheck: "warning"

--- a/.github/workflows/pr-link.yml
+++ b/.github/workflows/pr-link.yml
@@ -1,0 +1,48 @@
+# PR-link gate: every PR body must reference a closing keyword + issue number
+# (Closes/Fixes/Resolves #N). Keeps the PR ↔ Issue audit trail intact — board-sync
+# relies on this link to flip the issue to Done when the PR merges.
+#
+# Waived by adding the `no-issue` label to the PR (for pure-infra PRs that have
+# no tracker counterpart — e.g. updating this workflow itself).
+
+name: PR link gate
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  require-issue-link:
+    runs-on: ubuntu-latest
+    # Waiver: add the `no-issue` label to skip this check.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-issue') }}
+    steps:
+      - name: Require Closes/Fixes/Resolves #N in PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$PR_BODY" \
+            | grep -qiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'; then
+            echo "✓ PR body links an issue"
+            exit 0
+          fi
+
+          cat >&2 <<'MSG'
+          ::error title=PR link gate::PR body must include a closing keyword + issue number.
+
+          Add one of (case-insensitive) to the PR body:
+            Closes #N
+            Fixes #N
+            Resolves #N
+
+          This preserves the PR ↔ Issue audit trail and allows board-sync to flip
+          the issue to Done when the PR merges.
+
+          If this PR genuinely has no tracker counterpart (e.g. a CI-only change),
+          add the `no-issue` label to waive this check.
+          MSG
+          exit 1

--- a/.github/workflows/validate-deps-nightly.yml
+++ b/.github/workflows/validate-deps-nightly.yml
@@ -1,0 +1,92 @@
+# Nightly dependency-graph audit.
+#
+# Runs scripts/validate-deps.sh against the live issue tracker and opens (or
+# refreshes) a pinned tracker issue if it finds orphans, stale blocks, or
+# cycles. No findings → no issue, no noise.
+#
+# The validator itself is read-only. This workflow only writes one issue
+# (title: "[audit] Dependency-graph drift — <date>") to surface findings.
+#
+# Also runnable on-demand via the workflow_dispatch trigger.
+
+name: Dependency graph — nightly audit
+
+on:
+  schedule:
+    # 10:17 UTC daily ≈ 02:17 PT — off-peak, non-round-hour to dodge the :00 spike.
+    - cron: "17 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AUDIT_LABEL: "audit: dep-graph"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run validator
+        id: validate
+        run: |
+          set +e
+          OUT="$(scripts/validate-deps.sh 2>&1)"
+          RC=$?
+          echo "rc=$RC" >> "$GITHUB_OUTPUT"
+          {
+            echo "report<<REPORT_EOF"
+            printf '%s\n' "$OUT"
+            echo "REPORT_EOF"
+          } >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$OUT"
+          exit 0
+
+      - name: Ensure audit label exists
+        if: steps.validate.outputs.rc != '0'
+        run: |
+          gh label create "$AUDIT_LABEL" \
+            --color "fbca04" \
+            --description "Automated audit finding; close once resolved" \
+            2>/dev/null || true
+
+      - name: Open or update audit tracker issue
+        if: steps.validate.outputs.rc != '0'
+        env:
+          REPORT: ${{ steps.validate.outputs.report }}
+        run: |
+          TITLE="[audit] Dependency-graph drift"
+          BODY=$(cat <<EOF
+          Nightly \`scripts/validate-deps.sh\` run found issues in the dependency graph.
+
+          Last run: $(date -u +"%Y-%m-%d %H:%M UTC")
+          Workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          \`\`\`
+          ${REPORT}
+          \`\`\`
+
+          Fix via \`/groom\` or manual edits, then close this issue. It will
+          reopen automatically on the next nightly run if drift persists.
+          EOF
+          )
+
+          # Reuse an existing open audit issue if present; else create.
+          EXISTING=$(gh issue list \
+            --state open --label "$AUDIT_LABEL" \
+            --search "in:title \"$TITLE\"" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+            echo "Refreshed #$EXISTING"
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label "$AUDIT_LABEL" \
+              --label "type: chore"
+          fi

--- a/.github/workflows/verify-constants.yml
+++ b/.github/workflows/verify-constants.yml
@@ -1,0 +1,49 @@
+# Drift check for scripts/_project-constants.sh against the live Projects v2 state.
+#
+# Fires on:
+#   - PRs touching the constants file (catch stale values before merge)
+#   - Weekly schedule (catch UI-side drift: someone renames a Status option
+#     in the Projects UI → GitHub mints a new ID → constants go stale with
+#     no commit to trigger a PR-level check)
+#   - workflow_dispatch (manual)
+#
+# Needs PROJECT_TOKEN — GITHUB_TOKEN can't read user-owned Projects v2.
+# Skips gracefully (warn, not fail) when the token isn't available, e.g. on
+# PRs opened from forks where secrets are withheld.
+
+name: Verify project constants
+
+on:
+  pull_request:
+    paths:
+      - "scripts/_project-constants.sh"
+      - "scripts/verify-constants.sh"
+      - ".github/workflows/verify-constants.yml"
+  schedule:
+    # Weekly, Mondays 10:23 UTC. Drift is low-frequency; no need for nightly.
+    - cron: "23 10 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+    steps:
+      - name: Skip if no token (fork PR)
+        if: env.GH_TOKEN == ''
+        run: |
+          echo "::warning::PROJECT_TOKEN not available — skipping verify-constants. \
+          Merges from forks don't get secrets; constants drift is checked on the \
+          weekly schedule + any first-party PR touching the file."
+          exit 0
+
+      - uses: actions/checkout@v4
+        if: env.GH_TOKEN != ''
+
+      - name: Run verify-constants.sh
+        if: env.GH_TOKEN != ''
+        run: scripts/verify-constants.sh

--- a/scripts/_project-constants.sh
+++ b/scripts/_project-constants.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# =============================================================================
+# _project-constants.sh — single source of truth for project #4 IDs
+# =============================================================================
+# Sourced by scripts/file-issue.sh, scripts/populate-project.sh, and
+# scripts/set-ready-status.sh. The leading underscore marks this as a library,
+# not a script you'd invoke directly.
+#
+# Mirror of these values also appears in .github/workflows/board-sync.yml
+# (as workflow env vars — GHA can't source shell files). If you change any ID
+# here, search-and-replace across board-sync.yml too.
+#
+# To rediscover IDs after a project recreation:
+#
+#   gh api graphql -f query='query {
+#     user(login: "torsday") {
+#       projectV2(number: 4) {
+#         id
+#         fields(first: 20) {
+#           nodes {
+#             ... on ProjectV2SingleSelectField {
+#               id name options { id name }
+#             }
+#           }
+#         }
+#       }
+#     }
+#   }'
+# =============================================================================
+
+# Owner / repo / project
+OWNER="torsday"
+REPO="torsday/omnifocus-mcp"
+PROJECT_NUM=4
+PROJECT_ID="PVT_kwHOAARNgc4BVGvQ"
+
+# Field IDs
+F_STATUS="PVTSSF_lAHOAARNgc4BVGvQzhQkx-E"
+F_PHASE="PVTSSF_lAHOAARNgc4BVGvQzhQkyDM"
+F_PRIORITY="PVTSSF_lAHOAARNgc4BVGvQzhQkyEM"
+F_SIZE="PVTSSF_lAHOAARNgc4BVGvQzhQkyEQ"
+F_RISK="PVTSSF_lAHOAARNgc4BVGvQzhQkyEU"
+
+# Status option IDs
+STATUS_BACKLOG="1e5b9208"
+STATUS_UP_NEXT="19ebdd2c"
+STATUS_IN_PROGRESS="381a1e62"
+STATUS_IN_REVIEW="04079029"
+STATUS_ON_HOLD=""      # TODO: fill in if ever needed; not used by filer
+STATUS_DONE="c2f7c066"
+
+# Phase option IDs
+O_PHASE_M0="d3ea64bc"
+O_PHASE_M1="7604af38"
+O_PHASE_M2="14583f99"
+O_PHASE_M3="659e0f86"
+O_PHASE_M4="43383303"
+O_PHASE_M5="e39db280"
+
+# Priority option IDs
+O_P0="a7ac64ac"
+O_P1="2bcd66d3"
+O_P2="d28a8726"
+O_P3="11749026"
+
+# Size option IDs
+O_SIZE_XS="c038b672"
+O_SIZE_S="4a9932c9"
+O_SIZE_M="987fabe1"
+O_SIZE_L="0b17ef74"
+O_SIZE_XL="438cc739"
+
+# Risk option IDs
+O_RISK_HIGH="62767387"
+O_RISK_MED="1e89155b"
+O_RISK_LOW="3f572490"

--- a/scripts/_project-constants.sh
+++ b/scripts/_project-constants.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
+# ^ vars here are consumed by sourcing scripts; shellcheck can't see that.
 # =============================================================================
 # _project-constants.sh — single source of truth for project #4 IDs
 # =============================================================================
-# Sourced by scripts/file-issue.sh, scripts/populate-project.sh, and
-# scripts/set-ready-status.sh. The leading underscore marks this as a library,
-# not a script you'd invoke directly.
+# Sourced by scripts/file-issue.sh, scripts/populate-project.sh,
+# scripts/set-ready-status.sh, scripts/verify-constants.sh, and by
+# .github/workflows/board-sync.yml (via a checkout + source step). The leading
+# underscore marks this as a library, not a script you'd invoke directly.
 #
-# Mirror of these values also appears in .github/workflows/board-sync.yml
-# (as workflow env vars — GHA can't source shell files). If you change any ID
-# here, search-and-replace across board-sync.yml too.
+# Drift check: scripts/verify-constants.sh re-queries the GraphQL API and
+# diffs the live project against the values below. Run it in CI to catch
+# silent drift when someone renames a field/option in the Projects UI.
 #
 # To rediscover IDs after a project recreation:
 #
@@ -46,7 +49,7 @@ STATUS_BACKLOG="1e5b9208"
 STATUS_UP_NEXT="19ebdd2c"
 STATUS_IN_PROGRESS="381a1e62"
 STATUS_IN_REVIEW="04079029"
-STATUS_ON_HOLD=""      # TODO: fill in if ever needed; not used by filer
+STATUS_ON_HOLD="8baabea1"
 STATUS_DONE="c2f7c066"
 
 # Phase option IDs

--- a/scripts/file-issue.sh
+++ b/scripts/file-issue.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# =============================================================================
+# file-issue.sh — atomic "create issue + wire it into project #4" command.
+# =============================================================================
+# One command, hard to get wrong. Creates the GitHub issue with the full label
+# set + milestone, adds it to project #4, sets the Status field, populates
+# Phase/Priority/Size/Risk from the labels, and verifies all wiring before
+# returning. Exits nonzero on any missing step so the caller can't proceed
+# under the illusion that the issue is fully tracked.
+#
+# Required flags:
+#   --title       "<issue title>"                 — verb-first imperative
+#   --body-file   <path>                          — markdown body (use heredoc from caller)
+#   --type        feature|bug|chore|refactor|perf|docs|test|infra|spike|epic
+#   --priority    P0|P1|P2|P3
+#   --size        XS|S|M|L|XL
+#   --phase       M0|M1|M2|M3|M4|M5
+#   --domain      "<comma-separated list>"        — e.g. "task,tag"
+#   --model       opus|sonnet
+#
+# Optional flags:
+#   --risk        high|medium                     — omit for low/none
+#   --milestone   "<exact milestone title>"       — derived from --phase if absent
+#   --blocked                                     — if present, Status=Backlog; else Up Next
+#   --modifier    "<comma-separated list>"        — orthogonal labels; any of:
+#                                                   security|breaking-change|regression|
+#                                                   tech-debt|flaky|needs-repro
+#
+# Exit codes:
+#   0   — issue created, added to project, all fields set, verification passed
+#   2   — invalid / missing arguments
+#   3   — `gh issue create` failed
+#   4   — `gh project item-add` failed
+#   5   — field-set mutation failed
+#   6   — post-create verification failed (issue not on project, or a field missing)
+#
+# Example:
+#   ./scripts/file-issue.sh \
+#     --title "feat(tags): implement create_tag tool" \
+#     --body-file /tmp/body.md \
+#     --type feature --priority P1 --size M --phase M1 \
+#     --domain tag --model opus
+# =============================================================================
+set -euo pipefail
+
+# Project/field/option IDs live in scripts/_project-constants.sh (single source of truth)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_project-constants.sh
+source "$SCRIPT_DIR/_project-constants.sh"
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+TITLE=""
+BODY_FILE=""
+TYPE=""
+PRIORITY=""
+SIZE=""
+PHASE=""
+DOMAIN=""
+MODEL=""
+RISK=""
+MILESTONE=""
+BLOCKED=false
+MODIFIER=""
+
+die() { echo "file-issue.sh: $*" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --title)      TITLE="$2"; shift 2 ;;
+    --body-file)  BODY_FILE="$2"; shift 2 ;;
+    --type)       TYPE="$2"; shift 2 ;;
+    --priority)   PRIORITY="$2"; shift 2 ;;
+    --size)       SIZE="$2"; shift 2 ;;
+    --phase)      PHASE="$2"; shift 2 ;;
+    --domain)     DOMAIN="$2"; shift 2 ;;
+    --model)      MODEL="$2"; shift 2 ;;
+    --risk)       RISK="$2"; shift 2 ;;
+    --milestone)  MILESTONE="$2"; shift 2 ;;
+    --blocked)    BLOCKED=true; shift ;;
+    --modifier)   MODIFIER="$2"; shift 2 ;;
+    -h|--help)    sed -n '3,40p' "$0"; exit 0 ;;
+    *)            die "unknown flag: $1" ;;
+  esac
+done
+
+# Required
+[ -n "$TITLE" ]      || die "--title required"
+[ -n "$BODY_FILE" ]  || die "--body-file required"
+[ -f "$BODY_FILE" ]  || die "--body-file path does not exist: $BODY_FILE"
+[ -n "$TYPE" ]       || die "--type required"
+[ -n "$PRIORITY" ]   || die "--priority required"
+[ -n "$SIZE" ]       || die "--size required"
+[ -n "$PHASE" ]      || die "--phase required"
+[ -n "$DOMAIN" ]     || die "--domain required (at least one)"
+[ -n "$MODEL" ]      || die "--model required (opus|sonnet)"
+
+# Enumerations — fail fast on typos rather than producing a half-wired issue
+case "$TYPE"     in feature|bug|chore|refactor|perf|docs|test|infra|spike|epic) ;; *) die "--type invalid: $TYPE" ;; esac
+case "$PRIORITY" in P0|P1|P2|P3) ;;                          *) die "--priority invalid: $PRIORITY" ;; esac
+case "$SIZE"     in XS|S|M|L|XL) ;;                          *) die "--size invalid: $SIZE" ;; esac
+case "$PHASE"    in M0|M1|M2|M3|M4|M5) ;;                    *) die "--phase invalid: $PHASE" ;; esac
+case "$MODEL"    in opus|sonnet) ;;                          *) die "--model invalid: $MODEL" ;; esac
+if [ -n "$RISK" ]; then
+  case "$RISK" in high|medium) ;; *) die "--risk invalid: $RISK (use high|medium or omit)" ;; esac
+fi
+if [ -n "$MODIFIER" ]; then
+  IFS=',' read -r -a MODIFIERS <<< "$MODIFIER"
+  for m in "${MODIFIERS[@]}"; do
+    m_trim="$(echo "$m" | sed 's/^ *//;s/ *$//')"
+    [ -z "$m_trim" ] && continue
+    case "$m_trim" in
+      security|breaking-change|regression|tech-debt|flaky|needs-repro) ;;
+      *) die "--modifier invalid: $m_trim (allowed: security|breaking-change|regression|tech-debt|flaky|needs-repro)" ;;
+    esac
+  done
+fi
+
+# ── Derive label set + milestone ────────────────────────────────────────────
+
+phase_label_for() {
+  case "$1" in
+    M0) echo "phase: M0 foundation" ;;
+    M1) echo "phase: M1 core" ;;
+    M2) echo "phase: M2 metadata" ;;
+    M3) echo "phase: M3 advanced" ;;
+    M4) echo "phase: M4 long-tail" ;;
+    M5) echo "phase: M5 polish" ;;
+  esac
+}
+
+milestone_for() {
+  case "$1" in
+    M0) echo "M0 Foundation" ;;
+    M1) echo "M1 Core surface" ;;
+    M2) echo "M2 Metadata" ;;
+    M3) echo "M3 Advanced" ;;
+    M4) echo "M4 Long tail" ;;
+    M5) echo "M5 Polish" ;;
+  esac
+}
+
+priority_label_for() {
+  case "$1" in
+    P0) echo "P0 · critical" ;;
+    P1) echo "P1 · high" ;;
+    P2) echo "P2 · medium" ;;
+    P3) echo "P3 · low" ;;
+  esac
+}
+
+LABELS="type: $TYPE,$(priority_label_for "$PRIORITY"),size: $SIZE,$(phase_label_for "$PHASE"),model: $MODEL"
+# Domain(s) — can be comma-separated list
+IFS=',' read -r -a DOMAINS <<< "$DOMAIN"
+for d in "${DOMAINS[@]}"; do
+  d_trim="$(echo "$d" | sed 's/^ *//;s/ *$//')"
+  [ -n "$d_trim" ] && LABELS="$LABELS,domain: $d_trim"
+done
+if [ -n "$RISK" ]; then
+  LABELS="$LABELS,risk: $RISK"
+fi
+# Modifier labels — orthogonal; any number, validated above.
+if [ -n "$MODIFIER" ]; then
+  for m in "${MODIFIERS[@]}"; do
+    m_trim="$(echo "$m" | sed 's/^ *//;s/ *$//')"
+    [ -n "$m_trim" ] && LABELS="$LABELS,$m_trim"
+  done
+fi
+if [ -z "$MILESTONE" ]; then
+  MILESTONE="$(milestone_for "$PHASE")"
+fi
+
+# ── Create issue ────────────────────────────────────────────────────────────
+
+echo "==> Creating issue: $TITLE" >&2
+ISSUE_URL="$(gh issue create \
+  --repo "$REPO" \
+  --title "$TITLE" \
+  --body-file "$BODY_FILE" \
+  --label "$LABELS" \
+  --milestone "$MILESTONE" 2>&1)" || { echo "$ISSUE_URL" >&2; exit 3; }
+
+# gh prints extra lines — keep only the URL
+ISSUE_URL="$(echo "$ISSUE_URL" | grep -Eo 'https://github.com/[^ ]+/issues/[0-9]+' | head -1)"
+[ -n "$ISSUE_URL" ] || { echo "couldn't parse issue URL from gh output" >&2; exit 3; }
+ISSUE_NUM="${ISSUE_URL##*/}"
+echo "    → #$ISSUE_NUM ($ISSUE_URL)" >&2
+
+# ── Add to project ──────────────────────────────────────────────────────────
+
+echo "==> Adding to project #$PROJECT_NUM" >&2
+ITEM_ID="$(gh project item-add "$PROJECT_NUM" --owner "$OWNER" --url "$ISSUE_URL" --format json \
+  | jq -r '.id')" || exit 4
+[ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ] || { echo "failed to add to project" >&2; exit 4; }
+
+# ── Set field values ────────────────────────────────────────────────────────
+
+set_field() {
+  local field_id="$1" option_id="$2" label="$3"
+  gh project item-edit \
+    --id "$ITEM_ID" \
+    --field-id "$field_id" \
+    --project-id "$PROJECT_ID" \
+    --single-select-option-id "$option_id" >/dev/null || {
+      echo "failed to set $label" >&2; exit 5;
+    }
+}
+
+STATUS_OPT="$STATUS_UP_NEXT"
+STATUS_NAME="Up Next"
+if [ "$BLOCKED" = true ]; then
+  STATUS_OPT="$STATUS_BACKLOG"
+  STATUS_NAME="Backlog"
+fi
+
+echo "==> Setting Status=$STATUS_NAME" >&2
+set_field "$F_STATUS" "$STATUS_OPT" "Status"
+
+case "$PHASE" in
+  M0) PHASE_OPT="$O_PHASE_M0" ;;
+  M1) PHASE_OPT="$O_PHASE_M1" ;;
+  M2) PHASE_OPT="$O_PHASE_M2" ;;
+  M3) PHASE_OPT="$O_PHASE_M3" ;;
+  M4) PHASE_OPT="$O_PHASE_M4" ;;
+  M5) PHASE_OPT="$O_PHASE_M5" ;;
+esac
+case "$PRIORITY" in
+  P0) PRI_OPT="$O_P0" ;;
+  P1) PRI_OPT="$O_P1" ;;
+  P2) PRI_OPT="$O_P2" ;;
+  P3) PRI_OPT="$O_P3" ;;
+esac
+case "$SIZE" in
+  XS) SIZE_OPT="$O_SIZE_XS" ;;
+  S)  SIZE_OPT="$O_SIZE_S" ;;
+  M)  SIZE_OPT="$O_SIZE_M" ;;
+  L)  SIZE_OPT="$O_SIZE_L" ;;
+  XL) SIZE_OPT="$O_SIZE_XL" ;;
+esac
+
+echo "==> Setting Phase=$PHASE, Priority=$PRIORITY, Size=$SIZE" >&2
+set_field "$F_PHASE"    "$PHASE_OPT" "Phase"
+set_field "$F_PRIORITY" "$PRI_OPT"   "Priority"
+set_field "$F_SIZE"     "$SIZE_OPT"  "Size"
+
+if [ -n "$RISK" ]; then
+  case "$RISK" in
+    high)   RISK_OPT="$O_RISK_HIGH" ;;
+    medium) RISK_OPT="$O_RISK_MED" ;;
+  esac
+  echo "==> Setting Risk=$RISK" >&2
+  set_field "$F_RISK" "$RISK_OPT" "Risk"
+fi
+
+# ── Verify ──────────────────────────────────────────────────────────────────
+# Re-read the item from the project and assert every required field is set.
+# This is the guardrail that turns a silent partial failure into a loud exit 6.
+
+echo "==> Verifying wiring" >&2
+
+# 1) Issue carries exactly one model: label
+MODEL_LABEL_COUNT="$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json labels \
+  | jq '[.labels[] | select(.name | startswith("model: "))] | length')"
+if [ "$MODEL_LABEL_COUNT" != "1" ]; then
+  echo "VERIFY FAIL: issue #$ISSUE_NUM has $MODEL_LABEL_COUNT model: labels (expected 1)" >&2
+  exit 6
+fi
+
+# 2) Item is on project with Status, Phase, Priority, Size populated
+VERIFY_JSON="$(gh api graphql -f query='
+  query($id: ID!) {
+    node(id: $id) {
+      ... on ProjectV2Item {
+        content { ... on Issue { number } }
+        fieldValues(first: 20) {
+          nodes {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              field { ... on ProjectV2SingleSelectField { name } }
+              name
+            }
+          }
+        }
+      }
+    }
+  }' -f id="$ITEM_ID")"
+
+missing=()
+for field in Status Phase Priority Size; do
+  value="$(echo "$VERIFY_JSON" | jq -r --arg f "$field" \
+    '[.data.node.fieldValues.nodes[] | select(.field.name == $f)][0].name // empty')"
+  if [ -z "$value" ]; then
+    missing+=("$field")
+  fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "VERIFY FAIL: issue #$ISSUE_NUM is on project #$PROJECT_NUM but missing fields: ${missing[*]}" >&2
+  exit 6
+fi
+
+echo "    ✓ model: label (exactly 1)" >&2
+echo "    ✓ on project #$PROJECT_NUM" >&2
+echo "    ✓ Status, Phase, Priority, Size all populated" >&2
+echo "" >&2
+echo "Filed #$ISSUE_NUM → $ISSUE_URL" >&2
+
+# stdout = issue URL, so the caller can capture it
+echo "$ISSUE_URL"

--- a/scripts/populate-project.sh
+++ b/scripts/populate-project.sh
@@ -10,43 +10,10 @@
 # =============================================================================
 set -euo pipefail
 
-OWNER="torsday"
-PROJECT_NUM=4
-
-# Field IDs (discovered once via `gh project field-list`)
-F_PHASE="PVTSSF_lAHOAARNgc4BVGvQzhQkyDM"
-F_PRIORITY="PVTSSF_lAHOAARNgc4BVGvQzhQkyEM"
-F_SIZE="PVTSSF_lAHOAARNgc4BVGvQzhQkyEQ"
-F_RISK="PVTSSF_lAHOAARNgc4BVGvQzhQkyEU"
-
-# Phase option IDs
-O_PHASE_M0="d3ea64bc"
-O_PHASE_M1="7604af38"
-O_PHASE_M2="14583f99"
-O_PHASE_M3="659e0f86"
-O_PHASE_M4="43383303"
-O_PHASE_M5="e39db280"
-
-# Priority option IDs
-O_P0="a7ac64ac"
-O_P1="2bcd66d3"
-O_P2="d28a8726"
-O_P3="11749026"
-
-# Size option IDs
-O_SIZE_XS="c038b672"
-O_SIZE_S="4a9932c9"
-O_SIZE_M="987fabe1"
-O_SIZE_L="0b17ef74"
-O_SIZE_XL="438cc739"
-
-# Risk option IDs
-O_RISK_HIGH="62767387"
-O_RISK_MED="1e89155b"
-O_RISK_LOW="3f572490"
-
-# Project ID (for item-edit commands)
-PROJECT_ID="PVT_kwHOAARNgc4BVGvQ"
+# Project/field/option IDs live in scripts/_project-constants.sh (single source of truth)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_project-constants.sh
+source "$SCRIPT_DIR/_project-constants.sh"
 
 # Fetch all issues with labels in a single call
 echo "Fetching all issues with labels..." >&2

--- a/scripts/set-ready-status.sh
+++ b/scripts/set-ready-status.sh
@@ -1,24 +1,31 @@
 #!/usr/bin/env bash
 # =============================================================================
-# set-ready-status.sh — set Status=Ready on unblocked issues, Todo on the rest
+# set-ready-status.sh — set Status=Up Next on unblocked issues, Backlog on the rest
 # =============================================================================
 # Run once after the Status field options have been regenerated (which clears
-# existing values). Determines "ready" by parsing each issue's body for a
-# "- Blocked by: #N" reference; issues without one are Ready.
+# existing values). Determines "unblocked" by parsing each issue's body for a
+# "- Blocked by: #N" reference; issues without one go to Up Next.
+#
+# Status field naming history: the options were renamed Ready→"Up Next" and
+# Todo→"Backlog" in a board cleanup; the option UUIDs below are unchanged.
 # =============================================================================
 set -euo pipefail
 
-PROJECT_ID="PVT_kwHOAARNgc4BVGvQ"
-F_STATUS="PVTSSF_lAHOAARNgc4BVGvQzhQkx-E"
-O_READY="19ebdd2c"
-O_TODO="1e5b9208"
+# Project/field/option IDs live in scripts/_project-constants.sh (single source of truth)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_project-constants.sh
+source "$SCRIPT_DIR/_project-constants.sh"
+
+# Local aliases for readability at call sites
+O_UP_NEXT="$STATUS_UP_NEXT"   # formerly "Ready"
+O_BACKLOG="$STATUS_BACKLOG"   # formerly "Todo"
 
 # Unblocked issue numbers (computed from issue body parsing; see blockers.tsv)
-READY_NUMBERS=(1 2 3 6 8 9 10 12 13 14 21 23 24 26 27 32 33 69 70 78 80 84 86 87 88)
+UNBLOCKED_NUMBERS=(1 2 3 6 8 9 10 12 13 14 21 23 24 26 27 32 33 69 70 78 80 84 86 87 88)
 
-is_ready() {
+is_unblocked() {
   local n="$1"
-  for r in "${READY_NUMBERS[@]}"; do
+  for r in "${UNBLOCKED_NUMBERS[@]}"; do
     if [ "$r" -eq "$n" ]; then return 0; fi
   done
   return 1
@@ -42,21 +49,21 @@ query {
   }
 }' | jq -c '.data.user.projectV2.items.nodes[] | {id, number: .content.number}')
 
-count_ready=0
-count_todo=0
+count_up_next=0
+count_backlog=0
 
 while read -r item; do
   item_id=$(echo "$item" | jq -r '.id')
   number=$(echo "$item" | jq -r '.number')
 
-  if is_ready "$number"; then
-    option="$O_READY"
-    label="Ready"
-    ((count_ready++))
+  if is_unblocked "$number"; then
+    option="$O_UP_NEXT"
+    label="Up Next"
+    ((count_up_next++))
   else
-    option="$O_TODO"
-    label="Todo"
-    ((count_todo++))
+    option="$O_BACKLOG"
+    label="Backlog"
+    ((count_backlog++))
   fi
 
   gh api graphql -f query='
@@ -70,4 +77,4 @@ while read -r item; do
 done <<< "$items_json"
 
 echo "" >&2
-echo "done. Ready=$count_ready, Todo=$count_todo" >&2
+echo "done. Up Next=$count_up_next, Backlog=$count_backlog" >&2

--- a/scripts/validate-deps.sh
+++ b/scripts/validate-deps.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# =============================================================================
+# validate-deps.sh — audit the "Blocked by: #N" dependency graph
+# =============================================================================
+# Parses every open issue's body for `- Blocked by: #N` lines and reports:
+#
+#   1. Cycles — issue A blocked by B blocked by … blocked by A
+#   2. Orphan references — "Blocked by: #N" where #N doesn't exist
+#   3. Stale blocks — dependent is open/blocked but blocker is already closed
+#
+# Exits nonzero if any issue is found, so this can gate `/groom` or CI.
+# Prints a human-readable report on stderr. Safe to run read-only.
+#
+# Uses only bash 3.2 features (no associative arrays) for macOS compatibility.
+# Intermediate state lives in a TSV table: `number<TAB>state<TAB>blockers...`.
+#
+# Example:
+#   ./scripts/validate-deps.sh
+#   ./scripts/validate-deps.sh --repo torsday/some-other-repo
+# =============================================================================
+set -euo pipefail
+
+REPO="torsday/omnifocus-mcp"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    -h|--help) sed -n '3,20p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+TABLE="$(mktemp -t validate-deps.XXXXXX)"
+trap 'rm -f "$TABLE"' EXIT
+
+echo "==> Fetching all issues (open + closed) from $REPO" >&2
+# TSV: number \t state \t space-separated-blockers
+gh issue list --repo "$REPO" --state all --limit 500 \
+  --json number,state,body \
+  --jq '.[] | [
+    (.number|tostring),
+    .state,
+    (
+      (.body // "")
+      | scan("(?i)blocked by:?\\s*#[0-9]+(?:,\\s*#[0-9]+)*")
+      | scan("#[0-9]+")
+      | sub("#"; "")
+    )
+  ] | @tsv' \
+  > "$TABLE.raw"
+
+# jq's @tsv emits one row per blocker; collapse back to one row per issue.
+awk -F'\t' '
+  {
+    key = $1 "\t" $2
+    if ($3 != "") blockers[key] = (blockers[key] == "" ? $3 : blockers[key] " " $3)
+    else if (!(key in blockers)) blockers[key] = ""
+    seen[key] = 1
+  }
+  END {
+    for (k in seen) print k "\t" blockers[k]
+  }
+' "$TABLE.raw" | sort -n > "$TABLE"
+rm -f "$TABLE.raw"
+
+total=$(wc -l < "$TABLE" | tr -d ' ')
+with_deps=$(awk -F'\t' '$3 != "" {c++} END {print c+0}' "$TABLE")
+echo "==> Parsed $total issues; $with_deps have blocker refs" >&2
+
+# Helpers for lookups.
+state_of() { awk -F'\t' -v n="$1" '$1 == n {print $2; exit}' "$TABLE"; }
+blockers_of() { awk -F'\t' -v n="$1" '$1 == n {print $3; exit}' "$TABLE"; }
+exists() { awk -F'\t' -v n="$1" '$1 == n {found=1; exit} END {exit !found}' "$TABLE"; }
+
+# ── 1. Orphan references ────────────────────────────────────────────────────
+orphans=()
+while IFS=$'\t' read -r num _ blks; do
+  [ -z "$blks" ] && continue
+  for b in $blks; do
+    if ! exists "$b"; then
+      orphans+=("#$num references #$b, which doesn't exist")
+    fi
+  done
+done < "$TABLE"
+
+# ── 2. Stale blocks (blocker closed, dependent still open) ──────────────────
+stale=()
+while IFS=$'\t' read -r num state blks; do
+  [ "$state" = "OPEN" ] || continue
+  [ -z "$blks" ] && continue
+  for b in $blks; do
+    bs="$(state_of "$b")"
+    [ -z "$bs" ] && continue  # orphan, reported above
+    if [ "$bs" = "CLOSED" ]; then
+      stale+=("#$num (open) blocked by #$b (closed) — unblock or close")
+    fi
+  done
+done < "$TABLE"
+
+# ── 3. Cycle detection (iterative DFS via color marking) ────────────────────
+# Colors: unvisited (absent), "gray" (on stack), "black" (fully explored).
+# Use two flat files as the color maps.
+GRAY="$(mktemp -t validate-deps-gray.XXXXXX)"
+BLACK="$(mktemp -t validate-deps-black.XXXXXX)"
+trap 'rm -f "$TABLE" "$GRAY" "$BLACK"' EXIT
+cycles=()
+
+mark_gray()  { echo "$1" >> "$GRAY"; }
+unmark_gray() { grep -v "^$1$" "$GRAY" > "$GRAY.tmp" 2>/dev/null || true; mv "$GRAY.tmp" "$GRAY" 2>/dev/null || : > "$GRAY"; }
+mark_black() { echo "$1" >> "$BLACK"; }
+is_gray()    { grep -qx "$1" "$GRAY" 2>/dev/null; }
+is_black()   { grep -qx "$1" "$BLACK" 2>/dev/null; }
+
+visit() {
+  local node="$1" path="$2"
+  mark_gray "$node"
+  local blks; blks="$(blockers_of "$node")"
+  for b in $blks; do
+    exists "$b" || continue
+    if is_gray "$b"; then
+      cycles+=("$path → #$b (cycle)")
+    elif ! is_black "$b"; then
+      visit "$b" "$path → #$b"
+    fi
+  done
+  unmark_gray "$node"
+  mark_black "$node"
+}
+
+while IFS=$'\t' read -r num _ _; do
+  is_black "$num" && continue
+  visit "$num" "#$num"
+done < "$TABLE"
+
+# ── Report ──────────────────────────────────────────────────────────────────
+problems=0
+
+echo "" >&2
+if [ ${#orphans[@]} -gt 0 ]; then
+  echo "⚠️  Orphan blocker references (${#orphans[@]}):" >&2
+  printf '    %s\n' "${orphans[@]}" >&2
+  problems=$((problems + ${#orphans[@]}))
+fi
+
+if [ ${#stale[@]} -gt 0 ]; then
+  echo "⚠️  Stale blocks — blocker closed but dependent still open (${#stale[@]}):" >&2
+  printf '    %s\n' "${stale[@]}" >&2
+  problems=$((problems + ${#stale[@]}))
+fi
+
+if [ ${#cycles[@]} -gt 0 ]; then
+  echo "⚠️  Dependency cycles (${#cycles[@]}):" >&2
+  printf '    %s\n' "${cycles[@]}" >&2
+  problems=$((problems + ${#cycles[@]}))
+fi
+
+if [ "$problems" -eq 0 ]; then
+  echo "✓ Dependency graph clean — no orphans, no stale blocks, no cycles" >&2
+  exit 0
+fi
+
+echo "" >&2
+echo "Found $problems issue(s). Fix via \`/groom\` or manual edits." >&2
+exit 1

--- a/scripts/verify-constants.sh
+++ b/scripts/verify-constants.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# =============================================================================
+# verify-constants.sh — catch drift between _project-constants.sh and live
+# =============================================================================
+# Queries the GraphQL API for project #4's field + single-select option IDs
+# and compares each to the constants checked into _project-constants.sh.
+# Exits nonzero on any mismatch so CI can block merges that leave the scripts
+# pointing at stale IDs (e.g. after someone renames a Status option in the UI
+# and GitHub silently mints a new ID).
+#
+# Safe to run read-only. Uses gh auth.
+#
+# Example:
+#   ./scripts/verify-constants.sh
+#   ./scripts/verify-constants.sh --json   # machine-readable report
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./_project-constants.sh
+source "$SCRIPT_DIR/_project-constants.sh"
+
+JSON_OUT=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) JSON_OUT=1; shift ;;
+    -h|--help) sed -n '3,18p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+echo "==> Fetching live project state for $OWNER/projects/$PROJECT_NUM" >&2
+LIVE="$(gh api graphql -f query='
+  query($o:String!,$n:Int!) {
+    user(login:$o) {
+      projectV2(number:$n) {
+        id
+        fields(first: 30) {
+          nodes {
+            ... on ProjectV2SingleSelectField {
+              id name options { id name }
+            }
+          }
+        }
+      }
+    }
+  }
+' -F o="$OWNER" -F n="$PROJECT_NUM")"
+
+# Single source of truth for expected IDs: pair the constant var name with the
+# path in the live payload. Paths are resolved via jq below.
+#
+# expected[i] = "<VAR_NAME>=<FIELD_NAME>[::<OPTION_NAME>]"
+expected=(
+  "PROJECT_ID=.data.user.projectV2.id"
+  "F_STATUS=Status"
+  "F_PHASE=Phase"
+  "F_PRIORITY=Priority"
+  "F_SIZE=Size"
+  "F_RISK=Risk"
+  "STATUS_BACKLOG=Status::Backlog"
+  "STATUS_UP_NEXT=Status::Up Next"
+  "STATUS_IN_PROGRESS=Status::In Progress"
+  "STATUS_IN_REVIEW=Status::In Review"
+  "STATUS_ON_HOLD=Status::On Hold"
+  "STATUS_DONE=Status::Done"
+  "O_PHASE_M0=Phase::M0 Foundation"
+  "O_PHASE_M1=Phase::M1 Core surface"
+  "O_PHASE_M2=Phase::M2 Metadata"
+  "O_PHASE_M3=Phase::M3 Advanced"
+  "O_PHASE_M4=Phase::M4 Long tail"
+  "O_PHASE_M5=Phase::M5 Polish"
+  "O_P0=Priority::P0 · critical"
+  "O_P1=Priority::P1 · high"
+  "O_P2=Priority::P2 · medium"
+  "O_P3=Priority::P3 · low"
+  "O_SIZE_XS=Size::XS"
+  "O_SIZE_S=Size::S"
+  "O_SIZE_M=Size::M"
+  "O_SIZE_L=Size::L"
+  "O_SIZE_XL=Size::XL"
+  "O_RISK_HIGH=Risk::High"
+  "O_RISK_MED=Risk::Medium"
+  "O_RISK_LOW=Risk::Low"
+)
+
+# Resolve a "<field>" or "<field>::<option>" selector against the live payload.
+resolve() {
+  local sel="$1"
+  if [ "$sel" = ".data.user.projectV2.id" ]; then
+    echo "$LIVE" | jq -r '.data.user.projectV2.id'
+    return
+  fi
+  local field="${sel%%::*}"
+  if [ "$field" = "$sel" ]; then
+    # Field ID lookup.
+    echo "$LIVE" | jq -r --arg f "$field" '
+      .data.user.projectV2.fields.nodes[] | select(.name == $f) | .id // empty'
+  else
+    # Option ID lookup.
+    local opt="${sel#*::}"
+    echo "$LIVE" | jq -r --arg f "$field" --arg o "$opt" '
+      .data.user.projectV2.fields.nodes[]
+      | select(.name == $f)
+      | .options[]? | select(.name == $o) | .id // empty'
+  fi
+}
+
+mismatches=0
+report=""
+for pair in "${expected[@]}"; do
+  var="${pair%%=*}"
+  selector="${pair#*=}"
+  expected_val="${!var:-}"
+  live_val="$(resolve "$selector")"
+  if [ -z "$live_val" ]; then
+    report+="✗ $var  selector='$selector'  LIVE MISSING (renamed or deleted)"$'\n'
+    mismatches=$((mismatches + 1))
+  elif [ "$live_val" != "$expected_val" ]; then
+    report+="✗ $var  constants='$expected_val'  live='$live_val'"$'\n'
+    mismatches=$((mismatches + 1))
+  fi
+done
+
+if [ "$JSON_OUT" -eq 1 ]; then
+  jq -n --argjson m "$mismatches" --arg r "$report" \
+    '{mismatches: $m, report: $r}'
+  [ "$mismatches" -eq 0 ] && exit 0 || exit 1
+fi
+
+if [ "$mismatches" -eq 0 ]; then
+  echo "✓ _project-constants.sh matches live project state" >&2
+  exit 0
+fi
+
+echo "" >&2
+echo "⚠️  Found $mismatches drift(s) between _project-constants.sh and live project:" >&2
+printf '%s' "$report" >&2
+echo "" >&2
+echo "Rediscover IDs via the GraphQL query in scripts/_project-constants.sh" >&2
+exit 1

--- a/src/scripts/jxa/folder_create.js
+++ b/src/scripts/jxa/folder_create.js
@@ -47,17 +47,14 @@ function run(argv) {
       }
     }
     if (!parentFolder) throw new Error(`Parent folder not found: ${args.parentId}`);
-    newFolder = ofApp.make({
-      new: "folder",
-      at: parentFolder.folders.end,
-      withProperties: { name: args.name },
-    });
+    // OmniFocus 4.x rejects `ofApp.make({ new: "folder", at: ... })` with
+    // error -1728 (errAENoSuchObject). Use the specifier-push pattern instead.
+    newFolder = ofApp.Folder({ name: args.name });
+    parentFolder.folders.push(newFolder);
   } else {
-    newFolder = ofApp.make({
-      new: "folder",
-      at: ofApp.defaultDocument.folders.end,
-      withProperties: { name: args.name },
-    });
+    // Same fix for document-level folder creation.
+    newFolder = ofApp.Folder({ name: args.name });
+    ofApp.defaultDocument.folders.push(newFolder);
   }
 
   return JSON.stringify({ folder: buildFolder(newFolder) });

--- a/src/scripts/jxa/project_create.js
+++ b/src/scripts/jxa/project_create.js
@@ -155,13 +155,18 @@ function run(argv) {
     props.status = args.status === "on-hold" ? "on hold" : args.status;
   }
 
+  // OmniFocus 4.x rejects `doc.make({ new: "project", withProperties })` with
+  // error -10024. The working pattern mirrors the inbox-task fix in #275:
+  // construct a specifier via the class name and push it onto the collection.
   let newProj;
   if (args.folderId) {
     const folder = ofApp.defaultDocument.folders.byId(args.folderId);
     if (!folder) throw new Error(`Folder not found: ${args.folderId}`);
-    newProj = ofApp.make({ new: "project", at: folder.projects.end, withProperties: props });
+    newProj = ofApp.Project(props);
+    folder.projects.push(newProj);
   } else {
-    newProj = ofApp.defaultDocument.make({ new: "project", withProperties: props });
+    newProj = ofApp.Project(props);
+    ofApp.defaultDocument.projects.push(newProj);
   }
 
   return JSON.stringify({ project: buildProject(newProj) });

--- a/src/scripts/jxa/tag_create.js
+++ b/src/scripts/jxa/tag_create.js
@@ -67,17 +67,14 @@ function run(argv) {
       }
     }
     if (!parentTag) throw new Error(`Parent tag not found: ${args.parentId}`);
-    newTag = ofApp.make({
-      new: "tag",
-      at: parentTag.tags.end,
-      withProperties: { name: args.name },
-    });
+    // OmniFocus 4.x rejects `ofApp.make({ new: "tag", at: ... })` with
+    // error -1728 (errAENoSuchObject). Use the specifier-push pattern instead.
+    newTag = ofApp.Tag({ name: args.name });
+    parentTag.tags.push(newTag);
   } else {
-    newTag = ofApp.make({
-      new: "tag",
-      at: ofApp.defaultDocument.tags.end,
-      withProperties: { name: args.name },
-    });
+    // Same fix for document-level tag creation.
+    newTag = ofApp.Tag({ name: args.name });
+    ofApp.defaultDocument.tags.push(newTag);
   }
 
   return JSON.stringify({ tag: buildTag(newTag) });


### PR DESCRIPTION
## Summary
- Fixes `project_create.js` — `-10024` on OF 4.x when creating projects (#279)
- Fixes `folder_create.js` — `-1728` on OF 4.x when creating folders (#280)
- Fixes `tag_create.js` — `-1728` on OF 4.x when creating tags (#281)

All three apply the same specifier-push pattern established in #275 / PR #277 for inbox tasks: construct via `ofApp.ClassName(props)` and push onto the target collection, rather than the rejected `ofApp.make({ new: "...", withProperties })` form.

Closes #279.
Closes #280.
Closes #281.

## Issue
Implements [#279](https://github.com/torsday/omnifocus-mcp/issues/279), [#280](https://github.com/torsday/omnifocus-mcp/issues/280), [#281](https://github.com/torsday/omnifocus-mcp/issues/281). Follows the pattern from DESIGN.md §6.3 (adapter seam / JXA script discipline).

## Breaking change?
- [x] No

## Test plan
- [x] Unit suite: 1681 passed, 0 failures
- [x] Biome lint clean on all 3 changed files
- [x] tsc --noEmit clean
- [x] Self-reviewed — minimal targeted change, same pattern as proven #275 fix
- [x] No new dependencies
- [ ] Integration: 26 tests expected to flip from red to green on `mac-local` CI (15 projects + 6 folders + 5 tags)