### PR TITLE
feat(observability): emit structured cache.invalidated events with correlationId

### DIFF
--- a/src/cache/lruCache.test.ts
+++ b/src/cache/lruCache.test.ts
@@ -105,22 +105,52 @@ describe("OmniFocusLruCache", () => {
       expect(cache.has("search:def456")).toBe(false);
     });
 
-    it("emits cache.invalidated event with scope and keysRemoved", () => {
+    it("emits cache.invalidated event with typed payload when keys are removed", () => {
       const cache = new OmniFocusLruCache();
       cache.set("task:abc:list", "v1");
       cache.set("task:abc:detail", "v2");
       const handler = vi.fn();
       cache.on("cache.invalidated", handler);
       cache.invalidate("task:abc");
-      expect(handler).toHaveBeenCalledWith({ scope: "task:abc", keysRemoved: 2 });
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "cache.invalidated",
+          scopes: ["task:abc"],
+          evicted: 2,
+        }),
+      );
     });
 
-    it("reports keysRemoved: 0 when no keys match", () => {
+    it("emits with evicted:0 when no keys match (no-op invalidation)", () => {
       const cache = new OmniFocusLruCache();
       const handler = vi.fn();
       cache.on("cache.invalidated", handler);
       cache.invalidate("task:nonexistent");
-      expect(handler).toHaveBeenCalledWith({ scope: "task:nonexistent", keysRemoved: 0 });
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "cache.invalidated",
+          scopes: ["task:nonexistent"],
+          evicted: 0,
+        }),
+      );
+    });
+
+    it("includes correlationId in the payload when inside a correlation scope", async () => {
+      const { withCorrelationId } = await import("../logging/correlation.js");
+      const cache = new OmniFocusLruCache();
+      cache.set("task:xyz:list", "v1");
+      const handler = vi.fn();
+      cache.on("cache.invalidated", handler);
+      withCorrelationId(() => {
+        cache.invalidate("task:xyz");
+      }, "test-corr-id-123");
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          correlationId: "test-corr-id-123",
+        }),
+      );
     });
   });
 

--- a/src/cache/lruCache.ts
+++ b/src/cache/lruCache.ts
@@ -16,6 +16,8 @@
 
 import { EventEmitter } from "node:events";
 import { LRUCache } from "lru-cache";
+import { getCorrelationId } from "../logging/correlation.js";
+import { logger } from "../logging/logger.js";
 
 // ---------------------------------------------------------------------------
 // Invalidation scope types
@@ -183,7 +185,18 @@ export class OmniFocusLruCache extends EventEmitter {
       }
     }
 
-    this.emit("cache.invalidated", { scope, keysRemoved: keysToDelete.length });
+    const evicted = keysToDelete.length;
+    const correlationId = getCorrelationId();
+    const payload = {
+      event: "cache.invalidated" as const,
+      scopes: [scope],
+      evicted,
+      ...(correlationId !== undefined ? { correlationId } : {}),
+    };
+    if (evicted > 0) {
+      logger.info(payload, "cache.invalidated");
+    }
+    this.emit("cache.invalidated", payload);
   }
 
   /** Return a snapshot of cache stats for `internal_status`. */

--- a/src/tools/folder/folder.test.ts
+++ b/src/tools/folder/folder.test.ts
@@ -289,7 +289,7 @@ describe("FolderService — cache invalidation", () => {
     const adapter = new InMemoryAdapter({ now: () => new Date(0) });
     const cache = new OmniFocusLruCache();
     const scopes: InvalidationScope[] = [];
-    cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => scopes.push(e.scope));
+    cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => scopes.push(...e.scopes));
     const folderService = new FolderService({ adapter, cache });
 
     const { id } = await folderService.create({ name: "Area" });

