### PR TITLE
feat(transport): wire loop detector error threshold and warn logging

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -40,7 +40,9 @@ export type ErrorCode =
   // Lifecycle — stop and reconnect
   | "OF_SHUTTING_DOWN"
   // Protocol guard — stray write to stdout (MCP transport channel)
-  | "OF_STRAY_STDOUT";
+  | "OF_STRAY_STDOUT"
+  // Agent loop guard — same tool+args called too many times in a window
+  | "OF_LOOP_DETECTED";
 
 /**
  * Machine-readable remediation class. Agents switch on this to decide what
@@ -313,5 +315,33 @@ export class ServerShuttingDown extends OmniFocusError {
       suggestion: "Reconnect to a fresh server instance.",
       ...options,
     });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent loop guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the same `(tool, args)` combination has been called too many
+ * times within the detection window (DESIGN §6.11 — error threshold).
+ *
+ * The remediation class is `input` because the agent should change its
+ * behaviour (act on the previous result, not repeat the same call) before
+ * retrying.
+ */
+export class LoopDetected extends OmniFocusError {
+  constructor(toolName: string, count: number, windowSeconds: number, options: ErrorOptions = {}) {
+    super(
+      "OF_LOOP_DETECTED",
+      `Tool "${toolName}" has been called ${count} time(s) with identical arguments within ${windowSeconds}s. The agent appears to be stuck.`,
+      {
+        remediationClass: "input",
+        suggestion:
+          "Act on the result of the previous call before repeating this tool. If you need the same data again, verify the previous response was consumed.",
+        details: { tool: toolName, count, windowSeconds },
+        ...options,
+      },
+    );
   }
 }

--- a/src/loopDetector/LoopDetector.test.ts
+++ b/src/loopDetector/LoopDetector.test.ts
@@ -15,6 +15,10 @@ import { ok } from "../envelope/index.js";
 import { buildCallKey, LoopDetector } from "./LoopDetector.js";
 import { withLoopDetection } from "./withLoopDetection.js";
 
+vi.mock("../logging/logger.js", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn(), fatal: vi.fn() },
+}));
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -43,22 +47,32 @@ describe("LoopDetector", () => {
     }
   });
 
