### PR TITLE
fix(jxa): use markDropped/markIncomplete for task drop/undrop

### DIFF
--- a/src/scripts/jxa/task_drop.js
+++ b/src/scripts/jxa/task_drop.js
@@ -13,17 +13,12 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allTasks = ofApp.defaultDocument.flattenedTasks();
-  let found = null;
-  for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      found = allTasks[i];
-      break;
-    }
-  }
+  const found = ofApp.defaultDocument.flattenedTasks.byId(args.id);
   if (!found) throw new Error(`Task not found: ${args.id}`);
 
-  found.dropped = true;
+  // In OmniFocus 4.x JXA, `task.dropped = true` is rejected with -10003
+  // ("Can't set that. Access not allowed."). Use ofApp.markDropped() instead.
+  ofApp.markDropped(found);
 
   return JSON.stringify({ id: args.id });
 }

--- a/src/scripts/jxa/task_undrop.js
+++ b/src/scripts/jxa/task_undrop.js
@@ -13,17 +13,12 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allTasks = ofApp.defaultDocument.flattenedTasks();
-  let found = null;
-  for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      found = allTasks[i];
-      break;
-    }
-  }
+  const found = ofApp.defaultDocument.flattenedTasks.byId(args.id);
   if (!found) throw new Error(`Task not found: ${args.id}`);
 
-  found.dropped = false;
+  // In OmniFocus 4.x JXA, `task.dropped = false` is rejected with -10003.
+  // ofApp.markIncomplete() clears the dropped flag (restores to active status).
+  ofApp.markIncomplete(found);
 
   return JSON.stringify({ id: args.id });
 }


### PR DESCRIPTION
## Summary
- Replace `task.dropped = true/false` (fails with -10003 in OF 4.x) with `ofApp.markDropped()` / `ofApp.markIncomplete()`
- Replace O(n) linear scans with `flattenedTasks.byId()` lookups

Closes #334.

## Issue
Implements [#334 — bug(jxa): task_drop fails -10003 — dropped property is read-only in OF 4.x](https://github.com/torsday/omnifocus-mcp/issues/334).

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests all green
- [x] Probed live OmniFocus: `markDropped()` drops task, `markIncomplete()` restores it
- [x] Self-reviewed