--- a/src/tools/project/complete.test.ts
+++ b/src/tools/project/complete.test.ts
@@ -15,8 +15,8 @@ import {
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/project/create.test.ts
+++ b/src/tools/project/create.test.ts
@@ -26,8 +26,8 @@ function assertOk<T>(envelope: ToolEnvelope<T>): ToolSuccess<T> {
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/project/delete.test.ts
+++ b/src/tools/project/delete.test.ts
@@ -30,8 +30,8 @@ function assertOk<T>(envelope: ToolEnvelope<T>): ToolSuccess<T> {
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/project/drop.test.ts
+++ b/src/tools/project/drop.test.ts
@@ -11,8 +11,8 @@ import { PROJECT_DROP_DESCRIPTION, handleProjectDrop, projectDropInputSchema } f
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/project/move.test.ts
+++ b/src/tools/project/move.test.ts
@@ -12,8 +12,8 @@ import { handleProjectMove, projectMoveInputSchema } from "./move.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/project/update.test.ts
+++ b/src/tools/project/update.test.ts
@@ -22,8 +22,8 @@ function assertOk<T>(envelope: ToolEnvelope<T>): ToolSuccess<T> {
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/tag/mutations.test.ts
+++ b/src/tools/tag/mutations.test.ts
@@ -279,7 +279,7 @@ describe("TagService — cache invalidation", () => {
     const adapter = new InMemoryAdapter({ now: () => new Date(0) });
     const cache = new OmniFocusLruCache();
     const scopes: InvalidationScope[] = [];
-    cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => scopes.push(e.scope));
+    cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => scopes.push(...e.scopes));
     const tagService = new TagService({ adapter, cache });
 
     const { id } = await tagService.create({ name: "Work" });
@@ -291,7 +291,7 @@ describe("TagService — cache invalidation", () => {
     const adapter = new InMemoryAdapter({ now: () => new Date(0) });
     const cache = new OmniFocusLruCache();
     const scopes: InvalidationScope[] = [];
-    cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => scopes.push(e.scope));
+    cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => scopes.push(...e.scopes));
     const tagService = new TagService({ adapter, cache });
 
     const { id } = await tagService.create({ name: "Work" });

--- a/src/tools/task/complete.test.ts
+++ b/src/tools/task/complete.test.ts
@@ -13,8 +13,8 @@ import { handleTaskComplete, taskCompleteInputSchema } from "./complete.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/delete.test.ts
+++ b/src/tools/task/delete.test.ts
@@ -27,8 +27,8 @@ function assertOk<T>(envelope: ToolEnvelope<T>): ToolSuccess<T> {
  */
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/drop.test.ts
+++ b/src/tools/task/drop.test.ts
@@ -13,8 +13,8 @@ import { handleTaskDrop, taskDropInputSchema } from "./drop.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/duplicate.test.ts
+++ b/src/tools/task/duplicate.test.ts
@@ -17,8 +17,8 @@ import { handleTaskDuplicate, taskDuplicateInputSchema } from "./duplicate.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/move.test.ts
+++ b/src/tools/task/move.test.ts
@@ -16,8 +16,8 @@ import { handleTaskMove, taskMoveInputSchema } from "./move.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/reorder.test.ts
+++ b/src/tools/task/reorder.test.ts
@@ -18,8 +18,8 @@ import { handleTaskReorder, taskReorderInputSchema } from "./reorder.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/repetition.test.ts
+++ b/src/tools/task/repetition.test.ts
@@ -14,8 +14,8 @@ import { handleTaskSetRepetition, taskSetRepetitionInputSchema } from "./setRepe
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/uncomplete.test.ts
+++ b/src/tools/task/uncomplete.test.ts
@@ -13,8 +13,8 @@ import { handleTaskUncomplete, taskUncompleteInputSchema } from "./uncomplete.js
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/undrop.test.ts
+++ b/src/tools/task/undrop.test.ts
@@ -13,8 +13,8 @@ import { handleTaskUndrop, taskUndropInputSchema } from "./undrop.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }

--- a/src/tools/task/update.test.ts
+++ b/src/tools/task/update.test.ts
@@ -23,8 +23,8 @@ function assertOk<T>(envelope: ToolEnvelope<T>): ToolSuccess<T> {
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];
-  cache.on("cache.invalidated", (e: { scope: InvalidationScope }) => {
-    scopes.push(e.scope);
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
   });
   return scopes;
 }


### PR DESCRIPTION
## Summary
- Extend \`OmniFocusLruCache.invalidate()\` to emit a \`cache.invalidated\` event with typed payload \`{ event, scopes, evicted, correlationId }\`
- \`logger.info\` fires when \`evicted > 0\`; the EventEmitter always fires so blast-radius tests work on cold caches
- \`correlationId\` from \`getCorrelationId()\` is included when inside a correlation scope
- Update all tool tests (18 files) to consume the new \`e.scopes[]\` shape instead of \`e.scope\`
- 3 new unit tests in \`lruCache.test.ts\`: typed payload, no-op evicted:0, correlationId propagation

Closes #314.

## Issue
Implements [#314 — feat(observability): emit cache.invalidated events when cache scopes flush](https://github.com/torsday/omnifocus-mcp/issues/314). See DESIGN.md §21 and ADR-0006.

## Breaking change?
- [x] No — event payload shape changed but this is an internal EventEmitter; no external consumers

## Test plan
- [x] 1682 tests passing, typecheck clean
- [x] Self-reviewed, no new dependencies