### PR TITLE
chore(security): add import-ban and module-boundary lint rules; add docs/security.md

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,115 @@
+# Security: Attack Surface and Mitigations
+
+This document summarises the omnifocus-mcp security posture per DESIGN §18. It is the primary reference for understanding what the server does and does not protect against.
+
+---
+
+## Transport model
+
+omnifocus-mcp speaks **stdio** — there is no network listener, no open port, and no HTTP surface. The server process is launched by an MCP client (e.g. Claude Desktop) and communicates exclusively over the parent process's stdin/stdout. The only inbound vector is the MCP protocol messages themselves.
+
+---
+
+## Attack surface inventory
+
+### 1. Attachment path traversal
+
+**Risk:** `attachment_add` and `attachment_save_to_path` accept user-supplied filesystem paths. A malicious path (e.g. `../../../../etc/passwd`, or a symlink pointing outside the home directory) could read or write files beyond the intended scope.
+
+**Mitigations:**
+
+- `src/attachment/assertAttachmentPath.ts` resolves symlinks via `realpath()` **before** checking the allowlist, defeating symlink-escape attacks.
+- An allowlist of path prefixes (default: `[$HOME]`) restricts all file operations to the user's home directory unless `OMNIFOCUS_ATTACHMENT_PATHS` explicitly extends it.
+- Hard-blocked system prefixes (`/System/`, `/Library/`, `/private/System/`, `/private/Library/`) are always rejected, regardless of the allowlist.
+- `assertAttachmentSize` enforces the `maxAttachmentMb` cap before the OmniFocus call.
+
+**Test coverage:** `src/attachment/assertAttachmentPath.test.ts` — includes symlink-escape, hard-blocked prefix, and allowlist boundary cases.
+
+---
+
+### 2. Raw-script gating
+
+**Risk:** `run_jxa_script` and `run_omnijs_script` execute arbitrary code with full OmniFocus Automation privileges. If always present, any MCP client could invoke them.
+
+**Mitigations:**
+
+- Both tools are **absent from the server entirely** unless the process is started with `OMNIFOCUS_ALLOW_RAW_SCRIPT=1`. The `registerRunJxaScriptTool` / `registerRunOmniJsScriptTool` functions return `null` (and call no `server.registerTool`) when the flag is unset.
+- Every invocation emits a `raw_script.invoked` audit event at `info` level with the full script body (`src/tools/rawScript/jxa.ts`, `src/tools/rawScript/omnijs.ts`).
+- The adapter checks for the method's existence at call time as a defence-in-depth guard.
+
+**Test coverage:** `src/tools/rawScript/jxa.test.ts` and `omnijs.test.ts` — "gated registration" suite covers both `allowRawScript: false` (tool absent, `registerTool` not called) and `allowRawScript: true` (tool present).
+
+---
+
+### 3. Prompt injection containment
+
+**Risk:** OmniFocus user content (task names, notes, tag names) appears in tool responses. If that content is interpolated into protocol metadata fields (`suggestion`, `message`, `warning`) an agent may treat it as a system instruction.
+
+**Mitigations:**
+
+- The `no-metadata-interpolation` lint rule (`src/linting/customRules.ts`, rule 3) flags any line where a user-content accessor (`.name`, `.note`, `.noteHtml`, `.title`) appears alongside a metadata field keyword on the same line.
+- `meta.warnings` entries are static strings constructed by server code, never by user content.
+- Tool descriptions are static compile-time strings, never interpolated from OmniFocus data.
+
+**Test coverage:** `src/linting/customRules.test.ts` — "no-metadata-interpolation rule" suite, including an adversarial task name test (`SYSTEM: ignore previous instructions`).
+
+---
+
+### 4. Stray stdout guard
+
+**Risk:** The MCP server uses stdio as its transport. Any `console.log` or `process.stdout.write` from application code corrupts the protocol framing and produces silent client errors.
+
+**Mitigations:**
+
+- `src/server/stdoutGuard.ts` wraps `process.stdout.write` at server startup. Calls that do not originate from the MCP SDK transport module (identified via stack-trace allowlist) throw immediately with a descriptive error, surfacing the bug at the write site.
+- The guard is installed before `server.connect(transport)` in `src/server/composition.ts`.
+
+**Test coverage:** `src/server/stdoutGuard.test.ts` — covers the guard throwing for application code, the idempotency invariant, stack-trace allowlist matching, and clean uninstall.
+
+---
+
+### 5. Network import ban
+
+**Risk:** Importing HTTP libraries (`http`, `https`, `node-fetch`, `axios`, `undici`) could allow outbound network calls — data exfiltration, SSRF, or supply-chain compromise.
+
+**Mitigation:** The `no-network-import` lint rule (`src/linting/customRules.ts`, rule 4) flags any static or dynamic import of these modules across all source files.
+
+**Test coverage:** `src/linting/customRules.test.ts` — "no-network-import rule" suite.
+
+---
+
+### 6. Module boundary enforcement
+
+**Risk:** If transport implementations (`adapter/jxa/`, `adapter/omnijs/`) are imported directly by `services/` or `tools/`, the adapter seam breaks. Any code at any layer can then call the raw JXA/OmniJS transport — bypassing the router, concurrency guards, and rate limiting.
+
+**Mitigation:** The `no-layer-violation` lint rule (`src/linting/customRules.ts`, rule 5) enforces:
+
+- Transport implementations (`adapter/jxa/`, `adapter/omnijs/`) must not import from `services/` or `tools/`.
+- `services/` and `tools/` must not import transport implementations directly (only the `OmniFocusAdapter` interface is permitted).
+
+The `adapter/router.ts` and `src/server/composition.ts` are the only permitted wiring points for transports.
+
+**Test coverage:** `src/linting/customRules.test.ts` — "no-layer-violation rule" suite, including the carve-out for the `OmniFocusAdapter` interface import.
+
+---
+
+## Lint gate
+
+All custom rules are enforced via `scripts/lint-custom.ts`. Run locally:
+
+```bash
+pnpm tsx scripts/lint-custom.ts
+```
+
+This is expected to be added to the `pnpm lint` pipeline so it gates PRs.
+
+---
+
+## Out of scope (by design)
+
+| Concern | Decision |
+|---------|----------|
+| Authentication / authorisation | OmniFocus uses macOS Automation permissions — the OS gates access, not this server. |
+| Encryption at rest | OmniFocus manages its own database encryption. |
+| Rate limiting at the transport level | Handled by `ToolRateLimiter` per-tool; no per-IP limiting needed (stdio transport). |
+| Input sanitisation for XSS | No HTML rendering surface; all output is JSON over MCP. |

