### PR TITLE
feat(task): route reorderTask to OmniJS via moveTasks + ChildInsertionLocation

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1896,7 +1896,7 @@ _No parameters._
 
 ## task_search
 
-Search OmniFocus tasks by keyword. Scans task names and/or notes (controlled by scope) for a case-insensitive substring match. Optionally narrow results by projectId, tagIds (task must carry ALL listed tags), flagged state, and completion state. Returns the full Task domain shape — same as task_list — so no follow-up read is needed. Returns tasks[]; safe to call repeatedly; no side effects.
+Search OmniFocus tasks by keyword. Scans task names and/or notes (controlled by scope) for a case-insensitive substring match. Optionally narrow results by projectId, tagIds (task must carry ALL listed tags), flagged state, and completion state. Do NOT use when you already have an ID — prefer task_get instead. Do NOT use for structured browsing by project/tag; prefer task_list for that. Returns the full Task domain shape — same as task_list — so no follow-up read is needed. Returns tasks[]; safe to call repeatedly; no side effects.
 
 ### Input
 

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -82,7 +82,6 @@ import taskGetScript from "../../scripts/jxa/task_get.js";
 import taskGetManyScript from "../../scripts/jxa/task_get_many.js";
 import taskListScript from "../../scripts/jxa/task_list.js";
 import taskMoveScript from "../../scripts/jxa/task_move.js";
-import taskReorderScript from "../../scripts/jxa/task_reorder.js";
 import taskSearchScript from "../../scripts/jxa/task_search.js";
 import taskUncompleteScript from "../../scripts/jxa/task_uncomplete.js";
 import taskUndropScript from "../../scripts/jxa/task_undrop.js";
@@ -282,33 +281,14 @@ export class JxaTransport implements OmniFocusAdapter {
     );
   }
 
-  async reorderTask(id: TaskId, position: TaskPosition): Promise<void> {
-    let payload: {
-      id: TaskId;
-      mode: "before" | "after" | "start" | "end";
-      refId?: TaskId;
-      container?: {
-        projectId?: ProjectId | null;
-        parentId?: TaskId | null;
-        inbox?: true;
-      };
-    };
-    if ("before" in position) {
-      payload = { id, mode: "before", refId: position.before };
-    } else if ("after" in position) {
-      payload = { id, mode: "after", refId: position.after };
-    } else {
-      const container =
-        "projectId" in position.in
-          ? { projectId: position.in.projectId }
-          : "parentId" in position.in
-            ? { parentId: position.in.parentId }
-            : { inbox: true as const };
-      payload = { id, mode: position.at, container };
-    }
-    await runJxaScript<{ id: string }>(taskReorderScript, payload, {
-      ...this.runOpts,
-      scriptName: "task_reorder",
+  async reorderTask(_id: TaskId, _position: TaskPosition): Promise<void> {
+    // JXA's task.move() with `positioned:` shares the same broken code path
+    // as the non-positioned form — both throw error 9 ("Replacement not
+    // supported currently") in OmniFocus 4.x. reorderTask routes to
+    // OmniJsTransport which uses Database.moveTasks() + ChildInsertionLocation.
+    // See docs/spikes/2026-04-task-reorder.md for the full evaluation.
+    throw new ScriptError("reorderTask routes to OmniJsTransport — JXA transport unavailable", {
+      details: { transport: "jxa", reason: "routes-to-omnijs", method: "reorderTask" },
     });
   }
 

--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -157,8 +157,49 @@ export class OmniJsTransport implements OmniFocusAdapter {
       });
     }
   }
-  async reorderTask(_id: TaskId, _position: TaskPosition): Promise<void> {
-    return notYetWired("reorderTask");
+  async reorderTask(id: TaskId, position: TaskPosition): Promise<void> {
+    const script = await import("node:fs/promises").then((fs) =>
+      fs.readFile(new URL("../../scripts/omnijs/task_reorder.js", import.meta.url), "utf8"),
+    );
+
+    let payload: {
+      id: TaskId;
+      mode: "before" | "after" | "start" | "end";
+      refId?: TaskId;
+      container?: {
+        projectId?: ProjectId;
+        parentId?: TaskId;
+        inbox?: true;
+      };
+    };
+    if ("before" in position) {
+      payload = { id, mode: "before", refId: position.before };
+    } else if ("after" in position) {
+      payload = { id, mode: "after", refId: position.after };
+    } else {
+      const container =
+        "projectId" in position.in
+          ? { projectId: position.in.projectId }
+          : "parentId" in position.in
+            ? { parentId: position.in.parentId }
+            : { inbox: true as const };
+      payload = { id, mode: position.at, container };
+    }
+
+    const result = await runOmniJsScript<
+      { id: string } | { error: { code: "NOT_FOUND" | "VALIDATION"; message: string } }
+    >(script, payload, { ...this.runOpts, scriptName: "task_reorder" });
+
+    if ("error" in result) {
+      if (result.error.code === "NOT_FOUND") {
+        throw new NotFound(result.error.message, {
+          details: { transport: "omnijs", scriptName: "task_reorder" },
+        });
+      }
+      throw new ValidationError(result.error.message, {
+        details: { transport: "omnijs", scriptName: "task_reorder" },
+      });
+    }
   }
   async duplicateTask(
     _id: TaskId,

--- a/src/adapter/router.test.ts
+++ b/src/adapter/router.test.ts
@@ -245,6 +245,7 @@ describe("TransportRouter — table integrity", () => {
       "evaluateCustomPerspective",
       "moveTask", // JXA task.move() → error 9 in OF 4.x; OmniJS Database.moveTasks() works
       "pluginInvoke",
+      "reorderTask", // JXA task.move(positioned:) → same error 9; OmniJS moveTasks + ChildInsertionLocation
       "runOmniJsScript",
     ]);
   });

