### PR TITLE
feat(resources): add omnifocus://recent-activity session-priming resource

### DIFF
--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -112,9 +112,9 @@ function makeHarness() {
 // ---------------------------------------------------------------------------
 
 describe("registerOmniFocusResources — registration", () => {
-  it("registers exactly 12 resources", () => {
+  it("registers exactly 13 resources", () => {
     const { registered } = makeHarness();
-    expect(registered).toHaveLength(12);
+    expect(registered).toHaveLength(13);
   });
 
   it("registers omnifocus-snapshot with the correct URI", () => {

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -38,6 +38,9 @@ import type { ForecastService } from "../services/forecastService.js";
 import type { PerspectiveService } from "../services/perspectiveService.js";
 import type { ProjectService } from "../services/projectService.js";
 import type { ReviewService } from "../services/reviewService.js";
+import { registerRecentActivityResource } from "./recentActivity.js";
+
+export { RECENT_ACTIVITY_URI_TEMPLATE } from "./recentActivity.js";
 
 // ---------------------------------------------------------------------------
 // Dependency bundle
@@ -374,4 +377,7 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
       return jsonContents(`omnifocus://tasks/tag/${tagId}`, tasks);
     },
   );
+
+  // ── omnifocus://recent-activity{?hours} ───────────────────────────────────
+  registerRecentActivityResource(server, adapter);
 }

--- a/src/resources/recentActivity.test.ts
+++ b/src/resources/recentActivity.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit tests for the recent-activity resource.
+ *
+ * Tests cover:
+ * - `parseHours` — default, clamping, invalid input
+ * - `buildRecentActivityPayload` — section population, sorting, summary counts
+ * - Edge cases: empty adapter state, tasks at boundary
+ *
+ * Uses `InMemoryAdapter` seeded with predictable fixtures. No live OF required.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { ProjectId as ProjId, TaskId as TskId } from "../domain/ids.js";
+import {
+  buildRecentActivityPayload,
+  parseHours,
+  RECENT_ACTIVITY_DEFAULT_HOURS,
+  RECENT_ACTIVITY_MAX_HOURS,
+} from "./recentActivity.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hoursAgo(h: number): string {
+  return new Date(Date.now() - h * 3_600_000).toISOString();
+}
+
+function daysAgo(d: number): string {
+  return hoursAgo(d * 24);
+}
+
+// ---------------------------------------------------------------------------
+// parseHours
+// ---------------------------------------------------------------------------
+
+describe("parseHours", () => {
+  it("returns default for undefined", () => {
+    expect(parseHours(undefined)).toBe(RECENT_ACTIVITY_DEFAULT_HOURS);
+  });
+  it("returns default for empty string", () => {
+    expect(parseHours("")).toBe(RECENT_ACTIVITY_DEFAULT_HOURS);
+  });
+  it("parses a valid number", () => {
+    expect(parseHours("48")).toBe(48);
+  });
+  it("clamps to max", () => {
+    expect(parseHours("9999")).toBe(RECENT_ACTIVITY_MAX_HOURS);
+  });
+  it("clamps to min 1", () => {
+    expect(parseHours("0")).toBe(1);
+  });
+  it("returns default for NaN", () => {
+    expect(parseHours("not-a-number")).toBe(RECENT_ACTIVITY_DEFAULT_HOURS);
+  });
+  it("rounds fractional values", () => {
+    expect(parseHours("1.9")).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — empty state
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — empty adapter", () => {
+  it("returns empty arrays and zero counts", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildRecentActivityPayload(adapter, 24);
+
+    expect(payload.window.hours).toBe(24);
+    expect(payload.tasksCreated).toEqual([]);
+    expect(payload.tasksCompleted).toEqual([]);
+    expect(payload.tasksDropped).toEqual([]);
+    expect(payload.tasksDeferred).toEqual([]);
+    expect(payload.projectsModified).toEqual([]);
+    expect(payload.summary.taskCreatedCount).toBe(0);
+    expect(payload.summary.taskCompletedCount).toBe(0);
+    expect(payload.summary.taskDroppedCount).toBe(0);
+    expect(payload.summary.taskDeferredCount).toBe(0);
+    expect(payload.summary.projectsAffected).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — tasksCreated
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — tasksCreated", () => {
+  it("includes active tasks created within the window", async () => {
+    const adapter = new InMemoryAdapter();
+    // Tasks are created "now" by default via InMemoryAdapter — within any window > 0
+    await adapter.createTask({ name: "New task A" });
+    await adapter.createTask({ name: "New task B" });
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.tasksCreated).toHaveLength(2);
+    expect(payload.tasksCreated.map((t) => t.name)).toContain("New task A");
+    expect(payload.tasksCreated.map((t) => t.name)).toContain("New task B");
+  });
+
+  it("excludes completed tasks from tasksCreated (they appear in tasksCompleted)", async () => {
+    const adapter = new InMemoryAdapter();
+    const taskId = await adapter.createTask({ name: "Will complete" });
+    await adapter.completeTask(taskId);
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.tasksCreated.map((t) => t.name)).not.toContain("Will complete");
+    expect(payload.tasksCompleted.map((t) => t.name)).toContain("Will complete");
+  });
+
+  it("excludes dropped tasks from tasksCreated (they appear in tasksDropped)", async () => {
+    const adapter = new InMemoryAdapter();
+    const taskId = await adapter.createTask({ name: "Will drop" });
+    await adapter.dropTask(taskId);
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.tasksCreated.map((t) => t.name)).not.toContain("Will drop");
+    expect(payload.tasksDropped.map((t) => t.name)).toContain("Will drop");
+  });
+
+  it("sorts tasksCreated by createdAt descending", async () => {
+    const adapter = new InMemoryAdapter();
+    await adapter.createTask({ name: "Alpha" });
+    await adapter.createTask({ name: "Beta" });
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+    // Both are created "now"; order may be stable — just verify they're present
+    expect(payload.tasksCreated).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — tasksCompleted
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — tasksCompleted", () => {
+  it("includes tasks completed within the window", async () => {
+    const adapter = new InMemoryAdapter();
+    const taskId = await adapter.createTask({ name: "Done task" });
+    await adapter.completeTask(taskId);
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.tasksCompleted).toHaveLength(1);
+    expect(payload.tasksCompleted[0]?.name).toBe("Done task");
+  });
+
+  it("computes age_days_at_completion as non-negative", async () => {
+    const adapter = new InMemoryAdapter();
+    const taskId = await adapter.createTask({ name: "Aging task" });
+    await adapter.completeTask(taskId);
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+    expect(payload.tasksCompleted[0]?.age_days_at_completion).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes projectId when task belongs to a project", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "My project", status: "active" });
+    const taskId = await adapter.createTask({ name: "Project task", projectId: projId });
+    await adapter.completeTask(taskId);
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.tasksCompleted[0]?.projectId).toBe(String(projId));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — tasksDropped
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — tasksDropped", () => {
+  it("includes tasks dropped within the window", async () => {
+    const adapter = new InMemoryAdapter();
+    const taskId = await adapter.createTask({ name: "Dropped task" });
+    await adapter.dropTask(taskId);
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.tasksDropped).toHaveLength(1);
+    expect(payload.tasksDropped[0]?.name).toBe("Dropped task");
+    expect(payload.tasksDropped[0]?.droppedAt).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — tasksDeferred
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — tasksDeferred", () => {
+  it("includes tasks with deferDate within the window", async () => {
+    const adapter = new InMemoryAdapter();
+    const soon = new Date(Date.now() + 3_600_000).toISOString(); // 1h from now
+    await adapter.createTask({ name: "Deferred task", deferDate: soon });
+
+    const payload = await buildRecentActivityPayload(adapter, 24);
+
+    expect(payload.tasksDeferred).toHaveLength(1);
+    expect(payload.tasksDeferred[0]?.name).toBe("Deferred task");
+  });
+
+  it("includes tasks modified within the window that have a deferDate", async () => {
+    // tasksDeferred uses modifiedAt as a proxy for "recently deferred"
+    const adapter = new InMemoryAdapter();
+    const future = new Date(Date.now() + 7 * 24 * 3_600_000).toISOString(); // 1 week out
+    await adapter.createTask({ name: "Deferred-with-future-date", deferDate: future });
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    // Task was just created (modifiedAt === now) AND has a deferDate → appears in tasksDeferred
+    expect(payload.tasksDeferred.map((t) => t.name)).toContain("Deferred-with-future-date");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — projectsModified
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — projectsModified", () => {
+  it("includes projects modified within the window", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "Active project", status: "active" });
+    // Touching the project's name counts as a modification
+    await adapter.updateProject(projId, { name: "Renamed project" });
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    const found = payload.projectsModified.find((p) => p.projectId === String(projId));
+    expect(found).toBeDefined();
+    expect(found?.name).toBe("Renamed project");
+  });
+
+  it("includes project status in the payload", async () => {
+    const adapter = new InMemoryAdapter();
+    await adapter.createProject({ name: "On hold project", status: "on-hold" });
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.projectsModified.some((p) => p.status === "on-hold")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — summary
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — summary", () => {
+  it("counts match section lengths", async () => {
+    const adapter = new InMemoryAdapter();
+    await adapter.createTask({ name: "Active" });
+    const t2Id = await adapter.createTask({ name: "Completed" });
+    await adapter.completeTask(t2Id);
+    const t3Id = await adapter.createTask({ name: "Dropped" });
+    await adapter.dropTask(t3Id);
+
+    const payload = await buildRecentActivityPayload(adapter, 1);
+
+    expect(payload.summary.taskCreatedCount).toBe(payload.tasksCreated.length);
+    expect(payload.summary.taskCompletedCount).toBe(payload.tasksCompleted.length);
+    expect(payload.summary.taskDroppedCount).toBe(payload.tasksDropped.length);
+    expect(payload.summary.taskDeferredCount).toBe(payload.tasksDeferred.length);
+    expect(payload.summary.projectsAffected).toBe(payload.projectsModified.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRecentActivityPayload — window field
+// ---------------------------------------------------------------------------
+
+describe("buildRecentActivityPayload — window", () => {
+  it("reflects the requested hours", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildRecentActivityPayload(adapter, 48);
+    expect(payload.window.hours).toBe(48);
+    expect(typeof payload.window.since).toBe("string");
+  });
+
+  it("since is approximately (hours) ago", async () => {
+    const adapter = new InMemoryAdapter();
+    const before = new Date(Date.now() - 48 * 3_600_000 - 1000).toISOString();
+    const after = new Date(Date.now() - 48 * 3_600_000 + 1000).toISOString();
+    const payload = await buildRecentActivityPayload(adapter, 48);
+    expect(payload.window.since >= before).toBe(true);
+    expect(payload.window.since <= after).toBe(true);
+  });
+});

--- a/src/resources/recentActivity.test.ts
+++ b/src/resources/recentActivity.test.ts
@@ -11,7 +11,6 @@
 
 import { describe, expect, it } from "vitest";
 import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
-import { ProjectId as ProjId, TaskId as TskId } from "../domain/ids.js";
 import {
   buildRecentActivityPayload,
   parseHours,
@@ -22,14 +21,6 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function hoursAgo(h: number): string {
-  return new Date(Date.now() - h * 3_600_000).toISOString();
-}
-
-function daysAgo(d: number): string {
-  return hoursAgo(d * 24);
-}
 
 // ---------------------------------------------------------------------------
 // parseHours

--- a/src/resources/recentActivity.ts
+++ b/src/resources/recentActivity.ts
@@ -146,7 +146,8 @@ export async function buildRecentActivityPayload(
   const tasksCompleted = completedTasks
     .filter((t) => t.completedAt !== null)
     .map((t) => {
-      const completedAt = t.completedAt!;
+      // biome-ignore lint/style/noNonNullAssertion: filter above guarantees completedAt is set
+      const completedAt = t.completedAt as string;
       const ageMs = new Date(completedAt).getTime() - new Date(t.createdAt).getTime();
       return {
         taskId: String(t.id),
@@ -166,7 +167,8 @@ export async function buildRecentActivityPayload(
       taskId: String(t.id),
       name: t.name,
       projectId: t.projectId !== null ? String(t.projectId) : null,
-      droppedAt: t.droppedAt!,
+      // biome-ignore lint/style/noNonNullAssertion: filter above guarantees droppedAt is set
+      droppedAt: t.droppedAt as string,
     }))
     .sort((a, b) => (b.droppedAt > a.droppedAt ? 1 : b.droppedAt < a.droppedAt ? -1 : 0));
 
@@ -181,7 +183,8 @@ export async function buildRecentActivityPayload(
       taskId: String(t.id),
       name: t.name,
       projectId: t.projectId !== null ? String(t.projectId) : null,
-      deferDate: t.deferDate!,
+      // biome-ignore lint/style/noNonNullAssertion: filter above guarantees deferDate is set
+      deferDate: t.deferDate as string,
     }))
     .sort((a, b) => (b.deferDate > a.deferDate ? 1 : b.deferDate < a.deferDate ? -1 : 0));
 

--- a/src/resources/recentActivity.ts
+++ b/src/resources/recentActivity.ts
@@ -1,0 +1,262 @@
+/**
+ * `omnifocus://recent-activity` MCP resource.
+ *
+ * Returns a structured activity feed for a rolling time window, making it
+ * safe and cheap to call at every session start so the agent is already
+ * oriented before the first prompt fires.
+ *
+ * URI: `omnifocus://recent-activity{?hours}`
+ *   - `hours` (optional, default 24, max 168): how far back to look
+ *
+ * Payload shape:
+ *   {
+ *     window: { hours: number; since: string },
+ *     tasksCreated:   { taskId, name, projectId, createdAt }[]
+ *     tasksCompleted: { taskId, name, projectId, completedAt, age_days_at_completion }[]
+ *     tasksDropped:   { taskId, name, projectId, droppedAt }[]
+ *     tasksDeferred:  { taskId, name, projectId, deferDate }[]
+ *     projectsModified: { projectId, name, status, modifiedAt }[]
+ *     summary: { taskCreatedCount, taskCompletedCount, taskDroppedCount, taskDeferredCount, projectsAffected }
+ *   }
+ *
+ * All sections are sorted by timestamp descending (most recent first).
+ * Empty sections return `[]` — never omitted.
+ *
+ * Fidelity notes:
+ * - `tasksCreated` includes active tasks only (not tasks that were created
+ *   _and_ completed within the window; those appear only in `tasksCompleted`).
+ * - `tasksDeferred` uses `modifiedAt >= since && deferDate !== null` as a proxy
+ *   for "recently deferred" — OF does not expose when a deferDate was set.
+ *   Any task modified in the window that carries a deferDate appears here.
+ * - `projectsModified` includes any project with `modifiedAt` in the window,
+ *   not just status changes — OF does not surface the previous status value.
+ *
+ * @see DESIGN.md §28 — MCP resources
+ * @see docs/adr/0006-read-cache-strategy.md
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const RECENT_ACTIVITY_URI_TEMPLATE = "omnifocus://recent-activity{?hours}";
+export const RECENT_ACTIVITY_DEFAULT_HOURS = 24;
+export const RECENT_ACTIVITY_MAX_HOURS = 168; // 7 days
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RecentActivityPayload {
+  window: {
+    hours: number;
+    since: string;
+  };
+  tasksCreated: Array<{
+    taskId: string;
+    name: string;
+    projectId: string | null;
+    createdAt: string;
+  }>;
+  tasksCompleted: Array<{
+    taskId: string;
+    name: string;
+    projectId: string | null;
+    completedAt: string;
+    age_days_at_completion: number;
+  }>;
+  tasksDropped: Array<{
+    taskId: string;
+    name: string;
+    projectId: string | null;
+    droppedAt: string;
+  }>;
+  tasksDeferred: Array<{
+    taskId: string;
+    name: string;
+    projectId: string | null;
+    deferDate: string;
+  }>;
+  projectsModified: Array<{
+    projectId: string;
+    name: string;
+    status: string;
+    modifiedAt: string;
+  }>;
+  summary: {
+    taskCreatedCount: number;
+    taskCompletedCount: number;
+    taskDroppedCount: number;
+    taskDeferredCount: number;
+    projectsAffected: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/** Parse the `hours` variable from the URI template match, clamping to [1, MAX]. */
+export function parseHours(raw: string | undefined): number {
+  if (raw === undefined || raw === null || raw === "") {
+    return RECENT_ACTIVITY_DEFAULT_HOURS;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return RECENT_ACTIVITY_DEFAULT_HOURS;
+  return Math.min(Math.max(1, Math.round(n)), RECENT_ACTIVITY_MAX_HOURS);
+}
+
+/**
+ * Build the recent-activity payload from adapter data.
+ *
+ * Exported separately from the registration function so unit tests can call
+ * it directly with a mock adapter without wiring up an MCP server.
+ */
+export async function buildRecentActivityPayload(
+  adapter: OmniFocusAdapter,
+  hours: number,
+): Promise<RecentActivityPayload> {
+  const since = new Date(Date.now() - hours * 3_600_000).toISOString();
+
+  // Fetch data in parallel: three independent adapter calls.
+  const [incompleteTasks, completedTasks, allProjects] = await Promise.all([
+    // completed: false includes both active tasks AND dropped tasks (dropped ≠ completed in OF)
+    adapter.listTasks({ completed: false }),
+    adapter.listTasks({ completed: true, completedSince: since }),
+    adapter.listProjects(),
+  ]);
+
+  // ── tasksCreated ──────────────────────────────────────────────────────────
+  // Active (non-dropped) tasks created within the window.
+  const tasksCreated = incompleteTasks
+    .filter((t) => !t.dropped && t.createdAt >= since)
+    .map((t) => ({
+      taskId: String(t.id),
+      name: t.name,
+      projectId: t.projectId !== null ? String(t.projectId) : null,
+      createdAt: t.createdAt,
+    }))
+    .sort((a, b) => (b.createdAt > a.createdAt ? 1 : b.createdAt < a.createdAt ? -1 : 0));
+
+  // ── tasksCompleted ────────────────────────────────────────────────────────
+  const tasksCompleted = completedTasks
+    .filter((t) => t.completedAt !== null)
+    .map((t) => {
+      const completedAt = t.completedAt!;
+      const ageMs = new Date(completedAt).getTime() - new Date(t.createdAt).getTime();
+      return {
+        taskId: String(t.id),
+        name: t.name,
+        projectId: t.projectId !== null ? String(t.projectId) : null,
+        completedAt,
+        age_days_at_completion: Math.max(0, Math.round(ageMs / 86_400_000)),
+      };
+    })
+    .sort((a, b) => (b.completedAt > a.completedAt ? 1 : b.completedAt < a.completedAt ? -1 : 0));
+
+  // ── tasksDropped ──────────────────────────────────────────────────────────
+  // Dropped tasks (dropped: true, droppedAt within window).
+  const tasksDropped = incompleteTasks
+    .filter((t) => t.dropped && t.droppedAt !== null && t.droppedAt >= since)
+    .map((t) => ({
+      taskId: String(t.id),
+      name: t.name,
+      projectId: t.projectId !== null ? String(t.projectId) : null,
+      droppedAt: t.droppedAt!,
+    }))
+    .sort((a, b) => (b.droppedAt > a.droppedAt ? 1 : b.droppedAt < a.droppedAt ? -1 : 0));
+
+  // ── tasksDeferred ─────────────────────────────────────────────────────────
+  // Active tasks modified within the window that carry a deferDate.
+  // Approximation: OF does not expose when a deferDate was set, so this uses
+  // modifiedAt as a proxy — recently-modified tasks with a deferDate are likely
+  // recently deferred. Treat as a heuristic, not an exact change log.
+  const tasksDeferred = incompleteTasks
+    .filter((t) => !t.dropped && t.deferDate !== null && t.modifiedAt >= since)
+    .map((t) => ({
+      taskId: String(t.id),
+      name: t.name,
+      projectId: t.projectId !== null ? String(t.projectId) : null,
+      deferDate: t.deferDate!,
+    }))
+    .sort((a, b) => (b.deferDate > a.deferDate ? 1 : b.deferDate < a.deferDate ? -1 : 0));
+
+  // ── projectsModified ──────────────────────────────────────────────────────
+  // Projects modified within the window (approximation for status changes).
+  const projectsModified = allProjects
+    .filter((p) => p.modifiedAt >= since)
+    .map((p) => ({
+      projectId: String(p.id),
+      name: p.name,
+      status: p.status,
+      modifiedAt: p.modifiedAt,
+    }))
+    .sort((a, b) => (b.modifiedAt > a.modifiedAt ? 1 : b.modifiedAt < a.modifiedAt ? -1 : 0));
+
+  return {
+    window: { hours, since },
+    tasksCreated,
+    tasksCompleted,
+    tasksDropped,
+    tasksDeferred,
+    projectsModified,
+    summary: {
+      taskCreatedCount: tasksCreated.length,
+      taskCompletedCount: tasksCompleted.length,
+      taskDroppedCount: tasksDropped.length,
+      taskDeferredCount: tasksDeferred.length,
+      projectsAffected: projectsModified.length,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the `omnifocus://recent-activity{?hours}` resource.
+ *
+ * This resource is **safe to read on every session start** — it is designed
+ * for context priming. Agents should call it before the first task-related
+ * prompt so they walk into the conversation already oriented.
+ */
+export function registerRecentActivityResource(server: McpServer, adapter: OmniFocusAdapter): void {
+  server.registerResource(
+    "omnifocus-recent-activity",
+    new ResourceTemplate(RECENT_ACTIVITY_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Session-priming activity feed for the last N hours (default 24, max 168). " +
+        "Returns tasks created, completed, dropped, and deferred, plus projects modified. " +
+        "Safe to read at every session start — designed for agent context priming. " +
+        "All sections sorted by timestamp descending. Empty sections return [], never omitted. " +
+        "Fidelity notes: tasksCreated includes active tasks only (completed-within-window appear in tasksCompleted); " +
+        "tasksDeferred uses modifiedAt as a proxy (tasks modified in window with a deferDate set); " +
+        "projectsModified includes any project modification, not status-change-only.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const hours = parseHours((variables as Record<string, string | undefined>).hours);
+      const uri =
+        hours === RECENT_ACTIVITY_DEFAULT_HOURS
+          ? "omnifocus://recent-activity"
+          : `omnifocus://recent-activity?hours=${hours}`;
+
+      const payload = await buildRecentActivityPayload(adapter, hours);
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `omnifocus://recent-activity{?hours}` resource (default 24h, max 168h)
- Returns tasks created, completed, dropped, and deferred in the window, plus modified projects
- Designed to be read at every session start for agent context priming — safe, cheap, predictable shape
- All sections always present (empty `[]` when nothing in window, never omitted)
- 23 unit tests covering `parseHours`, each section, summary counts, and window field

## Fidelity trade-offs (documented in module JSDoc)

- `tasksCreated`: active tasks only — tasks created-and-completed within window appear in `tasksCompleted` only
- `tasksDeferred`: uses `modifiedAt` as proxy since OF has no defer-change history
- `projectsModified`: any project modification, not status-change-only

## Test plan

- [x] `parseHours` — default, clamp, invalid, fractional, min/max
- [x] Empty adapter returns zero counts and empty arrays
- [x] tasksCreated excludes completed/dropped (they appear in their own sections)
- [x] tasksCompleted populated via `completedSince` filter; `age_days_at_completion` ≥ 0
- [x] tasksDropped populated; includes `droppedAt` timestamp
- [x] tasksDeferred: recently-modified tasks with deferDate included
- [x] projectsModified: updated projects appear with correct name/status
- [x] Summary counts match section lengths
- [x] `registerOmniFocusResources` count updated to 13

Closes #488