### PR TITLE
chore(release): drop bootstrap-NPM_TOKEN caveat from release.yml header

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ name: Release
 # at publish time. Configure / verify the trusted publisher at:
 #   https://www.npmjs.com/package/@torsday/omnifocus-mcp/access
 # (org `torsday`, repo `omnifocus-mcp`, workflow filename `release.yml`,
-# environment blank). Bootstrap `NPM_TOKEN` was used for v1.0.0 only and
-# should be revoked once OIDC is verified working on a subsequent release.
+# environment blank). v1.0.1 was the first release verified end-to-end
+# under OIDC; the bootstrap `NPM_TOKEN` secret used for v1.0.0 has been
+# revoked (#428).
 on:
   push:
     tags:


### PR DESCRIPTION
## Summary
- Replaces the live "Bootstrap NPM_TOKEN was used for v1.0.0 only and should be revoked once OIDC is verified working" TODO in the \`release.yml\` header with a one-line historical reference.
- v1.0.1 published end-to-end via OIDC (Sigstore provenance attestation visible on the public registry; \`release.yml\` run completed clean).
- The \`NPM_TOKEN\` repo secret has been deleted (verified: \`gh secret list -R torsday/omnifocus-mcp\` returns empty).

Closes #428 (the GitHub-side cleanup; the npm-side token revocation at https://www.npmjs.com/settings/torsday/tokens is a separate maintainer action — see the issue for the link).

## Issue
Implements [#428](https://github.com/torsday/omnifocus-mcp/issues/428). Verifies the chain that #427 (release-please) and v1.0.1 just exercised.

## Breaking change?
- [x] No — comment-only change.

## Test plan
- [x] \`pnpm typecheck && pnpm lint\` clean
- [x] \`bash scripts/verify-no-hosted-runners.sh\` ok
- [x] AC verifications from the issue:
  - ✅ OIDC release verified (v1.0.1 published successfully)
  - ✅ NPM_TOKEN secret removed from GitHub
  - ⏳ User action: revoke the bootstrap token at https://www.npmjs.com/settings/torsday/tokens (separate npm UI step, not a repo change)
  - ⏳ Future: next release after this PR will confirm the cleanup didn't regress
  - ✅ Comment block updated (this PR)