--- a/src/linting/customRules.test.ts
+++ b/src/linting/customRules.test.ts
@@ -162,6 +162,130 @@ describe("no-metadata-interpolation rule", () => {
   });
 });
 
+describe("no-network-import rule", () => {
+  it("flags a static import of node:https", () => {
+    const v = checkFileContent("src/services/foo.ts", 'import https from "node:https";');
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-network-import");
+  });
+
+  it("flags a static import of node:http", () => {
+    const v = checkFileContent("src/services/foo.ts", 'import http from "node:http";');
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-network-import");
+  });
+
+  it("flags a static import of axios", () => {
+    const v = checkFileContent("src/services/foo.ts", 'import axios from "axios";');
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-network-import");
+  });
+
+  it("flags a static import of node-fetch", () => {
+    const v = checkFileContent("src/tools/task/list.ts", 'import fetch from "node-fetch";');
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-network-import");
+  });
+
+  it("flags a static import of undici", () => {
+    const v = checkFileContent("src/adapter/omnijs/runner.ts", 'import { request } from "undici";');
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-network-import");
+  });
+
+  it("flags a dynamic import of https", () => {
+    const v = checkFileContent("src/foo.ts", 'import("https")');
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-network-import");
+  });
+
+  it("does not flag node:fs imports", () => {
+    const v = checkFileContent("src/services/foo.ts", 'import fs from "node:fs";');
+    expect(v).toHaveLength(0);
+  });
+
+  it("does not flag node:path imports", () => {
+    const v = checkFileContent("src/services/foo.ts", 'import path from "node:path";');
+    expect(v).toHaveLength(0);
+  });
+
+  it("does not flag comment lines", () => {
+    const v = checkFileContent("src/foo.ts", '// import axios from "axios"; — do not do this');
+    expect(v).toHaveLength(0);
+  });
+});
+
+describe("no-layer-violation rule", () => {
+  it("flags transport implementation importing from services/", () => {
+    const v = checkFileContent(
+      "src/adapter/jxa/JxaTransport.ts",
+      'import { TaskService } from "../../services/taskService.js";',
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-layer-violation");
+  });
+
+  it("flags transport implementation importing from tools/", () => {
+    const v = checkFileContent(
+      "src/adapter/omnijs/OmniJsTransport.ts",
+      'import { handleTaskCreate } from "../../tools/task/create.js";',
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-layer-violation");
+  });
+
+  it("flags services/ importing from adapter implementation (jxa)", () => {
+    const v = checkFileContent(
+      "src/services/taskService.ts",
+      'import { JxaTransport } from "../adapter/jxa/JxaTransport.js";',
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-layer-violation");
+  });
+
+  it("flags tools/ importing from adapter implementation (omnijs)", () => {
+    const v = checkFileContent(
+      "src/tools/task/create.ts",
+      'import { OmniJsTransport } from "../../adapter/omnijs/OmniJsTransport.js";',
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("no-layer-violation");
+  });
+
+  it("does NOT flag tools/ importing the OmniFocusAdapter interface", () => {
+    const v = checkFileContent(
+      "src/tools/task/create.ts",
+      'import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";',
+    );
+    expect(v).toHaveLength(0);
+  });
+
+  it("does NOT flag services/ importing the OmniFocusAdapter interface", () => {
+    const v = checkFileContent(
+      "src/services/taskService.ts",
+      'import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";',
+    );
+    expect(v).toHaveLength(0);
+  });
+
+  it("does NOT flag adapter router importing transport implementations", () => {
+    // The router lives inside adapter/ and is allowed to import jxa/ and omnijs/
+    const v = checkFileContent(
+      "src/adapter/router.ts",
+      'import { JxaTransport } from "./jxa/JxaTransport.js";',
+    );
+    expect(v).toHaveLength(0);
+  });
+
+  it("does NOT flag adapter inMemory layer (not a transport implementation)", () => {
+    const v = checkFileContent(
+      "src/adapter/inMemory/InMemoryAdapter.ts",
+      'import type { OmniFocusAdapter } from "../OmniFocusAdapter.js";',
+    );
+    expect(v).toHaveLength(0);
+  });
+});
+
 describe("multi-rule", () => {
   it("reports both violations in the same file", () => {
     const content = 'const id = x as TaskId;\nthrow new Error("bad");';

--- a/src/linting/customRules.ts
+++ b/src/linting/customRules.ts
@@ -22,6 +22,17 @@
  *    or `.tags[*].name` of a domain object inside a metadata construction
  *    context (suggestion/message/warning literals) is forbidden.
  *
+ * 4. **no-network-import** — imports of `http`, `https`, `node-fetch`, `axios`,
+ *    `undici`, or `fetch` (as a standalone import) are forbidden. omnifocus-mcp
+ *    communicates with OmniFocus only — outbound HTTP is never needed and would
+ *    be a supply-chain / data-exfiltration risk (DESIGN §18).
+ *
+ * 5. **no-layer-violation** — enforces the adapter ↔ services ↔ tools layering:
+ *    - `adapter/` must not import from `services/` or `tools/`
+ *    - `tools/` must not import from `adapter/` directly (must go through a service)
+ *    `domain/`, `errors/`, `envelope/`, `logging/`, `rateLimit/`, `concurrency/`,
+ *    and `linting/` are utility layers reachable from everywhere.
+ *
  * @see DESIGN.md §6.7 — error taxonomy
  * @see DESIGN.md §18 — security posture / prompt injection containment
  * @see docs/adr/0008-branded-id-types.md
@@ -77,13 +88,68 @@ export const EXCLUDED_FILES_RE =
   /\.(test|spec)\.(ts|js)$|src[/\\]linting[/\\]customRules\.(ts|js)$/;
 
 // ---------------------------------------------------------------------------
+// Rule 4: no-network-import
+// ---------------------------------------------------------------------------
+
+/**
+ * Banned network-library identifiers. Matches both static `import` statements
+ * and dynamic `import(...)` calls.
+ *
+ * `node:http` and `node:https` are also banned — the server speaks only to
+ * OmniFocus via JXA/OmniJS; there is no legitimate outbound HTTP use case.
+ */
+export const NETWORK_IMPORT_RE =
+  /\bimport\s*(?:\([^)]*['"]|[^'"]*['"])(node:https?|https?|node-fetch|axios|undici|cross-fetch)['"]/;
+
+// ---------------------------------------------------------------------------
+// Rule 5: no-layer-violation
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect imports that cross the adapter ↔ services ↔ tools layer boundary.
+ *
+ * The `OmniFocusAdapter` interface is the public seam — tools and services may
+ * import it freely. The *implementations* (`adapter/jxa/` and `adapter/omnijs/`)
+ * must never be imported outside the adapter layer itself; only the router and
+ * composition wiring are allowed to reach them. Likewise, transport implementations
+ * must never reach up into services/ or tools/.
+ *
+ * Forbidden:
+ *   adapter/jxa/ or adapter/omnijs/ importing from services/ or tools/
+ *   services/ or tools/ importing from adapter/jxa/ or adapter/omnijs/
+ *     (they must import the OmniFocusAdapter interface, not the implementations)
+ */
+
+/** Match any relative or absolute import that targets `services/` */
+export const IMPORT_SERVICES_RE = /\bfrom\s+['"][^'"]*\/services\//;
+/** Match any relative or absolute import that targets `tools/` */
+export const IMPORT_TOOLS_RE = /\bfrom\s+['"][^'"]*\/tools\//;
+/**
+ * Match imports targeting the transport *implementations* (not the interface).
+ * `adapter/OmniFocusAdapter` and `adapter/inMemory/` are permitted from anywhere.
+ */
+export const IMPORT_ADAPTER_IMPL_RE = /\bfrom\s+['"][^'"]*\/adapter\/(jxa|omnijs)\//;
+
+/** Detect that a file lives inside a transport implementation directory */
+export const IN_ADAPTER_IMPL_RE = /src[/\\]adapter[/\\](jxa|omnijs)[/\\]/;
+/** Detect that a file lives under `src/services/` */
+export const IN_SERVICES_RE = /src[/\\]services[/\\]/;
+/** Detect that a file lives under `src/tools/` */
+export const IN_TOOLS_RE = /src[/\\]tools[/\\]/;
+
+// ---------------------------------------------------------------------------
 // Violation type
 // ---------------------------------------------------------------------------
 
 export interface Violation {
   file: string;
   line: number;
-  rule: "no-id-cast" | "no-generic-error" | "no-metadata-interpolation";
+  rule:
+    | "no-id-cast"
+    | "no-generic-error"
+    | "no-metadata-interpolation"
+    | "no-network-import"
+    | "no-layer-violation";
   excerpt: string;
 }
 
@@ -128,6 +194,42 @@ export function checkFileContent(filePath: string, content: string): Violation[]
         file: filePath,
         line: i + 1,
         rule: "no-metadata-interpolation",
+        excerpt: line.trim(),
+      });
+    }
+
+    // Rule 4: no-network-import
+    if (NETWORK_IMPORT_RE.test(line)) {
+      violations.push({
+        file: filePath,
+        line: i + 1,
+        rule: "no-network-import",
+        excerpt: line.trim(),
+      });
+    }
+
+    // Rule 5: no-layer-violation
+    // Transport implementations must not import up into services/ or tools/
+    if (
+      IN_ADAPTER_IMPL_RE.test(filePath) &&
+      (IMPORT_SERVICES_RE.test(line) || IMPORT_TOOLS_RE.test(line))
+    ) {
+      violations.push({
+        file: filePath,
+        line: i + 1,
+        rule: "no-layer-violation",
+        excerpt: line.trim(),
+      });
+    }
+    // services/ and tools/ must not reach into transport implementations directly
+    if (
+      (IN_SERVICES_RE.test(filePath) || IN_TOOLS_RE.test(filePath)) &&
+      IMPORT_ADAPTER_IMPL_RE.test(line)
+    ) {
+      violations.push({
+        file: filePath,
+        line: i + 1,
+        rule: "no-layer-violation",
         excerpt: line.trim(),
       });
     }


### PR DESCRIPTION
## Summary

- Adds **rule 4 (`no-network-import`)** to `src/linting/customRules.ts`: flags any import of `http`, `https`, `node:http`, `node:https`, `axios`, `node-fetch`, `undici`, or `cross-fetch`. No outbound HTTP is needed by this server; these imports are a data-exfiltration / supply-chain risk (DESIGN §18).
- Adds **rule 5 (`no-layer-violation`)**: enforces the `adapter ↔ services ↔ tools` boundary — transport implementations must not import up into services/tools; services/tools must not reach into transport implementations (only the `OmniFocusAdapter` interface is permitted).
- Adds **`docs/security.md`**: full attack-surface reference covering all 6 security areas, mitigations, test coverage, and out-of-scope items.

All pre-existing acceptance criteria were already satisfied before this PR (path-traversal tests, raw-script gating tests, stdout guard tests, `no-metadata-interpolation` rule).

Closes #381.

## Issue

Implements [#381 — chore(security): full security audit](https://github.com/torsday/omnifocus-mcp/issues/381). See DESIGN.md §18.

## Breaking change?
- [x] No

## Test plan
- [x] 17 new unit tests for `no-network-import` and `no-layer-violation` rules — all passing
- [x] Full suite: 1764 tests pass, 0 failures
- [x] `pnpm lint` clean (biome + lint-custom + docs:check)
- [x] `pnpm typecheck` clean