### PR TITLE
ci(release-please): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,10 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Manual trigger so the workflow can be re-run after a config change
+  # (e.g. fixing the "Allow GitHub Actions to create and approve pull
+  # requests" repo setting) without requiring a fresh push to main.
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds manual trigger so the workflow can be re-run after a config change without waiting for a fresh push to main. Pairs with the just-flipped repo setting that allows GitHub Actions to create PRs (the missing permission that blocked the first three runs of release-please.yml after #427 merged).