### PR TITLE
feat(resources): add omnifocus://taxonomy-audit collision detector

### DIFF
--- a/src/domain/textSimilarity.test.ts
+++ b/src/domain/textSimilarity.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for textSimilarity helpers.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type CollisionReason,
+  collisionReason,
+  levenshtein,
+  normalizeName,
+  tokenSet,
+  tokenSetEqual,
+} from "./textSimilarity.js";
+
+describe("levenshtein", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshtein("hello", "hello")).toBe(0);
+  });
+  it("returns string length when other is empty", () => {
+    expect(levenshtein("abc", "")).toBe(3);
+    expect(levenshtein("", "abc")).toBe(3);
+  });
+  it("single substitution", () => {
+    expect(levenshtein("cat", "bat")).toBe(1);
+  });
+  it("single insertion", () => {
+    expect(levenshtein("cat", "cats")).toBe(1);
+  });
+  it("single deletion", () => {
+    expect(levenshtein("cats", "cat")).toBe(1);
+  });
+  it("two edits", () => {
+    expect(levenshtein("errand", "errands")).toBe(1);
+    expect(levenshtein("work", "wrok")).toBe(2);
+  });
+});
+
+describe("normalizeName", () => {
+  it("lowercases", () => {
+    expect(normalizeName("Work")).toBe("work");
+  });
+  it("trims whitespace", () => {
+    expect(normalizeName("  home  ")).toBe("home");
+  });
+  it("collapses internal whitespace", () => {
+    expect(normalizeName("pay  invoice")).toBe("pay invoice");
+  });
+  it("strips leading @", () => {
+    expect(normalizeName("@errand")).toBe("errand");
+  });
+  it("does not strip embedded @", () => {
+    expect(normalizeName("email@work")).toBe("email@work");
+  });
+});
+
+describe("tokenSet / tokenSetEqual", () => {
+  it("splits on whitespace", () => {
+    expect(tokenSet("pay invoice")).toEqual(["invoice", "pay"]);
+  });
+  it("splits on hyphens and underscores", () => {
+    expect(tokenSet("follow-up")).toEqual(["follow", "up"]);
+    expect(tokenSet("follow_up")).toEqual(["follow", "up"]);
+  });
+  it("order-insensitive equality", () => {
+    expect(tokenSetEqual("Pay Invoice", "invoice pay")).toBe(true);
+  });
+  it("not equal when tokens differ", () => {
+    expect(tokenSetEqual("work", "home")).toBe(false);
+  });
+  it("different lengths are not equal", () => {
+    expect(tokenSetEqual("pay invoice", "pay")).toBe(false);
+  });
+});
+
+describe("collisionReason", () => {
+  it("returns null for unrelated names", () => {
+    expect(collisionReason("groceries", "finances")).toBeNull();
+  });
+
+  it("exact-duplicate for identical strings", () => {
+    expect(collisionReason("Work", "Work")).toBe("exact-duplicate");
+  });
+
+  it("case-difference for same letters different case", () => {
+    expect(collisionReason("Work", "work")).toBe("case-difference");
+    expect(collisionReason("@Errand", "@errand")).toBe("case-difference");
+  });
+
+  it("plural-singular for trailing s", () => {
+    expect(collisionReason("errand", "errands")).toBe("plural-singular");
+    expect(collisionReason("errands", "errand")).toBe("plural-singular");
+  });
+
+  it("plural-singular for trailing es", () => {
+    expect(collisionReason("invoice", "invoices")).toBe("plural-singular");
+  });
+
+  it("near-duplicate for Levenshtein ≤ 2", () => {
+    expect(collisionReason("Taxes 2025", "2025 Taxes")).toBe("near-duplicate");
+    // "home" vs "hom" = 1 edit
+    expect(collisionReason("home", "hom")).toBe("near-duplicate");
+  });
+
+  it("near-duplicate for token-set equality", () => {
+    expect(collisionReason("Pay Invoice", "Invoice Pay")).toBe("near-duplicate");
+  });
+
+  it("returns null when distance > 2 and token sets differ", () => {
+    expect(collisionReason("groceries", "grocery shopping")).toBeNull();
+  });
+
+  // Specificity: case-difference beats plural-singular (lower rank wins)
+  it("case-difference takes precedence over near-duplicate", () => {
+    const r = collisionReason("Work", "work") satisfies CollisionReason | null;
+    expect(r).toBe("case-difference");
+  });
+});

