### PR TITLE
chore(scripts): extend phase enum to support v1 post-10 work

### DIFF
--- a/scripts/check-automation-permission.sh
+++ b/scripts/check-automation-permission.sh
@@ -20,7 +20,6 @@
 
 set -euo pipefail
 
-OMNIFOCUS_BUNDLE="com.omnigroup.OmniFocus4"
 TEST_SCRIPT='Application("OmniFocus").name()'
 
 # Run a minimal JXA script that requires Automation access to OmniFocus.

--- a/scripts/file-issue.sh
+++ b/scripts/file-issue.sh
@@ -14,7 +14,7 @@
 #   --type        feature|bug|chore|refactor|perf|docs|test|infra|spike|epic
 #   --priority    P0|P1|P2|P3
 #   --size        XS|S|M|L|XL
-#   --phase       M0|M1|M2|M3|M4|M5
+#   --phase       M0|M1|M2|M3|M4|M5|v1
 #   --domain      "<comma-separated list>"        — e.g. "task,tag"
 #   --model       opus|sonnet
 #
@@ -99,7 +99,7 @@ done
 case "$TYPE"     in feature|bug|chore|refactor|perf|docs|test|infra|spike|epic) ;; *) die "--type invalid: $TYPE" ;; esac
 case "$PRIORITY" in P0|P1|P2|P3) ;;                          *) die "--priority invalid: $PRIORITY" ;; esac
 case "$SIZE"     in XS|S|M|L|XL) ;;                          *) die "--size invalid: $SIZE" ;; esac
-case "$PHASE"    in M0|M1|M2|M3|M4|M5) ;;                    *) die "--phase invalid: $PHASE" ;; esac
+case "$PHASE"    in M0|M1|M2|M3|M4|M5|v1) ;;                 *) die "--phase invalid: $PHASE" ;; esac
 case "$MODEL"    in opus|sonnet) ;;                          *) die "--model invalid: $MODEL" ;; esac
 if [ -n "$RISK" ]; then
   case "$RISK" in high|medium) ;; *) die "--risk invalid: $RISK (use high|medium or omit)" ;; esac
@@ -126,6 +126,7 @@ phase_label_for() {
     M3) echo "phase: M3 advanced" ;;
     M4) echo "phase: M4 long-tail" ;;
     M5) echo "phase: M5 polish" ;;
+    v1) echo "phase: v1" ;;
   esac
 }
 
@@ -137,6 +138,7 @@ milestone_for() {
     M3) echo "M3 Advanced" ;;
     M4) echo "M4 Long tail" ;;
     M5) echo "M5 Polish" ;;
+    v1) echo "v1 maintenance" ;;
   esac
 }
 
@@ -223,6 +225,7 @@ case "$PHASE" in
   M3) PHASE_OPT="$O_PHASE_M3" ;;
   M4) PHASE_OPT="$O_PHASE_M4" ;;
   M5) PHASE_OPT="$O_PHASE_M5" ;;
+  v1) PHASE_OPT="$O_PHASE_V1" ;;
 esac
 case "$PRIORITY" in
   P0) PRI_OPT="$O_P0" ;;


### PR DESCRIPTION
## Summary

- Adds `v1` as a valid `--phase` value in `scripts/file-issue.sh`, backed by a new "v1 maintenance" GitHub milestone and a new Project #4 Phase board option
- Fixes the post-1.0 issue-filing workflow: previously, every new issue required reopening a closed pre-1.0 milestone, filing, then closing it again
- All M0–M5 logic is unchanged; the new phase is purely additive

## Changes

- **`scripts/file-issue.sh`**: accept `v1` in enum guard, `phase_label_for()`, `milestone_for()`, and the `PHASE_OPT` board-option selector
- **`scripts/_project-constants.sh`** (gitignored): refresh all Phase option IDs (rotated by the `updateProjectV2Field` mutation) and add `O_PHASE_V1=b4ad68e1`
- **`.claude/commands/issue.md`** (gitignored): document `v1` phase in the mapping table, add post-1.0 callout, update example command

## Infrastructure wired externally

- GitHub milestone "v1 maintenance" created (milestone #7)
- GitHub label `phase: v1` created
- Project #4 Phase field updated with "v1 maintenance" option (id: `b4ad68e1`)

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm test` — all pass (1971 tests)
- [ ] End-to-end: `./scripts/file-issue.sh --title "test v1 phase" --body-file /tmp/t.md --type chore --priority P3 --size XS --phase v1 --domain config --model sonnet` succeeds with no closed-milestone error and the resulting issue has Phase = "v1 maintenance" on the project board

Closes #424