### PR TITLE
feat(forecast): wire JxaTransport.getForecast() and add JXA script

### DIFF
--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -50,6 +50,7 @@ import folderDeleteScript from "../../scripts/jxa/folder_delete.js";
 import folderGetScript from "../../scripts/jxa/folder_get.js";
 import folderListScript from "../../scripts/jxa/folder_list.js";
 import folderUpdateScript from "../../scripts/jxa/folder_update.js";
+import forecastGetScript from "../../scripts/jxa/forecast_get.js";
 import perspectiveEvaluateScript from "../../scripts/jxa/perspective_evaluate.js";
 import perspectiveListScript from "../../scripts/jxa/perspective_list.js";
 import projectCompleteScript from "../../scripts/jxa/project_complete.js";
@@ -93,6 +94,8 @@ import type {
   CreateProjectInput,
   CreateTagInput,
   CreateTaskInput,
+  ForecastInput,
+  ForecastResult,
   ListAttachmentsInput,
   OmniFocusAdapter,
   RemoveAttachmentInput,
@@ -669,10 +672,24 @@ export class JxaTransport implements OmniFocusAdapter {
     return result.tasks.map((t) => ({ ...t, id: TaskIdCtor.of(t.id) }));
   }
 
-  async getForecast(
-    _input: import("../OmniFocusAdapter.js").ForecastInput,
-  ): Promise<import("../OmniFocusAdapter.js").ForecastResult> {
-    return notYetWired("getForecast");
+  async getForecast(input: ForecastInput): Promise<ForecastResult> {
+    const result = await runJxaScript<ForecastResult>(
+      forecastGetScript,
+      {
+        from: input.from,
+        to: input.to,
+        includeOverdue: input.includeOverdue ?? true,
+        includeDeferred: input.includeDeferred ?? true,
+        includeFlagged: input.includeFlagged ?? true,
+      },
+      { ...this.runOpts, scriptName: "forecast_get" },
+    );
+    return {
+      overdue: result.overdue.map((t) => ({ ...t, id: TaskIdCtor.of(t.id) })),
+      dueToday: result.dueToday.map((t) => ({ ...t, id: TaskIdCtor.of(t.id) })),
+      deferredToday: result.deferredToday.map((t) => ({ ...t, id: TaskIdCtor.of(t.id) })),
+      flagged: result.flagged.map((t) => ({ ...t, id: TaskIdCtor.of(t.id) })),
+    };
   }
 
   // -- Attachments (wired) --------------------------------------------------

--- a/src/scripts/jxa/forecast_get.d.ts
+++ b/src/scripts/jxa/forecast_get.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `forecast_get.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/forecast_get.js
+++ b/src/scripts/jxa/forecast_get.js
@@ -1,0 +1,204 @@
+/**
+ * JXA: get forecast-view tasks grouped by category (overdue, dueToday,
+ * deferredToday, flagged).
+ *
+ * Args (argv[0] JSON): {
+ *   from: string,              // ISO-8601 — start of range (inclusive)
+ *   to: string,                // ISO-8601 — end of range (inclusive)
+ *   includeOverdue?: boolean,  // default true
+ *   includeDeferred?: boolean, // default true
+ *   includeFlagged?: boolean   // default true
+ * }
+ * Returns JSON: {
+ *   overdue: Task[],
+ *   dueToday: Task[],
+ *   deferredToday: Task[],
+ *   flagged: Task[]
+ * }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — getForecast() caller
+ * @see src/adapter/OmniFocusAdapter.ts — ForecastInput / ForecastResult types
+ * @see src/domain/task.ts — Task domain type
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  const from = args.from;
+  const to = args.to;
+  const includeOverdue = args.includeOverdue !== false;
+  const includeDeferred = args.includeDeferred !== false;
+  const includeFlagged = args.includeFlagged !== false;
+
+  // ---------------------------------------------------------------------------
+  // buildTask — same shape as task_list.js / task_search.js
+  // ---------------------------------------------------------------------------
+
+  function buildRepetition(task) {
+    try {
+      const rr = task.repetitionRule();
+      if (!rr) return null;
+      return { method: rr.method(), unit: rr.unit(), steps: rr.steps() };
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  function buildTask(task) {
+    let projectId = null;
+    try {
+      const cp = task.containingProject();
+      if (cp && cp.class() !== "document") projectId = cp.id();
+    } catch (_e) {}
+
+    let parentId = null;
+    try {
+      const pt = task.parentTask();
+      if (pt) parentId = pt.id();
+    } catch (_e) {}
+
+    const tagIds = [];
+    try {
+      const tags = task.tags();
+      for (let i = 0; i < tags.length; i++) {
+        tagIds.push(tags[i].id());
+      }
+    } catch (_e) {}
+
+    let deferDate = null;
+    try {
+      const dd = task.deferDate();
+      if (dd) deferDate = dd.toISOString();
+    } catch (_e) {}
+
+    let dueDate = null;
+    try {
+      const due = task.dueDate();
+      if (due) dueDate = due.toISOString();
+    } catch (_e) {}
+
+    let completedAt = null;
+    try {
+      const cd = task.completionDate();
+      if (cd) completedAt = cd.toISOString();
+    } catch (_e) {}
+
+    let dropped = false;
+    try {
+      dropped = task.dropped();
+    } catch (_e) {}
+
+    let flagged = false;
+    try {
+      flagged = task.flagged();
+    } catch (_e) {}
+
+    let isCompleted = false;
+    try {
+      isCompleted = task.completed();
+    } catch (_e) {}
+
+    let available = false;
+    try {
+      available = task.effectivelyAvailable ? task.effectivelyAvailable() : false;
+    } catch (_e) {}
+
+    let blocked = false;
+    try {
+      blocked = task.blocked ? task.blocked() : false;
+    } catch (_e) {}
+
+    let sequential = false;
+    try {
+      sequential = task.sequential ? task.sequential() : false;
+    } catch (_e) {}
+
+    let completedByChildren = false;
+    try {
+      completedByChildren = task.completedByChildren ? task.completedByChildren() : false;
+    } catch (_e) {}
+
+    let note = null;
+    try {
+      const raw = task.note ? task.note() : "";
+      note = raw || null;
+    } catch (_e) {}
+
+    return {
+      id: task.id(),
+      name: task.name(),
+      note,
+      noteHtml: null,
+      projectId,
+      parentId,
+      tagIds,
+      flagged,
+      dueDate,
+      deferDate,
+      completedAt,
+      droppedAt: null,
+      completed: isCompleted,
+      dropped,
+      available,
+      blocked,
+      sequential,
+      completedByChildren,
+      estimatedMinutes: null,
+      repetition: buildRepetition(task),
+      createdAt: task.creationDate ? task.creationDate().toISOString() : new Date().toISOString(),
+      modifiedAt: task.modificationDate
+        ? task.modificationDate().toISOString()
+        : new Date().toISOString(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Collect all active (not completed, not dropped) tasks
+  // ---------------------------------------------------------------------------
+
+  const allTasks = ofApp.defaultDocument.flattenedTasks();
+  const active = [];
+  for (let i = 0; i < allTasks.length; i++) {
+    const t = allTasks[i];
+    const built = buildTask(t);
+    if (!built.completed && !built.dropped) {
+      active.push(built);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bucket into forecast categories
+  // ---------------------------------------------------------------------------
+
+  const overdue = [];
+  const dueToday = [];
+  const deferredToday = [];
+  const flaggedTasks = [];
+
+  for (let i = 0; i < active.length; i++) {
+    const t = active[i];
+
+    if (includeOverdue && t.dueDate !== null && t.dueDate < from) {
+      overdue.push(t);
+    }
+    if (t.dueDate !== null && t.dueDate >= from && t.dueDate <= to) {
+      dueToday.push(t);
+    }
+    if (includeDeferred && t.deferDate !== null && t.deferDate >= from && t.deferDate <= to) {
+      deferredToday.push(t);
+    }
+    if (includeFlagged && t.flagged) {
+      flaggedTasks.push(t);
+    }
+  }
+
+  return JSON.stringify({
+    overdue,
+    dueToday,
+    deferredToday,
+    flagged: flaggedTasks,
+  });
+}

--- a/src/tools/forecast/get.test.ts
+++ b/src/tools/forecast/get.test.ts
@@ -103,4 +103,49 @@ describe("forecast_get — handler", () => {
     const envelope = await handleForecastGet(parseInput({ from: FROM, to: TO }), ctx);
     expect(envelope.meta.cacheHit).toBe(false);
   });
+
+  it("returns empty buckets when no tasks match the range", async () => {
+    const { ctx } = makeCtx();
+    // No tasks created — all buckets should be empty arrays.
+    const envelope = await handleForecastGet(parseInput({ from: FROM, to: TO }), ctx);
+    expect(envelope.data.overdue).toHaveLength(0);
+    expect(envelope.data.dueToday).toHaveLength(0);
+    expect(envelope.data.deferredToday).toHaveLength(0);
+    expect(envelope.data.flagged).toHaveLength(0);
+  });
+
+  it("spans a multi-day range and buckets correctly", async () => {
+    const { ctx, adapter } = makeCtx();
+    const from = "2026-04-23T00:00:00.000Z";
+    const to = "2026-04-25T23:59:59.999Z";
+
+    await adapter.createTask({ name: "Day 1", dueDate: "2026-04-23T09:00:00.000Z" });
+    await adapter.createTask({ name: "Day 3", dueDate: "2026-04-25T09:00:00.000Z" });
+    await adapter.createTask({ name: "Before range", dueDate: "2026-04-22T09:00:00.000Z" });
+    await adapter.createTask({ name: "After range", dueDate: "2026-04-26T09:00:00.000Z" });
+
+    const envelope = await handleForecastGet(parseInput({ from, to, includeOverdue: false }), ctx);
+    const names = envelope.data.dueToday.map((t) => t.name);
+    expect(names).toContain("Day 1");
+    expect(names).toContain("Day 3");
+    expect(names).not.toContain("Before range");
+    expect(names).not.toContain("After range");
+  });
+
+  it("places a flagged task in flagged bucket", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Important", flagged: true });
+    const envelope = await handleForecastGet(parseInput({ from: FROM, to: TO }), ctx);
+    expect(envelope.data.flagged.some((t) => t.name === "Important")).toBe(true);
+  });
+
+  it("excludes flagged bucket when includeFlagged=false", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Important", flagged: true });
+    const envelope = await handleForecastGet(
+      parseInput({ from: FROM, to: TO, includeFlagged: false }),
+      ctx,
+    );
+    expect(envelope.data.flagged).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `src/scripts/jxa/forecast_get.js` — iterates `flattenedTasks`, filters active tasks (not completed/dropped), and buckets them into overdue / dueToday / deferredToday / flagged per `ForecastResult`
- Wires `JxaTransport.getForecast()` to run the script (previously threw `notYetWired`)
- The `forecast_get` MCP tool, `ForecastService`, and server registration were already present — this PR completes the transport layer
- 4 new handler tests: empty range, multi-day range, flagged bucket, includeFlagged=false — total 13 tests

Closes #349.

## Issue
Implements [#349 — Implement getForecast and forecast_get MCP tool](https://github.com/torsday/omnifocus-mcp/issues/349).

## Breaking change?
- [x] No

## Test plan
- [x] 13 unit tests passing (InMemoryAdapter, no JXA required)
- [x] Typecheck clean
- [x] Lint clean
- [x] Self-reviewed