### PR TITLE
fix(ci): convert seed-integration-db.js to ESM

### DIFF
--- a/scripts/seed-integration-db.js
+++ b/scripts/seed-integration-db.js
@@ -16,7 +16,7 @@
 // Then run the integration suite:
 //   OMNIFOCUS_INTEGRATION=1 pnpm test:integration
 
-const { spawnSync } = require("node:child_process");
+import { spawnSync } from "node:child_process";
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary
- One-line conversion: \`const { spawnSync } = require(...)\` → \`import { spawnSync } from "node:child_process"\`. The script is the only remaining CommonJS-shaped \`.js\` file in the repo; \`package.json\` has \`"type": "module"\` so Node was throwing \`ReferenceError: require is not defined in ES module scope\` at the first line of execution.
- The bug was always there but PR #441 (this cycle) was the first time the script ran in CI. It exposed the latent issue.
- No behavioural change. \`--clean\` flag, seed/cleanup logic, fixture prefix (\`mcp-fixture:\`), idempotency contract all unchanged.

Closes #448.

## Issue
Implements [#448](https://github.com/torsday/omnifocus-mcp/issues/448).

## Breaking change?
- [x] No — script syntax migration only.

## Test plan
- [x] \`node scripts/seed-integration-db.js\` runs to completion locally (exit 0) against a live OmniFocus
- [x] \`pnpm typecheck\` and \`pnpm lint\` clean
- [x] \`scripts/verify-no-hosted-runners.sh\` ok
- [x] First \`integration.yml\` run after merge is the verification — should not hit the ReferenceError; subsequent failures (if any) belong to the OF-not-running / Automation-permission gate, not this script