### PR TITLE
chore(deps): migrate property tests to fast-check 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^1.5.0",
     "esbuild": "0.28.0",
-    "fast-check": "^3.17.0",
+    "fast-check": "^4.7.0",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: 0.28.0
         version: 0.28.0
       fast-check:
-        specifier: ^3.17.0
-        version: 3.23.2
+        specifier: ^4.7.0
+        version: 4.7.0
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@6.0.3)
@@ -988,9 +988,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
-  fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
+  fast-check@4.7.0:
+    resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
+    engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1347,8 +1347,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -2430,9 +2430,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-check@3.23.2:
+  fast-check@4.7.0:
     dependencies:
-      pure-rand: 6.1.0
+      pure-rand: 8.4.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -2753,7 +2753,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  pure-rand@6.1.0: {}
+  pure-rand@8.4.0: {}
 
   qs@6.15.1:
     dependencies:

--- a/src/domain/dates.test.ts
+++ b/src/domain/dates.test.ts
@@ -116,10 +116,12 @@ describe("property — every pattern-matching valid timestamp parses", () => {
   it("isoDateString accepts any well-formed timestamp with offset", () => {
     fc.assert(
       fc.property(
-        fc.date({
-          min: new Date("1970-01-01T00:00:00Z"),
-          max: new Date("2100-01-01T00:00:00Z"),
-        }),
+        fc
+          .date({
+            min: new Date("1970-01-01T00:00:00Z"),
+            max: new Date("2100-01-01T00:00:00Z"),
+          })
+          .filter((d) => !isNaN(d.getTime())),
         (d) => {
           const iso = d.toISOString(); // always ends in Z
           expect(ISO_8601_WITH_OFFSET.test(iso)).toBe(true);
@@ -135,10 +137,12 @@ describe("property — strings without offset are uniformly rejected", () => {
   it("isoDateString rejects any string that looks like ISO-8601 but lacks an offset", () => {
     fc.assert(
       fc.property(
-        fc.date({
-          min: new Date("1970-01-01T00:00:00Z"),
-          max: new Date("2100-01-01T00:00:00Z"),
-        }),
+        fc
+          .date({
+            min: new Date("1970-01-01T00:00:00Z"),
+            max: new Date("2100-01-01T00:00:00Z"),
+          })
+          .filter((d) => !isNaN(d.getTime())),
         (d) => {
           // Strip the trailing Z to produce a bare-local-time string.
           const bare = d.toISOString().replace(/Z$/, "");

--- a/src/pagination/cursor.property.test.ts
+++ b/src/pagination/cursor.property.test.ts
@@ -18,7 +18,7 @@ import { type CursorPayload, decodeCursor, encodeCursor } from "./cursor.js";
 // ---------------------------------------------------------------------------
 
 /** Generate a valid filterHash (64-char hex, as SHA-256 produces). */
-const filterHashArb = fc.hexaString({ minLength: 64, maxLength: 64 });
+const filterHashArb = fc.stringMatching(/^[0-9a-f]{64}$/);
 
 /** Generate a CursorPayload with arbitrary string id, sort value, and filterHash. */
 const cursorPayloadArb = fc.record<CursorPayload>({


### PR DESCRIPTION
## Summary
- Bump `fast-check` 3.23.2 → 4.7.0
- Replace `fc.hexaString()` (removed in 4.x) with `fc.stringMatching(/^[0-9a-f]{64}$/)` in cursor property tests
- Add `.filter(d => !isNaN(d.getTime()))` to `fc.date` arbitraries in dates tests — 4.x can generate `Invalid Date` even with explicit min/max bounds, causing `toISOString()` to throw

Closes #385

## Issue
Implements [#385 — chore(deps): migrate property tests to fast-check 4.x](https://github.com/torsday/omnifocus-mcp/issues/385).

## Breaking change?
- [x] No

## Test plan
- [x] 1771 tests pass (`pnpm test`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean