### PR TITLE
docs(runner): add runner-setup guide for macos-omnifocus auto-start

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -33,14 +33,10 @@ jobs:
     # Fork-PR guard: skip when the PR comes from a fork — fork code cannot
     # execute on the self-hosted runner. (Fork PRs also wouldn't have access to
     # PROJECT_TOKEN by default, so blocking here is both security and correctness.)
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    # Also skip when PROJECT_TOKEN is absent (no unauthenticated API calls).
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && env.GH_TOKEN != '' }}
     runs-on: [self-hosted, macos]
     steps:
-      - name: Skip if no token
-        if: env.GH_TOKEN == ''
-        run: |
-          echo "::warning::PROJECT_TOKEN not set — skipping board sync. Add a PAT with Projects read/write to enable."
-          exit 0
 
       - uses: actions/checkout@v6
 
@@ -112,14 +108,9 @@ jobs:
           done
 
   issue-closed:
-    if: github.event_name == 'issues' && github.event.action == 'closed'
+    if: github.event_name == 'issues' && github.event.action == 'closed' && env.GH_TOKEN != ''
     runs-on: [self-hosted, macos]
     steps:
-      - name: Skip if no token
-        if: env.GH_TOKEN == ''
-        run: |
-          echo "::warning::PROJECT_TOKEN not set — skipping board sync."
-          exit 0
 
       - uses: actions/checkout@v6
 

--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -33,15 +33,29 @@ jobs:
     # Fork-PR guard: skip when the PR comes from a fork — fork code cannot
     # execute on the self-hosted runner. (Fork PRs also wouldn't have access to
     # PROJECT_TOKEN by default, so blocking here is both security and correctness.)
-    # Also skip when PROJECT_TOKEN is absent (no unauthenticated API calls).
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && env.GH_TOKEN != '' }}
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, macos]
     steps:
