### PR TITLE
fix(omnijs): implement task_move via Database.moveTasks()

### DIFF
--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -33,7 +33,7 @@ import { TaskId as TaskIdCtor } from "../../domain/ids.js";
 import type { Project } from "../../domain/project.js";
 import type { Tag } from "../../domain/tag.js";
 import type { Task } from "../../domain/task.js";
-import { FeatureRequiresPro, NotFound, ScriptError } from "../../errors/index.js";
+import { FeatureRequiresPro, NotFound, ScriptError, ValidationError } from "../../errors/index.js";
 import type {
   CreateFolderInput,
   CreateProjectInput,
@@ -126,10 +126,36 @@ export class OmniJsTransport implements OmniFocusAdapter {
     return notYetWired("deleteTask");
   }
   async moveTask(
-    _id: TaskId,
-    _destination: { projectId?: ProjectId; parentId?: TaskId },
+    id: TaskId,
+    destination: { projectId?: ProjectId; parentId?: TaskId },
   ): Promise<void> {
-    return notYetWired("moveTask");
+    // JXA's task.move() fails with error 9 ("Replacement not supported") in
+    // OmniFocus 4.x. Database.moveTasks() in OmniJS performs genuine reparenting
+    // while preserving the task's persistent ID — hence this routes to OmniJS.
+    const script = await import("node:fs/promises").then((fs) =>
+      fs.readFile(new URL("../../scripts/omnijs/task_move.js", import.meta.url), "utf8"),
+    );
+    const result = await runOmniJsScript<
+      { id: string } | { error: { code: "NOT_FOUND" | "VALIDATION"; message: string } }
+    >(
+      script,
+      {
+        id,
+        projectId: destination.projectId ?? null,
+        parentId: destination.parentId ?? null,
+      },
+      { ...this.runOpts, scriptName: "task_move" },
+    );
+    if ("error" in result) {
+      if (result.error.code === "NOT_FOUND") {
+        throw new NotFound(result.error.message, {
+          details: { transport: "omnijs", scriptName: "task_move" },
+        });
+      }
+      throw new ValidationError(result.error.message, {
+        details: { transport: "omnijs", scriptName: "task_move" },
+      });
+    }
   }
   async reorderTask(_id: TaskId, _position: TaskPosition): Promise<void> {
     return notYetWired("reorderTask");

--- a/src/adapter/router.test.ts
+++ b/src/adapter/router.test.ts
@@ -202,15 +202,16 @@ describe("TransportRouter — routing", () => {
   });
 
   it("forwards arguments unchanged to the chosen transport", async () => {
-    const jxa = {
-      ...makeStub("jxa"),
+    const jxa = makeStub("jxa");
+    const omnijs = {
+      ...makeStub("omnijs"),
+      // moveTask routes to OmniJS (JXA task.move() → error 9 in OF 4.x)
       moveTask: vi.fn(async (_id: TaskId, _dest: unknown): Promise<void> => undefined),
     };
-    const omnijs = makeStub("omnijs");
     const router = new TransportRouter({ jxa, omnijs });
     const dest = { projectId: P_ID };
     await router.moveTask(T_ID, dest);
-    expect(jxa.moveTask).toHaveBeenCalledWith(T_ID, dest);
+    expect(omnijs.moveTask).toHaveBeenCalledWith(T_ID, dest);
   });
 });
 
@@ -240,7 +241,12 @@ describe("TransportRouter — table integrity", () => {
       .filter(([, t]) => t === "omnijs")
       .map(([m]) => m)
       .sort();
-    expect(omniJsRoutes).toEqual(["evaluateCustomPerspective", "pluginInvoke", "runOmniJsScript"]);
+    expect(omniJsRoutes).toEqual([
+      "evaluateCustomPerspective",
+      "moveTask", // JXA task.move() → error 9 in OF 4.x; OmniJS Database.moveTasks() works
+      "pluginInvoke",
+      "runOmniJsScript",
+    ]);
   });
 });
 