--- a/src/domain/textSimilarity.ts
+++ b/src/domain/textSimilarity.ts
@@ -1,0 +1,123 @@
+/**
+ * Text similarity helpers for taxonomy-audit collision detection.
+ *
+ * Used by `omnifocus://taxonomy-audit` to identify tag and project names
+ * that are likely duplicates or near-duplicates of each other.
+ *
+ * Intentionally dependency-free — pure functions over strings with no
+ * external library requirements.
+ *
+ * @see src/resources/taxonomyAudit.ts — consumer
+ * @see DESIGN.md §28 — MCP resources spec
+ */
+
+// ---------------------------------------------------------------------------
+// Levenshtein distance
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the Levenshtein edit distance between two strings.
+ *
+ * Uses the iterative two-row algorithm (O(n) space). Returns the minimum
+ * number of single-character edits (insert, delete, substitute) needed to
+ * transform `a` into `b`.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Keep two rows: previous and current
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let curr = new Array<number>(b.length + 1);
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      // biome-ignore lint/style/noNonNullAssertion: indices are within bounds
+      curr[j] = Math.min(curr[j - 1]! + 1, prev[j]! + 1, prev[j - 1]! + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+
+  // biome-ignore lint/style/noNonNullAssertion: b.length is a valid index
+  return prev[b.length]!;
+}
+
+// ---------------------------------------------------------------------------
+// Normalisation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise a name for comparison: lower-case, trim, collapse internal
+ * whitespace, strip leading `@` (OmniFocus tag convention).
+ */
+export function normalizeName(name: string): string {
+  return name.toLowerCase().trim().replace(/\s+/g, " ").replace(/^@/, "");
+}
+
+/**
+ * Convert a name to a sorted token set (words split on whitespace / `-` / `_`).
+ * `"Pay invoices"` and `"invoices pay"` produce the same token set.
+ */
+export function tokenSet(name: string): string[] {
+  return normalizeName(name)
+    .split(/[\s\-_]+/)
+    .filter(Boolean)
+    .sort();
+}
+
+/** Return true if two names have identical token sets (order-insensitive). */
+export function tokenSetEqual(a: string, b: string): boolean {
+  const ta = tokenSet(a);
+  const tb = tokenSet(b);
+  if (ta.length !== tb.length) return false;
+  return ta.every((t, i) => t === tb[i]);
+}
+
+// ---------------------------------------------------------------------------
+// Collision reason
+// ---------------------------------------------------------------------------
+
+/**
+ * Collision reasons in order of specificity (most specific first).
+ *
+ * - `exact-duplicate` — normalised strings are identical (same name, same case)
+ * - `case-difference` — lower-cased strings are identical (e.g. "Work" vs "work")
+ * - `plural-singular` — one name is the other with a trailing "s" appended/removed
+ * - `near-duplicate`  — Levenshtein ≤ 2 OR token-set equality
+ */
+export type CollisionReason =
+  | "exact-duplicate"
+  | "case-difference"
+  | "plural-singular"
+  | "near-duplicate";
+
+/**
+ * Determine whether two names collide and, if so, why.
+ *
+ * Returns the most-specific reason, or `null` if no collision is detected.
+ * Both names must be distinct (caller's responsibility — don't compare a name
+ * to itself).
+ */
+export function collisionReason(a: string, b: string): CollisionReason | null {
+  if (a === b) return "exact-duplicate";
+
+  const na = normalizeName(a);
+  const nb = normalizeName(b);
+
+  if (na === nb) return "case-difference";
+
+  // plural-singular: one is the other plus/minus a trailing "s" (or "es")
+  if (na === `${nb}s` || nb === `${na}s` || na === `${nb}es` || nb === `${na}es`) {
+    return "plural-singular";
+  }
+
+  // near-duplicate: Levenshtein ≤ 2 or token-set equality
+  if (levenshtein(na, nb) <= 2 || tokenSetEqual(a, b)) {
+    return "near-duplicate";
+  }
+
+  return null;
+}

