### PR TITLE
feat(resources): add tasks/project, tasks/tag, and tasks/inbox MCP resources

### DIFF
--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -112,9 +112,9 @@ function makeHarness() {
 // ---------------------------------------------------------------------------
 
 describe("registerOmniFocusResources — registration", () => {
-  it("registers exactly 9 resources", () => {
+  it("registers exactly 12 resources", () => {
     const { registered } = makeHarness();
-    expect(registered).toHaveLength(9);
+    expect(registered).toHaveLength(12);
   });
 
   it("registers omnifocus-snapshot with the correct URI", () => {

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -66,6 +66,9 @@ export const REVIEW_DUE_URI = "omnifocus://review-due";
 export const PROJECT_URI_TEMPLATE = "omnifocus://project/{id}";
 export const TAG_URI_TEMPLATE = "omnifocus://tag/{id}";
 export const PERSPECTIVE_URI_TEMPLATE = "omnifocus://perspective/{id}";
+export const TASKS_INBOX_URI = "omnifocus://tasks/inbox";
+export const TASKS_BY_PROJECT_URI_TEMPLATE = "omnifocus://tasks/project/{projectId}";
+export const TASKS_BY_TAG_URI_TEMPLATE = "omnifocus://tasks/tag/{tagId}";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -316,6 +319,59 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
         perspectiveId: id,
         tasks: result.tasks,
       });
+    },
+  );
+
+  // ── omnifocus://tasks/inbox ──────────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-tasks-inbox",
+    TASKS_INBOX_URI,
+    {
+      description:
+        "Inbox tasks as Task[]. Alias for omnifocus://inbox using the unified tasks namespace. " +
+        "Returns incomplete tasks not assigned to any project or parent task.",
+      mimeType: "application/json",
+    },
+    async () => {
+      const tasks = await adapter.listTasks({ completed: false });
+      const inbox = tasks.filter((t) => t.projectId === null && t.parentId === null);
+      return jsonContents(TASKS_INBOX_URI, inbox);
+    },
+  );
+
+  // ── omnifocus://tasks/project/{projectId} ─────────────────────────────────
+  server.registerResource(
+    "omnifocus-tasks-by-project",
+    new ResourceTemplate(TASKS_BY_PROJECT_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Active tasks in a project as Task[]. " +
+        "Get the project ID from project_list or project_get. " +
+        "Returns incomplete tasks whose projectId matches the given ID.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const projectId = ProjectId.of((variables as { projectId: string }).projectId);
+      const tasks = await adapter.listTasks({ projectId, completed: false });
+      return jsonContents(`omnifocus://tasks/project/${projectId}`, tasks);
+    },
+  );
+
+  // ── omnifocus://tasks/tag/{tagId} ─────────────────────────────────────────
+  server.registerResource(
+    "omnifocus-tasks-by-tag",
+    new ResourceTemplate(TASKS_BY_TAG_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Active tasks with a specific tag as Task[]. " +
+        "Get the tag ID from tag_list or tag_get. " +
+        "Returns incomplete tasks that carry the given tag.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const tagId = TagId.of((variables as { tagId: string }).tagId);
+      const tasks = await adapter.listTasks({ tagId, completed: false });
+      return jsonContents(`omnifocus://tasks/tag/${tagId}`, tasks);
     },
   );
 }


### PR DESCRIPTION
## Summary

- Adds three new MCP resources for filtered task lists, letting agents load structured context without spending a tool call:
  - `omnifocus://tasks/inbox` — inbox tasks (alias for `omnifocus://inbox`, unified namespace)
  - `omnifocus://tasks/project/{projectId}` — active tasks in a specific project
  - `omnifocus://tasks/tag/{tagId}` — active tasks carrying a specific tag
- All return `application/json` `Task[]` with no envelope wrapper (per DESIGN §28 AC2)
- Path-segment encoding used for dynamic parameters (`{projectId}`, `{tagId}`) matching `ResourceTemplate` capabilities
- Delegates to `adapter.listTasks()` so the existing 30s LRU cache applies automatically
- Updates resource count assertion from 9 → 12 in `omnifocus.test.ts`

Closes #414

## Test plan

- [x] `pnpm test` — 1939 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no errors
- [x] Resource count test updated from 9 → 12