### PR TITLE
chore(deps): bump pnpm/action-setup v4 → v5 in all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ github.event.inputs.ref || github.sha }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           fetch-depth: 0   # full history for release note generation
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Bumps \`pnpm/action-setup\` from v4 to v5.0.0 in all three workflows that use it (\`ci.yml\`, \`integration.yml\`, \`release.yml\`).
- v5 runs on Node 24 natively, silencing the *"Node.js 20 actions are deprecated"* warning that was emitted on every workflow run.
- The tracking issue (#431) was waiting for v5 to be published; that happened 2026-03-17 (over a month ago), so the premise is satisfied.

Closes #431.

## Issue
Implements [#431](https://github.com/torsday/omnifocus-mcp/issues/431). Verifier from the issue: \`grep -rn 'pnpm/action-setup' .github/workflows/\` returns three matches, all on \`@v5\`.

## Breaking change?
- [x] No — major version of an action; internal API unchanged.

## Test plan
- [x] All three workflows updated; \`grep -rn 'pnpm/action-setup@v4'\` returns zero matches
- [x] \`pnpm typecheck\` and \`pnpm lint\` clean
- [x] No-hosted-runners guard passes
- [x] Verification per the issue: the next workflow run will exercise the bump — the deprecation warning should be absent in the logs