### PR TITLE
fix(export): partitionTasksByParent treats project-rooted tasks as roots

### DIFF
--- a/src/services/export/tree.test.ts
+++ b/src/services/export/tree.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for partitionTasksByParent.
+ *
+ * Covers two real-world parentId shapes:
+ *   1. In-memory / test fixture shape  — top-level tasks have parentId: null
+ *   2. Real OmniFocus shape            — top-level tasks have parentId: projectId
+ *
+ * The bug fixed by #499: the old implementation only checked `parentId === null`,
+ * so real OF tasks (parentId === projectId) were all treated as non-root and
+ * the export rendered only the project header with no tasks.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { TaskId } from "../../domain/ids.js";
+import { ProjectId as ProjectIdCtor, TaskId as TaskIdCtor } from "../../domain/ids.js";
+import type { Task } from "../../domain/task.js";
+import { partitionTasksByParent } from "./tree.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW = "2026-01-01T00:00:00.000Z";
+
+// Real OF IDs are 3-64 alphanumeric / _ / - characters.
+const IDS = {
+  proj: ProjectIdCtor.of("proj-abc"),
+  t1: TaskIdCtor.of("task-aaa"),
+  t2: TaskIdCtor.of("task-bbb"),
+  t3: TaskIdCtor.of("task-ccc"),
+  bug: ProjectIdCtor.of("dWSBU3hkJ8h"),
+};
+
+function makeTask(overrides: Partial<Task> & { id: TaskId }): Task {
+  return {
+    name: "Task",
+    note: null,
+    noteHtml: null,
+    projectId: null,
+    parentId: null,
+    tagIds: [],
+    deferDate: null,
+    dueDate: null,
+    estimatedMinutes: null,
+    flagged: false,
+    completed: false,
+    completedAt: null,
+    dropped: false,
+    droppedAt: null,
+    available: true,
+    blocked: false,
+    sequential: false,
+    completedByChildren: false,
+    repetition: null,
+    createdAt: NOW,
+    modifiedAt: NOW,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — in-memory fixture shape (parentId: null for top-level tasks)
+// ---------------------------------------------------------------------------
+
+describe("partitionTasksByParent — in-memory fixture shape", () => {
+  it("treats null-parentId tasks as roots", () => {
+    const a = makeTask({ id: IDS.t1, name: "A" });
+    const b = makeTask({ id: IDS.t2, name: "B" });
+
+    const { rootTasks, byParent } = partitionTasksByParent([a, b]);
+
+    expect(rootTasks).toHaveLength(2);
+    expect(byParent.size).toBe(0);
+  });
+
+  it("places children under their parent", () => {
+    const parent = makeTask({ id: IDS.t1, name: "Parent" });
+    const child = makeTask({ id: IDS.t2, name: "Child", parentId: IDS.t1 });
+
+    const { rootTasks, byParent } = partitionTasksByParent([parent, child]);
+
+    expect(rootTasks).toHaveLength(1);
+    expect(rootTasks[0]?.id).toBe(IDS.t1);
+    expect(byParent.get(String(IDS.t1))).toHaveLength(1);
+    expect(byParent.get(String(IDS.t1))?.[0]?.id).toBe(IDS.t2);
+  });
+
+  it("handles empty list", () => {
+    const { rootTasks, byParent } = partitionTasksByParent([]);
+    expect(rootTasks).toHaveLength(0);
+    expect(byParent.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — real OmniFocus shape (parentId: projectId for top-level tasks)
+// This is the bug fixed by #499.
+// ---------------------------------------------------------------------------
+
+describe("partitionTasksByParent — real OmniFocus shape", () => {
+  it("treats tasks whose parentId equals projectId (not in task set) as roots", () => {
+    // Real OF shape: top-level tasks reference the project as parent.
+    // ProjectId and TaskId share the same branded-string format.
+    const projAsParent = IDS.proj as unknown as TaskId;
+    const taskA = makeTask({ id: IDS.t1, name: "A", parentId: projAsParent });
+    const taskB = makeTask({ id: IDS.t2, name: "B", parentId: projAsParent });
+
+    const { rootTasks, byParent } = partitionTasksByParent([taskA, taskB]);
+
+    expect(rootTasks).toHaveLength(2);
+    expect(byParent.size).toBe(0);
+  });
+
+  it("correctly roots project-level tasks while nesting their subtasks", () => {
+    const projAsParent = IDS.proj as unknown as TaskId;
+
+    // t1 and t2 are directly under the project; t3 is a subtask of t1
+    const t1 = makeTask({ id: IDS.t1, name: "Root A", parentId: projAsParent });
+    const t2 = makeTask({ id: IDS.t2, name: "Root B", parentId: projAsParent });
+    const t3 = makeTask({ id: IDS.t3, name: "Child of A", parentId: IDS.t1 });
+
+    const { rootTasks, byParent } = partitionTasksByParent([t1, t2, t3]);
+
+    expect(rootTasks).toHaveLength(2);
+    expect(rootTasks.map((t) => t.id)).toContain(IDS.t1);
+    expect(rootTasks.map((t) => t.id)).toContain(IDS.t2);
+
+    expect(byParent.get(String(IDS.t1))).toHaveLength(1);
+    expect(byParent.get(String(IDS.t1))?.[0]?.id).toBe(IDS.t3);
+  });
+
+  it("handles 38-task project — regression for the exact shape from bug report", () => {
+    // Bug report: task_list returns 38 tasks each with parentId = projectId.
+    // Old implementation: rootTasks was empty → export rendered only the header line.
+    // New implementation: all 38 should be roots.
+    const projAsParent = IDS.bug as unknown as TaskId;
+    const tasks = Array.from({ length: 38 }, (_, i) =>
+      makeTask({
+        id: TaskIdCtor.of(`bug-task-${String(i).padStart(2, "0")}`),
+        name: `Task ${i}`,
+        parentId: projAsParent,
+      }),
+    );
+
+    const { rootTasks, byParent } = partitionTasksByParent(tasks);
+
+    expect(rootTasks).toHaveLength(38);
+    expect(byParent.size).toBe(0);
+  });
+});

--- a/src/services/export/tree.ts
+++ b/src/services/export/tree.ts
@@ -50,19 +50,29 @@ export async function fetchProjectTaskTree(
 /**
  * Partition a flat task list into root tasks and a `parentId → children` map.
  *
- * Root tasks are those with `parentId === null` (directly under their project
- * or inbox). The map indexes children by their stringified parent ID, so
- * recursive renderers can look up a given task's children in O(1).
+ * A task is a root when its `parentId` is absent from the task set — either
+ * because `parentId` is `null` (inbox tasks) or because the parent ID belongs
+ * to a project rather than another task in the list (OmniFocus top-level
+ * tasks carry `parentId === projectId`).
+ *
+ * Using set membership instead of a null-check makes this robust to both the
+ * in-memory fixture shape (`parentId: null`) and real OmniFocus data
+ * (`parentId: "<projectId>"`).
+ *
+ * The map indexes children by their stringified parent ID so recursive
+ * renderers can look up a given task's children in O(1).
  */
 export function partitionTasksByParent(tasks: Task[]): {
   rootTasks: Task[];
   byParent: Map<string, Task[]>;
 } {
+  const taskIds = new Set(tasks.map((t) => String(t.id)));
   const rootTasks: Task[] = [];
   const byParent = new Map<string, Task[]>();
 
   for (const task of tasks) {
-    if (task.parentId === null) {
+    const isRoot = task.parentId === null || !taskIds.has(String(task.parentId));
+    if (isRoot) {
       rootTasks.push(task);
     } else {
       const key = String(task.parentId);


### PR DESCRIPTION
## Problem

`export_taskpaper` (and `export_opml`) returned projects with `taskCount > 0` but empty task content. All 38+ tasks appeared in the count but were missing from the export body.

## Root cause

`partitionTasksByParent` only checked `parentId === null` to identify root tasks. Real OmniFocus data has top-level project tasks with `parentId === projectId` (not `null`). Those tasks failed the null-check, fell into the `byParent` map keyed by `projectId`, and were never rendered — because the renderer only walks `rootTasks` and their descendants.

## Fix

Build a `Set` of all task IDs in the flat list. A task is a root when its `parentId` is absent from that set (or is `null`). This is robust to both shapes:

- In-memory fixture shape: `parentId: null` → `null` check catches it
- Real OmniFocus shape: `parentId: "<projectId>"` → projectId not in task-ID set → treated as root

## Tests

Added `src/services/export/tree.test.ts` with 6 tests covering:
- null-parentId roots (in-memory fixture shape)
- children under a parent
- empty list
- project-rooted tasks as roots (the bug)
- mixed project-level + subtask nesting
- 38-task regression (exact shape from the bug report)

Closes #499