### PR TITLE
chore(release-please): remove debug step now that PAT is verified

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,19 +46,6 @@ jobs:
       pull-requests: write  # open / update the Release PR
 
     steps:
-      - name: TEMP debug — which token did the fallback resolve to?
-        env:
-          T1: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          T2: ${{ secrets.GITHUB_TOKEN }}
-          PAT_PRESENT: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
-        run: |
-          echo "secrets.RELEASE_PLEASE_TOKEN != '' is: $PAT_PRESENT"
-          if [ "$T1" = "$T2" ]; then
-            echo "Fallback path: GITHUB_TOKEN (RELEASE_PLEASE_TOKEN was empty/missing)"
-          else
-            echo "Fallback path: RELEASE_PLEASE_TOKEN (PAT distinct from GITHUB_TOKEN)"
-          fi
-
       - uses: googleapis/release-please-action@v4
         with:
           # release-type / package config live in release-please-config.json so


### PR DESCRIPTION
## Summary
- Reverts the TEMP debug step from #453 now that \`RELEASE_PLEASE_TOKEN\` is verified working end-to-end. \`release-please.yml\` is back to its production shape; the fallback expression itself is unchanged.
- Verification: PR #454 (release-please's auto-PR for v1.0.2) was just re-created under the PAT identity. PR \`.user.login\` = \`torsday\` (User), not \`github-actions[bot]\` (Bot). CI fired automatically on open — no close-and-reopen needed.

Closes #447.

## Issue
Implements [#447](https://github.com/torsday/omnifocus-mcp/issues/447). Both gotchas the issue called out are now closed: bot tags trigger \`release.yml\` (will exercise on the next merge of the Release PR), and bot PRs trigger CI on open (just verified on #454).

## Breaking change?
- [x] No — debug-step removal only.

## Test plan
- [x] Empirical: PR #454 was created under the PAT and CI fired automatically (verified before this PR was opened)
- [x] \`pnpm typecheck && pnpm lint\` clean
- [x] \`bash scripts/verify-no-hosted-runners.sh\` ok