-  it("returns WARN_LOOP_DETECTED on the 5th identical call", () => {
-    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+  it("returns level:warn with WARN_LOOP_DETECTED on the 5th identical call", () => {
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
     const args = { projectId: "abc" };
     for (let i = 0; i < 4; i++) detector.record("task_list", args);
-    const warning = detector.record("task_list", args);
-    expect(warning).toBeDefined();
-    expect(warning?.code).toBe("WARN_LOOP_DETECTED");
-    expect(warning?.details).toMatchObject({ tool: "task_list", count: 5 });
+    const result = detector.record("task_list", args);
+    expect(result).toBeDefined();
+    expect(result?.level).toBe("warn");
+    expect(result?.warning.code).toBe("WARN_LOOP_DETECTED");
+    expect(result?.warning.details).toMatchObject({ tool: "task_list", count: 5 });
   });
 
-  it("continues to return the warning on subsequent identical calls", () => {
-    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+  it("continues to return level:warn on calls between threshold and errorThreshold", () => {
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
     const args = { projectId: "abc" };
     for (let i = 0; i < 5; i++) detector.record("task_list", args);
-    expect(detector.record("task_list", args)?.code).toBe("WARN_LOOP_DETECTED");
-    expect(detector.record("task_list", args)?.details?.count).toBe(7);
+    expect(detector.record("task_list", args)?.level).toBe("warn");
+    expect(detector.record("task_list", args)?.warning.details?.count).toBe(7);
+  });
+
+  it("returns level:error once errorThreshold is reached", () => {
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
+    const args = { projectId: "abc" };
+    for (let i = 0; i < 9; i++) detector.record("task_list", args);
+    const result = detector.record("task_list", args);
+    expect(result?.level).toBe("error");
+    expect(result?.warning.details?.count).toBe(10);
   });
 
   it("different args for the same tool never trigger the warning", () => {
@@ -102,11 +116,11 @@ describe("LoopDetector", () => {
   });
 
   it("respects a custom threshold", () => {
-    const detector = new LoopDetector({ threshold: 3, windowSeconds: 60 });
+    const detector = new LoopDetector({ threshold: 3, errorThreshold: 10, windowSeconds: 60 });
     const args = {};
     detector.record("sync_status", args);
     detector.record("sync_status", args);
-    expect(detector.record("sync_status", args)?.code).toBe("WARN_LOOP_DETECTED");
+    expect(detector.record("sync_status", args)?.warning.code).toBe("WARN_LOOP_DETECTED");
   });
 });
 
@@ -132,14 +146,14 @@ describe("buildCallKey", () => {
 
 describe("withLoopDetection", () => {
   it("is transparent when no loop is detected (returns handler result unchanged)", async () => {
-    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
     const result = await withLoopDetection("task_list", {}, detector, makeHandler({ tasks: [] }));
     expect(result.data).toEqual({ tasks: [] });
     expect(result.meta.warnings).toBeUndefined();
   });
 
   it("appends WARN_LOOP_DETECTED to meta.warnings after threshold", async () => {
-    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
     const args = { flagged: true };
     for (let i = 0; i < 4; i++) {
       await withLoopDetection("task_list", args, detector, makeHandler({ tasks: [] }));
@@ -149,8 +163,19 @@ describe("withLoopDetection", () => {
     expect(result.meta.warnings?.[0]?.code).toBe("WARN_LOOP_DETECTED");
   });
 
+  it("throws LoopDetected (OF_LOOP_DETECTED) once errorThreshold is reached", async () => {
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
+    const args = { id: "stuck" };
+    for (let i = 0; i < 9; i++) {
+      detector.record("task_get", args); // record without running handler
+    }
+    await expect(
+      withLoopDetection("task_get", args, detector, makeHandler({ id: "x" })),
+    ).rejects.toMatchObject({ code: "OF_LOOP_DETECTED" });
+  });
+
   it("preserves existing warnings when appending loop warning", async () => {
-    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
     const args = {};
     const existingWarning = {
       code: "WARN_SYNC_PENDING" as const,
@@ -168,7 +193,7 @@ describe("withLoopDetection", () => {
   });
 
   it("does not mutate the original meta.warnings array", async () => {
-    const detector = new LoopDetector({ threshold: 5, windowSeconds: 60 });
+    const detector = new LoopDetector({ threshold: 5, errorThreshold: 10, windowSeconds: 60 });
     const args = {};
     const original = [{ code: "WARN_SYNC_PENDING" as const, message: "x" }];
     const handlerWithWarning = () =>

--- a/src/loopDetector/LoopDetector.ts
+++ b/src/loopDetector/LoopDetector.ts
@@ -17,15 +17,32 @@
 import { createHash } from "node:crypto";
 import type { Warning } from "../envelope/index.js";
 
+/**
+ * Result from `LoopDetector.record()`.
+ *
+ * - `"warn"` — call count just crossed `threshold`; append to `meta.warnings`.
+ * - `"error"` — call count crossed `errorThreshold`; caller should throw.
+ */
+export type LoopDetectorResult =
+  | { level: "warn"; warning: Warning }
+  | { level: "error"; warning: Warning }
+  | undefined;
+
 export interface LoopDetectorConfig {
   /** Number of identical calls before the warning fires. Default 5. */
   threshold: number;
+  /**
+   * Number of identical calls before a hard `OF_LOOP_DETECTED` error is
+   * thrown (via `withLoopDetection`). Must be ≥ `threshold`. Default 10.
+   */
+  errorThreshold: number;
   /** Sliding window in seconds. Default 60. */
   windowSeconds: number;
 }
 
 const DEFAULT_CONFIG: LoopDetectorConfig = {
   threshold: 5,
+  errorThreshold: 10,
   windowSeconds: 60,
 };
 
@@ -51,14 +68,16 @@ export class LoopDetector {
   }
 
   /**
-   * Record an invocation and return a warning if the threshold is met.
+   * Record an invocation and return a result describing what action to take.
+   *
+   * - Returns `undefined` when below the warn threshold.
+   * - Returns `{ level: "warn", warning }` when count is in `[threshold, errorThreshold)`.
+   * - Returns `{ level: "error", warning }` when count reaches `errorThreshold`.
    *
    * @param toolName - MCP tool name (e.g. `"task_list"`)
    * @param args - Raw input arguments passed to the tool
-   * @returns A `WARN_LOOP_DETECTED` `Warning` when the threshold is reached,
-   *          or `undefined` otherwise.
    */
-  record(toolName: string, args: unknown): Warning | undefined {
+  record(toolName: string, args: unknown): LoopDetectorResult {
     const key = buildCallKey(toolName, args);
     const now = Date.now();
     const cutoff = now - this.config.windowSeconds * 1000;
@@ -67,17 +86,20 @@ export class LoopDetector {
     timestamps.push(now);
 
     const count = timestamps.length;
-    if (count >= this.config.threshold) {
-      return {
-        code: "WARN_LOOP_DETECTED",
-        message: `Tool "${toolName}" has been called ${count} time(s) with identical arguments within ${this.config.windowSeconds}s.`,
-        suggestion:
-          "The agent may be stuck in a loop. Verify that the previous response was acted on before repeating this call.",
-        details: { tool: toolName, count, windowSeconds: this.config.windowSeconds },
-      };
-    }
+    if (count < this.config.threshold) return undefined;
 
-    return undefined;
+    const warning: Warning = {
+      code: "WARN_LOOP_DETECTED",
+      message: `Tool "${toolName}" has been called ${count} time(s) with identical arguments within ${this.config.windowSeconds}s.`,
+      suggestion:
+        "The agent may be stuck in a loop. Verify that the previous response was acted on before repeating this call.",
+      details: { tool: toolName, count, windowSeconds: this.config.windowSeconds },
+    };
+
+    if (count >= this.config.errorThreshold) {
+      return { level: "error", warning };
+    }
+    return { level: "warn", warning };
   }
 
   /**

--- a/src/loopDetector/withLoopDetection.ts
+++ b/src/loopDetector/withLoopDetection.ts
@@ -3,12 +3,12 @@
  *
  * Wraps a tool handler to:
  * 1. Record the `(tool, args)` invocation via `LoopDetector.record()`.
- * 2. If a `WARN_LOOP_DETECTED` warning is returned, append it to the
- *    `meta.warnings` array of the response.
- *
- * The wrapper is transparent — it preserves the envelope shape and type
- * parameter of the wrapped handler. It never blocks or throws on loop
- * detection; the warning is advisory only.
+ * 2. Emit a `loop.detected` warn log event on every detection (warn or error).
+ * 3. If level is `"warn"` (calls ≥ `threshold`), append `WARN_LOOP_DETECTED`
+ *    to `meta.warnings` of the response.
+ * 4. If level is `"error"` (calls ≥ `errorThreshold`), throw `LoopDetected`
+ *    (`OF_LOOP_DETECTED`) before invoking the handler — the agent is told to
+ *    stop repeating and act on previous results.
  *
  * @see src/loopDetector/LoopDetector.ts
  * @see DESIGN.md §6.11 — loop detection
@@ -16,6 +16,8 @@
  */
 
 import type { ResponseMeta, ToolSuccess } from "../envelope/index.js";
+import { LoopDetected } from "../errors/index.js";
+import { logger } from "../logging/logger.js";
 import type { LoopDetector } from "./LoopDetector.js";
 
 /**
@@ -32,17 +34,37 @@ export function withLoopDetection<T>(
   detector: LoopDetector,
   handler: () => Promise<ToolSuccess<T>>,
 ): Promise<ToolSuccess<T>> {
-  const warning = detector.record(toolName, args);
+  const result = detector.record(toolName, args);
+
+  if (result !== undefined) {
+    const { level, warning } = result;
+    const count = (warning.details?.count as number | undefined) ?? 0;
+    const windowMs = ((warning.details?.windowSeconds as number | undefined) ?? 60) * 1000;
+
+    logger.warn({
+      event: "loop.detected",
+      tool: toolName,
+      callCount: count,
+      windowMs,
+      level,
+    });
+
+    if (level === "error") {
+      return Promise.reject(
+        new LoopDetected(toolName, count, (warning.details?.windowSeconds as number) ?? 60),
+      );
+    }
+  }
 
   return handler().then((envelope) => {
-    if (warning === undefined) return envelope;
+    if (result === undefined) return envelope;
 
     const existingWarnings = envelope.meta.warnings ?? [];
     return {
       ...envelope,
       meta: {
         ...envelope.meta,
-        warnings: [...existingWarnings, warning],
+        warnings: [...existingWarnings, result.warning],
       } satisfies ResponseMeta,
     };
   });


### PR DESCRIPTION
Closes #379

## What this does

Completes the loop-detection implementation per DESIGN §6.11 — the infrastructure existed but only warned; now it also hard-stops stuck agents.

### Changes

**`LoopDetector`**
- Adds `errorThreshold` to `LoopDetectorConfig` (default 10 calls/60s window)
- `record()` now returns `{ level: "warn" | "error", warning: Warning } | undefined` instead of `Warning | undefined`
- Warn level: `threshold` ≤ count < `errorThreshold`
- Error level: count ≥ `errorThreshold`

**`withLoopDetection`**
- Emits `loop.detected` warn log on every detection (both levels), with `{ event, tool, callCount, windowMs, level }`
- On `level: "warn"`: appends `WARN_LOOP_DETECTED` to `meta.warnings` as before
- On `level: "error"`: throws `LoopDetected` (`OF_LOOP_DETECTED`) *before* invoking the handler

**`src/errors/index.ts`**
- Adds `OF_LOOP_DETECTED` to `ErrorCode`
- Adds `LoopDetected` error class (`remediationClass: "input"` — agent must change behaviour)

## Test plan

- [x] `pnpm test` — 1773 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] New tests: warn level fires correctly, error level throws `OF_LOOP_DETECTED`, existing tests updated for new return type