### PR TITLE
ci(pr-link): skip require-issue-link on release-please + dependabot bot PRs

### DIFF
--- a/.github/workflows/pr-link.yml
+++ b/.github/workflows/pr-link.yml
@@ -17,10 +17,20 @@ permissions:
 jobs:
   require-issue-link:
     runs-on: [self-hosted, macos]
-    # Waiver: add the `no-issue` label to skip this check.
-    # Fork-PR guard: skip when the PR comes from a fork — fork code cannot
-    # execute on the self-hosted runner.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-issue') && github.event.pull_request.head.repo.full_name == github.repository }}
+    # Waivers (any one match → skip):
+    #   1. `no-issue` label on the PR — explicit waiver for pure-infra PRs.
+    #   2. Fork-PR guard — fork code cannot execute on the self-hosted runner.
+    #   3. release-please bot PRs — head branch matches `release-please--*`.
+    #      These are auto-generated; the body is a CHANGELOG draft and never
+    #      carries closing keywords. The PR-↔-issue audit trail is preserved
+    #      via the individual feature/fix PRs that landed on main since the
+    #      last release; this Release PR is just the version-bump rollup.
+    #   4. Dependabot PRs — auto-generated; no tracker counterpart.
+    if: >-
+      ${{ !contains(github.event.pull_request.labels.*.name, 'no-issue')
+       && github.event.pull_request.head.repo.full_name == github.repository
+       && !startsWith(github.event.pull_request.head.ref, 'release-please--')
+       && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Require Closes/Fixes/Resolves #N in PR body
         env:


### PR DESCRIPTION
## Summary
- The \`require-issue-link\` gate fails on every release-please Release PR because bot-PRs don't carry \`Closes #N\` keywords by design — the body is a CHANGELOG draft, not a counterpart to one tracker issue.
- Add two waivers to the existing \`if\` clause: head branch starts with \`release-please--\`, OR PR author is \`dependabot[bot]\`. Aligns with how \`pr-title.yml\` already skips dependabot.
- The PR-↔-issue audit trail is preserved via the individual feature/fix PRs that landed on main between releases.
- Human PRs still hit the gate — typing/forgetting \`Closes #N\` still fails the check.

Closes nothing — found while shipping the first release-please-driven release in #427. Pairs with #449 and #455 as fallout from the v1.0.1/v1.0.2 release rollout.

## Breaking change?
- [x] No — strictly additive waivers; non-bot PRs still gated.

## Test plan
- [x] \`pnpm typecheck && pnpm lint\` clean
- [x] \`bash scripts/verify-no-hosted-runners.sh\` ok
- [x] Verification on the next release-please run: PR will be re-opened or updated; \`require-issue-link\` should now show \`skipped\` instead of \`fail\`