### PR TITLE
docs(readme): genericize version-specific references

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ There is exactly one feature that's gated behind an environment variable because
 
 Three recipes that take seconds; you don't have to take this README's word for any of the above.
 
-1. **Audit the source.** The repo at [github.com/torsday/omnifocus-mcp](https://github.com/torsday/omnifocus-mcp) is the canonical source. The published artifact is built from a tagged commit (`v1.0.0`); compare `dist/index.js` against the build output of that tag.
+1. **Audit the source.** The repo at [github.com/torsday/omnifocus-mcp](https://github.com/torsday/omnifocus-mcp) is the canonical source. Each published artifact is built from its own tagged commit (`v<version>`); compare `dist/index.js` against the build output of the tag matching the version you installed.
 2. **Verify the published artifact's provenance.** npm publishes attestations via [Sigstore](https://www.sigstore.dev/):
    ```bash
    npm view @torsday/omnifocus-mcp dist.attestations
@@ -698,7 +698,7 @@ The full layered diagram with queues, circuit breakers, and the test adapter liv
 
 ## Status and roadmap
 
-v1.0.0 is [published on npm](https://www.npmjs.com/package/@torsday/omnifocus-mcp). The phase table below records the milestone work that landed; the live backlog and future enhancements track on the [Project board](https://github.com/users/torsday/projects/4), and the [unreleased section of the CHANGELOG](./CHANGELOG.md#unreleased) lists what's already merged toward the next release.
+The package is [published on npm](https://www.npmjs.com/package/@torsday/omnifocus-mcp); see the [latest release](https://github.com/torsday/omnifocus-mcp/releases/latest) for the current version and notes. The phase table below records the milestone work that shipped in v1.0.0; the live backlog and future enhancements track on the [Project board](https://github.com/users/torsday/projects/4), and the [unreleased section of the CHANGELOG](./CHANGELOG.md#unreleased) lists what's already merged toward the next release.
 
 | Phase | Milestone | Status |
 |---|---|---|


### PR DESCRIPTION
## Summary
- Two README references hard-coded \`v1.0.0\` and went stale the moment v1.0.1 shipped.
  - "Verify it yourself" recipe step 1 (Security & trust section)
  - "Status and roadmap" section lead
- Both replaced with version-agnostic phrasing that links the npm page / latest release. Self-maintaining; no per-release bumps.
- Caught while inspecting the v1.0.2 npm page — the dynamic shields.io badge was correct, but the README body in the tarball still mentioned v1.0.0 because that was static text.

## Breaking change?
- [x] No — wording change only.

## Test plan
- [x] \`grep -nE "v1\\.0\\.[0-9]" README.md\` returns only one historical reference: *"shipped in v1.0.0"* in the milestone-context phrasing, which is intentional and correct (a statement of historical fact, not the current version)
- [x] \`pnpm typecheck && pnpm lint\` clean
- [x] \`bash scripts/verify-no-hosted-runners.sh\` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)