### PR TITLE
fix(jxa): use Task()+push pattern and re-fetch for task_create

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1601,7 +1601,7 @@ _No parameters._
 
 ## task_find_by_name
 
-Find tasks in OmniFocus by name. Returns ALL matching tasks (names are not unique in OmniFocus). Names collide in OmniFocus; prefer task_get with an ID when you have one. Zero matches returns an empty array — not an error. Returns tasks[]; safe to call repeatedly; no side effects.
+Find tasks in OmniFocus by name. Returns ALL matching tasks (names are not unique in OmniFocus). Names collide in OmniFocus; prefer task_get with an ID when you have one. Use search_query instead when you need to search task notes as well, or want full-text content search. Zero matches returns an empty array — not an error. Returns tasks[]; safe to call repeatedly; no side effects.
 
 ### Input
 
@@ -1740,7 +1740,7 @@ Fetch up to 100 tasks by persistent ID in a single OmniFocus round-trip. Use whe
 
 ## task_list
 
-List tasks in OmniFocus with optional filters. Use this for queries across tasks. Do NOT use for a known single task (use `task_get`). Returns tasks[] with pagination; safe to call repeatedly; no side effects.
+List tasks in OmniFocus with optional filters (project, tag, flagged, completion, due dates). Use this for filter-based queries across tasks. Do NOT use for a known single task (use task_get). For name-based lookup, prefer task_find_by_name. For full-text content search across names and notes, prefer search_query. Returns tasks[] with pagination; safe to call repeatedly; no side effects.
 
 ### Input
 

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -159,15 +159,22 @@ function run(argv) {
   if (args.estimatedMinutes != null) props.estimatedMinutes = args.estimatedMinutes;
   if (args.sequential != null) props.sequential = args.sequential;
 
+  // OmniFocus 4.x rejects `container.make({ new: "task", withProperties })` with
+  // error -10024 ("Can't make or move that element into that container").
+  // The working pattern mirrors the inbox-task fix in #275 and the
+  // project/folder/tag fix in #319: construct a specifier via the class name
+  // and push it onto the target collection.
   let newTask;
   if (args.parentId) {
     const parent = ofApp.defaultDocument.flattenedTasks.byId(args.parentId);
     if (!parent) throw new Error(`Parent task not found: ${args.parentId}`);
-    newTask = parent.make({ new: "task", withProperties: props });
+    newTask = ofApp.Task(props);
+    parent.tasks.push(newTask);
   } else if (args.projectId) {
     const proj = ofApp.defaultDocument.flattenedProjects.byId(args.projectId);
     if (!proj) throw new Error(`Project not found: ${args.projectId}`);
-    newTask = proj.make({ new: "task", withProperties: props });
+    newTask = ofApp.Task(props);
+    proj.tasks.push(newTask);
   } else {
     // Inbox tasks cannot be created via `doc.make({ new: "inboxTask" })` —
     // OmniFocus 4.x rejects that with error -10024. Construct an InboxTask
@@ -192,5 +199,14 @@ function run(argv) {
     } catch (_e) {}
   }
 
+  // Re-fetch via a stable specifier for projectId/parentId branches.
+  // After push(), calling containingProject() / parentTask() on the pushed
+  // specifier returns stale null data until the JXA bridge flushes deferred
+  // events. .id() is safe immediately; all other properties require re-fetch.
+  if (args.parentId || args.projectId) {
+    const taskId = newTask.id();
+    const fetchedTask = ofApp.defaultDocument.flattenedTasks.byId(taskId);
+    return JSON.stringify({ task: buildTask(fetchedTask) });
+  }
   return JSON.stringify({ task: buildTask(newTask) });
 }


### PR DESCRIPTION
## Summary
- Replace `proj.make({ new: "task" })` / `parent.make({ new: "task" })` with `ofApp.Task(props) + container.tasks.push(task)` — OmniFocus 4.x rejects the `make()` pattern with error -10024
- After `push()`, re-fetch the task via `flattenedTasks.byId(id)` before calling `buildTask()` so `projectId`/`parentId` are correctly populated (pushed specifier returns stale null for `containingProject()` / `parentTask()`)

Closes #331.

## Issue
Implements [#331 — task_create: use Task()+push pattern (mirrors #275 inbox fix and #319 project/folder/tag fix)](https://github.com/torsday/omnifocus-mcp/issues/331).

## Breaking change?
- [x] No

## Test plan
- [x] Unit / integration tests all green locally
- [x] Self-reviewed
- [x] No new dependencies