### PR TITLE
chore(adapter): classify JXA exit-1 errors into typed taxonomy

### DIFF
--- a/src/adapter/jxa/JxaTransport.projects.test.ts
+++ b/src/adapter/jxa/JxaTransport.projects.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { FolderId, ProjectId } from "../../domain/ids.js";
-import { ScriptError } from "../../errors/index.js";
+import { NotFound, ScriptError } from "../../errors/index.js";
 import { JxaTransport } from "./JxaTransport.js";
 import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
 
@@ -121,9 +121,9 @@ describe("JxaTransport — getProject", () => {
     expect(arg.id).toBe("proj_aaa");
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("project not found") });
-    await expect(t.getProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.getProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 
@@ -219,9 +219,9 @@ describe("JxaTransport — dropProject", () => {
     await expect(t.dropProject("proj_aaa" as ProjectId)).resolves.toBeUndefined();
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("project not found") });
-    await expect(t.dropProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.dropProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 
@@ -269,9 +269,9 @@ describe("JxaTransport — deleteProject", () => {
     await expect(t.deleteProject("proj_aaa" as ProjectId)).resolves.toBeUndefined();
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("project not found") });
-    await expect(t.deleteProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.deleteProject("proj_missing" as ProjectId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 

--- a/src/adapter/jxa/JxaTransport.tags-folders.test.ts
+++ b/src/adapter/jxa/JxaTransport.tags-folders.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { FolderId, TagId } from "../../domain/ids.js";
-import { ScriptError } from "../../errors/index.js";
+import { NotFound, ScriptError } from "../../errors/index.js";
 import { JxaTransport } from "./JxaTransport.js";
 import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
 
@@ -122,9 +122,9 @@ describe("JxaTransport — getTag", () => {
     expect(arg.id).toBe("tag_aaa");
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("tag not found") });
-    await expect(t.getTag("tag_missing" as TagId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.getTag("tag_missing" as TagId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 
@@ -206,9 +206,9 @@ describe("JxaTransport — deleteTag", () => {
     expect(arg.id).toBe("tag_aaa");
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("tag not found") });
-    await expect(t.deleteTag("tag_missing" as TagId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.deleteTag("tag_missing" as TagId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 

--- a/src/adapter/jxa/JxaTransport.tasks.test.ts
+++ b/src/adapter/jxa/JxaTransport.tasks.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { ProjectId, TaskId } from "../../domain/ids.js";
-import { ScriptError } from "../../errors/index.js";
+import { NotFound, ScriptError } from "../../errors/index.js";
 import { JxaTransport } from "./JxaTransport.js";
 import type { ScriptSpawner, SpawnResult } from "./scriptRunner.js";
 
@@ -126,9 +126,9 @@ describe("JxaTransport — getTask", () => {
     expect(arg.id).toBe("task_aaa");
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
-    await expect(t.getTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.getTask("task_missing" as TaskId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 
@@ -250,9 +250,9 @@ describe("JxaTransport — uncompleteTask", () => {
     await expect(t.uncompleteTask("task_aaa" as TaskId)).resolves.toBeUndefined();
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
-    await expect(t.uncompleteTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.uncompleteTask("task_missing" as TaskId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 
@@ -288,9 +288,9 @@ describe("JxaTransport — undropTask", () => {
     await expect(t.undropTask("task_aaa" as TaskId)).resolves.toBeUndefined();
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
-    await expect(t.undropTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.undropTask("task_missing" as TaskId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 
@@ -304,9 +304,9 @@ describe("JxaTransport — deleteTask", () => {
     await expect(t.deleteTask("task_aaa" as TaskId)).resolves.toBeUndefined();
   });
 
-  it("surfaces ScriptError on not-found", async () => {
+  it("surfaces NotFound on not-found", async () => {
     const t = new JxaTransport({ spawner: spawnerFailing("task not found") });
-    await expect(t.deleteTask("task_missing" as TaskId)).rejects.toBeInstanceOf(ScriptError);
+    await expect(t.deleteTask("task_missing" as TaskId)).rejects.toBeInstanceOf(NotFound);
   });
 });
 

--- a/src/adapter/jxa/scriptRunner.test.ts
+++ b/src/adapter/jxa/scriptRunner.test.ts
@@ -9,11 +9,14 @@
 
 import { describe, expect, it, vi } from "vitest";
 import {
+  ConflictError,
+  NotFound,
   OmniFocusError,
   OmniFocusNotRunning,
   PermissionDenied,
   ScriptError,
   TransportUnavailable,
+  ValidationError,
 } from "../../errors/index.js";
 import { type ScriptSpawner, type SpawnResult, runJxaScript } from "./scriptRunner.js";
 
@@ -160,5 +163,70 @@ describe("runJxaScript — error mapping", () => {
       const err = await runJxaScript("script", {}, { spawner }).catch((e) => e);
       expect(err).toBeInstanceOf(OmniFocusError);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyJxaStderr — NotFound / ValidationError / ConflictError patterns
+// ---------------------------------------------------------------------------
+
+describe("runJxaScript — error taxonomy: NotFound", () => {
+  it("maps 'Task not found: <id>' to NotFound", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "Task not found: abc123" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("maps 'Project not found: <id>' to NotFound", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "Project not found: xyz" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("maps 'Folder not found: <id>' to NotFound", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "Folder not found: fid" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("maps 'Tag not found: <id>' to NotFound", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "Tag not found: tid" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("maps 'Parent task not found: <id>' to NotFound", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "Parent task not found: pid" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("maps 'OF_NOT_FOUND: project <id>' (batch scripts) to NotFound", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "OF_NOT_FOUND: project abc" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
+});
+
+describe("runJxaScript — error taxonomy: ValidationError", () => {
+  it("maps 'OF_VALIDATION: ...' to ValidationError", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "OF_VALIDATION: name is empty" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("maps 'X is required' patterns to ValidationError", async () => {
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "One of taskId or projectId is required",
+    });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(ValidationError);
+  });
+});
+
+describe("runJxaScript — error taxonomy: ConflictError", () => {
+  it("maps 'OF_CONFLICT: ...' to ConflictError", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "OF_CONFLICT: stale modifiedAt" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+describe("runJxaScript — error taxonomy: no false positives", () => {
+  it("does not map generic non-zero exit to NotFound", async () => {
+    const spawner = fakeSpawner({ exitCode: 1, stderr: "unexpected JXA crash" });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(ScriptError);
   });
 });

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -26,11 +26,14 @@
 
 import { execFile } from "node:child_process";
 import {
+  ConflictError,
+  NotFound,
   OmniFocusNotRunning,
   PermissionDenied,
   ScriptError,
   Timeout,
   TransportUnavailable,
+  ValidationError,
 } from "../../errors/index.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
 
@@ -250,6 +253,42 @@ function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
     /not allowed assistive access/i.test(stderr)
   ) {
     return new PermissionDenied({
+      details: {
+        transport: "jxa",
+        stderr: truncate(stderr, 512),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // "X not found: <id>" / "OF_NOT_FOUND: ..." → NotFound.
+  // Covers: `Task not found: abc`, `Project not found: xyz`,
+  //         `Folder not found: ...`, `Tag not found: ...`, `Parent X not found: ...`,
+  //         `OF_NOT_FOUND: parent task abc` (batch scripts).
+  if (/\bnot found\b/i.test(stderr) || /^OF_NOT_FOUND\b/m.test(stderr)) {
+    return new NotFound(stderr, {
+      details: {
+        transport: "jxa",
+        stderr: truncate(stderr, 512),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // "OF_VALIDATION: ..." / "is required" / empty-name guards → ValidationError.
+  if (/^OF_VALIDATION\b/m.test(stderr) || /\bis required\b/i.test(stderr)) {
+    return new ValidationError(stderr, {
+      details: {
+        transport: "jxa",
+        stderr: truncate(stderr, 512),
+        ...(scriptName !== undefined ? { scriptName } : {}),
+      },
+    });
+  }
+
+  // "OF_CONFLICT: ..." → ConflictError.
+  if (/^OF_CONFLICT\b/m.test(stderr)) {
+    return new ConflictError(stderr, {
       details: {
         transport: "jxa",
         stderr: truncate(stderr, 512),


### PR DESCRIPTION
## Summary
- Extend \`classifyJxaStderr\` in \`scriptRunner.ts\` to map \`not found\`, \`OF_NOT_FOUND\`, \`OF_VALIDATION\`, \`is required\`, and \`OF_CONFLICT\` stderr patterns to \`NotFound\`, \`ValidationError\`, and \`ConflictError\`
- Update \`scriptRunner.test.ts\` with 10 new taxonomy tests (23 total new/updated)
- Update \`JxaTransport.tasks/projects/tags-folders.test.ts\` to assert \`NotFound\` where applicable

Closes #282.

## Breaking change?
- [x] No

## Test plan
- [x] 1704 tests passing, typecheck + lint clean
- [x] Self-reviewed, no new dependencies