### PR TITLE
feat(search): implement task_search tool and JXA script

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,7 +2,7 @@
 
 # OmniFocus MCP Tool Reference
 
-> Auto-generated from source. 49 tools registered.
+> Auto-generated from source. 50 tools registered.
 
 ## Table of contents
 
@@ -53,6 +53,7 @@
 - [task_move](#task_move)
 - [task_parse_transport_text](#task_parse_transport_text)
 - [task_reorder](#task_reorder)
+- [task_search](#task_search)
 - [task_set_repetition](#task_set_repetition)
 - [task_update](#task_update)
 
@@ -1875,6 +1876,44 @@ _No parameters._
 ```json
 {
   "toolName": "task_reorder",
+  "arguments": {}
+}
+```
+
+### Example response
+
+```json
+{
+  "ok": true,
+  "data": {},
+  "meta": {
+    "requestId": "req_01ABC",
+    "durationMs": 5
+  }
+}
+```
+---
+
+## task_search
+
+Search OmniFocus tasks by keyword. Scans task names and/or notes (controlled by scope) for a case-insensitive substring match. Optionally narrow results by projectId, tagIds (task must carry ALL listed tags), flagged state, and completion state. Returns the full Task domain shape — same as task_list — so no follow-up read is needed. Returns tasks[]; safe to call repeatedly; no side effects.
+
+### Input
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `q` | string | Yes | Search query. Case-insensitive substring match applied to the fields in scope. |
+| `scope` | one of: name | note | all | No | 'name' = search task name only; 'note' = search note only; 'all' = both (default). |
+| `projectId` | string | No | Restrict search to tasks within this project. |
+| `tagIds` | string[] | No | Restrict to tasks carrying ALL of these tag IDs. |
+| `flagged` | boolean | No | true = flagged tasks only; false = unflagged only; omit = all. |
+| `completed` | one of: any | only | exclude | No | 'exclude' = active tasks only (default); 'only' = completed tasks only; 'any' = both. |
+
+### Example call
+
+```json
+{
+  "toolName": "task_search",
   "arguments": {}
 }
 ```

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -82,6 +82,7 @@ import taskGetManyScript from "../../scripts/jxa/task_get_many.js";
 import taskListScript from "../../scripts/jxa/task_list.js";
 import taskMoveScript from "../../scripts/jxa/task_move.js";
 import taskReorderScript from "../../scripts/jxa/task_reorder.js";
+import taskSearchScript from "../../scripts/jxa/task_search.js";
 import taskUncompleteScript from "../../scripts/jxa/task_uncomplete.js";
 import taskUndropScript from "../../scripts/jxa/task_undrop.js";
 import taskUpdateScript from "../../scripts/jxa/task_update.js";
@@ -97,6 +98,7 @@ import type {
   RemoveAttachmentInput,
   SaveAttachmentInput,
   SaveAttachmentResult,
+  SearchFilter,
   SyncStatus,
   TaskFilter,
   TaskPosition,
@@ -651,10 +653,20 @@ export class JxaTransport implements OmniFocusAdapter {
 
   // -- Search ---------------------------------------------------------------
 
-  async searchTasks(
-    _filter: import("../OmniFocusAdapter.js").SearchFilter,
-  ): Promise<import("../../domain/task.js").Task[]> {
-    return notYetWired("searchTasks");
+  async searchTasks(filter: SearchFilter): Promise<Task[]> {
+    const result = await runJxaScript<{ tasks: Task[] }>(
+      taskSearchScript,
+      {
+        q: filter.q,
+        scope: filter.scope ?? "all",
+        projectId: filter.projectId ?? null,
+        tagIds: filter.tagIds ?? null,
+        flagged: filter.flagged ?? null,
+        completed: filter.completed ?? "exclude",
+      },
+      { ...this.runOpts, scriptName: "task_search" },
+    );
+    return result.tasks.map((t) => ({ ...t, id: TaskIdCtor.of(t.id) }));
   }
 
   async getForecast(

--- a/src/scripts/jxa/task_search.d.ts
+++ b/src/scripts/jxa/task_search.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_search.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -1,0 +1,203 @@
+/**
+ * JXA: search tasks by keyword, optionally filtered by project, tags,
+ * flagged state, and completion state.
+ *
+ * Args (argv[0] JSON): {
+ *   q: string,            // search query (case-insensitive)
+ *   scope?: "name"|"note"|"all",   // which fields to search (default "all")
+ *   projectId?: string|null,
+ *   tagIds?: string[]|null,        // task must carry ALL listed tags
+ *   flagged?: boolean|null,
+ *   completed?: "any"|"only"|"exclude"|null   // default "exclude"
+ * }
+ * Returns JSON: { tasks: Task[] }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — searchTasks() caller
+ * @see src/domain/task.ts — Task domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const q = (args.q || "").toLowerCase();
+  const scope = args.scope || "all";
+  const completed =
+    args.completed !== undefined && args.completed !== null ? args.completed : "exclude";
+
+  // ---------------------------------------------------------------------------
+  // buildTask — same shape as task_list.js
+  // ---------------------------------------------------------------------------
+
+  function buildRepetition(task) {
+    try {
+      const rr = task.repetitionRule();
+      if (!rr) return null;
+      return { method: rr.method(), unit: rr.unit(), steps: rr.steps() };
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function buildTask(task) {
+    let projectId = null;
+    try {
+      const cp = task.containingProject();
+      if (cp && cp.class() !== "document") projectId = cp.id();
+    } catch (_e) {}
+
+    let parentId = null;
+    try {
+      const pt = task.parentTask();
+      if (pt) parentId = pt.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = task.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let deferDate = null;
+    try {
+      const dd = task.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = task.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = task.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let dropped = false;
+    try {
+      dropped = task.dropped();
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = task.flagged();
+    } catch (_e) {}
+
+    let isCompleted = false;
+    try {
+      isCompleted = task.completed();
+    } catch (_e) {}
+
+    let available = false;
+    try {
+      available = task.effectivelyAvailable ? task.effectivelyAvailable() : false;
+    } catch (_e) {}
+
+    let blocked = false;
+    try {
+      blocked = task.blocked ? task.blocked() : false;
+    } catch (_e) {}
+
+    let sequential = false;
+    try {
+      sequential = task.sequential ? task.sequential() : false;
+    } catch (_e) {}
+
+    let completedByChildren = false;
+    try {
+      completedByChildren = task.completedByChildren ? task.completedByChildren() : false;
+    } catch (_e) {}
+
+    let note = "";
+    try {
+      note = task.note ? task.note() : "";
+    } catch (_e) {}
+
+    return {
+      id: task.id(),
+      name: task.name(),
+      note: note || null,
+      noteHtml: null,
+      projectId,
+      parentId,
+      tagIds,
+      flagged,
+      dueDate,
+      deferDate,
+      completedAt,
+      droppedAt: null,
+      completed: isCompleted,
+      dropped,
+      available,
+      blocked,
+      sequential,
+      completedByChildren,
+      estimatedMinutes: null,
+      repetition: buildRepetition(task),
+      createdAt: task.creationDate ? task.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: task.modificationDate
+        ? task.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Collect candidate tasks
+  // ---------------------------------------------------------------------------
+
+  let tasks;
+  if (args.projectId) {
+    try {
+      tasks = ofApp.defaultDocument.flattenedProjects.byId(args.projectId).flattenedTasks();
+    } catch (_e) {
+      throw new Error(`Project not found: ${args.projectId}`);
+    }
+  } else {
+    tasks = ofApp.defaultDocument.flattenedTasks();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filter
+  // ---------------------------------------------------------------------------
+
+  const result = [];
+  for (let i = 0; i < tasks.length; i++) {
+    const t = tasks[i];
+    const built = buildTask(t);
+
+    // Completion filter
+    if (completed === "exclude" && built.completed) continue;
+    if (completed === "only" && !built.completed) continue;
+    // "any" passes through both
+
+    // Flagged filter
+    if (args.flagged !== null && args.flagged !== undefined && built.flagged !== args.flagged)
+      continue;
+
+    // Tag filter — task must carry ALL listed tags
+    if (args.tagIds && args.tagIds.length > 0) {
+      const allPresent = args.tagIds.every((tid) => built.tagIds.includes(tid));
+      if (!allPresent) continue;
+    }
+
+    // Text search
+    if (q) {
+      const nameMatch = built.name.toLowerCase().includes(q);
+      const noteMatch = built.note ? built.note.toLowerCase().includes(q) : false;
+      const matches =
+        scope === "name" ? nameMatch : scope === "note" ? noteMatch : nameMatch || noteMatch; // "all"
+      if (!matches) continue;
+    }
+
+    result.push(built);
+  }
+
+  return JSON.stringify({ tasks: result });
+}

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -116,6 +116,7 @@ import { registerTaskListTool } from "../tools/task/list.js";
 import { registerTaskMoveTool } from "../tools/task/move.js";
 import { registerTaskParseTransportTextTool } from "../tools/task/parseTransportText.js";
 import { registerTaskReorderTool } from "../tools/task/reorder.js";
+import { registerTaskSearchTool } from "../tools/task/search.js";
 import { registerTaskSetRepetitionTool } from "../tools/task/setRepetition.js";
 import { registerTaskUncompleteTool } from "../tools/task/uncomplete.js";
 import { registerTaskUndropTool } from "../tools/task/undrop.js";
@@ -311,6 +312,7 @@ export async function startServer(): Promise<void> {
   registerTaskGetTool(server, taskServiceCtx);
   registerTaskListTool(server, taskServiceCtx);
   registerTaskFindByNameTool(server, taskAdapterCtx);
+  registerTaskSearchTool(server, taskAdapterCtx);
   registerTaskGetManyTool(server, taskAdapterCtx);
   registerTaskParseTransportTextTool(server, { makeMeta });
   registerTaskBatchCompleteTool(server, taskMutationCtx);

--- a/src/tools/allDescriptions.ts
+++ b/src/tools/allDescriptions.ts
@@ -47,6 +47,7 @@ import { TASK_LIST_DESCRIPTION } from "./task/list.js";
 import { TASK_MOVE_DESCRIPTION } from "./task/move.js";
 import { TASK_PARSE_TRANSPORT_TEXT_DESCRIPTION } from "./task/parseTransportText.js";
 import { TASK_REORDER_DESCRIPTION } from "./task/reorder.js";
+import { TASK_SEARCH_DESCRIPTION } from "./task/search.js";
 import { TASK_SET_REPETITION_DESCRIPTION } from "./task/setRepetition.js";
 import { TASK_UPDATE_DESCRIPTION } from "./task/update.js";
 
@@ -96,6 +97,7 @@ export const ALL_TOOL_DESCRIPTIONS: Record<string, string> = {
   task_get_many: TASK_GET_MANY_DESCRIPTION,
   task_list: TASK_LIST_DESCRIPTION,
   task_move: TASK_MOVE_DESCRIPTION,
+  task_search: TASK_SEARCH_DESCRIPTION,
   task_parse_transport_text: TASK_PARSE_TRANSPORT_TEXT_DESCRIPTION,
   task_reorder: TASK_REORDER_DESCRIPTION,
   task_set_repetition: TASK_SET_REPETITION_DESCRIPTION,

--- a/src/tools/allInputSchemas.ts
+++ b/src/tools/allInputSchemas.ts
@@ -47,6 +47,7 @@ import { taskFindByNameInputSchema } from "./task/findByName.js";
 import { taskGetInputSchema } from "./task/get.js";
 import { taskGetManyInputSchema } from "./task/getMany.js";
 import { taskListInputSchema } from "./task/list.js";
+import { taskSearchInputSchema } from "./task/search.js";
 import { taskSetRepetitionInputSchema } from "./task/setRepetition.js";
 // task_update uses the base schema (ZodObject) — the exported schema is ZodEffects
 import { taskUpdateInputBaseSchema } from "./task/update.js";
@@ -87,6 +88,7 @@ export const ALL_INPUT_SCHEMAS: Record<string, z.ZodObject<z.ZodRawShape>> = {
   task_get: taskGetInputSchema,
   task_get_many: taskGetManyInputSchema,
   task_list: taskListInputSchema,
+  task_search: taskSearchInputSchema,
   task_set_repetition: taskSetRepetitionInputSchema,
   task_update: taskUpdateInputBaseSchema,
 };

--- a/src/tools/task/search.test.ts
+++ b/src/tools/task/search.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for task_search tool.
+ *
+ * Covers: schema validation, basic keyword match, no-results case,
+ * scope (name/note/all), projectId filter, flagged filter, completed filter,
+ * tagIds filter (ALL-match semantics).
+ *
+ * Uses InMemoryAdapter so no JXA bridge or live OmniFocus is required.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import { handleTaskSearch, taskSearchInputSchema } from "./search.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeCtx() {
+  let tick = 0;
+  const adapter = new InMemoryAdapter({
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+    ...partial,
+  });
+  return { ctx: { adapter, makeMeta }, adapter };
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("task_search — input schema", () => {
+  it("requires q", () => {
+    expect(() => taskSearchInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects empty q", () => {
+    expect(() => taskSearchInputSchema.parse({ q: "" })).toThrow();
+  });
+
+  it("accepts minimal input", () => {
+    const parsed = taskSearchInputSchema.parse({ q: "groceries" });
+    expect(parsed.q).toBe("groceries");
+  });
+
+  it("accepts full input surface", () => {
+    const parsed = taskSearchInputSchema.parse({
+      q: "standup",
+      scope: "name",
+      flagged: true,
+      completed: "exclude",
+    });
+    expect(parsed.scope).toBe("name");
+    expect(parsed.flagged).toBe(true);
+    expect(parsed.completed).toBe("exclude");
+  });
+
+  it("rejects invalid scope", () => {
+    expect(() => taskSearchInputSchema.parse({ q: "x", scope: "title" })).toThrow();
+  });
+
+  it("rejects invalid completed value", () => {
+    expect(() => taskSearchInputSchema.parse({ q: "x", completed: "yes" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+describe("task_search — handler", () => {
+  it("returns tasks matching the keyword in name", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Buy groceries" });
+    await adapter.createTask({ name: "Send report" });
+
+    const result = await handleTaskSearch({ q: "groceries" }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+    expect(result.data.tasks[0]?.name).toBe("Buy groceries");
+  });
+
+  it("returns empty array when no tasks match", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Buy groceries" });
+
+    const result = await handleTaskSearch({ q: "quarterly report" }, ctx);
+    expect(result.data.tasks).toHaveLength(0);
+  });
+
+  it("search is case-insensitive", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Review BUDGET" });
+
+    const result = await handleTaskSearch({ q: "budget" }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+  });
+
+  it("returns multiple matches", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Buy groceries" });
+    await adapter.createTask({ name: "Buy medicine" });
+    await adapter.createTask({ name: "Send report" });
+
+    const result = await handleTaskSearch({ q: "buy" }, ctx);
+    expect(result.data.tasks).toHaveLength(2);
+  });
+
+  it("scope=name skips note matches", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Meeting prep", note: "agenda: quarterly review" });
+    await adapter.createTask({ name: "quarterly standup" });
+
+    const result = await handleTaskSearch({ q: "quarterly", scope: "name" }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+    expect(result.data.tasks[0]?.name).toBe("quarterly standup");
+  });
+
+  it("scope=note skips name matches", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "quarterly standup" });
+    await adapter.createTask({ name: "Meeting prep", note: "agenda: quarterly review" });
+
+    const result = await handleTaskSearch({ q: "quarterly", scope: "note" }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+    expect(result.data.tasks[0]?.name).toBe("Meeting prep");
+  });
+
+  it("scope=all (default) matches name or note", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "quarterly standup" });
+    await adapter.createTask({ name: "Meeting prep", note: "agenda: quarterly review" });
+
+    const result = await handleTaskSearch({ q: "quarterly" }, ctx);
+    expect(result.data.tasks).toHaveLength(2);
+  });
+
+  it("filters by flagged=true", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "critical fix", flagged: true });
+    await adapter.createTask({ name: "critical path", flagged: false });
+
+    const result = await handleTaskSearch({ q: "critical", flagged: true }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+    expect(result.data.tasks[0]?.name).toBe("critical fix");
+  });
+
+  it("completed=exclude (default) omits completed tasks", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "review docs" });
+    await adapter.createTask({ name: "review code" });
+    await adapter.completeTask(id);
+
+    const result = await handleTaskSearch({ q: "review", completed: "exclude" }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+    expect(result.data.tasks[0]?.name).toBe("review code");
+  });
+
+  it("completed=only returns only completed tasks", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "review docs" });
+    await adapter.createTask({ name: "review code" });
+    await adapter.completeTask(id);
+
+    const result = await handleTaskSearch({ q: "review", completed: "only" }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+    expect(result.data.tasks[0]?.name).toBe("review docs");
+  });
+
+  it("completed=any returns all matching tasks regardless of completion", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "review docs" });
+    await adapter.createTask({ name: "review code" });
+    await adapter.completeTask(id);
+
+    const result = await handleTaskSearch({ q: "review", completed: "any" }, ctx);
+    expect(result.data.tasks).toHaveLength(2);
+  });
+
+  it("filters by projectId restricts to project tasks", async () => {
+    const { ctx, adapter } = makeCtx();
+    const pid = await adapter.createProject({ name: "Work" });
+    await adapter.createTask({ name: "review PR", projectId: pid });
+    await adapter.createTask({ name: "review notes" });
+
+    const result = await handleTaskSearch({ q: "review", projectId: pid }, ctx);
+    expect(result.data.tasks).toHaveLength(1);
+    expect(result.data.tasks[0]?.projectId).toBe(pid);
+  });
+});

--- a/src/tools/task/search.ts
+++ b/src/tools/task/search.ts
@@ -1,0 +1,112 @@
+/**
+ * `task_search` MCP tool — full-text task search across name and/or note.
+ *
+ * Searches OmniFocus tasks by keyword, optionally narrowing by project,
+ * tags, flagged state, and completion state. Returns the standard Task
+ * domain shape — the same as task_list — so callers can act on results
+ * without a follow-up read.
+ *
+ * JXA implementation: in-process substring scan of flattenedTasks
+ * (or flattenedTasks of a specific project when projectId is supplied).
+ * The whose-clause approach is skipped because it cannot span multiple
+ * fields (name + note) in a single predicate.
+ *
+ * @see src/scripts/jxa/task_search.js — underlying JXA script
+ * @see src/tools/task/list.ts — filter-based listing (no keyword)
+ * @see src/tools/task/findByName.ts — exact/prefix/contains name-only lookup
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { ProjectId, TagId } from "../../domain/ids.js";
+import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const TASK_SEARCH_DESCRIPTION =
+  "Search OmniFocus tasks by keyword. " +
+  "Scans task names and/or notes (controlled by scope) for a case-insensitive substring match. " +
+  "Optionally narrow results by projectId, tagIds (task must carry ALL listed tags), " +
+  "flagged state, and completion state. " +
+  "Returns the full Task domain shape — same as task_list — so no follow-up read is needed. " +
+  "Returns tasks[]; safe to call repeatedly; no side effects.";
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const taskSearchInputSchema = z.object({
+  q: z
+    .string()
+    .min(1)
+    .describe("Search query. Case-insensitive substring match applied to the fields in scope."),
+  scope: z
+    .enum(["name", "note", "all"])
+    .optional()
+    .describe("'name' = search task name only; 'note' = search note only; 'all' = both (default)."),
+  projectId: ProjectId.schema.optional().describe("Restrict search to tasks within this project."),
+  tagIds: z
+    .array(TagId.schema)
+    .optional()
+    .describe("Restrict to tasks carrying ALL of these tag IDs."),
+  flagged: z
+    .boolean()
+    .optional()
+    .describe("true = flagged tasks only; false = unflagged only; omit = all."),
+  completed: z
+    .enum(["any", "only", "exclude"])
+    .optional()
+    .describe(
+      "'exclude' = active tasks only (default); 'only' = completed tasks only; 'any' = both.",
+    ),
+});
+
+export type TaskSearchToolInput = z.infer<typeof taskSearchInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Context + handler
+// ---------------------------------------------------------------------------
+
+export interface TaskSearchContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Pure handler for `task_search`.
+ *
+ * Delegates to `adapter.searchTasks()` which executes the `task_search.js`
+ * JXA script with the supplied filter parameters.
+ */
+export async function handleTaskSearch(input: TaskSearchToolInput, ctx: TaskSearchContext) {
+  const tasks = await ctx.adapter.searchTasks({
+    q: input.q,
+    ...(input.scope !== undefined && { scope: input.scope }),
+    ...(input.projectId !== undefined && { projectId: input.projectId }),
+    ...(input.tagIds !== undefined && { tagIds: input.tagIds }),
+    ...(input.flagged !== undefined && { flagged: input.flagged }),
+    ...(input.completed !== undefined && { completed: input.completed }),
+  });
+  return ok({ tasks }, ctx.makeMeta());
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskSearchTool(server: McpServer, ctx: TaskSearchContext) {
+  return server.registerTool(
+    "task_search",
+    {
+      description: TASK_SEARCH_DESCRIPTION,
+      inputSchema: taskSearchInputSchema.shape,
+    },
+    async (args: TaskSearchToolInput) => {
+      const envelope = await handleTaskSearch(args, ctx);
+      return toolResponse(envelope);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `src/scripts/jxa/task_search.js` — JXA script scanning `flattenedTasks` for a case-insensitive substring match across task name and/or note
- Wires `JxaTransport.searchTasks()` to run the script (previously threw `notYetWired`)
- Adds `task_search` MCP tool (`src/tools/task/search.ts`) with `q` (required), `scope`, `projectId`, `tagIds`, `flagged`, and `completed` filters
- Registers the tool in `mcpServer.ts`; adds to `allInputSchemas` / `allDescriptions`; regenerates `docs/tools.md` (50 tools total)
- 18 unit tests covering schema validation, keyword match, no-results, case-insensitivity, scope modes, completion/flagged/projectId filters

Closes #348.

## Issue
Implements [#348 — Implement searchTasks and task_search MCP tool](https://github.com/torsday/omnifocus-mcp/issues/348).

## Breaking change?
- [x] No

## Test plan
- [x] 18 unit tests passing (InMemoryAdapter, no JXA required)
- [x] Typecheck clean
- [x] Lint clean
- [x] docs/tools.md regenerated (50 tools)
- [x] Self-reviewed