### PR TITLE
feat(transport): wire ReadPool, WriteQueue, and OmniJS queue into adapter chain

### DIFF
--- a/src/adapter/concurrent.test.ts
+++ b/src/adapter/concurrent.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for {@link wrapWithConcurrency} (#376).
+ *
+ * Goldilocks coverage — one case per dispatch arm proves the routing
+ * decision; one ordering case per arm proves the concurrency contract.
+ * Heavy state-machine branches (FIFO fairness, queue cap rejection) live
+ * in `ReadPool.test.ts` / `WriteQueue.test.ts`; we don't restate them.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ReadPool } from "../concurrency/ReadPool.js";
+import { WriteQueue } from "../concurrency/WriteQueue.js";
+import type { OmniFocusAdapter } from "./OmniFocusAdapter.js";
+import { MUTATING_METHODS, pickGate, wrapWithConcurrency } from "./concurrent.js";
+
+function makeDeps() {
+  return {
+    readPool: new ReadPool({ size: 2, name: "read" }),
+    jxaWriteQueue: new WriteQueue({ cap: 50, name: "jxa-write" }),
+    omniJsQueue: new WriteQueue({ cap: 50, name: "omnijs" }),
+  };
+}
+
+/**
+ * A spy adapter that records the order in which methods entered and exited,
+ * and lets each call's resolution be controlled. Only the methods the tests
+ * touch are implemented; the rest delegate to a thrown sentinel so a
+ * routing miss is loud.
+ */
+function makeSpyAdapter() {
+  const events: string[] = [];
+  const gates = new Map<string, () => void>();
+
+  const enterAndWait = (label: string): Promise<void> => {
+    events.push(`enter:${label}`);
+    return new Promise<void>((resolve) => {
+      gates.set(label, () => {
+        events.push(`exit:${label}`);
+        resolve();
+      });
+    });
+  };
+
+  const adapter = {
+    listTasks: async (filter: { tag?: string }) => {
+      await enterAndWait(`listTasks:${filter.tag ?? "*"}`);
+      return [] as unknown[];
+    },
+    createTask: async (input: { name: string }) => {
+      await enterAndWait(`createTask:${input.name}`);
+      return "id-1" as unknown;
+    },
+    moveTask: async (id: string) => {
+      await enterAndWait(`moveTask:${id}`);
+    },
+  } as unknown as OmniFocusAdapter;
+
+  return {
+    adapter,
+    events,
+    /** Release a previously-entered call by label so it can finish. */
+    release(label: string) {
+      const g = gates.get(label);
+      if (g === undefined) throw new Error(`no in-flight call labelled ${label}`);
+      g();
+      gates.delete(label);
+    },
+  };
+}
+
+describe("pickGate", () => {
+  it("routes JXA reads to the read pool", () => {
+    const deps = makeDeps();
+    expect(pickGate("listTasks", deps)).toBe(deps.readPool);
+  });
+
+  it("routes JXA mutations to the write queue", () => {
+    const deps = makeDeps();
+    expect(pickGate("createTask", deps)).toBe(deps.jxaWriteQueue);
+  });
+
+  it("routes every OmniJS-bound method to the omnijs queue regardless of mutation flag", () => {
+    const deps = makeDeps();
+    // moveTask is OmniJS-routed *and* a mutation — must take the OmniJS path.
+    expect(pickGate("moveTask", deps)).toBe(deps.omniJsQueue);
+    // evaluateCustomPerspective is OmniJS-routed and a *read* — same gate.
+    expect(pickGate("evaluateCustomPerspective", deps)).toBe(deps.omniJsQueue);
+  });
+});
+
+describe("wrapWithConcurrency", () => {
+  it("lets multiple concurrent reads run inside the pool's slot budget", async () => {
+    const deps = makeDeps();
+    const spy = makeSpyAdapter();
+    const wrapped = wrapWithConcurrency(spy.adapter, deps);
+
+    // Two concurrent reads — pool has 2 slots, so both should enter immediately.
+    const p1 = wrapped.listTasks({ tag: "a" } as never);
+    const p2 = wrapped.listTasks({ tag: "b" } as never);
+    await new Promise((r) => setImmediate(r));
+
+    expect(spy.events).toEqual(["enter:listTasks:a", "enter:listTasks:b"]);
+    expect(deps.readPool.inFlightCount()).toBe(2);
+
+    spy.release("listTasks:a");
+    spy.release("listTasks:b");
+    await Promise.all([p1, p2]);
+  });
+
+  it("serializes JXA writes — second write does not enter until first exits", async () => {
+    const deps = makeDeps();
+    const spy = makeSpyAdapter();
+    const wrapped = wrapWithConcurrency(spy.adapter, deps);
+
+    const p1 = wrapped.createTask({ name: "a" } as never);
+    const p2 = wrapped.createTask({ name: "b" } as never);
+    await new Promise((r) => setImmediate(r));
+
+    // Only the first write should be in flight.
+    expect(spy.events).toEqual(["enter:createTask:a"]);
+
+    spy.release("createTask:a");
+    await new Promise((r) => setImmediate(r));
+    expect(spy.events).toEqual(["enter:createTask:a", "exit:createTask:a", "enter:createTask:b"]);
+
+    spy.release("createTask:b");
+    await Promise.all([p1, p2]);
+  });
+
+  it("OmniJS calls share their own queue independent of JXA writes", async () => {
+    const deps = makeDeps();
+    const spy = makeSpyAdapter();
+    const wrapped = wrapWithConcurrency(spy.adapter, deps);
+
+    // A JXA write and an OmniJS call kicked off back-to-back must NOT block
+    // each other — they live in different queues.
+    const pWrite = wrapped.createTask({ name: "x" } as never);
+    const pOmni = wrapped.moveTask("id-1" as never, {} as never);
+    await new Promise((r) => setImmediate(r));
+
+    expect(spy.events.sort()).toEqual(["enter:createTask:x", "enter:moveTask:id-1"]);
+
+    spy.release("createTask:x");
+    spy.release("moveTask:id-1");
+    await Promise.all([pWrite, pOmni]);
+  });
+});
+
+describe("MUTATING_METHODS coverage", () => {
+  // Sanity: ensure the obvious write families are flagged. If a new write
+  // method lands without joining this set, it would silently route through
+  // the read pool and cause undefined ordering.
+  it("flags the canonical task / project / tag / folder mutators", () => {
+    for (const m of [
+      "createTask",
+      "updateTask",
+      "deleteTask",
+      "createProject",
+      "updateProject",
+      "deleteProject",
+      "createTag",
+      "updateTag",
+      "deleteTag",
+      "createFolder",
+      "updateFolder",
+      "deleteFolder",
+    ] as const) {
+      // Failure message is "expected false to be true" — the loop variable
+      // makes which method failed obvious in the stack frame.
+      expect(MUTATING_METHODS.has(m)).toBe(true);
+    }
+  });
+});

--- a/src/adapter/concurrent.ts
+++ b/src/adapter/concurrent.ts
@@ -1,0 +1,153 @@
+/**
+ * `wrapWithConcurrency` — thread-disciplined `OmniFocusAdapter` wrapper.
+ *
+ * Per ADR-0009 / DESIGN §16, every adapter call is gated by exactly one of
+ * three concurrency primitives:
+ *
+ * - **ReadPool** — bounded-concurrency semaphore for non-mutating JXA calls.
+ *   Default 2 slots (`OMNIFOCUS_READ_POOL_SIZE`). Multiple concurrent reads
+ *   may run; the pool prevents `osascript` stampedes.
+ * - **JXA WriteQueue** — serial single-slot for mutating JXA calls. The JXA
+ *   runtime is single-threaded relative to OmniFocus's main thread; a
+ *   second concurrent write produces undefined ordering.
+ * - **OmniJS Queue** — serial single-slot for *every* OmniJS call (read or
+ *   write). The `evaluateJavascript` URL-scheme callback contends on the
+ *   filesystem regardless of whether the script is reading or writing OF
+ *   data, so the conservative move is to serialize all OmniJS traffic.
+ *
+ * Dispatch decision per call:
+ *
+ *   if (ROUTING_TABLE[method] === "omnijs")    → omniJsQueue
+ *   else if (MUTATING_METHODS.has(method))      → jxaWriteQueue
+ *   else                                        → readPool
+ *
+ * Implementation note: a `Proxy` is used rather than an explicit class with
+ * one delegate per method. The `OmniFocusAdapter` surface is wide (~50
+ * methods) and the dispatch logic is uniform; Proxy keeps the wrapping
+ * code single-screen and guarantees that any future method added to the
+ * interface (and to `ROUTING_TABLE`) is automatically routed without an
+ * accompanying change here. If a method is on the underlying adapter but
+ * absent from `ROUTING_TABLE`, the proxy falls back to a direct call —
+ * the adapter contract still holds.
+ *
+ * @see DESIGN.md §16 — concurrency model
+ * @see docs/adr/0009-concurrency-pool-and-queue.md
+ */
+
+import type { ReadPool } from "../concurrency/ReadPool.js";
+import type { WriteQueue } from "../concurrency/WriteQueue.js";
+import type { OmniFocusAdapter } from "./OmniFocusAdapter.js";
+import { type AdapterMethod, ROUTING_TABLE } from "./router.js";
+
+// ---------------------------------------------------------------------------
+// Mutating-method classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapter methods that mutate OmniFocus state. Membership decides whether
+ * a JXA-routed call goes through `readPool` (fast, concurrent) or
+ * `jxaWriteQueue` (serial, capped). OmniJS-routed methods bypass this set
+ * entirely — they all funnel through `omniJsQueue` regardless.
+ *
+ * Kept as a `Set<AdapterMethod>` (not a string array) so a typo surfaces
+ * at compile time rather than silently routing a write through the read
+ * pool.
+ */
+export const MUTATING_METHODS: ReadonlySet<AdapterMethod> = new Set<AdapterMethod>([
+  // Tasks
+  "createTask",
+  "updateTask",
+  "completeTask",
+  "uncompleteTask",
+  "dropTask",
+  "undropTask",
+  "deleteTask",
+  "moveTask",
+  "reorderTask",
+  "duplicateTask",
+  "batchCreateTasks",
+  "batchUpdateTasks",
+  "batchCompleteTasks",
+  // Projects
+  "createProject",
+  "updateProject",
+  "completeProject",
+  "dropProject",
+  "moveProject",
+  "deleteProject",
+  "markProjectReviewed",
+  "setProjectReviewInterval",
+  // Tags
+  "createTag",
+  "updateTag",
+  "deleteTag",
+  // Folders
+  "createFolder",
+  "updateFolder",
+  "deleteFolder",
+  // Sync — kicks the sync engine, side-effecting
+  "syncTrigger",
+  // Attachments
+  "addAttachment",
+  "removeAttachment",
+  // App lifecycle
+  "appLaunch",
+  // Plug-in / OmniJS-only mutations (still routed through omniJsQueue, but
+  // listed here for completeness when the routing table changes)
+  "pluginInvoke",
+  // Raw escape hatches — conservative: serialize, since callers can do
+  // anything inside them.
+  "runJxaScript",
+  "runOmniJsScript",
+]);
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+export interface ConcurrencyDeps {
+  readPool: ReadPool;
+  jxaWriteQueue: WriteQueue;
+  omniJsQueue: WriteQueue;
+}
+
+/**
+ * Pick the concurrency primitive that should gate a given adapter method.
+ * Exported for unit tests; production code calls {@link wrapWithConcurrency}.
+ */
+export function pickGate(method: AdapterMethod, deps: ConcurrencyDeps): ReadPool | WriteQueue {
+  if (ROUTING_TABLE[method] === "omnijs") return deps.omniJsQueue;
+  if (MUTATING_METHODS.has(method)) return deps.jxaWriteQueue;
+  return deps.readPool;
+}
+
+/**
+ * Wrap an `OmniFocusAdapter` so every method call is gated by the
+ * appropriate concurrency primitive (ReadPool / JXA WriteQueue / OmniJS
+ * Queue). The returned object satisfies `OmniFocusAdapter` exactly — the
+ * wrapper is invisible to callers.
+ *
+ * Properties that are not in `ROUTING_TABLE` (notably accessors that the
+ * concrete adapter exposes for diagnostics, like `routingTable` on
+ * `TransportRouter`) pass through untouched.
+ */
+export function wrapWithConcurrency(
+  inner: OmniFocusAdapter,
+  deps: ConcurrencyDeps,
+): OmniFocusAdapter {
+  return new Proxy(inner, {
+    get(target, prop, receiver) {
+      if (typeof prop !== "string" || !(prop in ROUTING_TABLE)) {
+        return Reflect.get(target, prop, receiver);
+      }
+      const method = prop as AdapterMethod;
+      const gate = pickGate(method, deps);
+      // Bind once so the inner adapter sees its own `this`.
+      const original = Reflect.get(target, method, receiver) as (
+        ...args: unknown[]
+      ) => Promise<unknown>;
+      const bound = original.bind(target);
+      return (...args: unknown[]): Promise<unknown> => gate.run(() => bound(...args));
+    },
+  }) as OmniFocusAdapter;
+}

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -25,6 +25,9 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { wrapWithConcurrency } from "../adapter/concurrent.js";
+import { ReadPool } from "../concurrency/ReadPool.js";
+import { WriteQueue } from "../concurrency/WriteQueue.js";
 import { parseConfig, redactConfig } from "../config/env.js";
 import { logger } from "../logging/logger.js";
 import { LoopDetector } from "../loopDetector/LoopDetector.js";
@@ -183,9 +186,27 @@ export async function startServer(): Promise<void> {
   const transport = new StdioServerTransport();
 
   // Compose the live adapter chain (JxaTransport + OmniJsTransport →
-  // TransportRouter) and the full service bundle. Cache wrapping at the
-  // adapter layer (#22) arrives in a follow-up.
-  const adapter = composeAdapter(config);
+  // TransportRouter) and front it with the concurrency primitives from
+  // ADR-0009 / DESIGN §16: a ReadPool for non-mutating JXA reads, a
+  // single-slot WriteQueue for JXA mutations, and a separate single-slot
+  // queue for OmniJS calls. Every adapter call from this point on goes
+  // through one of those three gates — `wrapWithConcurrency` decides per
+  // method (#376). Each queue is registered with the shutdown controller
+  // so SIGINT/SIGTERM drain in-flight calls before exit (DESIGN §17).
+  const router = composeAdapter(config);
+  const readPool = new ReadPool({ size: config.OMNIFOCUS_READ_POOL_SIZE, name: "jxa-read" });
+  const jxaWriteQueue = new WriteQueue({
+    cap: config.OMNIFOCUS_WRITE_QUEUE_CAP,
+    name: "jxa-write",
+  });
+  const omniJsQueue = new WriteQueue({
+    cap: config.OMNIFOCUS_WRITE_QUEUE_CAP,
+    name: "omnijs",
+  });
+  shutdownController.registerQueue(readPool);
+  shutdownController.registerQueue(jxaWriteQueue);
+  shutdownController.registerQueue(omniJsQueue);
+  const adapter = wrapWithConcurrency(router, { readPool, jxaWriteQueue, omniJsQueue });
   const services = composeServices(adapter, config);
 
   // Register internal_status tool.

--- a/tests/e2e/per-tool.test.ts
+++ b/tests/e2e/per-tool.test.ts
@@ -127,6 +127,7 @@ const TOOL_INPUTS: Record<string, Record<string, unknown>> = {
   task_move: { id: FAKE_TASK_ID, projectId: null },
   task_parse_transport_text: { text: "Reply to Alice @email !!" },
   task_reorder: { id: FAKE_TASK_ID, position: "top" },
+  task_search: { q: "test" },
   task_set_repetition: {
     id: FAKE_TASK_ID,
     rule: { unit: "days", steps: 1, anchor: "due-date", method: "fixed" },


### PR DESCRIPTION
## Summary
- Implements ADR-0009 / DESIGN §16 concurrency discipline. New `wrapWithConcurrency` (Proxy-based) gates every adapter call through one of three primitives: `ReadPool` (concurrent JXA reads), `WriteQueue` (serial JXA mutations), or a separate single-slot OmniJS queue.
- Dispatch decision is one branch in `pickGate`: OmniJS-routed → omniJsQueue; mutating → jxaWriteQueue; otherwise → readPool. The `MUTATING_METHODS` set is typed against `AdapterMethod` so a typo fails the build.
- All three queues register with `shutdownController` so SIGINT/SIGTERM drains in-flight calls before exit (DESIGN §17).
- The `ToolRateLimiter` half of #376's acceptance was already wired in via the per-tool middleware stack (#375).
- Adds a fixture entry for the newly-registered `task_search` tool — the per-tool E2E coverage guard caught the gap, exactly as designed.

Closes #376.

## Issue
Implements [#376](https://github.com/torsday/omnifocus-mcp/issues/376). Cross-refs ADR-0009 (concurrency policy), DESIGN.md §16 (concurrency model), DESIGN.md §17 (shutdown), and #375 (per-tool middleware that already wires ToolRateLimiter).

## Breaking change?
- [x] No — additive. `composeAdapter` returns the same `TransportRouter`; the wrapping happens in `mcpServer.startServer` before services see the adapter. Existing tests assert on the unwrapped router and still pass.

## Test plan
- [x] `pnpm test src/adapter/concurrent.test.ts` — 7/7 (pickGate routing × 3, concurrent reads, serialized writes, independent OmniJS queue, MUTATING_METHODS sanity)
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build` — green; bundle 462.34 KB
- [x] `OMNIFOCUS_E2E=1 pnpm test tests/e2e/` — 6/6 (smoke + per-tool)
- [x] Self-reviewed via /review-pr
- [x] No new dependencies