--- a/src/adapter/router.ts
+++ b/src/adapter/router.ts
@@ -99,7 +99,7 @@ export const ROUTING_TABLE: Readonly<Record<AdapterMethod, TransportName>> = Obj
   undropTask: "jxa",
   deleteTask: "jxa",
   moveTask: "omnijs", // JXA task.move() → error 9 in OF 4.x; Database.moveTasks() via OmniJS works
-  reorderTask: "jxa",
+  reorderTask: "omnijs",
   duplicateTask: "jxa",
   batchCreateTasks: "jxa",
   batchUpdateTasks: "jxa",

--- a/src/scripts/omnijs/task_reorder.d.ts
+++ b/src/scripts/omnijs/task_reorder.d.ts
@@ -1,0 +1,2 @@
+declare const source: string;
+export default source;

--- a/src/scripts/omnijs/task_reorder.js
+++ b/src/scripts/omnijs/task_reorder.js
@@ -1,0 +1,88 @@
+/**
+ * OmniJS: reorder a task among its siblings.
+ *
+ * JXA's `task.move({ to: ref, positioned: ... })` shares the same broken
+ * code path as `task.move({ to: container })` — both throw error 9
+ * ("Replacement not supported currently") in OmniFocus 4.x. The OmniJS
+ * `Database.moveTasks(tasks, ChildInsertionLocation)` API supports precise
+ * sibling positioning via `.before` / `.after` / `.beginning` / `.ending`
+ * and is the Omni-recommended automation route — hence this script.
+ *
+ * Args injected as `globalThis.__args`:
+ *   {
+ *     id: string,               // task to reorder
+ *     mode: "before" | "after" | "start" | "end",
+ *     refId?: string,           // required for before/after
+ *     container?: {             // required for start/end
+ *       projectId?: string,
+ *       parentId?: string,
+ *       inbox?: true,
+ *     }
+ *   }
+ *
+ * Returns JSON: { id: string }
+ *
+ * @see src/adapter/omnijs/OmniJsTransport.ts — reorderTask() caller
+ * @see docs/spikes/2026-04-task-reorder.md — Route A vs Route B rationale
+ * @see docs/adr/0002-omnifocus-transport-dual.md — JXA/OmniJS split
+ */
+(() => {
+  const { id, mode, refId, container } = globalThis.__args;
+
+  if (!id) {
+    return JSON.stringify({ error: { code: "VALIDATION", message: "id is required" } });
+  }
+  if (!mode) {
+    return JSON.stringify({ error: { code: "VALIDATION", message: "mode is required" } });
+  }
+
+  const task = flattenedTasks.filter((t) => t.id.primaryKey === id)[0];
+  if (!task) {
+    return JSON.stringify({ error: { code: "NOT_FOUND", message: `Task not found: ${id}` } });
+  }
+
+  let location;
+
+  if (mode === "before" || mode === "after") {
+    if (!refId) {
+      return JSON.stringify({
+        error: { code: "VALIDATION", message: `refId is required for mode "${mode}"` },
+      });
+    }
+    const ref = flattenedTasks.filter((t) => t.id.primaryKey === refId)[0];
+    if (!ref) {
+      return JSON.stringify({
+        error: { code: "NOT_FOUND", message: `Reference task not found: ${refId}` },
+      });
+    }
+    location = mode === "before" ? ref.before : ref.after;
+  } else if (mode === "start" || mode === "end") {
+    let c;
+    if (container?.projectId) {
+      c = flattenedProjects.filter((p) => p.id.primaryKey === container.projectId)[0];
+      if (!c) {
+        return JSON.stringify({
+          error: { code: "NOT_FOUND", message: `Project not found: ${container.projectId}` },
+        });
+      }
+    } else if (container?.parentId) {
+      c = flattenedTasks.filter((t) => t.id.primaryKey === container.parentId)[0];
+      if (!c) {
+        return JSON.stringify({
+          error: { code: "NOT_FOUND", message: `Parent task not found: ${container.parentId}` },
+        });
+      }
+    } else {
+      // inbox.beginning / inbox.ending
+      c = inbox;
+    }
+    location = mode === "start" ? c.beginning : c.ending;
+  } else {
+    return JSON.stringify({
+      error: { code: "VALIDATION", message: `Unknown mode: ${mode}` },
+    });
+  }
+
+  moveTasks([task], location);
+  return JSON.stringify({ id });
+})();


### PR DESCRIPTION
## Summary

- Add `src/scripts/omnijs/task_reorder.js` — OmniJS script using `moveTasks()` + `ChildInsertionLocation` for before/after sibling positioning and start/end container (inbox, project, parent task)
- Wire `OmniJsTransport.reorderTask()` to the new script with typed `NOT_FOUND` / `VALIDATION` error handling
- Change `router.ts`: `reorderTask: "jxa"` → `reorderTask: "omnijs"`
- Replace `JxaTransport.reorderTask` body with `ScriptError` explaining the routing rationale
- Add `reorderTask` to the OmniJS-only assertion in `router.test.ts`

Closes #350.

## Issue

Implements [#350 — Implement reorderTask and task_reorder MCP tool](https://github.com/torsday/omnifocus-mcp/issues/350). Decision rationale in [docs/spikes/2026-04-task-reorder.md](docs/spikes/2026-04-task-reorder.md): JXA `task.move()` with `positioned:` shares the error-9 failure mode of the non-positioned form in OF 4.x; OmniJS `moveTasks()` is the proven route already used by `moveTask`.

## Breaking change?
- [x] No

## Test plan
- [x] Router test updated: `reorderTask` in OmniJS-only assertion, all 1747 tests pass
- [x] TypeCheck clean
- [x] Lint clean
- [x] No new dependencies