### PR TITLE
fix(ci): allow periods inside PR-title subjects

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -30,7 +30,11 @@ jobs:
           types='feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|spike|infra'
           # Pattern: type(scope)?: subject — scope optional, subject must
           # start lowercase and not end with a period or whitespace.
-          pattern="^(${types})(\([^)]+\))?!?: [a-z][^.]*[^. ]\$"
+          # Periods *inside* the subject are fine (e.g. release-please's
+          # "chore(main): release 1.0.1" needs a version number); only the
+          # trailing character is constrained. Single-character subjects are
+          # tolerated by collapsing to `[a-z][^. ]?$` via `.*`.
+          pattern="^(${types})(\([^)]+\))?!?: [a-z].*[^. ]\$"
 
           if [[ "$PR_TITLE" =~ $pattern ]]; then
             echo "ok: $PR_TITLE"


### PR DESCRIPTION
Bash port of amannn/action-semantic-pull-request's `subjectPattern` was stricter than the original — `[^.]*` in the middle banned every period, so release-please's `chore(main): release 1.0.1` PR fails lint on the version number. Original regex (`^[a-z].+[^.]$`) only constrained the trailing character.

Middle is now `.*`; only the last character is constrained to non-period, non-space. Behaviour matches the original action.

Closes nothing — found while shipping #427's first Release PR. PR #445 will pass on the rebase after this merges.