### PR TITLE
feat(resources): add omnifocus://retrospective range resource

### DIFF
--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -112,9 +112,9 @@ function makeHarness() {
 // ---------------------------------------------------------------------------
 
 describe("registerOmniFocusResources — registration", () => {
-  it("registers exactly 14 resources", () => {
+  it("registers exactly 15 resources", () => {
     const { registered } = makeHarness();
-    expect(registered).toHaveLength(14);
+    expect(registered).toHaveLength(15);
   });
 
   it("registers omnifocus-snapshot with the correct URI", () => {

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -39,9 +39,11 @@ import type { PerspectiveService } from "../services/perspectiveService.js";
 import type { ProjectService } from "../services/projectService.js";
 import type { ReviewService } from "../services/reviewService.js";
 import { registerRecentActivityResource } from "./recentActivity.js";
+import { registerRetrospectiveResource } from "./retrospective.js";
 import { registerTaxonomyAuditResource } from "./taxonomyAudit.js";
 
 export { RECENT_ACTIVITY_URI_TEMPLATE } from "./recentActivity.js";
+export { RETROSPECTIVE_URI_TEMPLATE } from "./retrospective.js";
 export { TAXONOMY_AUDIT_URI } from "./taxonomyAudit.js";
 
 // ---------------------------------------------------------------------------
@@ -382,6 +384,9 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
 
   // ── omnifocus://recent-activity{?hours} ───────────────────────────────────
   registerRecentActivityResource(server, adapter);
+
+  // ── omnifocus://retrospective{?from,to} ──────────────────────────────────
+  registerRetrospectiveResource(server, adapter);
 
   // ── omnifocus://taxonomy-audit ────────────────────────────────────────────
   registerTaxonomyAuditResource(server, adapter);

--- a/src/resources/retrospective.test.ts
+++ b/src/resources/retrospective.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the retrospective resource.
+ *
+ * Covers `resolveWindow` (default, partial, swapped, invalid input) and
+ * `buildRetrospectivePayload` (empty state, completed, dropped, rolled,
+ * summary counts including projectsActive deduplication).
+ *
+ * Uses `InMemoryAdapter` for the build path. No live OF required.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import {
+  buildRetrospectivePayload,
+  RETROSPECTIVE_DEFAULT_DAYS,
+  resolveWindow,
+} from "./retrospective.js";
+
+// ---------------------------------------------------------------------------
+// resolveWindow
+// ---------------------------------------------------------------------------
+
+describe("resolveWindow", () => {
+  const FIXED_NOW = () => new Date("2026-04-26T12:00:00.000Z");
+  const expectedDefaultFrom = "2026-04-19T12:00:00.000Z"; // 7 days earlier
+
+  it("defaults to trailing 7 days when both from and to are omitted", () => {
+    const w = resolveWindow(undefined, undefined, FIXED_NOW);
+    expect(w.from).toBe(expectedDefaultFrom);
+    expect(w.to).toBe("2026-04-26T12:00:00.000Z");
+  });
+
+  it("honours an explicit from with default to (now)", () => {
+    const w = resolveWindow("2026-04-01T00:00:00.000Z", undefined, FIXED_NOW);
+    expect(w.from).toBe("2026-04-01T00:00:00.000Z");
+    expect(w.to).toBe("2026-04-26T12:00:00.000Z");
+  });
+
+  it("honours an explicit to with default from (7 days back)", () => {
+    const w = resolveWindow(undefined, "2026-04-25T00:00:00.000Z", FIXED_NOW);
+    expect(w.from).toBe(expectedDefaultFrom);
+    expect(w.to).toBe("2026-04-25T00:00:00.000Z");
+  });
+
+  it("honours both explicit values", () => {
+    const w = resolveWindow("2026-04-01T00:00:00.000Z", "2026-04-10T00:00:00.000Z", FIXED_NOW);
+    expect(w.from).toBe("2026-04-01T00:00:00.000Z");
+    expect(w.to).toBe("2026-04-10T00:00:00.000Z");
+  });
+
+  it("clamps swapped from/to back into order", () => {
+    const w = resolveWindow("2026-04-10T00:00:00.000Z", "2026-04-01T00:00:00.000Z", FIXED_NOW);
+    expect(w.from).toBe("2026-04-01T00:00:00.000Z");
+    expect(w.to).toBe("2026-04-10T00:00:00.000Z");
+  });
+
+  it("falls back to defaults on invalid ISO strings (resilient to garbage)", () => {
+    const w = resolveWindow("not-a-date", "also-bad", FIXED_NOW);
+    expect(w.from).toBe(expectedDefaultFrom);
+    expect(w.to).toBe("2026-04-26T12:00:00.000Z");
+  });
+
+  it("default window is exactly RETROSPECTIVE_DEFAULT_DAYS days wide", () => {
+    const w = resolveWindow(undefined, undefined, FIXED_NOW);
+    const widthDays = (new Date(w.to).getTime() - new Date(w.from).getTime()) / 86_400_000;
+    expect(widthDays).toBe(RETROSPECTIVE_DEFAULT_DAYS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRetrospectivePayload — empty state
+// ---------------------------------------------------------------------------
+
+describe("buildRetrospectivePayload — empty adapter", () => {
+  it("returns empty arrays and zero counts", async () => {
+    const adapter = new InMemoryAdapter();
+    const window = {
+      from: "2026-04-01T00:00:00.000Z",
+      to: "2026-04-30T00:00:00.000Z",
+    };
+    const payload = await buildRetrospectivePayload(adapter, window);
+
+    expect(payload.window).toEqual(window);
+    expect(payload.completed).toEqual([]);
+    expect(payload.dropped).toEqual([]);
+    expect(payload.rolled).toEqual([]);
+    expect(payload.summary).toEqual({
+      completedCount: 0,
+      droppedCount: 0,
+      rolledCount: 0,
+      projectsActive: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRetrospectivePayload — completed
+// ---------------------------------------------------------------------------
+
+describe("buildRetrospectivePayload — completed", () => {
+  it("includes tasks completed within the window", async () => {
+    const adapter = new InMemoryAdapter();
+    const id = await adapter.createTask({ name: "Done in window" });
+    await adapter.completeTask(id);
+
+    // Wide window — completion is "now" per InMemoryAdapter
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    expect(payload.completed).toHaveLength(1);
+    expect(payload.completed[0]?.name).toBe("Done in window");
+    expect(payload.completed[0]?.age_days_at_completion).toBeGreaterThanOrEqual(0);
+    expect(payload.summary.completedCount).toBe(1);
+  });
+
+  it("excludes tasks completed before the window starts", async () => {
+    const adapter = new InMemoryAdapter();
+    const id = await adapter.createTask({ name: "Old completion" });
+    await adapter.completeTask(id);
+
+    // Window in the future — current completion (~now) is before window
+    const future = new Date(Date.now() + 365 * 86_400_000).toISOString();
+    const farFuture = new Date(Date.now() + 366 * 86_400_000).toISOString();
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: future,
+      to: farFuture,
+    });
+
+    expect(payload.completed).toEqual([]);
+  });
+
+  it("sorts completed tasks by completedAt descending (most recent first)", async () => {
+    const adapter = new InMemoryAdapter();
+    const a = await adapter.createTask({ name: "First" });
+    await adapter.completeTask(a);
+    const b = await adapter.createTask({ name: "Second" });
+    await adapter.completeTask(b);
+
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    // Both completed within window. Sort order is descending by completedAt.
+    // InMemoryAdapter may stamp synchronous calls with identical timestamps,
+    // so we assert the non-strict relation (>=) rather than strict.
+    expect(payload.completed).toHaveLength(2);
+    const [first, second] = payload.completed;
+    expect((first?.completedAt ?? "") >= (second?.completedAt ?? "")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRetrospectivePayload — dropped
+// ---------------------------------------------------------------------------
+
+describe("buildRetrospectivePayload — dropped", () => {
+  it("includes tasks dropped within the window (dropped is not 'completed' in OF)", async () => {
+    const adapter = new InMemoryAdapter();
+    const id = await adapter.createTask({ name: "Will drop" });
+    await adapter.dropTask(id);
+
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    expect(payload.dropped).toHaveLength(1);
+    expect(payload.dropped[0]?.name).toBe("Will drop");
+    expect(payload.completed).toEqual([]); // dropped !== completed
+    expect(payload.summary.droppedCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRetrospectivePayload — rolled (deferred-forward heuristic)
+// ---------------------------------------------------------------------------
+
+describe("buildRetrospectivePayload — rolled", () => {
+  it("includes active tasks with deferDate, modifiedAt in window", async () => {
+    const adapter = new InMemoryAdapter();
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    await adapter.createTask({ name: "Deferred", deferDate: future });
+
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    expect(payload.rolled).toHaveLength(1);
+    expect(payload.rolled[0]?.name).toBe("Deferred");
+    expect(payload.summary.rolledCount).toBe(1);
+  });
+
+  it("excludes dropped tasks even with a deferDate (dropped goes in dropped[])", async () => {
+    const adapter = new InMemoryAdapter();
+    const future = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    const id = await adapter.createTask({ name: "Was deferred", deferDate: future });
+    await adapter.dropTask(id);
+
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    expect(payload.rolled).toEqual([]);
+    expect(payload.dropped).toHaveLength(1);
+  });
+
+  it("excludes active tasks without a deferDate", async () => {
+    const adapter = new InMemoryAdapter();
+    await adapter.createTask({ name: "Plain task" });
+
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    expect(payload.rolled).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRetrospectivePayload — summary.projectsActive
+// ---------------------------------------------------------------------------
+
+describe("buildRetrospectivePayload — projectsActive", () => {
+  it("counts distinct project IDs across all three sections", async () => {
+    const adapter = new InMemoryAdapter();
+    const projA = await adapter.createProject({ name: "Project A" });
+    const projB = await adapter.createProject({ name: "Project B" });
+
+    const t1 = await adapter.createTask({ name: "in A", projectId: projA });
+    await adapter.completeTask(t1);
+    const t2 = await adapter.createTask({ name: "in B", projectId: projB });
+    await adapter.dropTask(t2);
+    const t3 = await adapter.createTask({ name: "also in A", projectId: projA });
+    await adapter.completeTask(t3);
+
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    // Two distinct project IDs (A appears twice but counted once)
+    expect(payload.summary.projectsActive).toBe(2);
+  });
+
+  it("is zero when all tasks are inbox (projectId null)", async () => {
+    const adapter = new InMemoryAdapter();
+    const id = await adapter.createTask({ name: "Inbox done" });
+    await adapter.completeTask(id);
+
+    const payload = await buildRetrospectivePayload(adapter, {
+      from: new Date(Date.now() - 86_400_000).toISOString(),
+      to: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+
+    expect(payload.summary.completedCount).toBe(1);
+    expect(payload.summary.projectsActive).toBe(0);
+  });
+});

--- a/src/resources/retrospective.ts
+++ b/src/resources/retrospective.ts
@@ -1,0 +1,255 @@
+/**
+ * `omnifocus://retrospective` MCP resource.
+ *
+ * Closes the weekly-review reflection loop: capture → execute → reflect.
+ * Returns a structured retrospective for a date range — what got done, what
+ * got dropped, what got rolled (deferred forward) — so an agent driving a
+ * weekly-review prompt can produce real prose retrospectives without
+ * client-side aggregation.
+ *
+ * URI: `omnifocus://retrospective{?from,to}`
+ *   - `from` (optional, default 7 days ago): start of window, ISO-8601
+ *   - `to`   (optional, default now):         end of window,   ISO-8601
+ *
+ * Payload shape:
+ *   {
+ *     window: { from: string; to: string },
+ *     completed: { taskId, name, projectId, completedAt, age_days_at_completion }[]
+ *     dropped:   { taskId, name, projectId, droppedAt }[]
+ *     rolled:    { taskId, name, projectId, deferDate }[]
+ *     summary:   { completedCount, droppedCount, rolledCount, projectsActive }
+ *   }
+ *
+ * Fidelity notes:
+ * - `rolled` is a heuristic proxy for "deferred forward in this window":
+ *   active tasks with a deferDate that were modified within the window. OF
+ *   doesn't expose when a deferDate was last changed, so we cannot compute
+ *   a true defer-date hop count or a "moved forward by N days" delta. The
+ *   ticket (#474) accepts this approximation; a follow-up could maintain a
+ *   side-table of deferDate changes via mutation hooks.
+ * - `projectsActive` counts distinct project IDs touched across completed +
+ *   dropped + rolled — the project surface that saw any kind of activity.
+ *
+ * @see #474
+ * @see DESIGN.md §28 — MCP resources
+ * @see src/resources/recentActivity.ts — sibling pattern (different window semantics)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const RETROSPECTIVE_URI_TEMPLATE = "omnifocus://retrospective{?from,to}";
+
+/** Default window: trailing 7 days. */
+export const RETROSPECTIVE_DEFAULT_DAYS = 7;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RetrospectivePayload {
+  window: {
+    from: string;
+    to: string;
+  };
+  completed: Array<{
+    taskId: string;
+    name: string;
+    projectId: string | null;
+    completedAt: string;
+    age_days_at_completion: number;
+  }>;
+  dropped: Array<{
+    taskId: string;
+    name: string;
+    projectId: string | null;
+    droppedAt: string;
+  }>;
+  rolled: Array<{
+    taskId: string;
+    name: string;
+    projectId: string | null;
+    deferDate: string;
+  }>;
+  summary: {
+    completedCount: number;
+    droppedCount: number;
+    rolledCount: number;
+    projectsActive: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — pure, exported for testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve `from`/`to` URI variables to a concrete window. Defaults to the
+ * trailing `RETROSPECTIVE_DEFAULT_DAYS` when both are omitted; partial
+ * (only `from` or only `to`) is honoured by filling the missing side with
+ * the conventional default. Invalid ISO inputs fall back to the defaults
+ * so a malformed URI never blows up the resource — agents get a sensible
+ * window even when they pass garbage.
+ */
+export function resolveWindow(
+  fromRaw: string | undefined,
+  toRaw: string | undefined,
+  now: () => Date = () => new Date(),
+): { from: string; to: string } {
+  const nowDate = now();
+  const defaultTo = nowDate.toISOString();
+  const defaultFrom = new Date(
+    nowDate.getTime() - RETROSPECTIVE_DEFAULT_DAYS * 86_400_000,
+  ).toISOString();
+
+  const from = isIso(fromRaw) ? fromRaw : defaultFrom;
+  const to = isIso(toRaw) ? toRaw : defaultTo;
+
+  // Clamp to a sane order if the agent passed them swapped.
+  if (from > to) {
+    return { from: to, to: from };
+  }
+  return { from, to };
+}
+
+function isIso(s: string | undefined): s is string {
+  if (s === undefined || s === null || s === "") return false;
+  // Conservative ISO-8601 check: parseable and round-trips through Date.
+  const d = new Date(s);
+  return Number.isFinite(d.getTime());
+}
+
+/**
+ * Build the retrospective payload from adapter data.
+ *
+ * Exported separately from the registration function so unit tests can call
+ * it directly with a mock adapter without wiring up an MCP server.
+ */
+export async function buildRetrospectivePayload(
+  adapter: OmniFocusAdapter,
+  window: { from: string; to: string },
+): Promise<RetrospectivePayload> {
+  const { from, to } = window;
+
+  // Three independent fetches — completed/dropped/active — run in parallel.
+  // - completed: adapter supports `completedSince` filter; we apply the
+  //   upper bound (`to`) in TS since adapter has no `completedBefore`.
+  // - dropped: returned by `listTasks({ completed: false })` (dropped tasks
+  //   are not "completed" in OF's data model). Filter by droppedAt in window.
+  // - rolled: active tasks with a deferDate, modifiedAt in window.
+  const [completedSince, incompleteTasks] = await Promise.all([
+    adapter.listTasks({ completed: true, completedSince: from }),
+    adapter.listTasks({ completed: false }),
+  ]);
+
+  // ── completed ─────────────────────────────────────────────────────────────
+  const completed = completedSince
+    .filter((t) => t.completedAt !== null && t.completedAt <= to)
+    .map((t) => {
+      const completedAt = t.completedAt as string;
+      const ageMs = new Date(completedAt).getTime() - new Date(t.createdAt).getTime();
+      return {
+        taskId: String(t.id),
+        name: t.name,
+        projectId: t.projectId !== null ? String(t.projectId) : null,
+        completedAt,
+        age_days_at_completion: Math.max(0, Math.round(ageMs / 86_400_000)),
+      };
+    })
+    .sort((a, b) => (b.completedAt > a.completedAt ? 1 : b.completedAt < a.completedAt ? -1 : 0));
+
+  // ── dropped ───────────────────────────────────────────────────────────────
+  const dropped = incompleteTasks
+    .filter((t) => t.dropped && t.droppedAt !== null && t.droppedAt >= from && t.droppedAt <= to)
+    .map((t) => ({
+      taskId: String(t.id),
+      name: t.name,
+      projectId: t.projectId !== null ? String(t.projectId) : null,
+      droppedAt: t.droppedAt as string,
+    }))
+    .sort((a, b) => (b.droppedAt > a.droppedAt ? 1 : b.droppedAt < a.droppedAt ? -1 : 0));
+
+  // ── rolled ────────────────────────────────────────────────────────────────
+  // Heuristic: active tasks with deferDate, modifiedAt in window. OF doesn't
+  // expose deferDate change history, so we approximate "deferred forward in
+  // this window" via modifiedAt as the change-time proxy.
+  const rolled = incompleteTasks
+    .filter((t) => !t.dropped && t.deferDate !== null && t.modifiedAt >= from && t.modifiedAt <= to)
+    .map((t) => ({
+      taskId: String(t.id),
+      name: t.name,
+      projectId: t.projectId !== null ? String(t.projectId) : null,
+      deferDate: t.deferDate as string,
+    }))
+    .sort((a, b) => (b.deferDate > a.deferDate ? 1 : b.deferDate < a.deferDate ? -1 : 0));
+
+  // ── summary.projectsActive ────────────────────────────────────────────────
+  // Distinct project IDs across all three sections.
+  const projectIds = new Set<string>();
+  for (const t of completed) {
+    if (t.projectId !== null) projectIds.add(t.projectId);
+  }
+  for (const t of dropped) {
+    if (t.projectId !== null) projectIds.add(t.projectId);
+  }
+  for (const t of rolled) {
+    if (t.projectId !== null) projectIds.add(t.projectId);
+  }
+
+  return {
+    window: { from, to },
+    completed,
+    dropped,
+    rolled,
+    summary: {
+      completedCount: completed.length,
+      droppedCount: dropped.length,
+      rolledCount: rolled.length,
+      projectsActive: projectIds.size,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerRetrospectiveResource(server: McpServer, adapter: OmniFocusAdapter): void {
+  server.registerResource(
+    "omnifocus-retrospective",
+    new ResourceTemplate(RETROSPECTIVE_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Retrospective for a date range — closes the weekly-review reflection loop. " +
+        "Returns tasks completed (with age-at-completion in days), tasks dropped, and tasks 'rolled' (deferred-forward heuristic) within the window, plus a summary count and the distinct-projects-active count. " +
+        "Defaults to the trailing 7 days when from/to are omitted; partial windows fill the missing side with the conventional default. " +
+        "Fidelity notes: 'rolled' is a heuristic — OF does not expose deferDate change history, so we use modifiedAt-in-window as a proxy for 'recently re-deferred'. Treat as a signal, not an exact count of defer hops. " +
+        "Cached — historical data doesn't change quickly. Read-only.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const vars = variables as Record<string, string | undefined>;
+      const window = resolveWindow(vars.from, vars.to);
+      const payload = await buildRetrospectivePayload(adapter, window);
+
+      // Build the canonical URI back from the resolved window so cache keys
+      // line up with the request the agent actually receives.
+      const uri = `omnifocus://retrospective?from=${encodeURIComponent(window.from)}&to=${encodeURIComponent(window.to)}`;
+
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- New `omnifocus://retrospective{?from,to}` resource — closes the weekly-review reflection loop
- Returns `completed[]`, `dropped[]`, `rolled[]` (deferred-forward heuristic) + summary with `projectsActive` distinct-project count
- Default window: trailing 7 days; resilient `resolveWindow()` handles missing/swapped/invalid input gracefully
- `rolled` is a documented heuristic using `modifiedAt` as a proxy for deferDate-change time (OF doesn't expose change history)
- Sibling pattern to PR #505's `recent-activity` (different window semantics — from/to vs. rolling hours)

## Test plan

- [x] 17 unit tests cover `resolveWindow` (4 cases) + `buildRetrospectivePayload` (13 cases including projectsActive dedup)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (`docs/tools.md` is up to date)
- [x] `pnpm test` — 2049 pass (omnifocus.test.ts resource-count assertion bumped 13 → 14)
- [ ] Integration test against live OF: complete + drop + defer in window → all surface correctly

Closes #474