### PR TITLE
fix(jxa): normalize OF 4.8.8 verbose status strings in project scripts

### DIFF
--- a/src/scripts/jxa/project_create.js
+++ b/src/scripts/jxa/project_create.js
@@ -17,9 +17,12 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   function normalizeStatus(raw) {
-    if (raw === "on hold") return "on-hold";
-    if (raw === "done") return "completed";
-    return raw;
+    // OmniFocus 4.8.8 returns verbose strings with a " status" suffix
+    // (e.g. "active status", "on hold status"). Strip for uniform handling.
+    const s = typeof raw === "string" ? raw.replace(/ status$/, "") : raw;
+    if (s === "on hold") return "on-hold";
+    if (s === "done") return "completed";
+    return s; // "active", "dropped"
   }
 
   function buildProject(proj) {

--- a/src/scripts/jxa/project_get.js
+++ b/src/scripts/jxa/project_get.js
@@ -15,9 +15,12 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   function normalizeStatus(raw) {
-    if (raw === "on hold") return "on-hold";
-    if (raw === "done") return "completed";
-    return raw;
+    // OmniFocus 4.8.8 returns verbose strings with a " status" suffix
+    // (e.g. "active status", "on hold status"). Strip for uniform handling.
+    const s = typeof raw === "string" ? raw.replace(/ status$/, "") : raw;
+    if (s === "on hold") return "on-hold";
+    if (s === "done") return "completed";
+    return s; // "active", "dropped"
   }
 
   function buildProject(proj) {

--- a/src/scripts/jxa/project_list.js
+++ b/src/scripts/jxa/project_list.js
@@ -15,9 +15,12 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   function normalizeStatus(raw) {
-    if (raw === "on hold") return "on-hold";
-    if (raw === "done") return "completed";
-    return raw; // "active", "dropped"
+    // OmniFocus 4.8.8 returns verbose strings with a " status" suffix
+    // (e.g. "active status", "on hold status"). Strip for uniform handling.
+    const s = typeof raw === "string" ? raw.replace(/ status$/, "") : raw;
+    if (s === "on hold") return "on-hold";
+    if (s === "done") return "completed";
+    return s; // "active", "dropped"
   }
 
   function buildProject(proj) {

--- a/src/scripts/jxa/project_update.js
+++ b/src/scripts/jxa/project_update.js
@@ -18,9 +18,12 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   function normalizeStatus(raw) {
-    if (raw === "on hold") return "on-hold";
-    if (raw === "done") return "completed";
-    return raw;
+    // OmniFocus 4.8.8 returns verbose strings with a " status" suffix
+    // (e.g. "active status", "on hold status"). Strip for uniform handling.
+    const s = typeof raw === "string" ? raw.replace(/ status$/, "") : raw;
+    if (s === "on hold") return "on-hold";
+    if (s === "done") return "completed";
+    return s; // "active", "dropped"
   }
 
   function buildProject(proj) {


### PR DESCRIPTION
## Summary
- OmniFocus 4.8.8 returns `"active status"`, `"on hold status"`, etc. instead of plain `"active"`, `"on hold"` — strip the ` status` suffix in `normalizeStatus()` across all 4 project scripts

Closes #333.

## Issue
Implements [#333 — bug(jxa): project.status() returns 'active status' not 'active' in OF 4.8.8](https://github.com/torsday/omnifocus-mcp/issues/333).

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests all green
- [x] Self-reviewed