### PR TITLE
feat(resources): add syncStatus to omnifocus://snapshot

### DIFF
--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -173,12 +173,30 @@ describe("registerOmniFocusResources — registration", () => {
 describe("omnifocus://snapshot", () => {
   it("returns all five counts as 0 on an empty adapter", async () => {
     const { read } = makeHarness();
-    const data = (await read("omnifocus-snapshot")) as Record<string, number>;
+    const data = (await read("omnifocus-snapshot")) as Record<string, unknown>;
     expect(data.inboxCount).toBe(0);
     expect(data.overdueCount).toBe(0);
     expect(data.dueTodayCount).toBe(0);
     expect(data.flaggedCount).toBe(0);
     expect(data.reviewDueCount).toBe(0);
+  });
+
+  it("includes syncStatus with lastSyncAt and inFlight", async () => {
+    const { read } = makeHarness();
+    const data = (await read("omnifocus-snapshot")) as Record<string, unknown>;
+    expect(data.syncStatus).toMatchObject({
+      lastSyncAt: null,
+      inFlight: false,
+    });
+  });
+
+  it("syncStatus.lastSyncAt updates after a sync", async () => {
+    const { adapter, read } = makeHarness();
+    await adapter.syncTrigger();
+    const data = (await read("omnifocus-snapshot")) as Record<string, unknown>;
+    const ss = data.syncStatus as { lastSyncAt: string | null; inFlight: boolean };
+    expect(ss.lastSyncAt).not.toBeNull();
+    expect(typeof ss.lastSyncAt).toBe("string");
   });
 
   it("counts inbox tasks (no project, no parent)", async () => {

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -5,7 +5,7 @@
  * They let an agent load structured context without spending a tool call.
  *
  * Static URIs:
- *   omnifocus://snapshot       — five-count orientation object
+ *   omnifocus://snapshot       — orientation object with counts + sync status
  *   omnifocus://inbox          — inbox tasks as Task[]
  *   omnifocus://forecast/today — today's forecast grouped by category
  *   omnifocus://overdue        — overdue tasks sorted by dueDate ASC
@@ -112,17 +112,20 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
     SNAPSHOT_URI,
     {
       description:
-        "Five-count snapshot of the current OmniFocus state: " +
-        "inboxCount, overdueCount, dueTodayCount, flaggedCount, reviewDueCount. " +
-        "Read at session start to orient before calling task_list or forecast_get.",
+        "Orientation snapshot of the current OmniFocus state: " +
+        "inboxCount, overdueCount, dueTodayCount, flaggedCount, reviewDueCount, " +
+        "and syncStatus { lastSyncAt, inFlight }. " +
+        "Read at session start to orient before calling task_list or forecast_get. " +
+        "Use syncStatus.lastSyncAt to detect stale data before making decisions.",
       mimeType: "application/json",
     },
     async (_uri) => {
       const { from, to } = todayRange();
-      const [inboxTasks, forecast, reviewProjects] = await Promise.all([
+      const [inboxTasks, forecast, reviewProjects, syncStatus] = await Promise.all([
         adapter.listTasks({ completed: false }),
         adapter.getForecast({ from, to, includeOverdue: true, includeFlagged: true }),
         adapter.listProjectsDueForReview(),
+        adapter.getLastSync(),
       ]);
 
       const inboxCount = inboxTasks.filter(
@@ -135,6 +138,10 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
         dueTodayCount: forecast.dueToday.length,
         flaggedCount: forecast.flagged.length,
         reviewDueCount: reviewProjects.length,
+        syncStatus: {
+          lastSyncAt: syncStatus.lastSyncAt,
+          inFlight: syncStatus.inFlight,
+        },
       });
     },
   );


### PR DESCRIPTION
## Summary
- Adds `syncStatus: { lastSyncAt, inFlight }` to the `omnifocus://snapshot` resource payload
- Calls `adapter.getLastSync()` in parallel with existing queries (no latency added)
- Agents can now detect stale data at session start without a separate `sync_get_last` call
- 2 new tests; description updated

Closes #402