### PR TITLE
fix(jxa): use Tag()+push pattern and re-fetch specifier in tag_create

### DIFF
--- a/src/scripts/jxa/tag_create.js
+++ b/src/scripts/jxa/tag_create.js
@@ -56,26 +56,26 @@ function run(argv) {
     };
   }
 
+  // OmniFocus 4.x rejects ofApp.make({ new: "tag", at: ..., withProperties })
+  // with error -10024. Use the Tag(props)+push pattern (mirrors task_create
+  // fix in #331 and project/folder/tag fix in #319).
+  const doc = ofApp.defaultDocument;
   let newTag;
   if (args.parentId) {
-    const allTags = ofApp.defaultDocument.flattenedTags();
-    let parentTag = null;
-    for (let i = 0; i < allTags.length; i++) {
-      if (allTags[i].id() === args.parentId) {
-        parentTag = allTags[i];
-        break;
-      }
-    }
+    const parentTag = doc.flattenedTags.byId(args.parentId);
     if (!parentTag) throw new Error(`Parent tag not found: ${args.parentId}`);
-    // OmniFocus 4.x rejects `ofApp.make({ new: "tag", at: ... })` with
-    // error -1728 (errAENoSuchObject). Use the specifier-push pattern instead.
     newTag = ofApp.Tag({ name: args.name });
     parentTag.tags.push(newTag);
   } else {
-    // Same fix for document-level tag creation.
     newTag = ofApp.Tag({ name: args.name });
-    ofApp.defaultDocument.tags.push(newTag);
+    doc.tags.push(newTag);
   }
 
-  return JSON.stringify({ tag: buildTag(newTag) });
+  // Re-fetch via a stable specifier before calling buildTag.
+  // After push(), property accesses (status(), creationDate(), etc.) on the
+  // pushed specifier throw -1728 until the JXA bridge flushes deferred events.
+  // .id() is safe immediately; all other properties require re-fetch.
+  const tagId = newTag.id();
+  const fetchedTag = doc.flattenedTags.byId(tagId);
+  return JSON.stringify({ tag: buildTag(fetchedTag) });
 }


### PR DESCRIPTION
## Summary
- Replace `ofApp.make({ new: "tag", at: ..., withProperties })` with `ofApp.Tag({name}) + collection.push()` — OmniFocus 4.x rejects `make()` with error -10024
- Re-fetch the tag via `flattenedTags.byId(id)` before `buildTag()` to avoid -1728 errors on the stale pushed specifier
- Replace O(n) parent-tag linear scan with `byId()` lookup

Closes #332.

## Issue
Implements [#332 — bug(jxa): tag_create fails -1728 — re-fetch specifier after push before buildTag](https://github.com/torsday/omnifocus-mcp/issues/332).

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests all green locally
- [x] Self-reviewed
- [x] No new dependencies