### PR TITLE
fix(export): treat project-rooted tasks as roots in tree partition

### DIFF
--- a/src/services/export/tree.test.ts
+++ b/src/services/export/tree.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { ProjectId, TaskId } from "../../domain/ids.js";
+import type { Task } from "../../domain/task.js";
+import { partitionTasksByParent } from "./tree.js";
+
+/**
+ * Minimal Task fixture — only the fields `partitionTasksByParent` reads. The
+ * full `Task` shape carries dozens of fields; copying them all just to test
+ * tree partitioning would be noise.
+ */
+function task(id: string, parentId: string | null): Task {
+  return {
+    id: TaskId.of(id),
+    name: id,
+    parentId: parentId === null ? null : (parentId as Task["parentId"]),
+    projectId: null,
+    note: null,
+    flagged: false,
+    completed: false,
+    completedAt: null,
+    dropped: false,
+    droppedAt: null,
+    deferDate: null,
+    dueDate: null,
+    estimatedMinutes: null,
+    sequential: false,
+    completedByChildren: false,
+    creationDate: new Date().toISOString(),
+    modificationDate: new Date().toISOString(),
+    tags: [],
+    repetition: null,
+  } as unknown as Task;
+}
+
+describe("partitionTasksByParent", () => {
+  it("treats null-parent tasks as roots (inbox case)", () => {
+    const tasks = [task("aaa", null), task("bbb", null)];
+    const { rootTasks, byParent } = partitionTasksByParent(tasks);
+    expect(rootTasks.map((t) => t.id)).toEqual(["aaa", "bbb"]);
+    expect(byParent.size).toBe(0);
+  });
+
+  it("groups children under their parent task", () => {
+    const tasks = [task("root", null), task("kid1", "root"), task("kid2", "root")];
+    const { rootTasks, byParent } = partitionTasksByParent(tasks);
+    expect(rootTasks.map((t) => t.id)).toEqual(["root"]);
+    expect(byParent.get("root")?.map((t) => t.id)).toEqual(["kid1", "kid2"]);
+  });
+
+  // Regression — #499. Real OmniFocus data: top-level tasks of a project
+  // carry `parentId === <projectId>` rather than `parentId === null`. The
+  // previous partition logic only treated null-parent tasks as roots, so
+  // every project-rooted task was silently dropped from the tree, every
+  // export rendered an empty body despite a non-zero taskCount.
+  it("treats project-rooted tasks (parentId not in set) as roots — #499", () => {
+    const projectId = ProjectId.of("dWSBU3hkJ8h");
+    const tasks = [task("topA", projectId), task("topB", projectId), task("childA1", "topA")];
+    const { rootTasks, byParent } = partitionTasksByParent(tasks);
+    expect(rootTasks.map((t) => t.id)).toEqual(["topA", "topB"]);
+    expect(byParent.get("topA")?.map((t) => t.id)).toEqual(["childA1"]);
+    // The project ID must NOT appear as a parent key — it's not in the set.
+    expect(byParent.has(projectId)).toBe(false);
+  });
+
+  it("treats tasks whose parent is missing from the set as roots", () => {
+    // Defensive: if a child somehow appears without its parent (pagination
+    // boundary, filtered fetch), treat it as root rather than silently
+    // dropping it. The renderer surfaces orphaned subtrees instead of
+    // returning an empty body.
+    const tasks = [task("orphan", "missing-parent"), task("child", "orphan")];
+    const { rootTasks, byParent } = partitionTasksByParent(tasks);
+    expect(rootTasks.map((t) => t.id)).toEqual(["orphan"]);
+    expect(byParent.get("orphan")?.map((t) => t.id)).toEqual(["child"]);
+  });
+
+  it("handles empty input cleanly", () => {
+    const { rootTasks, byParent } = partitionTasksByParent([]);
+    expect(rootTasks).toEqual([]);
+    expect(byParent.size).toBe(0);
+  });
+
+  it("preserves input order within each bucket", () => {
+    const tasks = [
+      task("par", null),
+      task("kid2", "par"),
+      task("kid1", "par"),
+      task("kid3", "par"),
+    ];
+    const { byParent } = partitionTasksByParent(tasks);
+    expect(byParent.get("par")?.map((t) => t.id)).toEqual(["kid2", "kid1", "kid3"]);
+  });
+});

--- a/src/services/export/tree.ts
+++ b/src/services/export/tree.ts
@@ -50,19 +50,41 @@ export async function fetchProjectTaskTree(
 /**
  * Partition a flat task list into root tasks and a `parentId → children` map.
  *
- * Root tasks are those with `parentId === null` (directly under their project
- * or inbox). The map indexes children by their stringified parent ID, so
- * recursive renderers can look up a given task's children in O(1).
+ * A task is a root if its `parentId` is null OR if its `parentId` does not
+ * appear as the `id` of any other task in the input set. The latter case
+ * matters for two reasons:
+ *
+ *   1. **Project-rooted tasks** (#499). OmniFocus's data model treats a
+ *      project as a container task; top-level tasks of a project carry
+ *      `parentId === <projectId>` rather than `parentId === null`. The
+ *      project itself is never in the fetched task set, so those tasks
+ *      surface as roots here. Without this rule, `export_taskpaper` returned
+ *      `taskCount > 0` with an empty body for every real-database project.
+ *
+ *   2. **Defensive against fetch boundaries.** If a child appears without
+ *      its parent (pagination, filtered fetch, race against a deletion),
+ *      treat it as root rather than silently dropping it from the rendered
+ *      tree.
+ *
+ * The map indexes children by their stringified parent ID, so recursive
+ * renderers can look up a given task's children in O(1).
  */
 export function partitionTasksByParent(tasks: Task[]): {
   rootTasks: Task[];
   byParent: Map<string, Task[]>;
 } {
+  // First pass: index every task ID present in the input set so the second
+  // pass can recognize parentId references that point outside it.
+  const idsInSet = new Set<string>();
+  for (const task of tasks) {
+    idsInSet.add(String(task.id));
+  }
+
   const rootTasks: Task[] = [];
   const byParent = new Map<string, Task[]>();
 
   for (const task of tasks) {
-    if (task.parentId === null) {
+    if (task.parentId === null || !idsInSet.has(String(task.parentId))) {
       rootTasks.push(task);
     } else {
       const key = String(task.parentId);


### PR DESCRIPTION
## Summary

- Fix #499: every `export_taskpaper` against a real-database project rendered `taskCount: N` with an empty body because top-level project tasks carry `parentId === <projectId>`, not `parentId === null`. The partition logic only recognized null-parent tasks as roots.
- Switch to "parentId is null OR parentId is not the id of any other task in the set" — handles project-rooted tasks correctly and defends against pagination/filter boundaries (orphaned subtrees surface as roots instead of vanishing).
- Add `tree.test.ts` (no prior unit tests on this file) — six cases including the realistic OF-ID regression from #499.

## Test plan

- [x] New tree partition tests (6) — all green
- [x] Full unit suite (1978 tests) — all green
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Integration test against a live database with project-rooted tasks (gated on `OMNIFOCUS_INTEGRATION=1`; verify `export_taskpaper {scope:"project", id:<real-id>}` now renders task lines)

Closes #499