### PR TITLE
ci(release): switch runner from macos-latest to self-hosted macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-latest
+    runs-on: [self-hosted, macos]
     permissions:
       contents: write   # needed to create a GitHub Release
       id-token: write   # needed for npm provenance


### PR DESCRIPTION
## Summary
- Changes `release.yml` runner from `macos-latest` to `[self-hosted, macos]` to match `ci.yml`

Closes #284.

## Issue
Implements [#284 — feat(release): first npm publish + verify release workflow end-to-end](https://github.com/torsday/omnifocus-mcp/issues/284).

`macos-latest` is billing-blocked on GitHub-hosted runners. The self-hosted runner (`[self-hosted, macos]`) is the same runner `ci.yml` already uses successfully. This unblocks the npm publish workflow when a semver tag is pushed.

**Note for maintainer:** Actual publish requires:
1. `NPM_TOKEN` secret set under Settings → Secrets and variables → Actions
2. Version bump (`pnpm version patch/minor/major` or edit `package.json`)  
3. Git tag (`git tag v0.1.0 && git push --tags`)

## Breaking change?
- [x] No

## Test plan
- [x] `release.yml` diff reviewed — single runner line change
- [x] Verified `ci.yml` uses identical `[self-hosted, macos]` label successfully
- [x] `pnpm build` → 272 KB (< 500 KB budget ✅)
- [x] `pnpm publish --dry-run --access public --no-git-checks` → correct 5-file tarball ✅
- [x] Self-reviewed via /review-pr