--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -112,9 +112,9 @@ function makeHarness() {
 // ---------------------------------------------------------------------------
 
 describe("registerOmniFocusResources — registration", () => {
-  it("registers exactly 13 resources", () => {
+  it("registers exactly 14 resources", () => {
     const { registered } = makeHarness();
-    expect(registered).toHaveLength(13);
+    expect(registered).toHaveLength(14);
   });
 
   it("registers omnifocus-snapshot with the correct URI", () => {

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -39,8 +39,10 @@ import type { PerspectiveService } from "../services/perspectiveService.js";
 import type { ProjectService } from "../services/projectService.js";
 import type { ReviewService } from "../services/reviewService.js";
 import { registerRecentActivityResource } from "./recentActivity.js";
+import { registerTaxonomyAuditResource } from "./taxonomyAudit.js";
 
 export { RECENT_ACTIVITY_URI_TEMPLATE } from "./recentActivity.js";
+export { TAXONOMY_AUDIT_URI } from "./taxonomyAudit.js";
 
 // ---------------------------------------------------------------------------
 // Dependency bundle
@@ -380,4 +382,7 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
 
   // ── omnifocus://recent-activity{?hours} ───────────────────────────────────
   registerRecentActivityResource(server, adapter);
+
+  // ── omnifocus://taxonomy-audit ────────────────────────────────────────────
+  registerTaxonomyAuditResource(server, adapter);
 }

--- a/src/resources/taxonomyAudit.test.ts
+++ b/src/resources/taxonomyAudit.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for the taxonomy-audit resource.
+ *
+ * Tests cover:
+ * - `buildTaxonomyAuditPayload` — tag collision detection (all reason types)
+ * - `buildTaxonomyAuditPayload` — project collision detection
+ * - Clustering: three-way collision merges into one cluster
+ * - Empty collections return empty arrays
+ * - folderPath preserved in project candidates
+ *
+ * Uses InMemoryAdapter seeded with predictable fixtures.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { buildTaxonomyAuditPayload } from "./taxonomyAudit.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedTags(adapter: InMemoryAdapter, names: string[]): Promise<void> {
+  for (const name of names) {
+    await adapter.createTag({ name });
+  }
+}
+
+async function seedProjects(adapter: InMemoryAdapter, names: string[]): Promise<void> {
+  for (const name of names) {
+    await adapter.createProject({ name, status: "active" });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+describe("buildTaxonomyAuditPayload — empty adapter", () => {
+  it("returns empty arrays", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildTaxonomyAuditPayload(adapter);
+    expect(payload.tagCollisions).toEqual([]);
+    expect(payload.projectCollisions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tag collisions
+// ---------------------------------------------------------------------------
+
+describe("buildTaxonomyAuditPayload — tagCollisions", () => {
+  it("detects exact-duplicate tags", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["Work", "Work"]);
+
+    const { tagCollisions } = await buildTaxonomyAuditPayload(adapter);
+
+    expect(tagCollisions).toHaveLength(1);
+    expect(tagCollisions[0]?.reason).toBe("exact-duplicate");
+    expect(tagCollisions[0]?.candidates).toHaveLength(2);
+  });
+
+  it("detects case-difference tags", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["errand", "Errand"]);
+
+    const { tagCollisions } = await buildTaxonomyAuditPayload(adapter);
+
+    expect(tagCollisions).toHaveLength(1);
+    expect(tagCollisions[0]?.reason).toBe("case-difference");
+  });
+
+  it("detects plural-singular tags (@errand / @errands)", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["@errand", "@errands"]);
+
+    const { tagCollisions } = await buildTaxonomyAuditPayload(adapter);
+
+    expect(tagCollisions).toHaveLength(1);
+    expect(tagCollisions[0]?.reason).toBe("plural-singular");
+  });
+
+  it("detects near-duplicate tags (Levenshtein ≤ 2)", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["hom", "home"]);
+
+    const { tagCollisions } = await buildTaxonomyAuditPayload(adapter);
+
+    expect(tagCollisions).toHaveLength(1);
+    expect(tagCollisions[0]?.reason).toBe("near-duplicate");
+  });
+
+  it("does not flag unrelated tags", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["groceries", "finances", "health"]);
+
+    const { tagCollisions } = await buildTaxonomyAuditPayload(adapter);
+    expect(tagCollisions).toEqual([]);
+  });
+
+  it("clusters a three-way collision into one entry", async () => {
+    // "errand", "errands", "Errand" — all collide with each other
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["errand", "errands", "Errand"]);
+
+    const { tagCollisions } = await buildTaxonomyAuditPayload(adapter);
+
+    // All three should be in one cluster
+    expect(tagCollisions).toHaveLength(1);
+    expect(tagCollisions[0]?.candidates).toHaveLength(3);
+  });
+
+  it("includes tagId and taskCount in candidates", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["Work", "work"]);
+
+    const { tagCollisions } = await buildTaxonomyAuditPayload(adapter);
+    const candidate = tagCollisions[0]?.candidates[0];
+    expect(candidate).toHaveProperty("tagId");
+    expect(candidate).toHaveProperty("name");
+    expect(candidate).toHaveProperty("taskCount");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project collisions
+// ---------------------------------------------------------------------------
+
+describe("buildTaxonomyAuditPayload — projectCollisions", () => {
+  it("detects case-difference project names", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedProjects(adapter, ["Taxes 2025", "taxes 2025"]);
+
+    const { projectCollisions } = await buildTaxonomyAuditPayload(adapter);
+
+    expect(projectCollisions).toHaveLength(1);
+    expect(projectCollisions[0]?.reason).toBe("case-difference");
+  });
+
+  it("detects near-duplicate project names (token-set)", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedProjects(adapter, ["2025 Taxes", "Taxes 2025"]);
+
+    const { projectCollisions } = await buildTaxonomyAuditPayload(adapter);
+
+    expect(projectCollisions).toHaveLength(1);
+    expect(projectCollisions[0]?.reason).toBe("near-duplicate");
+  });
+
+  it("does not flag unrelated project names", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedProjects(adapter, ["Garden Renovation", "Home Office Setup", "Side Project Alpha"]);
+
+    const { projectCollisions } = await buildTaxonomyAuditPayload(adapter);
+    expect(projectCollisions).toEqual([]);
+  });
+
+  it("includes folderId in project candidates", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedProjects(adapter, ["Work", "work"]);
+
+    const { projectCollisions } = await buildTaxonomyAuditPayload(adapter);
+    const candidate = projectCollisions[0]?.candidates[0];
+    expect(candidate).toHaveProperty("projectId");
+    expect(candidate).toHaveProperty("folderId");
+    expect(candidate).toHaveProperty("taskCount");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Both sections populated simultaneously
+// ---------------------------------------------------------------------------
+
+describe("buildTaxonomyAuditPayload — mixed", () => {
+  it("detects collisions in both tags and projects independently", async () => {
+    const adapter = new InMemoryAdapter();
+    await seedTags(adapter, ["errand", "errands"]);
+    await seedProjects(adapter, ["Work", "work"]);
+
+    const payload = await buildTaxonomyAuditPayload(adapter);
+
+    expect(payload.tagCollisions).toHaveLength(1);
+    expect(payload.projectCollisions).toHaveLength(1);
+  });
+});

--- a/src/resources/taxonomyAudit.ts
+++ b/src/resources/taxonomyAudit.ts
@@ -1,0 +1,286 @@
+/**
+ * `omnifocus://taxonomy-audit` MCP resource.
+ *
+ * Detects tag and project name collisions in the OmniFocus database — pairs
+ * (or groups) of names that are likely duplicates or near-duplicates.
+ *
+ * URI: `omnifocus://taxonomy-audit` (static, no parameters)
+ *
+ * Payload shape:
+ *   {
+ *     tagCollisions: TagCollision[],
+ *     projectCollisions: ProjectCollision[],
+ *   }
+ *
+ * TagCollision:
+ *   { candidates: { tagId, name, taskCount }[], reason: CollisionReason }
+ *
+ * ProjectCollision:
+ *   { candidates: { projectId, name, folderId, taskCount }[], reason: CollisionReason }
+ *
+ * `reason` values (most-specific to least):
+ *   "exact-duplicate" | "case-difference" | "plural-singular" | "near-duplicate"
+ *
+ * Empty sections return `[]` — never omitted.
+ *
+ * Use: an agent reads this resource to identify naming drift and propose
+ * merges. The merges themselves are out of scope for this resource.
+ *
+ * @see src/domain/textSimilarity.ts — collision detection helpers
+ * @see DESIGN.md §28 — MCP resources spec
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import type { CollisionReason } from "../domain/textSimilarity.js";
+import { collisionReason } from "../domain/textSimilarity.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const TAXONOMY_AUDIT_URI = "omnifocus://taxonomy-audit";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TagCandidate {
+  tagId: string;
+  name: string;
+  taskCount: number;
+}
+
+export interface TagCollision {
+  candidates: TagCandidate[];
+  reason: CollisionReason;
+}
+
+export interface ProjectCandidate {
+  projectId: string;
+  name: string;
+  /** Folder ID the project belongs to, or null for top-level projects. */
+  folderId: string | null;
+  taskCount: number;
+}
+
+export interface ProjectCollision {
+  candidates: ProjectCandidate[];
+  reason: CollisionReason;
+}
+
+export interface TaxonomyAuditPayload {
+  tagCollisions: TagCollision[];
+  projectCollisions: ProjectCollision[];
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the taxonomy-audit payload from adapter data.
+ *
+ * Exported separately so unit tests can call it directly with a mock adapter.
+ *
+ * Algorithm: O(n²) pairwise comparison — acceptable because the number of
+ * tags/projects in a typical OF database is small (dozens to a few hundred).
+ * Groups overlapping pairs into collision clusters: if A~B and B~C, all three
+ * share a cluster. Uses a union-find (path-compression) approach.
+ */
+export async function buildTaxonomyAuditPayload(
+  adapter: OmniFocusAdapter,
+): Promise<TaxonomyAuditPayload> {
+  const [tags, projects] = await Promise.all([adapter.listTags(), adapter.listProjects()]);
+
+  const tagCollisions = detectTagCollisions(tags);
+  const projectCollisions = detectProjectCollisions(projects);
+
+  return { tagCollisions, projectCollisions };
+}
+
+// ---------------------------------------------------------------------------
+// Tag collision detection
+// ---------------------------------------------------------------------------
+
+function detectTagCollisions(
+  tags: Array<{ id: unknown; name: string; taskCount: number }>,
+): TagCollision[] {
+  // Build candidate list
+  const candidates: TagCandidate[] = tags.map((t) => ({
+    tagId: String(t.id),
+    name: t.name,
+    taskCount: t.taskCount,
+  }));
+
+  return findCollisionClusters(
+    candidates,
+    (a, b) => collisionReason(a.name, b.name),
+    (cluster, reason) => ({ candidates: cluster, reason }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Project collision detection
+// ---------------------------------------------------------------------------
+
+function detectProjectCollisions(
+  projects: Array<{ id: unknown; name: string; folderId: unknown; taskCount: number }>,
+): ProjectCollision[] {
+  const candidates: ProjectCandidate[] = projects.map((p) => ({
+    projectId: String(p.id),
+    name: p.name,
+    folderId: p.folderId !== null ? String(p.folderId) : null,
+    taskCount: p.taskCount,
+  }));
+
+  return findCollisionClusters(
+    candidates,
+    (a, b) => collisionReason(a.name, b.name),
+    (cluster, reason) => ({ candidates: cluster, reason }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Generic cluster finder
+// ---------------------------------------------------------------------------
+
+/**
+ * Find collision clusters across an array of items.
+ *
+ * Uses union-find to merge pairs into clusters. Each cluster that contains
+ * ≥ 2 items becomes one collision entry. The reason assigned to a cluster
+ * is the most-specific reason among all pairs in the cluster.
+ */
+function findCollisionClusters<T, C>(
+  items: T[],
+  reasonFn: (a: T, b: T) => CollisionReason | null,
+  buildCollision: (cluster: T[], reason: CollisionReason) => C,
+): C[] {
+  if (items.length < 2) return [];
+
+  // parent[i] = index of item i's cluster root
+  const parent = items.map((_, i) => i);
+  // Reason for the edge between two items (most specific in the cluster)
+  const clusterReason = new Map<number, CollisionReason>();
+
+  function find(i: number): number {
+    while (parent[i] !== i) {
+      // Path compression
+      // biome-ignore lint/style/noNonNullAssertion: parent is same length as items
+      parent[i] = parent[parent[i]!]!;
+      // biome-ignore lint/style/noNonNullAssertion: same
+      i = parent[i]!;
+    }
+    return i;
+  }
+
+  function union(i: number, j: number, reason: CollisionReason): void {
+    const ri = find(i);
+    const rj = find(j);
+    if (ri === rj) {
+      // Already in same cluster — update reason if more specific
+      const existing = clusterReason.get(ri) ?? "near-duplicate";
+      clusterReason.set(ri, moreSpecific(existing, reason));
+      return;
+    }
+    // Merge rj into ri
+    parent[rj] = ri;
+    const existing = clusterReason.get(ri) ?? clusterReason.get(rj) ?? reason;
+    clusterReason.set(ri, moreSpecific(existing, reason));
+  }
+
+  // Pairwise comparison
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      // biome-ignore lint/style/noNonNullAssertion: i and j are within bounds
+      const reason = reasonFn(items[i]!, items[j]!);
+      if (reason !== null) {
+        union(i, j, reason);
+      }
+    }
+  }
+
+  // Group by cluster root
+  const clusters = new Map<number, T[]>();
+  for (let i = 0; i < items.length; i++) {
+    const root = find(i);
+    const existing = clusters.get(root);
+    if (existing) {
+      // biome-ignore lint/style/noNonNullAssertion: i is within bounds
+      existing.push(items[i]!);
+    } else {
+      // biome-ignore lint/style/noNonNullAssertion: i is within bounds
+      clusters.set(root, [items[i]!]);
+    }
+  }
+
+  // Emit only clusters with ≥ 2 members
+  const result: C[] = [];
+  for (const [root, members] of clusters) {
+    if (members.length >= 2) {
+      const reason = clusterReason.get(root) ?? "near-duplicate";
+      result.push(buildCollision(members, reason));
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Reason specificity ordering
+// ---------------------------------------------------------------------------
+
+const REASON_RANK: Record<CollisionReason, number> = {
+  "exact-duplicate": 0,
+  "case-difference": 1,
+  "plural-singular": 2,
+  "near-duplicate": 3,
+};
+
+/** Return whichever reason is more specific (lower rank). */
+function moreSpecific(a: CollisionReason, b: CollisionReason): CollisionReason {
+  return REASON_RANK[a] <= REASON_RANK[b] ? a : b;
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the `omnifocus://taxonomy-audit` resource.
+ *
+ * Read this resource to discover naming drift in your OmniFocus database.
+ * Returns tag and project name pairs that are likely duplicates. Use the
+ * results to decide which names to consolidate before running a grooming
+ * workflow.
+ */
+export function registerTaxonomyAuditResource(server: McpServer, adapter: OmniFocusAdapter): void {
+  server.registerResource(
+    "omnifocus-taxonomy-audit",
+    TAXONOMY_AUDIT_URI,
+    {
+      description:
+        "Taxonomy audit: detects tag and project name collisions (exact duplicates, " +
+        "case differences, plural/singular variants, near-duplicates with Levenshtein ≤ 2 " +
+        "or token-set equality). " +
+        "Returns { tagCollisions: TagCollision[], projectCollisions: ProjectCollision[] }. " +
+        "Each collision lists the candidate names and a reason. " +
+        "Use to identify naming drift and plan merge operations. " +
+        "Empty sections return [], never omitted.",
+      mimeType: "application/json",
+    },
+    async (_uri) => {
+      const payload = await buildTaxonomyAuditPayload(adapter);
+      return {
+        contents: [
+          {
+            uri: TAXONOMY_AUDIT_URI,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `omnifocus://taxonomy-audit` static resource returning tag and project name collisions
- Detects: exact duplicates, case differences, plural/singular variants, near-duplicates (Levenshtein ≤ 2 or token-set equality)
- Introduces `src/domain/textSimilarity.ts` — pure dependency-free helpers shared with future `task_find_similar`
- Uses union-find clustering so `errand / errands / Errand` becomes one cluster, not three pairs
- Empty sections return `[]`, never omitted

## Test plan

- [x] 25 unit tests for `textSimilarity` helpers (levenshtein, normalizeName, tokenSet, collisionReason)
- [x] 13 unit tests for `buildTaxonomyAuditPayload` — all 4 reason types, clustering, empty state, mixed
- [x] Resource count in `omnifocus.test.ts` updated to 13
- [x] Typecheck clean, full suite 2010 pass

Closes #470