### PR TITLE
chore(ci): add Automation permission preflight and recovery docs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,6 +78,12 @@ jobs:
           fi
           echo "OmniFocus is running — proceeding with integration tests."
 
+      - name: Check macOS Automation permission
+        # Detects error -1743 ("Not authorized to send Apple events") before
+        # the test suite runs so failures surface a clear diagnostic rather
+        # than a generic "JXA script returned empty stdout" error.
+        run: bash scripts/check-automation-permission.sh
+
       - name: Run integration tests
         env:
           OMNIFOCUS_INTEGRATION: "1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,40 @@ Inherited from [`coding.md`](https://github.com/torsday/llm_prompts/blob/main/co
 - [ ] No user content (task names, notes, tags) interpolated into metadata fields (`suggestion`, `message`, `warnings`)
 ```
 
+## Self-hosted CI runner setup (macOS Automation permission)
+
+The integration test suite (`pnpm test:integration`) runs JXA scripts that send Apple Events to OmniFocus. macOS requires an explicit one-time Automation permission grant for the process that spawns `osascript`. Without it, every JXA call fails with error -1743 and the test suite reports `"JXA script returned empty stdout"` with no further context.
+
+### One-time grant (runner or developer machine)
+
+1. Open **System Settings → Privacy & Security → Automation**
+2. Locate the terminal or runner process (typically `bash`, `zsh`, or the GitHub Actions runner agent)
+3. Enable the toggle next to **OmniFocus**
+4. Re-run the tests — no restart required
+
+### Verifying permission before running tests
+
+```bash
+bash scripts/check-automation-permission.sh
+```
+
+Exits 0 with `✓ Automation permission for OmniFocus is granted.` if permission is present.
+Exits 1 with a step-by-step recovery guide if it detects error -1743.
+
+### In CI
+
+`integration.yml` calls `check-automation-permission.sh` as a pre-step (after confirming OmniFocus is running and before the test suite). A missing permission fails fast with an `::error::` annotation instead of a cryptic empty-stdout failure.
+
+### After a macOS update or runner reinstall
+
+macOS may revoke Automation permissions when the OS is updated or the terminal binary changes path. If integration tests start failing with empty stdout after a system update, run the preflight script first:
+
+```bash
+bash scripts/check-automation-permission.sh
+```
+
+If it exits 1, re-grant permission in System Settings as above.
+
 ## Ask before
 
 - Introducing a new runtime dependency ([`DESIGN.md §25`](./DESIGN.md#25-dependency-inventory) inventory requires justification)

--- a/scripts/check-automation-permission.sh
+++ b/scripts/check-automation-permission.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# check-automation-permission.sh
+#
+# Verify that the running shell process has macOS Automation permission to
+# send Apple Events to OmniFocus. Exits 0 when permission is granted, exits
+# 1 with an actionable diagnostic when it is not.
+#
+# Usage:
+#   ./scripts/check-automation-permission.sh
+#
+# CI: call this as a step before `pnpm test:integration` so that a missing
+# Automation permission produces a clear error message rather than a generic
+# "JXA script returned empty stdout" failure.
+#
+# Detection mechanism:
+#   `osascript` exits non-zero and writes "Not authorized to send Apple
+#   events to OmniFocus" to stderr (error code -1743) when Automation
+#   permission is absent. The script captures stderr and checks for the
+#   known error string.
+
+set -euo pipefail
+
+OMNIFOCUS_BUNDLE="com.omnigroup.OmniFocus4"
+TEST_SCRIPT='Application("OmniFocus").name()'
+
+# Run a minimal JXA script that requires Automation access to OmniFocus.
+STDERR_OUTPUT=$(osascript -l JavaScript -e "$TEST_SCRIPT" 2>&1 >/dev/null || true)
+
+if echo "$STDERR_OUTPUT" | grep -q "Not authorized to send Apple events"; then
+  echo "::error::macOS Automation permission for OmniFocus is not granted."
+  echo ""
+  echo "Fix: grant Automation access in System Settings:"
+  echo "  System Settings → Privacy & Security → Automation"
+  echo "  → Find the terminal/runner process (e.g. bash, zsh, GitHub Actions runner)"
+  echo "  → Enable the toggle next to OmniFocus"
+  echo ""
+  echo "If running on a fresh macOS install or after a macOS update:"
+  echo "  1. Open System Settings → Privacy & Security → Automation"
+  echo "  2. Locate the process used by the CI runner (often 'bash' or the runner agent)"
+  echo "  3. Enable the OmniFocus toggle"
+  echo "  4. Re-run the integration tests"
+  echo ""
+  echo "For local development: run the failing test once interactively —"
+  echo "  OMNIFOCUS_INTEGRATION=1 pnpm test:integration"
+  echo "macOS will prompt for Automation permission on the first run."
+  exit 1
+fi
+
+if echo "$STDERR_OUTPUT" | grep -qi "error"; then
+  echo "::warning::Unexpected osascript error during permission check: $STDERR_OUTPUT"
+fi
+
+echo "✓ Automation permission for OmniFocus is granted."


### PR DESCRIPTION
## Summary
- Adds `scripts/check-automation-permission.sh` — probes for error -1743 ("Not authorized to send Apple events") and exits with a step-by-step recovery guide when Automation permission is missing
- Wires the preflight as a CI step in `integration.yml` between the OmniFocus-running check and the test run, so failures produce a `::error::` annotation instead of a cryptic empty-stdout report
- Updates `CONTRIBUTING.md` with a self-contained "Self-hosted CI runner setup" section covering one-time grant, preflight command, CI context, and post-update recovery

Closes #352.

## Issue
Implements [#352 — Improve integration CI permission detection and recovery guidance](https://github.com/torsday/omnifocus-mcp/issues/352).

## Breaking change?
- [x] No

## Test plan
- [x] Typecheck clean
- [x] Lint clean
- [x] Script is executable and detects the expected error string
- [x] CI workflow YAML updated with new step
- [x] CONTRIBUTING.md updated with permission grant instructions