### PR TITLE
docs: stop restating tool counts in living docs — defer to omnifocus://capabilities

### DIFF
--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -21,6 +21,7 @@ on:
     paths:
       - "scripts/**"
       - ".github/workflows/**"
+      - "**/*.md"
 
 permissions:
   contents: read
@@ -68,3 +69,17 @@ jobs:
       - uses: actions/checkout@v6
       - name: Verify no GitHub-hosted runners are referenced
         run: scripts/verify-no-hosted-runners.sh
+
+  no-tool-counts:
+    # Regression guard — fails if any living doc restates the count of
+    # registered MCP tools. Per #478, prose docs describe the SHAPE of
+    # the tool surface; the COUNT lives at `omnifocus://capabilities`
+    # and `internal_status` at runtime, plus `docs/tools.md` (auto-
+    # generated, allowlisted). Every release used to touch one doc and
+    # miss four others; this guard removes the regression class.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, macos]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify no tool-count strings in living docs
+        run: scripts/verify-no-tool-counts.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Inherited from [`coding.md`](https://github.com/torsday/llm_prompts/blob/main/co
 - Error messages answer: what operation, which IDs, why, what to do next
 - Goldilocks testing — enough to catch real bugs, not so many the suite is a burden
 - Every public method has a docblock with `@param` / `@returns` / `@throws`
+- **Don't restate the tool count in prose.** Living docs describe the shape of the tool surface (domains, verbs, patterns), not the integer count. The live count lives at `omnifocus://capabilities` and `internal_status` at runtime, plus `docs/tools.md` (auto-generated). See DESIGN.md §6.8.1 — `scripts/verify-no-tool-counts.sh` enforces this in CI.
 
 ## Workflow
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -101,7 +101,7 @@ We must cover the full OmniFocus feature surface (per `project_scope.md`) via MC
 | Option | Approach | Fits when | Tradeoffs |
 | ------ | -------- | --------- | --------- |
 | A. Few, powerful tools | 8–12 generic tools with wide schemas (`omnifocus_query`, `omnifocus_mutate`) | Want small tool list | Agent must understand complex nested schemas; tool descriptions become essays; error disambiguation is hard |
-| **B. Many, narrow tools with consistent verbs** | ~60–70 tools: `task_list`, `task_create`, `task_update`, …, `project_list`, … | Want LLM-friendly discoverability | Larger tool count (agents now handle 60+ fine); more handler boilerplate (mitigated by patterns) |
+| **B. Many, narrow tools with consistent verbs** | A wide surface of `<noun>_<verb>` tools: `task_list`, `task_create`, `task_update`, …, `project_list`, … | Want LLM-friendly discoverability | Larger tool surface (modern agents handle wide surfaces fine); more handler boilerplate (mitigated by patterns) |
 | C. Split across multiple MCP servers | Read-server + write-server (or per-noun servers) | Want privilege separation | User configures multiple servers; more ops surface; premature for a single-user tool |
 
 **Recommendation: Option B, with namespaced `<noun>_<verb>` naming.** Recorded as **ADR-0003**.
@@ -371,6 +371,19 @@ Side effects: Read-only. Safe to retry. Cached for 30s.
 ```
 
 The linter test (TASKS #78) asserts every tool description includes all four sections. The Success Criteria (SPEC) includes an LLM-readability review: a fresh Claude instance must pick the correct tool for 20 representative prompts without additional context.
+
+### 6.8.1 Tool-count policy (#478)
+
+Living docs describe the **shape** of the tool surface (domains, verbs, patterns), never the **count**. The capabilities resource (`omnifocus://capabilities`) and `internal_status` publish the live count at runtime; `docs/tools.md` is auto-generated from `ALL_TOOL_DESCRIPTIONS` on every build. Anything else is a copy that decays.
+
+This policy is enforced by `scripts/verify-no-tool-counts.sh`, wired into `meta-lint.yml`. The lint allowlist covers genuinely-dated artifacts:
+
+- `CHANGELOG.md` — historical release entries are point-in-time
+- `docs/tools.md` — auto-generated; the count IS the live truth, regenerated per build
+- `docs/validation/**` — dated audit / readability reports
+- `docs/llm-readability-review-v1.md` — versioned snapshot
+
+Add to the allowlist only with a one-line rationale per entry; rewording is almost always cheaper.
 
 ### 6.9 Observability
 

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ All responses have this shape:
 
 ## Tools
 
-80 tools are registered, organized by domain. See [`docs/tools.md`](./docs/tools.md) for the full auto-generated reference with input schemas, example calls, and example responses.
+Tools are organized by domain — tasks, projects, tags, folders, perspectives, forecast, review, search, notes, attachments, sync, export, and observability. See [`docs/tools.md`](./docs/tools.md) for the full auto-generated reference with the live registered count, input schemas, example calls, and example responses.
 
 ### App lifecycle
 | Tool | Description |

--- a/docs/adr/0003-tool-surface-namespaced.md
+++ b/docs/adr/0003-tool-surface-namespaced.md
@@ -9,9 +9,9 @@
 
 MCP tools are the API the LLM agent sees. Two dimensions of decision: (1) **granularity** — few broad tools vs many narrow ones — and (2) **naming** — flat, hierarchical, or namespaced.
 
-Empirically, modern agent models handle 50+ tools well if descriptions are clear and names are predictable. The failure mode of "few broad tools" is complex nested schemas the agent has to interpret; the failure mode of "many narrow tools" is name-space pollution where near-duplicates confuse the agent.
+Empirically, modern agent models handle wide tool surfaces well if descriptions are clear and names are predictable. The failure mode of "few broad tools" is complex nested schemas the agent has to interpret; the failure mode of "many narrow tools" is name-space pollution where near-duplicates confuse the agent.
 
-Full OmniFocus coverage implies ~60–70 operations. We must choose a shape before writing any tool handlers; retrofitting the shape later means renaming every tool (which is a breaking change to anyone using the MCP).
+Full OmniFocus coverage implies a sizeable verb-per-noun surface. We must choose a shape before writing any tool handlers; retrofitting the shape later means renaming every tool (which is a breaking change to anyone using the MCP).
 
 ## Decision
 

--- a/docs/adr/0014-e2e-harness-strategy.md
+++ b/docs/adr/0014-e2e-harness-strategy.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-The E2E tier (DESIGN §19, tier 5) gates on `OMNIFOCUS_E2E=1`, spawns the bundled `dist/index.js` as a subprocess, and acts as an MCP client over stdio. Issue #80 sets the bar at "every registered tool is invoked at least once" with a valid `ToolEnvelope` response. Today the smoke test (`tests/e2e/smoke.test.ts`) only invokes a handful of pure tools (`internal_status`, `task_parse_transport_text`) plus prompt and resource listings. The remaining 65+ tools all touch the JXA / OmniJS transports through `composeAdapter(config)`, which today returns the live `TransportRouter`. Without a live OmniFocus and macOS Automation permission, those calls throw before any MCP-layer assertion can run.
+The E2E tier (DESIGN §19, tier 5) gates on `OMNIFOCUS_E2E=1`, spawns the bundled `dist/index.js` as a subprocess, and acts as an MCP client over stdio. Issue #80 sets the bar at "every registered tool is invoked at least once" with a valid `ToolEnvelope` response. Today the smoke test (`tests/e2e/smoke.test.ts`) only invokes a handful of pure tools (`internal_status`, `task_parse_transport_text`) plus prompt and resource listings. The remaining tools all touch the JXA / OmniJS transports through `composeAdapter(config)`, which today returns the live `TransportRouter`. Without a live OmniFocus and macOS Automation permission, those calls throw before any MCP-layer assertion can run.
 
 Three architectural options exist for closing the gap. Choosing one is hard to reverse — it determines harness shape, CI footprint, what bug classes we catch on every push, and how `composeAdapter` is structured.
 
@@ -33,7 +33,7 @@ Option C — error-envelope-shape-only assertions — is rejected.
 
 **Positive**
 
-- Per-tool E2E coverage runs on every push: the registration manifest (80 tools, sourced from `ALL_TOOL_DESCRIPTIONS`) cannot drift from the boot path without a test failure.
+- Per-tool E2E coverage runs on every push: the registration manifest (sourced from `ALL_TOOL_DESCRIPTIONS`) cannot drift from the boot path without a test failure.
 - Middleware composition (assertNotShuttingDown → circuit-breaker → rate-limit → loop-detection → invocation-logging) is exercised end-to-end in CI, not just in unit tests against the inner stack.
 - The `InMemoryAdapter` is preserved as a load-bearing seam — increases the value of every contract test that already targets it.
 - Cold-start budget (`< 500ms`, DESIGN §17) is meaningfully testable on every push: in-memory paths complete fast enough that a regression in startup cost surfaces at PR time, not release time.

--- a/docs/clients/generic-stdio.md
+++ b/docs/clients/generic-stdio.md
@@ -103,7 +103,7 @@ Send **SIGTERM** or **SIGINT** to the process. It will:
 
 ## Verifying connectivity
 
-After connection, call `tools/list` — you should see 60+ tools. Then call `internal_status`:
+After connection, call `tools/list` — you should see the full registered tool list (live count is published at `omnifocus://capabilities`). Then call `internal_status`:
 
 ```json
 {

--- a/scripts/verify-no-tool-counts.sh
+++ b/scripts/verify-no-tool-counts.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Fail if any living doc restates the count of registered MCP tools.
+#
+# Why this exists (#478): the count drifts every release. Maintainers update
+# one doc, miss four others. The capabilities resource (`omnifocus://capabilities`)
+# and `internal_status` already report the live count at runtime — anything
+# in prose is a copy that decays.
+#
+# Policy: docs describe the *shape* of the tool surface (domains, patterns,
+# verbs), not a numeric *count*. Numbers in markdown rot; descriptions of
+# shape don't.
+#
+# Allowlist: files that legitimately carry a tool count are exempt. The
+# allowlist is small on purpose — adding to it should be deliberate.
+#
+#   - CHANGELOG.md             — historical release entries; dated snapshots
+#   - docs/tools.md            — auto-generated from source by
+#                                scripts/generate-tool-docs.ts; the count
+#                                IS the live truth, regenerated on every build
+#   - docs/validation/**       — dated audit / validation reports (point-in-time)
+#   - docs/llm-readability-review-v1.md — versioned snapshot (the `-v1` is
+#                                the tell)
+#
+# Wired into meta-lint.yml's `no-tool-counts` job so every PR that touches
+# docs catches a regression at PR time.
+#
+# Detects: integers (with optional `+`) followed by `tool` or `tools` within
+# a small word window. Examples that fail:
+#   - "80 tools"
+#   - "60+ tools"
+#   - "82 MCP tools"
+#   - "65+ tools all touch …"
+# Examples that pass (the regex requires `tool[s]?` immediately or via a
+# bounded modifier word like "MCP"):
+#   - "65 tasks" — different noun
+#   - "the project has 5 toolchains" — `toolchain`, not `tool`/`tools`
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+ALLOWLIST=(
+  "CHANGELOG.md"
+  "docs/tools.md"
+  "docs/llm-readability-review-v1.md"
+)
+# Directory-prefix allowlist — anything under these is exempt.
+ALLOWLIST_PREFIXES=(
+  "docs/validation/"
+)
+
+# Files to scan: every Markdown file at the repo root or under docs/, except
+# the allowlist. Globbing with bash 3.2 (macOS default), so build the list
+# explicitly rather than relying on `**`.
+files=()
+while IFS= read -r f; do
+  skip=false
+  for allowed in "${ALLOWLIST[@]}"; do
+    [ "$f" = "$allowed" ] && skip=true && break
+  done
+  if [ "$skip" = false ]; then
+    for prefix in "${ALLOWLIST_PREFIXES[@]}"; do
+      case "$f" in
+        "$prefix"*) skip=true; break ;;
+      esac
+    done
+  fi
+  $skip || files+=("$f")
+done < <(git ls-files '*.md' 'docs/**/*.md' | sort -u)
+
+# The pattern: a digit run, optional `+`, optional whitespace + a single
+# bridge word, then `tool` or `tools` as a whole word. The bridge-word slot
+# tolerates the natural prose "80 MCP tools" / "60 registered tools" without
+# opening up to "65 tasks" or "5 toolchains".
+#
+# `(MCP[[:space:]]+|registered[[:space:]]+|of[[:space:]]+)?` — small allowlist
+# of bridge words. Add others only if real doc prose surfaces them.
+PATTERN='\b[0-9]+\+?[[:space:]]+(MCP[[:space:]]+|registered[[:space:]]+|of[[:space:]]+)?tools?\b'
+
+hits=$(grep -nIE "$PATTERN" "${files[@]}" 2>/dev/null || true)
+
+# Filter: ignore matches inside fenced code blocks would be ideal but expensive
+# in pure bash. Instead, keep the regex narrow enough that real code references
+# (e.g. `tool_name: "task_list"`) don't match — they wouldn't anyway, since
+# the regex requires a number-then-tool sequence, not a name.
+
+if [ -z "$hits" ]; then
+  echo "ok: no tool-count strings in living docs"
+  exit 0
+fi
+
+cat <<EOF >&2
+Tool-count strings detected in living docs. Per #478 (the policy that
+introduced this lint), prose docs should describe the SHAPE of the tool
+surface ("comprehensive surface across tasks, projects, tags, folders,
+…"), not the COUNT. Numbers in markdown rot; the shape doesn't.
+
+The live count is in \`omnifocus://capabilities\` and \`internal_status\`
+at runtime, and \`docs/tools.md\` (auto-generated, allowlisted) carries
+it on every build.
+
+Offending lines:
+$hits
+
+To fix:
+  - Reword to a shape description, OR
+  - Remove the sentence if the count was the whole point, OR
+  - If this file is genuinely a dated snapshot that should be exempt
+    (like CHANGELOG.md or a validation report), add it to the allowlist
+    in scripts/verify-no-tool-counts.sh with a one-line rationale.
+EOF
+exit 1


### PR DESCRIPTION
## Summary

- Reword 6 tool-count violations across README, DESIGN, two ADRs, and the generic-stdio client doc — shape descriptions instead of integers
- Add `scripts/verify-no-tool-counts.sh` lint guard, modeled on `verify-no-hosted-runners.sh`; allowlist covers CHANGELOG, auto-generated `docs/tools.md`, and dated validation/readability snapshots
- Wire into `meta-lint.yml` as a `no-tool-counts` job; expand the workflow's `paths:` filter to `**/*.md` so docs PRs trigger
- Document the policy in DESIGN.md §6.8.1 + add a CONTRIBUTING checklist bullet

## Test plan

- [x] `bash scripts/verify-no-tool-counts.sh` — green on this branch
- [x] Confirmed regression detection: temporarily reintroduced "80 tools" in README → script exits 1 with clear "Offending lines" output
- [x] `shellcheck --shell=bash --severity=warning scripts/verify-no-tool-counts.sh` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (`docs/tools.md is up to date`)
- [x] `pnpm test` — 1978 pass
- [ ] Future docs PR triggers the new `no-tool-counts` job (will verify on first qualifying merge)

Closes #478