--- a/src/adapter/router.ts
+++ b/src/adapter/router.ts
@@ -98,7 +98,7 @@ export const ROUTING_TABLE: Readonly<Record<AdapterMethod, TransportName>> = Obj
   dropTask: "jxa",
   undropTask: "jxa",
   deleteTask: "jxa",
-  moveTask: "jxa",
+  moveTask: "omnijs", // JXA task.move() → error 9 in OF 4.x; Database.moveTasks() via OmniJS works
   reorderTask: "jxa",
   duplicateTask: "jxa",
   batchCreateTasks: "jxa",

--- a/src/scripts/omnijs/task_move.js
+++ b/src/scripts/omnijs/task_move.js
@@ -1,0 +1,56 @@
+/**
+ * OmniJS: move a task to a different project, parent task, or the inbox.
+ *
+ * JXA's `task.move({ to: container })` is unimplemented in OmniFocus 4.x
+ * (error 9 "Replacement not supported currently"). The OmniJS
+ * `Database.moveTasks(tasks, location)` API performs genuine reparenting
+ * while preserving the task's persistent ID — hence this script routes
+ * through the OmniJS transport instead.
+ *
+ * Args injected as `globalThis.__args`:
+ *   { id: string, projectId?: string|null, parentId?: string|null }
+ *   Pass neither projectId nor parentId to move the task to the inbox.
+ *
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/omnijs/OmniJsTransport.ts — moveTask() caller
+ * @see docs/adr/0002-omnifocus-transport-dual.md — JXA/OmniJS split rationale
+ */
+(() => {
+  const { id, projectId, parentId } = globalThis.__args;
+
+  if (!id) {
+    return JSON.stringify({ error: { code: "VALIDATION", message: "id is required" } });
+  }
+
+  const task = flattenedTasks.filter((t) => t.id.primaryKey === id)[0];
+  if (!task) {
+    return JSON.stringify({ error: { code: "NOT_FOUND", message: `Task not found: ${id}` } });
+  }
+
+  if (parentId != null) {
+    // Move under a parent task.
+    const parent = flattenedTasks.filter((t) => t.id.primaryKey === parentId)[0];
+    if (!parent) {
+      return JSON.stringify({
+        error: { code: "NOT_FOUND", message: `Parent task not found: ${parentId}` },
+      });
+    }
+    moveTasks([task], parent);
+  } else if (projectId != null) {
+    // Move into a project (as a top-level action of that project).
+    const proj = flattenedProjects.filter((p) => p.id.primaryKey === projectId)[0];
+    if (!proj) {
+      return JSON.stringify({
+        error: { code: "NOT_FOUND", message: `Project not found: ${projectId}` },
+      });
+    }
+    moveTasks([task], proj);
+  } else {
+    // No destination specified — move to inbox.
+    // `inbox` alone is not a valid moveTasks position; use inbox.beginning.
+    moveTasks([task], inbox.beginning);
+  }
+
+  return JSON.stringify({ id });
+})();


### PR DESCRIPTION
## Summary
- JXA `task.move({ to: container })` has been unimplemented in OmniFocus since OF2 (error 9 "Replacement not supported currently" — pre-OF4, not a regression)
- OmniJS `Database.moveTasks(tasks, location)` performs genuine reparenting while preserving the task's persistent ID
- New `src/scripts/omnijs/task_move.js` handles project, parent-task, and inbox destinations
- `OmniJsTransport.moveTask()` wired; `ROUTING_TABLE` flipped from `"jxa"` → `"omnijs"`

Closes #335.

## Issue
Implements [#335 — bug(jxa): task_move fails — JXA replacement not supported in OF 4.x](https://github.com/torsday/omnifocus-mcp/issues/335).

## Breaking change?
- [x] No — same method signature, same returned `void`; routing is an internal detail

## Test plan
- [x] Unit tests all green (111 suites)
- [x] Probed live OmniFocus: `moveTasks([task], proj)` ✅, `moveTasks([task], parentTask)` ✅, `moveTasks([task], inbox.beginning)` ✅
- [x] Self-reviewed