### PR TITLE
infra(ci): route 5 workflows to the self-hosted macOS runner

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   pr:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
     steps:
       - name: Skip if no token
         if: env.GH_TOKEN == ''
@@ -110,7 +110,7 @@ jobs:
 
   issue-closed:
     if: github.event_name == 'issues' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
     steps:
       - name: Skip if no token
         if: env.GH_TOKEN == ''

--- a/.github/workflows/issue-lint.yml
+++ b/.github/workflows/issue-lint.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
     # Skip if the edit was made by the filer script — it verifies its own output.
     if: github.event.issue.state == 'open'
     env:

--- a/.github/workflows/pr-link.yml
+++ b/.github/workflows/pr-link.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   require-issue-link:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
     # Waiver: add the `no-issue` label to skip this check.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-issue') }}
     steps:

--- a/.github/workflows/validate-deps-nightly.yml
+++ b/.github/workflows/validate-deps-nightly.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       AUDIT_LABEL: "audit: dep-graph"

--- a/.github/workflows/verify-constants.yml
+++ b/.github/workflows/verify-constants.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos]
     env:
       GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,8 @@ For `/loop` dynamic mode (no interval specified) in this project, default `Sched
 
 ## CI status — current known issues
 
-- **Self-hosted runner `mac-local` handles PR CI.** Labels: `self-hosted, macOS, ARM64, macos-omnifocus`. `ci.yml` targets `[self-hosted, macos]` and runs locally, bypassing the GitHub Actions billing issue on macOS.
-- **GitHub-hosted workflows remain blocked on billing.** `release.yml` (`macos-latest`), `board-sync.yml` and `pr-title.yml` (`ubuntu-latest`) will not run until the billing issue on the GitHub account is resolved. None of these gate day-to-day development: release fires on version tags, the other two are informational.
+- **Self-hosted runner `mac-local` handles PR CI.** Labels: `self-hosted, macOS, ARM64, macos-omnifocus`. The following workflows target `[self-hosted, macos]` and run locally, bypassing GitHub-hosted billing: `ci.yml`, `release.yml`, `integration.yml`, `board-sync.yml`, `issue-lint.yml`, `pr-link.yml`, `validate-deps-nightly.yml`, `verify-constants.yml`.
+- **Two workflows remain on `ubuntu-latest`** because they depend on Linux-only Docker actions: `meta-lint.yml` (`ludeeus/action-shellcheck`) and `pr-title.yml` (`amannn/action-semantic-pull-request`). They will not run until either the GitHub-hosted billing issue is resolved, a Linux self-hosted runner is added, or the Docker actions are replaced with macOS-native equivalents (e.g. `brew install shellcheck` + a script step for shellcheck). None of these gate day-to-day development.
 - **Integration CI requires macOS Automation permission.** `integration.yml` runs JXA scripts against a live OmniFocus on `mac-local`. The runner's shell process must have Automation access to OmniFocus (System Settings → Privacy & Security → Automation) or all tests fail with `"JXA script returned empty stdout"`.
 - **Branch protection is unavailable** on this plan (private repo, free tier) — nothing gates merge on CI. `gh pr merge --auto` behaves like immediate merge. Prefer explicit `gh pr merge <N> --rebase --delete-branch` after local verification.
 


### PR DESCRIPTION
## Summary
- Five Ubuntu-targeted workflows (\`board-sync\`, \`issue-lint\`, \`pr-link\`, \`validate-deps-nightly\`, \`verify-constants\`) only need shell + node + \`gh\` CLI — no Linux-specific tooling. Retarget them at the existing \`[self-hosted, macos]\` runner that already runs \`ci.yml\` / \`release.yml\` / \`integration.yml\`.
- Two workflows stay on \`ubuntu-latest\` because they pull Docker actions (Linux-only): \`meta-lint.yml\` (\`ludeeus/action-shellcheck\`) and \`pr-title.yml\` (\`amannn/action-semantic-pull-request\`). Documented in CLAUDE.md with the unblock paths.
- This unsticks board-sync (project-board automation), pr-link (closing-keyword check), validate-deps-nightly, and verify-constants — all of which were silently failing with \"job was not started because recent account payments have failed\" on every PR including the just-merged dependabot batch.

## Why
Looking at PR #320–#326 (dependabot), the systematic \"actionlint / shellcheck / verify / pr\" failures weren't real CI signal — they were GitHub refusing to schedule jobs on the Ubuntu fleet under the billing block. That's been hiding the actual workflow checks the repo cares about. The self-hosted runner is fine for everything except Docker-action workloads.

## Breaking change?
- [x] No — workflow execution shifts onto the self-hosted runner; YAML structure unchanged otherwise.

## Test plan
- [x] No code changes; only \`runs-on:\` retargeted in 5 workflow files
- [x] CLAUDE.md CI status block updated to reflect the new picture and the unblock paths for the two remaining Ubuntu workflows
- [ ] First PR after merge will exercise the new routing — expect board-sync / pr-link / verify-constants checks to actually run (and possibly find real issues that were hidden behind the billing block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)