### PR TITLE
fix(jxa): build parent-map from children to fix listFolders parentId filter

### DIFF
--- a/src/scripts/jxa/folder_list.js
+++ b/src/scripts/jxa/folder_list.js
@@ -14,15 +14,29 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  function buildFolder(folder) {
-    let parentId = null;
+  // OmniFocus 4.8.8: folder.parent() throws "Can't convert types." for
+  // sub-folders. Build a reverse map (childId → parentId) by iterating each
+  // folder's .folders() children instead — that API works correctly.
+  const allFolders = ofApp.defaultDocument.flattenedFolders();
+  const parentMap = {};
+  for (let i = 0; i < allFolders.length; i++) {
     try {
-      const p = folder.parent();
-      if (p && p.class() !== "document") parentId = p.id();
+      const subs = allFolders[i].folders();
+      const pid = allFolders[i].id();
+      for (let j = 0; j < subs.length; j++) {
+        try {
+          parentMap[subs[j].id()] = pid;
+        } catch (_e) {}
+      }
     } catch (_e) {}
+  }
+
+  function buildFolder(folder) {
+    const id = folder.id();
+    const parentId = parentMap[id] !== undefined ? parentMap[id] : null;
 
     return {
-      id: folder.id(),
+      id: id,
       name: folder.name(),
       parentId: parentId,
       projectCount: folder.projects ? folder.projects().length : 0,
@@ -36,9 +50,7 @@ function run(argv) {
     };
   }
 
-  const allFolders = ofApp.defaultDocument.flattenedFolders();
   const result = [];
-
   for (let i = 0; i < allFolders.length; i++) {
     const built = buildFolder(allFolders[i]);
     if (args.parentId !== undefined && built.parentId !== args.parentId) continue;


### PR DESCRIPTION
## Summary
- `folder.parent()` throws `"Can't convert types."` for sub-folders in OF 4.8.8, causing `buildFolder` to return `parentId: null` and the `parentId` filter to silently return `[]`
- Fix: iterate each folder's `.folders()` children to build a `childId→parentId` reverse map, then use that in `buildFolder` — no `.parent()` call needed

Closes #338.

## Issue
Implements [#338 — bug(jxa): listFolders with parentId returns empty — nested folder filter broken](https://github.com/torsday/omnifocus-mcp/issues/338).

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests all green
- [x] Probed live OmniFocus: child folder now returned with correct parentId
- [x] Self-reviewed