### PR TITLE
docs(readme): make Quick Start agent-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,29 @@ The server is built to a single-user local-first standard: no network surface, n
    npm install -g @torsday/omnifocus-mcp
    ```
 
-2. **Connect your MCP client** — the server speaks the standard MCP stdio protocol. For Claude Desktop, add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+2. **Configure your MCP client.** Every client uses the same `command` + `args` + `env` shape — only the file path and serialization (JSON vs TOML) differ. The universal shape:
+
+   ```text
+   command: omnifocus-mcp
+   args:    (none)
+   env:     OMNIFOCUS_LOG_LEVEL=info   # optional; "debug" is verbose
+   ```
+
+   Find your client below. Order is alphabetical; no client is recommended over another.
+
+   <details>
+   <summary><strong>Claude Code</strong> (CLI; no file edit)</summary>
+
+   ```bash
+   claude mcp add omnifocus omnifocus-mcp
+   ```
+
+   Detailed guide: [`docs/clients/claude-code.md`](./docs/clients/claude-code.md)
+   </details>
+
+   <details>
+   <summary><strong>Claude Desktop</strong> — <code>~/Library/Application Support/Claude/claude_desktop_config.json</code> (JSON)</summary>
+
    ```json
    {
      "mcpServers": {
@@ -65,7 +87,92 @@ The server is built to a single-user local-first standard: no network surface, n
      }
    }
    ```
-   Any MCP client that supports stdio transport (Claude Desktop, Claude Code, Cursor, Windsurf, etc.) uses the same `command` / `args` / `env` shape.
+
+   Detailed guide: [`docs/clients/claude-desktop.md`](./docs/clients/claude-desktop.md)
+   </details>
+
+   <details>
+   <summary><strong>Cline</strong> (VS Code extension) — extension settings (JSON)</summary>
+
+   In VS Code, open the Cline extension's MCP settings panel and add:
+
+   ```json
+   {
+     "mcpServers": {
+       "omnifocus": {
+         "command": "omnifocus-mcp",
+         "args": [],
+         "env": { "OMNIFOCUS_LOG_LEVEL": "info" }
+       }
+     }
+   }
+   ```
+
+   Cline's settings UI may surface the same fields as labelled inputs rather than raw JSON; the values are identical. Verify the panel location against the current Cline docs.
+   </details>
+
+   <details>
+   <summary><strong>OpenAI Codex CLI</strong> — <code>~/.codex/config.toml</code> (TOML)</summary>
+
+   ```toml
+   [mcp_servers.omnifocus]
+   command = "omnifocus-mcp"
+   args = []
+   env = { OMNIFOCUS_LOG_LEVEL = "info" }
+   ```
+
+   Detailed guide: [`docs/clients/codex.md`](./docs/clients/codex.md)
+   </details>
+
+   <details>
+   <summary><strong>Cursor</strong> — <code>~/.cursor/mcp.json</code> (JSON)</summary>
+
+   ```json
+   {
+     "mcpServers": {
+       "omnifocus": {
+         "command": "omnifocus-mcp",
+         "args": [],
+         "env": { "OMNIFOCUS_LOG_LEVEL": "info" }
+       }
+     }
+   }
+   ```
+
+   Verify the path against the current Cursor docs — recent versions also accept project-scoped `.cursor/mcp.json` at the repo root.
+   </details>
+
+   <details>
+   <summary><strong>Windsurf</strong> — <code>~/.codeium/windsurf/mcp_config.json</code> (JSON)</summary>
+
+   ```json
+   {
+     "mcpServers": {
+       "omnifocus": {
+         "command": "omnifocus-mcp",
+         "args": [],
+         "env": { "OMNIFOCUS_LOG_LEVEL": "info" }
+       }
+     }
+   }
+   ```
+
+   Verify the path against the current Windsurf docs — Codeium occasionally relocates config under `~/.codeium/`.
+   </details>
+
+   <details>
+   <summary><strong>Generic stdio client</strong> (anything else that speaks MCP/stdio)</summary>
+
+   Use your client's MCP config form. The shape is:
+
+   ```text
+   command: "omnifocus-mcp"
+   args:    []
+   env:     { "OMNIFOCUS_LOG_LEVEL": "info" }
+   ```
+
+   Detailed guide: [`docs/clients/generic-stdio.md`](./docs/clients/generic-stdio.md)
+   </details>
 
 3. **Grant macOS Automation permission** on first use — the app running the MCP server will prompt to control OmniFocus; click **OK**. If denied by mistake: **System Settings → Privacy & Security → Automation → [app] → OmniFocus** ✓
 
@@ -117,7 +224,7 @@ The assistant calls `task_list` with `{ "available": true, "limit": 20 }` and re
 
 ## Prompts
 
-`omnifocus-mcp` ships four **MCP prompt templates** — structured workflows you can invoke by name from any MCP client that supports prompts (e.g. Claude Desktop's prompt picker, or any client that surfaces `prompts/list`).
+`omnifocus-mcp` ships four **MCP prompt templates** — structured workflows you can invoke by name from any MCP client that surfaces `prompts/list` (most clients with a prompt picker UI).
 
 ### `daily-review` — triage your day
 
@@ -681,8 +788,9 @@ Writes are saved locally and show up immediately in subsequent tool calls. Chang
 
 | Client | Guide |
 |---|---|
-| Claude Desktop | [`docs/clients/claude-desktop.md`](./docs/clients/claude-desktop.md) |
 | Claude Code (CLI) | [`docs/clients/claude-code.md`](./docs/clients/claude-code.md) |
+| Claude Desktop | [`docs/clients/claude-desktop.md`](./docs/clients/claude-desktop.md) |
+| OpenAI Codex CLI | [`docs/clients/codex.md`](./docs/clients/codex.md) |
 | Generic stdio client | [`docs/clients/generic-stdio.md`](./docs/clients/generic-stdio.md) |
 
 ---

--- a/docs/clients/codex.md
+++ b/docs/clients/codex.md
@@ -1,0 +1,96 @@
+# OpenAI Codex CLI — omnifocus-mcp setup
+
+Adds omnifocus-mcp as a local MCP server in [OpenAI Codex CLI](https://github.com/openai/codex).
+
+## Prerequisites
+
+- macOS 13 (Ventura) or later
+- OmniFocus 3.15+ or OmniFocus 4.x
+- Node.js 24 or newer (`node --version`)
+- Codex CLI installed (`codex --version`)
+
+## One-time install
+
+```bash
+npm install -g @torsday/omnifocus-mcp
+```
+
+Verify the binary is available:
+
+```bash
+omnifocus-mcp --version
+```
+
+## Configuration
+
+Codex configures MCP servers via `~/.codex/config.toml`. Add an `[mcp_servers.<name>]` table:
+
+```toml
+[mcp_servers.omnifocus]
+command = "omnifocus-mcp"
+args = []
+env = { OMNIFOCUS_LOG_LEVEL = "info" }
+```
+
+If the file or `[mcp_servers.*]` tables don't exist yet, create them. Don't remove other server entries.
+
+## Verify
+
+Restart Codex (it reads the config on startup), then ask:
+
+> Use the `internal_status` tool and tell me what it returns.
+
+Codex should call the tool and surface a JSON object with `uptimeMs`, `cacheStats`, and `circuitState`. If it can't find the tool, see [Troubleshooting](#troubleshooting).
+
+## Grant macOS Automation permission
+
+On the first call that touches OmniFocus, macOS prompts:
+
+> "**Codex** wants access to control **OmniFocus**."
+
+Click **OK**. If denied by mistake:
+
+**System Settings → Privacy & Security → Automation → Codex → OmniFocus** ✓
+
+The server itself runs under whatever process Codex spawned it from, so the permission needs to be granted to that process. If you launch Codex from a terminal, the permission may belong to your terminal app (Terminal.app, iTerm2, etc.) rather than to Codex itself.
+
+## Per-client environment variables
+
+Anything in `env` is set on the spawned server process. The most useful values:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OMNIFOCUS_LOG_LEVEL` | `info` | `debug` for verbose stderr (PII visible); `warn`/`error` to mute |
+| `OMNIFOCUS_E2E` | (unset) | Set to `1` only for the E2E test suite — never in production |
+| `OMNIFOCUS_ALLOW_RAW_SCRIPT` | (unset) | Set to `1` to expose `run_jxa_script` / `run_omnijs_script`. **Off by default for safety** (ADR-0004) |
+
+Full reference: [README — Environment variables](../../README.md#environment-variables).
+
+## Troubleshooting
+
+### "tool not found" or no tools surfaced
+
+The server failed to start. Run it manually to see startup logs:
+
+```bash
+omnifocus-mcp 2>&1 | head -20
+```
+
+A clean start logs `server started` on stderr. Anything else (config error, port-bind, stray-stdout guard) explains the failure.
+
+### "OmniFocus is not running"
+
+The server can't drive a closed app. Open OmniFocus once; subsequent calls will connect.
+
+### "Automation permission denied"
+
+See the Automation permission note above. The denied state is sticky — the server returns a typed `OF_PERMISSION_DENIED` error with a remediation hint until you toggle the permission on.
+
+### Codex doesn't pick up changes to `config.toml`
+
+Codex reads MCP config at process start. After editing, exit and re-run `codex` so the new server is registered.
+
+## Related
+
+- [Generic stdio client setup](./generic-stdio.md) — the underlying transport contract every MCP client uses
+- [README — Trust & security](../../README.md) — what data leaves the machine (none) and how the server is sandboxed


### PR DESCRIPTION
## Summary
- Quick Start step 2 now leads with the universal command + args + env shape; per-client matrix follows below as expandable `<details>` blocks. Order is alphabetical: Claude Code, Claude Desktop, Cline, Codex, Cursor, Windsurf, Generic — no client recommended over another.
- New `docs/clients/codex.md` mirrors the existing claude-desktop.md / claude-code.md / generic-stdio.md structure.
- Prompts intro reframed from "e.g. Claude Desktop's prompt picker" to "any MCP client that surfaces `prompts/list`" — capability, not vendor-specific UI.
- "Client setup guides" table at the bottom of README adds Codex and re-sorts alphabetically.

Closes #433.

## Issue
Implements [#433](https://github.com/torsday/omnifocus-mcp/issues/433). Pairs with #422 (Trust & Security) per the issue notes; that lands separately.

## Breaking change?
- [x] No — docs only.

## Test plan
- [x] `pnpm typecheck && pnpm lint` — clean (8 pre-existing lint warnings unchanged per CLAUDE.md)
- [x] Issue's tone-audit AC satisfied: `grep -in claude README.md` returns 7 hits, every one inside a Claude-specific subsection (matrix entry, code snippet, or setup-guide table row)
- [x] Verification scenario from the issue: a reader using Codex can open the README, expand the Codex `<details>` block within ~30s, and copy-paste the TOML snippet into `~/.codex/config.toml` without seeing any Claude-first framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)