### PR TITLE
fix(task): reject dueDate earlier than deferDate in create and update

### DIFF
--- a/src/tools/task/create.test.ts
+++ b/src/tools/task/create.test.ts
@@ -71,6 +71,44 @@ describe("task_create — input schema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects dueDate earlier than deferDate", () => {
+    const result = taskCreateInputSchema.safeParse({
+      name: "Test",
+      deferDate: "2025-06-01T00:00:00+00:00",
+      dueDate: "2025-05-01T00:00:00+00:00",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toContain("dueDate");
+    }
+  });
+
+  it("accepts dueDate equal to deferDate", () => {
+    const result = taskCreateInputSchema.safeParse({
+      name: "Test",
+      deferDate: "2025-06-01T00:00:00+00:00",
+      dueDate: "2025-06-01T00:00:00+00:00",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts dueDate after deferDate", () => {
+    const result = taskCreateInputSchema.safeParse({
+      name: "Test",
+      deferDate: "2025-05-01T00:00:00+00:00",
+      dueDate: "2025-06-01T00:00:00+00:00",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts dueDate with no deferDate", () => {
+    const result = taskCreateInputSchema.safeParse({
+      name: "Test",
+      dueDate: "2025-05-01T00:00:00+00:00",
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts idempotency_key", () => {
     const result = taskCreateInputSchema.safeParse({ name: "Test", idempotency_key: "abc" });
     expect(result.success).toBe(true);

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -96,10 +96,20 @@ const taskCreateInputBaseSchema = z.object({
  * The base schema's `.shape` is used for MCP tool registration so the SDK
  * can read individual field descriptors (ZodEffects from `.refine()` lacks `.shape`).
  */
-export const taskCreateInputSchema = taskCreateInputBaseSchema.refine(
-  (v) => !(v.projectId !== undefined && v.parentTaskId !== undefined),
-  { message: "Supply at most one of projectId or parentTaskId", path: ["projectId"] },
-);
+export const taskCreateInputSchema = taskCreateInputBaseSchema
+  .refine((v) => !(v.projectId !== undefined && v.parentTaskId !== undefined), {
+    message: "Supply at most one of projectId or parentTaskId",
+    path: ["projectId"],
+  })
+  .refine(
+    (v) =>
+      !(
+        v.dueDate !== undefined &&
+        v.deferDate !== undefined &&
+        new Date(v.dueDate) < new Date(v.deferDate)
+      ),
+    { message: "dueDate must not be earlier than deferDate", path: ["dueDate"] },
+  );
 
 export type TaskCreateToolInput = z.infer<typeof taskCreateInputSchema>;
 

--- a/src/tools/task/update.test.ts
+++ b/src/tools/task/update.test.ts
@@ -98,6 +98,42 @@ describe("task_update — input schema", () => {
     ).toThrow();
   });
 
+  it("rejects dueDate earlier than deferDate", () => {
+    expect(() =>
+      taskUpdateInputSchema.parse({
+        id: "task_000001",
+        deferDate: "2025-06-01T00:00:00+00:00",
+        dueDate: "2025-05-01T00:00:00+00:00",
+      }),
+    ).toThrow();
+  });
+
+  it("accepts dueDate equal to deferDate", () => {
+    const parsed = taskUpdateInputSchema.parse({
+      id: "task_000001",
+      deferDate: "2025-06-01T00:00:00+00:00",
+      dueDate: "2025-06-01T00:00:00+00:00",
+    });
+    expect(parsed.dueDate).toBe("2025-06-01T00:00:00+00:00");
+  });
+
+  it("accepts dueDate after deferDate", () => {
+    const parsed = taskUpdateInputSchema.parse({
+      id: "task_000001",
+      deferDate: "2025-05-01T00:00:00+00:00",
+      dueDate: "2025-06-01T00:00:00+00:00",
+    });
+    expect(parsed.dueDate).toBe("2025-06-01T00:00:00+00:00");
+  });
+
+  it("accepts dueDate with no deferDate in patch", () => {
+    const parsed = taskUpdateInputSchema.parse({
+      id: "task_000001",
+      dueDate: "2025-05-01T00:00:00+00:00",
+    });
+    expect(parsed.dueDate).toBe("2025-05-01T00:00:00+00:00");
+  });
+
   it("accepts addTags and removeTags together (no tagIds)", () => {
     const parsed = taskUpdateInputSchema.parse({
       id: "task_000001",

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -158,16 +158,22 @@ export const taskUpdateInputBaseSchema = z.object({
  * The base schema's `.shape` is used for MCP tool registration so the SDK
  * can read individual field descriptors (ZodEffects from `.refine()` lacks `.shape`).
  */
-export const taskUpdateInputSchema = taskUpdateInputBaseSchema.refine(
-  (val) =>
-    !(val.tagIds !== undefined && (val.addTags !== undefined || val.removeTags !== undefined)),
-  {
-    message:
-      "tagIds cannot be combined with addTags/removeTags. " +
-      "Use tagIds for full replacement, or addTags/removeTags for additive diff.",
-    path: ["tagIds"],
-  },
-);
+export const taskUpdateInputSchema = taskUpdateInputBaseSchema
+  .refine(
+    (val) =>
+      !(val.tagIds !== undefined && (val.addTags !== undefined || val.removeTags !== undefined)),
+    {
+      message:
+        "tagIds cannot be combined with addTags/removeTags. " +
+        "Use tagIds for full replacement, or addTags/removeTags for additive diff.",
+      path: ["tagIds"],
+    },
+  )
+  .refine(
+    (v) =>
+      !(v.dueDate != null && v.deferDate != null && new Date(v.dueDate) < new Date(v.deferDate)),
+    { message: "dueDate must not be earlier than deferDate", path: ["dueDate"] },
+  );
 
 export type TaskUpdateToolInput = z.infer<typeof taskUpdateInputSchema>;
 


### PR DESCRIPTION
## Summary
- Adds a cross-field `.refine()` to `taskCreateInputSchema` rejecting input where `dueDate < deferDate`
- Adds the same check to `taskUpdateInputSchema`, correctly handling `null` values (date-clearing patches are excluded from the check)
- Surfaces a `ValidationError` at `path: ["dueDate"]` so callers know exactly which field is invalid
- 8 new schema-level unit tests covering reject/equal/after/single-date cases for both tools

Closes #356.

## Issue
Implements [#356 — Validate dueDate >= deferDate in task_create and task_update](https://github.com/torsday/omnifocus-mcp/issues/356).

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests: 68 passing (21 create, 47 update)
- [x] Typecheck clean
- [x] Lint clean
- [x] Self-reviewed