### PR TITLE
docs: post-1.0 audit — refresh stale 'in preparation' framing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,7 @@
 # Design: omnifocus-mcp
 
-**Status:** v1 Draft — design-complete, implementation-ready
-**Date:** 2026-04-19
+**Status:** v1.0 — implemented and shipped 2026-04-25
+**Date:** 2026-04-19 (initial); shipped 2026-04-25
 **Evaluates:** `SPEC.md`
 
 A design document in the `systems_design.md` tradition: surfaces options, names tradeoffs, commits a recommendation, and flags what's being cut. Load-bearing decisions are recorded as ADRs under `docs/adr/`.

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ The full layered diagram with queues, circuit breakers, and the test adapter liv
 
 ## Status and roadmap
 
-All six milestones shipped. v1.0.0 is in preparation for npm release — see the [unreleased section of the CHANGELOG](./CHANGELOG.md#unreleased) for what's queued.
+v1.0.0 is [published on npm](https://www.npmjs.com/package/@torsday/omnifocus-mcp). The phase table below records the milestone work that landed; the live backlog and future enhancements track on the [Project board](https://github.com/users/torsday/projects/4), and the [unreleased section of the CHANGELOG](./CHANGELOG.md#unreleased) lists what's already merged toward the next release.
 
 | Phase | Milestone | Status |
 |---|---|---|

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # Spec: omnifocus-mcp
 
-**Status:** Draft — assumptions flagged for review
-**Date:** 2026-04-19
+**Status:** v1.0 — locked; reflects shipped surface as of 2026-04-25. Future scope changes go through ADRs under `docs/adr/`, not edits to this file.
+**Date:** 2026-04-19 (initial); locked 2026-04-25
 
 ## Summary
 

--- a/docs/project-views.md
+++ b/docs/project-views.md
@@ -7,9 +7,8 @@
 The repo's bootstrap already created:
 
 - Six custom fields: **Status**, **Phase**, **Priority**, **Size**, **Risk** (+ GitHub's built-in Labels, Milestone, Repository)
-- **Status** option set expanded to: `Ready` · `Todo` · `In Progress` · `In Review` · `Blocked` · `Done`
-- 94 issues populated with Phase / Priority / Size / Risk field values derived from labels
-- Current distribution: **7 Done · 26 Ready · 61 Todo** (shift as work ships)
+- **Status** option set: `Backlog` · `Up Next` · `In Progress` · `In Review` · `On Hold` · `Done` (forward flow: `Backlog → Up Next → In Progress → In Review → Done`; `On Hold` is a side-track reachable from any non-terminal column with a comment giving the reason)
+- Issues populated with Phase / Priority / Size / Risk field values derived from labels
 
 The project ships with a single default **View 1** (table layout). None of the views below are created yet — Projects v2's GraphQL API has no `createProjectV2View` mutation, so they must be added in the web UI. Follow the steps below once; they persist.
 
@@ -29,10 +28,10 @@ All that remains is laying out the views below.
 2. Open the view's **Layout** picker (top-right, next to the filter bar) → switch from **Table** to **Board**
 3. Group by: **Status**
 4. Visible fields (click "Fields" → toggle): `Title`, `Labels`, `Priority`, `Size`, `Phase`, `Risk`, `Milestone`
-5. Sort by: `Priority` ascending, then `Phase` ascending (so P0 M0 items bubble to the top of the `Ready` column)
+5. Sort by: `Priority` ascending, then `Phase` ascending (so P0 items bubble to the top of the `Up Next` column)
 6. Save changes to the view
 
-Six status columns appear: `Ready` (pick from here) → `Todo` (queued behind dependencies) → `In Progress` → `In Review` → `Blocked` → `Done`. The `Ready` column should currently show ~26 items; `/ship-next` automatically flips them through `In Progress` → `In Review` → `Done`.
+Six status columns appear: `Backlog` (raw / untriaged) → `Up Next` (`/ship-next` picks from here) → `In Progress` → `In Review` → `Done`, with `On Hold` as a side-track for items deferred or blocked on external dependencies. `/ship-next` automatically flips items through `In Progress` → `In Review` → `Done`.
 
 After this, `https://github.com/users/torsday/projects/4/views/1` will load as a board.
 


### PR DESCRIPTION
## Summary
- README "Status and roadmap" lead now reflects shipped reality (links the npm package, project board, and `[Unreleased]` CHANGELOG section).
- SPEC.md front-matter: `Draft` → `v1.0 — locked` with the standing note that scope changes go through ADRs, not edits.
- DESIGN.md front-matter: `v1 Draft` → `v1.0 — implemented and shipped 2026-04-25`. Body unchanged.
- `docs/project-views.md`: replaces the old six-state enum (`Ready · Todo · In Progress · In Review · Blocked · Done`) with the current canonical one (`Backlog · Up Next · In Progress · In Review · On Hold · Done`), drops the frozen pre-1.0 issue count, and updates downstream prose so the doc agrees with itself end-to-end.

Closes #425.

## Issue
Implements [#425](https://github.com/torsday/omnifocus-mcp/issues/425). Verifier from the issue returns zero hits:
- `git grep -i "in preparation\|design-complete, implementation-ready"` across README/SPEC/DESIGN — empty
- Old status enum (`Ready` / `Todo` / `Blocked` as project columns) in `docs/project-views.md` — empty

## Breaking change?
- [x] No — docs only.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (unchanged pre-existing warnings, per CLAUDE.md)
- [x] `pnpm docs:check` — `docs/tools.md` still up to date
- [x] AC verifiers above return zero hits

## Out of scope (deliberate)
- **Contributing-stance pick** (Closed / Open-light / Open-formal) — filed as a follow-up rather than picked from autonomous work; that's a real maintainer decision, not a mechanical edit.
- **`docs/llm-readability-review-v1.md`** — issue calls this maintainer's choice; left as-is, self-flags as a v1-era artifact.
- **Trust & Security README section** — explicitly a separate PR per #425's own notes (#422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)