### PR TITLE
chore(deps): migrate to @biomejs/biome 2.x

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.7.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,11 +7,9 @@
     "defaultBranch": "main"
   },
   "files": {
-    "ignore": ["dist", "node_modules", "coverage", "*.min.js"]
+    "includes": ["**", "!**/dist", "!**/node_modules", "!**/coverage", "!**/*.min.js"]
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
@@ -47,13 +45,7 @@
       "style": {
         "useConst": "error",
         "useTemplate": "error",
-        "useNamingConvention": "off"
-      },
-      "suspicious": {
-        "noExplicitAny": "error",
-        "noConsoleLog": "error"
-      },
-      "nursery": {
+        "useNamingConvention": "off",
         "noRestrictedImports": {
           "level": "error",
           "options": {
@@ -69,12 +61,27 @@
             }
           }
         }
-      }
+      },
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noConsole": "error"
+      },
+      "nursery": {}
     }
   },
   "overrides": [
     {
-      "include": ["src/scripts/**/*.js"],
+      "includes": ["**/scripts/**/*.ts", "**/scripts/**/*.js"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/src/scripts/**/*.js"],
       "linter": {
         "rules": {
           "suspicious": {
@@ -87,11 +94,12 @@
       }
     },
     {
-      "include": ["tests/**/*.ts"],
+      "includes": ["**/tests/**/*.ts", "**/src/**/*.test.ts"],
       "linter": {
         "rules": {
           "suspicious": {
-            "noExplicitAny": "off"
+            "noExplicitAny": "off",
+            "noTemplateCurlyInString": "off"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,18 @@
   "bin": {
     "omnifocus-mcp": "./dist/index.js"
   },
-  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "engines": {
     "node": ">=20"
   },
-  "os": ["darwin"],
+  "os": [
+    "darwin"
+  ],
   "publishConfig": {
     "access": "public"
   },
@@ -60,7 +67,7 @@
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.7.0",
+    "@biomejs/biome": "^2.4.13",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^1.5.0",
     "esbuild": "0.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         version: 3.25.2(zod@4.3.6)
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.7.0
-        version: 1.9.4
+        specifier: ^2.4.13
+        version: 2.4.13
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -81,55 +81,55 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@2.4.13':
+    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1698,39 +1698,39 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@2.4.13':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-darwin-x64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@2.4.13':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@2.4.13':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@2.4.13':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@2.4.13':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@2.4.13':
     optional: true
 
   '@esbuild/aix-ppc64@0.21.5':

--- a/scripts/lint-custom.ts
+++ b/scripts/lint-custom.ts
@@ -8,7 +8,7 @@
 import { readFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join, relative } from "node:path";
-import { type Violation, checkFileContent } from "../src/linting/customRules.js";
+import { checkFileContent, type Violation } from "../src/linting/customRules.js";
 
 async function collectSourceFiles(dir = "src"): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });

--- a/src/adapter/concurrent.test.ts
+++ b/src/adapter/concurrent.test.ts
@@ -10,8 +10,8 @@
 import { describe, expect, it } from "vitest";
 import { ReadPool } from "../concurrency/ReadPool.js";
 import { WriteQueue } from "../concurrency/WriteQueue.js";
-import type { OmniFocusAdapter } from "./OmniFocusAdapter.js";
 import { MUTATING_METHODS, pickGate, wrapWithConcurrency } from "./concurrent.js";
+import type { OmniFocusAdapter } from "./OmniFocusAdapter.js";
 
 function makeDeps() {
   return {

--- a/src/adapter/inMemory/InMemoryAdapter.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.ts
@@ -27,6 +27,8 @@
 import type { Attachment } from "../../domain/attachment.js";
 import type { Folder } from "../../domain/folder.js";
 import {
+  type AttachmentId,
+  AttachmentId as AttachmentIdCtor,
   type FolderId,
   FolderId as FolderIdCtor,
   type ProjectId,
@@ -36,7 +38,6 @@ import {
   type TaskId,
   TaskId as TaskIdCtor,
 } from "../../domain/ids.js";
-import { type AttachmentId, AttachmentId as AttachmentIdCtor } from "../../domain/ids.js";
 import {
   BUILTIN_PERSPECTIVE_IDS,
   type BuiltinPerspectiveId,

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -25,6 +25,7 @@
 import type { Attachment } from "../../domain/attachment.js";
 import type { Folder } from "../../domain/folder.js";
 import {
+  AttachmentId,
   type FolderId,
   FolderId as FolderIdCtor,
   type ProjectId,
@@ -34,7 +35,6 @@ import {
   type TaskId,
   TaskId as TaskIdCtor,
 } from "../../domain/ids.js";
-import { AttachmentId } from "../../domain/ids.js";
 import type { BuiltinPerspectiveId, Perspective } from "../../domain/perspective.js";
 import type { Project } from "../../domain/project.js";
 import type { Tag } from "../../domain/tag.js";
@@ -109,7 +109,7 @@ import type {
   UpdateTagInput,
   UpdateTaskInput,
 } from "../OmniFocusAdapter.js";
-import { type RunScriptOptions, type ScriptSpawner, runJxaScript } from "./scriptRunner.js";
+import { type RunScriptOptions, runJxaScript, type ScriptSpawner } from "./scriptRunner.js";
 
 // ---------------------------------------------------------------------------
 // Construction
@@ -378,9 +378,10 @@ export class JxaTransport implements OmniFocusAdapter {
 
   // -- Projects (wired) -----------------------------------------------------
 
-  async listProjects(filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<
-    Project[]
-  > {
+  async listProjects(filter?: {
+    folderId?: FolderId;
+    status?: Project["status"];
+  }): Promise<Project[]> {
     const result = await runJxaScript<{ projects: Project[] }>(
       projectListScript,
       { folderId: filter?.folderId ?? null, status: filter?.status ?? null },

--- a/src/adapter/jxa/scriptRunner.test.ts
+++ b/src/adapter/jxa/scriptRunner.test.ts
@@ -18,7 +18,7 @@ import {
   TransportUnavailable,
   ValidationError,
 } from "../../errors/index.js";
-import { type ScriptSpawner, type SpawnResult, runJxaScript } from "./scriptRunner.js";
+import { runJxaScript, type ScriptSpawner, type SpawnResult } from "./scriptRunner.js";
 
 function fakeSpawner(result: Partial<SpawnResult>): ScriptSpawner {
   return vi.fn(

--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -50,7 +50,7 @@ import type {
   UpdateTagInput,
   UpdateTaskInput,
 } from "../OmniFocusAdapter.js";
-import { type RunScriptOptions, type ScriptSpawner, runOmniJsScript } from "./scriptRunner.js";
+import { type RunScriptOptions, runOmniJsScript, type ScriptSpawner } from "./scriptRunner.js";
 
 // ---------------------------------------------------------------------------
 // Construction
@@ -228,9 +228,10 @@ export class OmniJsTransport implements OmniFocusAdapter {
 
   // -- Projects -------------------------------------------------------------
 
-  async listProjects(_filter?: { folderId?: FolderId; status?: Project["status"] }): Promise<
-    Project[]
-  > {
+  async listProjects(_filter?: {
+    folderId?: FolderId;
+    status?: Project["status"];
+  }): Promise<Project[]> {
     return notYetWired("listProjects");
   }
   async getProject(_id: ProjectId): Promise<Project> {

--- a/src/adapter/omnijs/scriptRunner.test.ts
+++ b/src/adapter/omnijs/scriptRunner.test.ts
@@ -18,9 +18,9 @@ import {
   TransportUnavailable,
 } from "../../errors/index.js";
 import {
+  runOmniJsScript,
   type ScriptSpawner,
   type SpawnResult,
-  runOmniJsScript,
   wrapOmniJsForJxa,
 } from "./scriptRunner.js";
 

--- a/src/adapter/router.ts
+++ b/src/adapter/router.ts
@@ -44,6 +44,7 @@ import type { FolderId, ProjectId, TagId, TaskId } from "../domain/ids.js";
 import type { Project } from "../domain/project.js";
 import type { Tag } from "../domain/tag.js";
 import type { Task } from "../domain/task.js";
+import type { JxaTransport } from "./jxa/JxaTransport.js";
 import type {
   CreateFolderInput,
   CreateProjectInput,
@@ -58,7 +59,6 @@ import type {
   UpdateTagInput,
   UpdateTaskInput,
 } from "./OmniFocusAdapter.js";
-import type { JxaTransport } from "./jxa/JxaTransport.js";
 import type { OmniJsTransport } from "./omnijs/OmniJsTransport.js";
 
 // ---------------------------------------------------------------------------

--- a/src/attachment/assertAttachmentPath.test.ts
+++ b/src/attachment/assertAttachmentPath.test.ts
@@ -15,6 +15,7 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 import { realpath } from "node:fs/promises";
+
 const mockRealpath = vi.mocked(realpath);
 
 // ---------------------------------------------------------------------------

--- a/src/attachment/assertAttachmentSize.test.ts
+++ b/src/attachment/assertAttachmentSize.test.ts
@@ -18,6 +18,7 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 import { stat } from "node:fs/promises";
+
 const mockStat = vi.mocked(stat);
 
 const MB = 1024 * 1024;

--- a/src/domain/dates.test.ts
+++ b/src/domain/dates.test.ts
@@ -2,11 +2,11 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
-  ISO_8601_WITH_OFFSET,
   flexDateString,
+  ISO_8601_WITH_OFFSET,
   isIsoDateString,
-  isRelativeDateShortcut,
   isoDateString,
+  isRelativeDateShortcut,
   resolveRelativeDate,
 } from "./dates.js";
 

--- a/src/domain/ids.test.ts
+++ b/src/domain/ids.test.ts
@@ -5,11 +5,11 @@ import {
   AttachmentId,
   FolderId,
   IdConstructors,
+  isOmniFocusId,
   OMNIFOCUS_ID_PATTERN,
   ProjectId,
   TagId,
   TaskId,
-  isOmniFocusId,
 } from "./ids.js";
 
 describe("isOmniFocusId", () => {

--- a/src/envelope/index.test.ts
+++ b/src/envelope/index.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { NotFound, OmniFocusError, ValidationError } from "../errors/index.js";
 import {
+  err,
+  isError,
+  isSuccess,
+  ok,
   type Pagination,
   type ResponseMeta,
   type ToolEnvelope,
   type ToolError,
   type ToolSuccess,
   type Warning,
-  err,
-  isError,
-  isSuccess,
-  ok,
   warnDeprecatedField,
   warnDryRun,
   warnIdsNotFound,

--- a/src/errors/index.test.ts
+++ b/src/errors/index.test.ts
@@ -4,6 +4,7 @@ import {
   ConflictError,
   FeatureRequiresOfVersion,
   FeatureRequiresPro,
+  isOmniFocusError,
   NotFound,
   OmniFocusError,
   OmniFocusNotRunning,
@@ -15,7 +16,6 @@ import {
   Timeout,
   TransportUnavailable,
   ValidationError,
-  isOmniFocusError,
 } from "./index.js";
 
 describe("OmniFocusError", () => {

--- a/src/lifecycle/LifecycleManager.test.ts
+++ b/src/lifecycle/LifecycleManager.test.ts
@@ -14,10 +14,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { FeatureRequiresOfVersion } from "../errors/index.js";
 import {
+  compareVersions,
   type LifecycleLogger,
   LifecycleManager,
   type OfAppInfo,
-  compareVersions,
 } from "./LifecycleManager.js";
 
 function silentLogger(): LifecycleLogger {

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -6,8 +6,8 @@
 
 export {
   compareVersions,
-  LifecycleManager,
   type LifecycleLogger,
+  LifecycleManager,
   type LifecycleManagerOptions,
   type OfAppInfo,
 } from "./LifecycleManager.js";

--- a/src/loopDetector/LoopDetector.test.ts
+++ b/src/loopDetector/LoopDetector.test.ts
@@ -10,9 +10,9 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { ok } from "../envelope/index.js";
 import type { ResponseMeta } from "../envelope/index.js";
-import { LoopDetector, buildCallKey } from "./LoopDetector.js";
+import { ok } from "../envelope/index.js";
+import { buildCallKey, LoopDetector } from "./LoopDetector.js";
 import { withLoopDetection } from "./withLoopDetection.js";
 
 // ---------------------------------------------------------------------------

--- a/src/prompts/omnifocus.test.ts
+++ b/src/prompts/omnifocus.test.ts
@@ -11,15 +11,15 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, expect, it, vi } from "vitest";
 import {
-  CAPTURE_MEETING_PROMPT,
-  DAILY_REVIEW_PROMPT,
-  PROJECT_PLANNING_PROMPT,
-  WEEKLY_REVIEW_PROMPT,
   buildCaptureMeetingMessage,
   buildDailyReviewMessage,
   buildProjectPlanningMessage,
   buildWeeklyReviewMessage,
+  CAPTURE_MEETING_PROMPT,
+  DAILY_REVIEW_PROMPT,
+  PROJECT_PLANNING_PROMPT,
   registerOmniFocusPrompts,
+  WEEKLY_REVIEW_PROMPT,
 } from "./omnifocus.js";
 
 // ---------------------------------------------------------------------------

--- a/src/resources/capabilities.test.ts
+++ b/src/resources/capabilities.test.ts
@@ -6,8 +6,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, expect, it, vi } from "vitest";
 import type { Config } from "../config/env.js";
 import {
-  CAPABILITIES_URI,
   buildCapabilities,
+  CAPABILITIES_URI,
   registerCapabilitiesResource,
 } from "./capabilities.js";
 

--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -31,9 +31,9 @@ import {
   PERSPECTIVE_URI_TEMPLATE,
   PROJECT_URI_TEMPLATE,
   REVIEW_DUE_URI,
+  registerOmniFocusResources,
   SNAPSHOT_URI,
   TAG_URI_TEMPLATE,
-  registerOmniFocusResources,
 } from "./omnifocus.js";
 
 // ---------------------------------------------------------------------------

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -29,8 +29,8 @@
  * @see docs/adr/0006-read-cache-strategy.md
  */
 
-import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import { ProjectId, TagId } from "../domain/ids.js";
 import type { BuiltinPerspectiveId } from "../domain/perspective.js";

--- a/src/scripts/jxa/task_get_many.js
+++ b/src/scripts/jxa/task_get_many.js
@@ -154,7 +154,7 @@ function run(argv) {
   const allTasks = ofApp.defaultDocument.flattenedTasks();
   for (let i = 0; i < allTasks.length; i++) {
     const tid = allTasks[i].id();
-    if (Object.prototype.hasOwnProperty.call(idSet, tid)) {
+    if (Object.hasOwn(idSet, tid)) {
       idSet[tid] = buildTask(allTasks[i]);
     }
   }

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -163,17 +163,17 @@ function run(argv) {
   if (!found) throw new Error(`Task not found: ${args.id}`);
 
   if (args.name !== undefined) found.name = args.name;
-  if (Object.prototype.hasOwnProperty.call(args, "note")) {
+  if (Object.hasOwn(args, "note")) {
     found.note = args.note ?? "";
   }
   if (args.flagged !== undefined) found.flagged = args.flagged;
-  if (Object.prototype.hasOwnProperty.call(args, "deferDate")) {
+  if (Object.hasOwn(args, "deferDate")) {
     found.deferDate = args.deferDate ? new Date(args.deferDate) : null;
   }
-  if (Object.prototype.hasOwnProperty.call(args, "dueDate")) {
+  if (Object.hasOwn(args, "dueDate")) {
     found.dueDate = args.dueDate ? new Date(args.dueDate) : null;
   }
-  if (Object.prototype.hasOwnProperty.call(args, "estimatedMinutes")) {
+  if (Object.hasOwn(args, "estimatedMinutes")) {
     found.estimatedMinutes = args.estimatedMinutes;
   }
   if (args.sequential !== undefined) found.sequential = args.sequential;

--- a/src/server/composition.ts
+++ b/src/server/composition.ts
@@ -13,9 +13,9 @@
  * @see ADR-0009 — read pool + write queue + OmniJS queue
  */
 
-import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
 import { JxaTransport } from "../adapter/jxa/JxaTransport.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import { OmniJsTransport } from "../adapter/omnijs/OmniJsTransport.js";
 import { TransportRouter } from "../adapter/router.js";
 import { OmniFocusLruCache } from "../cache/lruCache.js";

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -35,13 +35,13 @@ import {
   CAPTURE_MEETING_PROMPT,
   DAILY_REVIEW_PROMPT,
   PROJECT_PLANNING_PROMPT,
-  WEEKLY_REVIEW_PROMPT,
   registerOmniFocusPrompts,
+  WEEKLY_REVIEW_PROMPT,
 } from "../prompts/omnifocus.js";
 import { ToolRateLimiter } from "../rateLimit/ToolRateLimiter.js";
 import {
-  CAPABILITIES_URI,
   buildCapabilities,
+  CAPABILITIES_URI,
   registerCapabilitiesResource,
 } from "../resources/capabilities.js";
 import {
@@ -52,9 +52,9 @@ import {
   PERSPECTIVE_URI_TEMPLATE,
   PROJECT_URI_TEMPLATE,
   REVIEW_DUE_URI,
+  registerOmniFocusResources,
   SNAPSHOT_URI,
   TAG_URI_TEMPLATE,
-  registerOmniFocusResources,
 } from "../resources/omnifocus.js";
 import { registerAppLaunchTool } from "../tools/app/launch.js";
 import { registerAttachmentTools } from "../tools/attachment/index.js";

--- a/src/services/taskService.test.ts
+++ b/src/services/taskService.test.ts
@@ -18,8 +18,8 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import { OmniFocusLruCache } from "../cache/lruCache.js";
 import type { ProjectId, TagId, TaskId } from "../domain/ids.js";
 import { NotFound, ValidationError } from "../errors/index.js";

--- a/src/tools/app/launch.ts
+++ b/src/tools/app/launch.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/attachment/index.ts
+++ b/src/tools/attachment/index.ts
@@ -18,7 +18,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { AttachmentOwner } from "../../adapter/OmniFocusAdapter.js";
 import { AttachmentId, ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import type { AttachmentService } from "../../services/attachmentService.js";
 

--- a/src/tools/descriptionShape.test.ts
+++ b/src/tools/descriptionShape.test.ts
@@ -8,8 +8,8 @@
 
 import { describe, expect, it } from "vitest";
 import {
-  type DescriptionShapeResult,
   checkDescriptionShape,
+  type DescriptionShapeResult,
   formatShapeViolations,
 } from "./descriptionShape.js";
 

--- a/src/tools/export/opml.ts
+++ b/src/tools/export/opml.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId, ProjectId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import type { ExportScope, ExportService } from "../../services/exportService.js";
 

--- a/src/tools/export/taskpaper.ts
+++ b/src/tools/export/taskpaper.ts
@@ -17,7 +17,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId, ProjectId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import type { ExportScope, ExportService } from "../../services/exportService.js";
 

--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
 export const FOLDER_CREATE_DESCRIPTION =

--- a/src/tools/folder/delete.ts
+++ b/src/tools/folder/delete.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
 export const FOLDER_DELETE_DESCRIPTION =

--- a/src/tools/folder/get.ts
+++ b/src/tools/folder/get.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
 export const FOLDER_GET_DESCRIPTION =

--- a/src/tools/folder/list.ts
+++ b/src/tools/folder/list.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderListInput, FolderService } from "../../services/folderService.js";
 
 export const FOLDER_LIST_DESCRIPTION =

--- a/src/tools/folder/move.ts
+++ b/src/tools/folder/move.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
 export const FOLDER_MOVE_DESCRIPTION =

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
 export const FOLDER_UPDATE_DESCRIPTION =

--- a/src/tools/forecast/get.ts
+++ b/src/tools/forecast/get.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { flexDateString } from "../../domain/dates.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ForecastService } from "../../services/forecastService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/note/append.ts
+++ b/src/tools/note/append.ts
@@ -20,7 +20,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/note/get.ts
+++ b/src/tools/note/get.ts
@@ -13,7 +13,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/note/get_html.ts
+++ b/src/tools/note/get_html.ts
@@ -14,7 +14,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/note/set.ts
+++ b/src/tools/note/set.ts
@@ -18,7 +18,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/note/set_html.ts
+++ b/src/tools/note/set_html.ts
@@ -22,7 +22,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/observability/index.ts
+++ b/src/tools/observability/index.ts
@@ -1,12 +1,12 @@
-export {
-  INTERNAL_STATUS_DESCRIPTION,
-  handleInternalStatus,
-  internalStatusInputSchema,
-  registerInternalStatusTool,
-} from "./internalStatus.js";
 export type {
   CircuitSnapshot,
   InternalStatusContext,
   InternalStatusData,
   InternalStatusInput,
+} from "./internalStatus.js";
+export {
+  handleInternalStatus,
+  INTERNAL_STATUS_DESCRIPTION,
+  internalStatusInputSchema,
+  registerInternalStatusTool,
 } from "./internalStatus.js";

--- a/src/tools/observability/internalStatus.ts
+++ b/src/tools/observability/internalStatus.ts
@@ -14,7 +14,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { CircuitState } from "../../server/circuitBreaker.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/perspective/evaluate.test.ts
+++ b/src/tools/perspective/evaluate.test.ts
@@ -7,8 +7,8 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { PerspectiveService } from "../../services/perspectiveService.js";
 import {
-  PERSPECTIVE_EVALUATE_DESCRIPTION,
   handlePerspectiveEvaluate,
+  PERSPECTIVE_EVALUATE_DESCRIPTION,
   perspectiveEvaluateInputSchema,
 } from "./evaluate.js";
 

--- a/src/tools/perspective/evaluate.ts
+++ b/src/tools/perspective/evaluate.ts
@@ -13,7 +13,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { PerspectiveService } from "../../services/perspectiveService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/perspective/list.test.ts
+++ b/src/tools/perspective/list.test.ts
@@ -7,8 +7,8 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { PerspectiveService } from "../../services/perspectiveService.js";
 import {
-  PERSPECTIVE_LIST_DESCRIPTION,
   handlePerspectiveList,
+  PERSPECTIVE_LIST_DESCRIPTION,
   perspectiveListInputSchema,
 } from "./list.js";
 

--- a/src/tools/perspective/list.ts
+++ b/src/tools/perspective/list.ts
@@ -10,7 +10,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { PerspectiveService } from "../../services/perspectiveService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/plugin/invoke.test.ts
+++ b/src/tools/plugin/invoke.test.ts
@@ -11,8 +11,8 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { NotFound } from "../../errors/index.js";
 import {
-  PLUGIN_INVOKE_DESCRIPTION,
   handlePluginInvoke,
+  PLUGIN_INVOKE_DESCRIPTION,
   pluginInvokeInputSchema,
 } from "./invoke.js";
 

--- a/src/tools/plugin/invoke.ts
+++ b/src/tools/plugin/invoke.ts
@@ -13,7 +13,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { PluginService } from "../../services/pluginService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/complete.test.ts
+++ b/src/tools/project/complete.test.ts
@@ -8,8 +8,8 @@ import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ProjectService } from "../../services/projectService.js";
 import {
-  PROJECT_COMPLETE_DESCRIPTION,
   handleProjectComplete,
+  PROJECT_COMPLETE_DESCRIPTION,
   projectCompleteInputSchema,
 } from "./complete.js";
 

--- a/src/tools/project/complete.ts
+++ b/src/tools/project/complete.ts
@@ -9,7 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { ProjectId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/create.test.ts
+++ b/src/tools/project/create.test.ts
@@ -11,8 +11,8 @@ import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.
 import type { ResponseMeta, ToolEnvelope, ToolSuccess } from "../../envelope/index.js";
 import { IdempotencyStore } from "../../server/idempotencyStore.js";
 import {
-  PROJECT_CREATE_DESCRIPTION,
   handleProjectCreate,
+  PROJECT_CREATE_DESCRIPTION,
   projectCreateInputSchema,
 } from "./create.js";
 

--- a/src/tools/project/create.ts
+++ b/src/tools/project/create.ts
@@ -18,10 +18,10 @@ import { z } from "zod";
 import type { CreateProjectInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { FolderId, TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
-  type IdempotencyStore,
   idempotencyStore as defaultIdempotencyStore,
+  type IdempotencyStore,
   withIdempotencyKey,
 } from "../../server/idempotencyStore.js";
 

--- a/src/tools/project/delete.ts
+++ b/src/tools/project/delete.ts
@@ -22,12 +22,12 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import type { ProjectId as ProjectIdType } from "../../domain/ids.js";
 import { ProjectId } from "../../domain/ids.js";
-import { type ResponseMeta, type ToolEnvelope, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
 import {
-  type IdempotencyStore,
   idempotencyStore as defaultIdempotencyStore,
+  type IdempotencyStore,
   withIdempotencyKey,
 } from "../../server/idempotencyStore.js";
 

--- a/src/tools/project/drop.test.ts
+++ b/src/tools/project/drop.test.ts
@@ -7,7 +7,7 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ProjectService } from "../../services/projectService.js";
-import { PROJECT_DROP_DESCRIPTION, handleProjectDrop, projectDropInputSchema } from "./drop.js";
+import { handleProjectDrop, PROJECT_DROP_DESCRIPTION, projectDropInputSchema } from "./drop.js";
 
 function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
   const scopes: InvalidationScope[] = [];

--- a/src/tools/project/drop.ts
+++ b/src/tools/project/drop.ts
@@ -9,7 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { ProjectId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/get.test.ts
+++ b/src/tools/project/get.test.ts
@@ -9,7 +9,7 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import { OmniFocusLruCache } from "../../cache/lruCache.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ProjectService } from "../../services/projectService.js";
-import { PROJECT_GET_DESCRIPTION, handleProjectGet, projectGetInputSchema } from "./get.js";
+import { handleProjectGet, PROJECT_GET_DESCRIPTION, projectGetInputSchema } from "./get.js";
 
 function makeCtx() {
   let tick = 0;

--- a/src/tools/project/get.ts
+++ b/src/tools/project/get.ts
@@ -13,7 +13,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/list.test.ts
+++ b/src/tools/project/list.test.ts
@@ -11,7 +11,7 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import { OmniFocusLruCache } from "../../cache/lruCache.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ProjectService } from "../../services/projectService.js";
-import { PROJECT_LIST_DESCRIPTION, handleProjectList, projectListInputSchema } from "./list.js";
+import { handleProjectList, PROJECT_LIST_DESCRIPTION, projectListInputSchema } from "./list.js";
 
 function makeCtx() {
   let tick = 0;

--- a/src/tools/project/list.ts
+++ b/src/tools/project/list.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
-import { type Pagination, type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectListInput, ProjectService } from "../../services/projectService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/move.ts
+++ b/src/tools/project/move.ts
@@ -9,7 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { FolderId, ProjectId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/update.ts
+++ b/src/tools/project/update.ts
@@ -22,12 +22,12 @@ import type { OmniFocusAdapter, UpdateProjectInput } from "../../adapter/OmniFoc
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import type { ProjectId as ProjectIdType } from "../../domain/ids.js";
 import { ProjectId, TagId } from "../../domain/ids.js";
-import { type ResponseMeta, type ToolEnvelope, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
 import {
-  type IdempotencyStore,
   idempotencyStore as defaultIdempotencyStore,
+  type IdempotencyStore,
   withIdempotencyKey,
 } from "../../server/idempotencyStore.js";
 

--- a/src/tools/rawScript/jxa.ts
+++ b/src/tools/rawScript/jxa.ts
@@ -17,7 +17,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "pino";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import { logger as defaultLogger } from "../../logging/logger.js";
 

--- a/src/tools/rawScript/omnijs.ts
+++ b/src/tools/rawScript/omnijs.ts
@@ -17,7 +17,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "pino";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import { logger as defaultLogger } from "../../logging/logger.js";
 

--- a/src/tools/review/listDue.test.ts
+++ b/src/tools/review/listDue.test.ts
@@ -7,8 +7,8 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ReviewService } from "../../services/reviewService.js";
 import {
-  REVIEW_LIST_DUE_DESCRIPTION,
   handleReviewListDue,
+  REVIEW_LIST_DUE_DESCRIPTION,
   reviewListDueInputSchema,
 } from "./listDue.js";
 

--- a/src/tools/review/listDue.ts
+++ b/src/tools/review/listDue.ts
@@ -6,7 +6,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/review/markReviewed.test.ts
+++ b/src/tools/review/markReviewed.test.ts
@@ -8,8 +8,8 @@ import type { InvalidatingCache } from "../../cache/invalidation.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ReviewService } from "../../services/reviewService.js";
 import {
-  REVIEW_MARK_REVIEWED_DESCRIPTION,
   handleReviewMarkReviewed,
+  REVIEW_MARK_REVIEWED_DESCRIPTION,
   reviewMarkReviewedInputSchema,
 } from "./markReviewed.js";
 

--- a/src/tools/review/markReviewed.ts
+++ b/src/tools/review/markReviewed.ts
@@ -7,7 +7,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId as ProjectIdCtor } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/review/projectMarkReviewed.test.ts
+++ b/src/tools/review/projectMarkReviewed.test.ts
@@ -7,8 +7,8 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ReviewService } from "../../services/reviewService.js";
 import {
-  PROJECT_MARK_REVIEWED_DESCRIPTION,
   handleProjectMarkReviewed,
+  PROJECT_MARK_REVIEWED_DESCRIPTION,
   projectMarkReviewedInputSchema,
 } from "./projectMarkReviewed.js";
 

--- a/src/tools/review/projectMarkReviewed.ts
+++ b/src/tools/review/projectMarkReviewed.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId as ProjectIdCtor } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/review/setInterval.test.ts
+++ b/src/tools/review/setInterval.test.ts
@@ -8,8 +8,8 @@ import type { InvalidatingCache } from "../../cache/invalidation.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ReviewService } from "../../services/reviewService.js";
 import {
-  REVIEW_SET_INTERVAL_DESCRIPTION,
   handleReviewSetInterval,
+  REVIEW_SET_INTERVAL_DESCRIPTION,
   reviewSetIntervalInputSchema,
 } from "./setInterval.js";
 

--- a/src/tools/review/setInterval.ts
+++ b/src/tools/review/setInterval.ts
@@ -7,7 +7,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId as ProjectIdCtor } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/search/query.ts
+++ b/src/tools/search/query.ts
@@ -13,7 +13,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId, TagId } from "../../domain/ids.js";
-import { type Pagination, type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { SearchInput, SearchService } from "../../services/searchService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/sync/status.ts
+++ b/src/tools/sync/status.ts
@@ -11,7 +11,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/sync/trigger.ts
+++ b/src/tools/sync/trigger.ts
@@ -18,7 +18,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type ClearableCache, invalidateOnSync } from "../../cache/invalidation.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_CREATE_DESCRIPTION =

--- a/src/tools/tag/delete.ts
+++ b/src/tools/tag/delete.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_DELETE_DESCRIPTION =

--- a/src/tools/tag/get.test.ts
+++ b/src/tools/tag/get.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { TagService } from "../../services/tagService.js";
-import { TAG_GET_DESCRIPTION, handleTagGet, tagGetInputSchema } from "./get.js";
+import { handleTagGet, TAG_GET_DESCRIPTION, tagGetInputSchema } from "./get.js";
 
 // ---------------------------------------------------------------------------
 // Harness

--- a/src/tools/tag/get.ts
+++ b/src/tools/tag/get.ts
@@ -13,7 +13,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/tag/getLocation.ts
+++ b/src/tools/tag/getLocation.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_GET_LOCATION_DESCRIPTION =

--- a/src/tools/tag/list.test.ts
+++ b/src/tools/tag/list.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { TagService } from "../../services/tagService.js";
-import { TAG_LIST_DESCRIPTION, handleTagList, tagListInputSchema } from "./list.js";
+import { handleTagList, TAG_LIST_DESCRIPTION, tagListInputSchema } from "./list.js";
 
 // ---------------------------------------------------------------------------
 // Harness

--- a/src/tools/tag/list.ts
+++ b/src/tools/tag/list.ts
@@ -13,7 +13,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagListInput, TagService } from "../../services/tagService.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/tag/move.ts
+++ b/src/tools/tag/move.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_MOVE_DESCRIPTION =

--- a/src/tools/tag/setAllowsNextAction.ts
+++ b/src/tools/tag/setAllowsNextAction.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_SET_ALLOWS_NEXT_ACTION_DESCRIPTION =

--- a/src/tools/tag/setLocation.ts
+++ b/src/tools/tag/setLocation.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_SET_LOCATION_DESCRIPTION =

--- a/src/tools/tag/setStatus.ts
+++ b/src/tools/tag/setStatus.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_SET_STATUS_DESCRIPTION =

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -8,7 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
 export const TAG_UPDATE_DESCRIPTION =

--- a/src/tools/task/batch.test.ts
+++ b/src/tools/task/batch.test.ts
@@ -10,8 +10,8 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import type { ProjectId, TaskId } from "../../domain/ids.js";
 import type { ResponseMeta, ToolEnvelope } from "../../envelope/index.js";
 import { handleTaskBatchComplete, taskBatchCompleteInputBaseSchema } from "./batchComplete.js";

--- a/src/tools/task/batchComplete.ts
+++ b/src/tools/task/batchComplete.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_COMPLETE_DESCRIPTION =
   "Mark many OmniFocus tasks complete in a single JXA round trip. " +

--- a/src/tools/task/batchCreate.ts
+++ b/src/tools/task/batchCreate.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_CREATE_DESCRIPTION =
   "Create many OmniFocus tasks in a single JXA round trip. " +

--- a/src/tools/task/batchUpdate.ts
+++ b/src/tools/task/batchUpdate.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter, UpdateTaskInput } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TagId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_UPDATE_DESCRIPTION =
   "Partially update many OmniFocus tasks in a single JXA round trip. " +

--- a/src/tools/task/clearRepetition.ts
+++ b/src/tools/task/clearRepetition.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/task/complete.ts
+++ b/src/tools/task/complete.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/task/create.test.ts
+++ b/src/tools/task/create.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta, ToolEnvelope, ToolSuccess } from "../../envelope/index.js";
 import { IdempotencyStore } from "../../server/idempotencyStore.js";
-import { TASK_CREATE_DESCRIPTION, handleTaskCreate, taskCreateInputSchema } from "./create.js";
+import { handleTaskCreate, TASK_CREATE_DESCRIPTION, taskCreateInputSchema } from "./create.js";
 
 /** Narrow a handler envelope to ToolSuccess or fail the assertion. */
 function assertOk<T>(envelope: ToolEnvelope<T>): ToolSuccess<T> {

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -19,10 +19,10 @@ import { z } from "zod";
 import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
-  type IdempotencyStore,
   idempotencyStore as defaultIdempotencyStore,
+  type IdempotencyStore,
   withIdempotencyKey,
 } from "../../server/idempotencyStore.js";
 

--- a/src/tools/task/delete.ts
+++ b/src/tools/task/delete.ts
@@ -22,12 +22,12 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import type { TaskId as TaskIdType } from "../../domain/ids.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, type ToolEnvelope, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
 import {
-  type IdempotencyStore,
   idempotencyStore as defaultIdempotencyStore,
+  type IdempotencyStore,
   withIdempotencyKey,
 } from "../../server/idempotencyStore.js";
 

--- a/src/tools/task/drop.ts
+++ b/src/tools/task/drop.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/task/duplicate.ts
+++ b/src/tools/task/duplicate.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/findByName.ts
+++ b/src/tools/task/findByName.ts
@@ -19,7 +19,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description
@@ -102,6 +102,8 @@ export async function handleTaskFindByName(input: TaskFindByNameInput, ctx: Task
         return name.startsWith(q);
       case "contains":
         return name.includes(q);
+      default:
+        return false;
     }
   });
 

--- a/src/tools/task/get.ts
+++ b/src/tools/task/get.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TaskGetInput, TaskService } from "../../services/taskService.js";
 
 export const TASK_GET_DESCRIPTION =

--- a/src/tools/task/getMany.ts
+++ b/src/tools/task/getMany.ts
@@ -25,7 +25,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse, warnIdsNotFound } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse, warnIdsNotFound } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/list.test.ts
+++ b/src/tools/task/list.test.ts
@@ -12,7 +12,7 @@ import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import { OmniFocusLruCache } from "../../cache/lruCache.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { TaskService } from "../../services/taskService.js";
-import { TASK_LIST_DESCRIPTION, handleTaskList, taskListInputSchema } from "./list.js";
+import { handleTaskList, TASK_LIST_DESCRIPTION, taskListInputSchema } from "./list.js";
 
 // ---------------------------------------------------------------------------
 // Harness

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -22,9 +22,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { flexDateString } from "../../domain/dates.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
-import { type Pagination, type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
-import { TaskSortBySchema } from "../../services/taskService.js";
+import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TaskListInput, TaskService } from "../../services/taskService.js";
+import { TaskSortBySchema } from "../../services/taskService.js";
 
 // ---------------------------------------------------------------------------
 // Tool description (shown to the LLM via tools/list)

--- a/src/tools/task/move.ts
+++ b/src/tools/task/move.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/parseTransportText.test.ts
+++ b/src/tools/task/parseTransportText.test.ts
@@ -5,8 +5,8 @@
 import { describe, expect, it } from "vitest";
 import type { ResponseMeta } from "../../envelope/index.js";
 import {
-  TASK_PARSE_TRANSPORT_TEXT_DESCRIPTION,
   handleTaskParseTransportText,
+  TASK_PARSE_TRANSPORT_TEXT_DESCRIPTION,
 } from "./parseTransportText.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/parseTransportText.ts
+++ b/src/tools/task/parseTransportText.ts
@@ -8,7 +8,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { parseTransportText } from "../../taskParser/transportText.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/reorder.test.ts
+++ b/src/tools/task/reorder.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
 import type { ResponseMeta } from "../../envelope/index.js";

--- a/src/tools/task/reorder.ts
+++ b/src/tools/task/reorder.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter, TaskPosition } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/search.ts
+++ b/src/tools/task/search.ts
@@ -20,7 +20,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { ProjectId, TagId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/task/setRepetition.ts
+++ b/src/tools/task/setRepetition.ts
@@ -20,7 +20,7 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
 import { RepetitionRuleSchema } from "../../domain/task.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/task/uncomplete.ts
+++ b/src/tools/task/uncomplete.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/task/undrop.ts
+++ b/src/tools/task/undrop.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
-import { type ResponseMeta, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -28,12 +28,12 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TagId, TaskId } from "../../domain/ids.js";
 import type { Task } from "../../domain/task.js";
-import { type ResponseMeta, type ToolEnvelope, ok, toolResponse } from "../../envelope/index.js";
+import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
 import {
-  type IdempotencyStore,
   idempotencyStore as defaultIdempotencyStore,
+  type IdempotencyStore,
   withIdempotencyKey,
 } from "../../server/idempotencyStore.js";
 

--- a/tests/integration/transportRouter.contract.test.ts
+++ b/tests/integration/transportRouter.contract.test.ts
@@ -21,8 +21,8 @@
  */
 
 import { describe, test } from "vitest";
-import type { OmniFocusAdapter } from "../../src/adapter/OmniFocusAdapter.js";
 import { JxaTransport } from "../../src/adapter/jxa/JxaTransport.js";
+import type { OmniFocusAdapter } from "../../src/adapter/OmniFocusAdapter.js";
 import { OmniJsTransport } from "../../src/adapter/omnijs/OmniJsTransport.js";
 import { TransportRouter } from "../../src/adapter/router.js";
 import type { FolderId, ProjectId, TagId, TaskId } from "../../src/domain/ids.js";

--- a/tests/perf/spec-targets.perf.test.ts
+++ b/tests/perf/spec-targets.perf.test.ts
@@ -67,7 +67,7 @@ if (!PERF) {
   ) {
     const margin = targetMs * 1.2;
     const pass = results.p95 <= margin ? "✅" : "❌";
-    // biome-ignore lint/suspicious/noConsoleLog: intentional benchmark output
+    // biome-ignore lint/suspicious/noConsole: intentional benchmark output
     console.log(
       `  ${pass} ${label.padEnd(30)} p50=${results.p50.toFixed(0).padStart(5)}ms  p95=${results.p95.toFixed(0).padStart(5)}ms  p99=${results.p99.toFixed(0).padStart(5)}ms  target=${targetMs}ms`,
     );
@@ -101,7 +101,7 @@ if (!PERF) {
   const FIXTURE_TASK_COUNT = 50; // small — enough to measure relative timing
 
   beforeAll(async () => {
-    // biome-ignore lint/suspicious/noConsoleLog: intentional benchmark output
+    // biome-ignore lint/suspicious/noConsole: intentional benchmark output
     console.log("\n📊 Perf suite: setting up fixture...");
     // Create a dedicated project with enough tasks to exercise list/get paths.
     fixtureProjectId = await router.createProject({ name: "perf-bench-fixture" });
@@ -116,7 +116,7 @@ if (!PERF) {
       createdTaskIds.push(id);
     }
     firstTaskId = createdTaskIds[0] ?? null;
-    // biome-ignore lint/suspicious/noConsoleLog: intentional benchmark output
+    // biome-ignore lint/suspicious/noConsole: intentional benchmark output
     console.log(`   Created ${FIXTURE_TASK_COUNT} tasks in project ${fixtureProjectId}`);
   }, 120_000);
 
@@ -136,7 +136,7 @@ if (!PERF) {
         /* already gone */
       }
     }
-    // biome-ignore lint/suspicious/noConsoleLog: intentional benchmark output
+    // biome-ignore lint/suspicious/noConsole: intentional benchmark output
     console.log("   Fixture cleaned up.");
   }, 120_000);
 


### PR DESCRIPTION
## Summary
- Bump `@biomejs/biome` 1.9.4 → 2.4.13
- Migrate `biome.json` to the 2.x schema: `files.includes`, `assist.actions.source.organizeImports`, `noRestrictedImports` graduated from nursery → style, `noConsoleLog` → `noConsole`
- Add `scripts/` override to allow `console.*` in CLI scripts (legitimate output)
- Add `noTemplateCurlyInString: off` in test override (cache key patterns like `"project:${id}"` are intentional literals)
- Fix `useIterableCallbackReturn` in `findByName.ts` (add `default: false` to exhaustive switch)
- Update 4 `biome-ignore` comments: `noConsoleLog` → `noConsole` in perf tests
- Apply auto-fixed import organization across ~120 files

Closes #384

## Issue
Implements [#384 — chore(deps): migrate to @biomejs/biome 2.x](https://github.com/torsday/omnifocus-mcp/issues/384).

## Breaking change?
- [x] No

## Test plan
- [x] `pnpm lint` passes (biome check + lint-custom + docs:check)
- [x] `pnpm typecheck` clean
- [x] 1771 tests pass