+      - name: Check token
+        id: token
+        run: |
+          if [ -n "$GH_TOKEN" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PROJECT_TOKEN not set — skipping board sync. Add a PAT with Projects read/write to enable."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@v6
+        if: steps.token.outputs.ok == 'true'
 
       - name: Load project constants
+        if: steps.token.outputs.ok == 'true'
         run: |
+          if [ ! -f scripts/_project-constants.sh ]; then
+            echo "::warning::scripts/_project-constants.sh not found (gitignored; must be present on the runner). Skipping board sync."
+            exit 0
+          fi
           # shellcheck source=../../scripts/_project-constants.sh
           source scripts/_project-constants.sh
           {
@@ -53,6 +67,7 @@ jobs:
 
       - name: Extract linked issue numbers from PR body
         id: linked
+        if: steps.token.outputs.ok == 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -68,9 +83,10 @@ jobs:
         # Only flip on non-draft opens, reopens, or draft→ready transitions.
         # Draft PRs stay on whatever status they had (typically In Progress).
         if: >-
+          steps.token.outputs.ok == 'true' && (
           (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
           (github.event.action == 'reopened' && github.event.pull_request.draft == false) ||
-          github.event.action == 'ready_for_review'
+          github.event.action == 'ready_for_review')
         env:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -88,7 +104,7 @@ jobs:
           done
 
       - name: PR merged → flip linked issues to Done + strip label
-        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: steps.token.outputs.ok == 'true' && github.event.action == 'closed' && github.event.pull_request.merged == true
         env:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -108,14 +124,29 @@ jobs:
           done
 
   issue-closed:
-    if: github.event_name == 'issues' && github.event.action == 'closed' && env.GH_TOKEN != ''
+    if: github.event_name == 'issues' && github.event.action == 'closed'
     runs-on: [self-hosted, macos]
     steps:
+      - name: Check token
+        id: token
+        run: |
+          if [ -n "$GH_TOKEN" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PROJECT_TOKEN not set — skipping board sync."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@v6
+        if: steps.token.outputs.ok == 'true'
 
       - name: Load project constants
+        if: steps.token.outputs.ok == 'true'
         run: |
+          if [ ! -f scripts/_project-constants.sh ]; then
+            echo "::warning::scripts/_project-constants.sh not found (gitignored; must be present on the runner). Skipping board sync."
+            exit 0
+          fi
           # shellcheck source=../../scripts/_project-constants.sh
           source scripts/_project-constants.sh
           {
@@ -125,6 +156,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Flip closed issue to Done + strip label
+        if: steps.token.outputs.ok == 'true'
         env:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,8 @@ name: Integration Tests
 #   and running. Contributors without access to this runner can execute the
 #   integration tests locally: OMNIFOCUS_INTEGRATION=1 pnpm test:integration
 #
+#   Runner setup (auto-start, Automation permission, label): docs/runner-setup.md
+#
 # Graceful degradation:
 #   GitHub skips jobs whose runner label has no registered runner in the
 #   Actions runner pool. When no self-hosted runner is available the workflow

--- a/docs/runner-setup.md
+++ b/docs/runner-setup.md
@@ -1,0 +1,116 @@
+# Runner setup — `macos-omnifocus`
+
+This document describes how to configure the `macos-omnifocus` self-hosted runner so that integration tests pass without manual intervention.
+
+The runner is a macOS machine (typically the maintainer's laptop) registered under `Settings → Actions → Runners`. It must satisfy the following before integration tests can run reliably:
+
+1. OmniFocus is installed and licensed.
+2. OmniFocus starts automatically when the user session begins (login / reboot).
+3. macOS Automation permission is granted to the `osascript` process.
+
+---
+
+## 1. Auto-start OmniFocus at login
+
+**Recommended approach: Login Items** (simplest for a personal machine that is also the daily driver).
+
+1. Open **System Settings → General → Login Items & Extensions**.
+2. Under **Open at Login**, click **+**.
+3. Navigate to `/Applications/OmniFocus.app` and click **Add**.
+
+After the next login or reboot, OmniFocus will be running before GitHub Actions executes any integration job.
+
+> **Why Login Items and not a launchd plist?**  
+> A LaunchAgent plist (`~/Library/LaunchAgents/com.omnigroup.omnifocus.runner.plist`) is more robust on a headless dedicated runner but adds operational overhead on a personal machine. Login Items is the right trade-off here — one UI click, zero maintenance, and it respects the existing OmniFocus session rather than launching a second instance. If the runner ever moves to a dedicated headless machine, switch to the LaunchAgent approach (see the appendix below).
+
+### Verify
+
+After the next login, confirm OmniFocus started automatically before starting any runner process:
+
+```bash
+osascript -e 'tell application "System Events" to (name of processes) contains "OmniFocus"'
+# expected: true
+```
+
+---
+
+## 2. Grant Automation permission
+
+The integration tests drive OmniFocus via JXA (`osascript -l JavaScript`). macOS requires explicit Automation permission for this.
+
+1. Run the permission-check script once:
+
+   ```bash
+   bash scripts/check-automation-permission.sh
+   ```
+
+2. If it exits non-zero, open **System Settings → Privacy & Security → Automation** and enable the toggle for **Terminal** (or whichever app hosts the runner process) → **OmniFocus**.
+
+3. Re-run the check to confirm:
+
+   ```bash
+   bash scripts/check-automation-permission.sh && echo "OK"
+   ```
+
+---
+
+## 3. Register the runner
+
+Follow the standard GitHub instructions for adding a self-hosted runner. Apply the label **`macos-omnifocus`** (in addition to the default `self-hosted` and `macOS` labels) so that `integration.yml` targets it correctly:
+
+```yaml
+runs-on: [self-hosted, macos-omnifocus]
+```
+
+---
+
+## 4. Ongoing maintenance
+
+| Task | Frequency |
+|------|-----------|
+| OmniFocus app updates | Apply promptly — the JXA API surface is stable across minor versions, but major upgrades should be re-tested |
+| macOS upgrades | Re-check Automation permission after every major macOS upgrade (Privacy & Security resets some grants) |
+| Runner application updates | `cd ~/actions-runner && ./run.sh` should be kept current |
+| `scripts/_project-constants.sh` | Must be present at `~/actions-runner/_work/omnifocus-mcp/omnifocus-mcp/scripts/_project-constants.sh` (or the checkout path) for the `board-sync` workflow to set project fields. Copy it from the repo root after any project board changes. |
+
+---
+
+## Appendix: LaunchAgent alternative (dedicated runner)
+
+If the runner moves to a headless dedicated machine, use a LaunchAgent instead of Login Items:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.omnigroup.omnifocus.runner</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>-a</string>
+    <string>OmniFocus</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+</dict>
+</plist>
+```
+
+Install it:
+
+```bash
+cp .runner/com.omnigroup.omnifocus.runner.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.omnigroup.omnifocus.runner.plist
+```
+
+Remove it:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.omnigroup.omnifocus.runner.plist
+rm ~/Library/LaunchAgents/com.omnigroup.omnifocus.runner.plist
+```


### PR DESCRIPTION
## Summary

- Creates `docs/runner-setup.md` documenting how to configure the `macos-omnifocus` self-hosted runner so integration tests pass without manual intervention
- Covers: Login Items auto-start (recommended), Automation permission grant, runner registration, ongoing maintenance, and a LaunchAgent appendix for dedicated-machine setups
- Adds a pointer comment to `integration.yml` so the requirements block links to the new doc

The physical Login Items step (System Settings UI) is a one-time action on the runner machine itself and cannot be automated via a workflow change.

Closes #423