### PR TITLE
ci(integration): seed fixture database before running integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -89,6 +89,18 @@ jobs:
         # than a generic "JXA script returned empty stdout" error.
         run: bash scripts/check-automation-permission.sh
 
+      - name: Seed integration fixtures
+        # The integration suite operates on `mcp-fixture:`-prefixed
+        # folders, projects, tasks, and tags. The seed script is
+        # idempotent — it removes any existing fixtures with that prefix
+        # before re-creating the canonical set, so re-running it across
+        # runs (or partial runs, after a previous failure) leaves the
+        # database in the same known-good state every time. Without
+        # this step the integration suite hits ~23 failures of the form
+        # `expected '<id>' to be null` and `Hook timed out in 30000ms`
+        # — symptoms of tests asserting against missing or stale fixtures.
+        run: node scripts/seed-integration-db.js
+
       - name: Run integration tests
         env:
           OMNIFOCUS_INTEGRATION: "1"

--- a/scripts/seed-integration-db.js
+++ b/scripts/seed-integration-db.js
@@ -1,4 +1,20 @@
 #!/usr/bin/env node
+// Seed the integration-test fixtures into a live OmniFocus database.
+//
+// **Idempotent.** Every call removes any existing entities with the
+// `mcp-fixture:` prefix before re-creating the canonical set, so it is
+// safe to re-run across CI invocations and after partial / failed runs
+// without accumulating stale state. `integration.yml` invokes it before
+// every test run for this reason.
+//
+// Production OmniFocus data is untouched: only `mcp-fixture:`-prefixed
+// objects are touched. Pass `--clean` to delete fixtures without
+// re-creating them (used by interactive cleanup).
+//
+// Run locally with:
+//   node scripts/seed-integration-db.js
+// Then run the integration suite:
+//   OMNIFOCUS_INTEGRATION=1 pnpm test:integration
 
 const { spawnSync } = require("node:child_process");
 


### PR DESCRIPTION
## Summary
- Adds a \`Seed integration fixtures\` step to \`integration.yml\` between the Automation-permission check and the test run, invoking \`node scripts/seed-integration-db.js\` (same path the README documents for local runs).
- Documents the seed script's idempotency contract in its header — `mcp-fixture:`-prefixed entities are cleared and re-created on every call; production data is untouched.
- Without this step the integration suite hit ~23 failures (`expected '<id>' to be null`, `Hook timed out in 30000ms`) on a manually-triggered run on \`main\` after #423's OmniFocus-not-running fix exposed the gap.

Closes #426.

## Issue
Implements [#426](https://github.com/torsday/omnifocus-mcp/issues/426). Pairs with [#423](https://github.com/torsday/omnifocus-mcp/issues/423) (auto-start OmniFocus) — both are integration-CI hardening; #423 needs runner-machine config so isn't shippable from this PR.

## Breaking change?
- [x] No — adds one workflow step; the integration suite already ran the seed locally.

## Test plan
- [x] \`bash scripts/verify-no-hosted-runners.sh\` — ok (workflow still on self-hosted)
- [x] \`pnpm typecheck\` and \`pnpm lint\` — clean
- [x] First integration run after merge is the verification: should not hit the ~23 fixture-related failures any more