### PR TITLE
feat(resources): add velocity + burndown analytics resources

### DIFF
--- a/src/domain/calendarWeeks.test.ts
+++ b/src/domain/calendarWeeks.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for calendarWeeks.ts helpers.
+ *
+ * All assertions use Monday-based ISO-8601 weeks:
+ * - week containing 2026-04-27 (Monday) → starts 2026-04-27
+ * - week containing 2026-04-26 (Sunday) → starts 2026-04-20
+ * - week containing 2026-04-28 (Tuesday) → starts 2026-04-27
+ */
+
+import { describe, expect, it } from "vitest";
+import { isoWeekEnd, isoWeekStart, trailingWeekStarts, weekBounds } from "./calendarWeeks.js";
+
+// Helper: parse a local-midnight date string and return UTC midnight equivalent for comparison.
+// We compare with toDateString() to avoid timezone-offset noise in CI.
+function dateStr(d: Date): string {
+  return d.toDateString(); // e.g. "Mon Apr 27 2026"
+}
+
+describe("isoWeekStart", () => {
+  it("returns the same Monday for a Monday input", () => {
+    const d = new Date("2026-04-27T10:00:00"); // Monday
+    expect(dateStr(isoWeekStart(d))).toBe("Mon Apr 27 2026");
+  });
+
+  it("returns the preceding Monday for a Sunday input", () => {
+    const d = new Date("2026-04-26T10:00:00"); // Sunday
+    expect(dateStr(isoWeekStart(d))).toBe("Mon Apr 20 2026");
+  });
+
+  it("returns the preceding Monday for a Tuesday input", () => {
+    const d = new Date("2026-04-28T10:00:00"); // Tuesday
+    expect(dateStr(isoWeekStart(d))).toBe("Mon Apr 27 2026");
+  });
+
+  it("returns the preceding Monday for a Saturday input", () => {
+    const d = new Date("2026-04-25T10:00:00"); // Saturday
+    expect(dateStr(isoWeekStart(d))).toBe("Mon Apr 20 2026");
+  });
+
+  it("zeroes the time to midnight", () => {
+    const d = new Date("2026-04-27T23:59:59.999"); // Monday late
+    const ws = isoWeekStart(d);
+    expect(ws.getHours()).toBe(0);
+    expect(ws.getMinutes()).toBe(0);
+    expect(ws.getSeconds()).toBe(0);
+    expect(ws.getMilliseconds()).toBe(0);
+  });
+});
+
+describe("isoWeekEnd", () => {
+  it("returns the next Monday (7 days later)", () => {
+    const weekStart = new Date("2026-04-27T00:00:00"); // Monday
+    const weekEnd = isoWeekEnd(weekStart);
+    expect(dateStr(weekEnd)).toBe("Mon May 04 2026");
+  });
+});
+
+describe("weekBounds", () => {
+  it("returns [Monday, next Monday) for a mid-week date", () => {
+    const d = new Date("2026-04-29T14:00:00"); // Wednesday
+    const { from, to } = weekBounds(d);
+    expect(dateStr(from)).toBe("Mon Apr 27 2026");
+    expect(dateStr(to)).toBe("Mon May 04 2026");
+  });
+});
+
+describe("trailingWeekStarts", () => {
+  it("returns n week-start Mondays in chronological order", () => {
+    // Anchor: Monday 2026-04-27
+    const now = new Date("2026-04-27T10:00:00");
+    const weeks = trailingWeekStarts(3, now);
+    expect(weeks).toHaveLength(3);
+    expect(dateStr(weeks[0] as Date)).toBe("Mon Apr 13 2026"); // 2 weeks ago
+    expect(dateStr(weeks[1] as Date)).toBe("Mon Apr 20 2026"); // 1 week ago
+    expect(dateStr(weeks[2] as Date)).toBe("Mon Apr 27 2026"); // this week
+  });
+
+  it("returns 1 element for n=1", () => {
+    const now = new Date("2026-04-27T10:00:00");
+    const weeks = trailingWeekStarts(1, now);
+    expect(weeks).toHaveLength(1);
+    expect(dateStr(weeks[0] as Date)).toBe("Mon Apr 27 2026");
+  });
+
+  it("anchors on the current week for a mid-week date", () => {
+    // Wednesday 2026-04-29 → current week starts Mon 2026-04-27
+    const now = new Date("2026-04-29T10:00:00");
+    const weeks = trailingWeekStarts(2, now);
+    expect(dateStr(weeks[0] as Date)).toBe("Mon Apr 20 2026");
+    expect(dateStr(weeks[1] as Date)).toBe("Mon Apr 27 2026");
+  });
+});

--- a/src/domain/calendarWeeks.ts
+++ b/src/domain/calendarWeeks.ts
@@ -1,0 +1,83 @@
+/**
+ * Calendar-week boundary helpers shared by analytics resources.
+ *
+ * All helpers use **ISO-8601 weeks** — weeks start on Monday, end on Sunday.
+ * "Week start" is the Monday at 00:00:00.000 local time.
+ *
+ * Rationale for Monday-start: OmniFocus defaults to Monday-start in its
+ * Forecast week view; using the same boundary keeps velocity numbers
+ * interpretable alongside what the user sees in the app.
+ *
+ * @see src/resources/velocity.ts — primary consumer
+ * @see src/resources/burndown.ts — uses weekStart for progress tracking
+ */
+
+// ---------------------------------------------------------------------------
+// Core helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the Monday (start) of the ISO week that contains `date`.
+ * Time is set to 00:00:00.000 in **local** time (matching OmniFocus's
+ * own date interpretation).
+ */
+export function isoWeekStart(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  // JS getDay(): 0=Sun, 1=Mon, …, 6=Sat
+  const day = d.getDay();
+  // days to subtract to reach the preceding Monday (Sunday → 6 days back)
+  const delta = day === 0 ? 6 : day - 1;
+  d.setDate(d.getDate() - delta);
+  return d;
+}
+
+/**
+ * Return the Monday-start ISO-8601 string for the week containing `date`.
+ * e.g. `"2026-04-20T00:00:00.000+05:30"` (offset reflects local timezone).
+ */
+export function isoWeekStartIso(date: Date): string {
+  return isoWeekStart(date).toISOString();
+}
+
+/**
+ * Return the exclusive end of the week starting at `weekStartDate`
+ * (i.e. the Monday one week later, at 00:00:00.000 local).
+ */
+export function isoWeekEnd(weekStartDate: Date): Date {
+  const d = new Date(weekStartDate);
+  d.setDate(d.getDate() + 7);
+  return d;
+}
+
+/**
+ * Return the [from, to) bounds for the week containing `date`.
+ * `from` is inclusive (Monday 00:00), `to` is exclusive (next Monday 00:00).
+ */
+export function weekBounds(date: Date): { from: Date; to: Date } {
+  const from = isoWeekStart(date);
+  return { from, to: isoWeekEnd(from) };
+}
+
+// ---------------------------------------------------------------------------
+// Multi-week range
+// ---------------------------------------------------------------------------
+
+/**
+ * Return an array of `n` consecutive week-start `Date`s ending with the
+ * week that contains `now`, in **chronological order** (oldest first).
+ *
+ * @example
+ *   trailingWeekStarts(3, new Date("2026-04-27")) // Mon 2026-04-06, -13, -20, -27 — wait, n=3
+ *   // → [Mon 2026-04-13, Mon 2026-04-20, Mon 2026-04-27]
+ */
+export function trailingWeekStarts(n: number, now: Date = new Date()): Date[] {
+  const currentWeekStart = isoWeekStart(now);
+  const result: Date[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(currentWeekStart);
+    d.setDate(d.getDate() - i * 7);
+    result.push(d);
+  }
+  return result;
+}

--- a/src/resources/burndown.test.ts
+++ b/src/resources/burndown.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the burndown resource.
+ *
+ * Covers:
+ * - buildBurndownPayload: ProjectNotFound error, NoDueDate error,
+ *   zero-task project, behind/ahead/on-pace scenarios, deltaDays sign,
+ *   startDate derivation, actualPercent calculation.
+ *
+ * Uses InMemoryAdapter — no live OmniFocus required.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { buildBurndownPayload } from "./burndown.js";
+
+// Fixed "now" for deterministic ideal-line calculations.
+// Project: started 2026-01-01, due 2026-05-01 (120 days total).
+// At 2026-03-01 (59 days elapsed), ideal = 59/120 ≈ 49.17%.
+const _PROJECT_START = "2026-01-01T00:00:00.000Z";
+const PROJECT_DUE = "2026-05-01T00:00:00.000Z";
+const NOW_MIDWAY = new Date("2026-03-01T00:00:00.000Z");
+
+describe("buildBurndownPayload — errors", () => {
+  it("returns ProjectNotFound for unknown project id", async () => {
+    const adapter = new InMemoryAdapter();
+    const result = await buildBurndownPayload(adapter, "nonexistent-id", NOW_MIDWAY);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.code).toBe("ProjectNotFound");
+    }
+  });
+
+  it("returns NoDueDate when project has no due date", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "No Due Date" });
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.code).toBe("NoDueDate");
+      expect(result.error.message).toContain("No Due Date");
+    }
+  });
+});
+
+describe("buildBurndownPayload — zero tasks", () => {
+  it("returns 100% actualPercent for project with no tasks", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "Empty", dueDate: PROJECT_DUE });
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.totalTasks).toBe(0);
+      expect(result.completedTasks).toBe(0);
+      expect(result.remainingTasks).toBe(0);
+      expect(result.actualPercent).toBe(100);
+    }
+  });
+});
+
+describe("buildBurndownPayload — task counts", () => {
+  it("reports correct totalTasks, completedTasks, remainingTasks", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P", dueDate: PROJECT_DUE });
+
+    const t1 = await adapter.createTask({ name: "done1", projectId: projId });
+    const t2 = await adapter.createTask({ name: "done2", projectId: projId });
+    await adapter.createTask({ name: "todo", projectId: projId });
+
+    await adapter.completeTask(t1);
+    await adapter.completeTask(t2);
+
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.totalTasks).toBe(3);
+      expect(result.completedTasks).toBe(2);
+      expect(result.remainingTasks).toBe(1);
+    }
+  });
+
+  it("excludes dropped tasks from remainingTasks", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P", dueDate: PROJECT_DUE });
+    await adapter.createTask({ name: "active", projectId: projId });
+    const dropped = await adapter.createTask({ name: "dropped", projectId: projId });
+    await adapter.dropTask(dropped);
+
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      // dropped task should not count as remaining
+      expect(result.remainingTasks).toBe(1);
+    }
+  });
+});
+
+describe("buildBurndownPayload — progress math", () => {
+  it("actualPercent = completedTasks / totalTasks × 100", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P", dueDate: PROJECT_DUE });
+
+    const t1 = await adapter.createTask({ name: "t1", projectId: projId });
+    await adapter.createTask({ name: "t2", projectId: projId });
+    await adapter.createTask({ name: "t3", projectId: projId });
+    await adapter.completeTask(t1);
+
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      // 1/3 = 33.33%
+      expect(result.actualPercent).toBeCloseTo(33.33, 1);
+    }
+  });
+
+  it("deltaDays is positive when ahead of ideal pace", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P", dueDate: PROJECT_DUE });
+
+    // Complete all tasks → 100% actual; ideal line will be < 100% if we're mid-project.
+    const t1 = await adapter.createTask({ name: "t1", projectId: projId });
+    await adapter.completeTask(t1);
+
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.deltaDays).toBeGreaterThan(0);
+    }
+  });
+
+  it("deltaDays is negative when behind ideal pace", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P", dueDate: PROJECT_DUE });
+
+    // 10 tasks, 0 completed → 0% actual.
+    // Use a `now` 1 day before the due date so idealLinePercent ≈ 100%
+    // regardless of when InMemoryAdapter sets createdAt.
+    for (let i = 0; i < 10; i++) {
+      await adapter.createTask({ name: `t${i}`, projectId: projId });
+    }
+
+    // now = one day before due date → ideal ≈ ~99%, actual = 0 → delta < 0
+    const nowNearDue = new Date(new Date(PROJECT_DUE).getTime() - 86_400_000);
+    const result = await buildBurndownPayload(adapter, String(projId), nowNearDue);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.deltaDays).toBeLessThan(0);
+    }
+  });
+
+  it("idealLinePercent is 0 when now is at or before startDate", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P", dueDate: PROJECT_DUE });
+    await adapter.createTask({ name: "t", projectId: projId });
+
+    // now = well before the project was created (use a date far in the past)
+    const nowBeforeStart = new Date("2020-01-01T00:00:00.000Z");
+    const result = await buildBurndownPayload(adapter, String(projId), nowBeforeStart);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.idealLinePercent).toBe(0);
+    }
+  });
+});
+
+describe("buildBurndownPayload — output shape", () => {
+  it("includes dueDate, name, projectId in payload", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "My Project", dueDate: PROJECT_DUE });
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.name).toBe("My Project");
+      expect(result.dueDate).toBe(PROJECT_DUE);
+      expect(result.projectId).toBe(String(projId));
+    }
+  });
+
+  it("note field is a non-empty string", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P", dueDate: PROJECT_DUE });
+    const result = await buildBurndownPayload(adapter, String(projId), NOW_MIDWAY);
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(typeof result.note).toBe("string");
+      expect(result.note.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/resources/burndown.test.ts
+++ b/src/resources/burndown.test.ts
@@ -37,7 +37,7 @@ describe("buildBurndownPayload — errors", () => {
     expect("error" in result).toBe(true);
     if ("error" in result) {
       expect(result.error.code).toBe("NoDueDate");
-      expect(result.error.message).toContain("No Due Date");
+      expect(result.error.message).toContain("no due date");
     }
   });
 });

--- a/src/resources/burndown.ts
+++ b/src/resources/burndown.ts
@@ -1,0 +1,246 @@
+/**
+ * `omnifocus://burndown/{projectId}` MCP resource.
+ *
+ * Per-project burndown — how much work remains relative to where a naive
+ * linear progress model says the project should be given its start date and
+ * due date.
+ *
+ * URI: `omnifocus://burndown/{projectId}`
+ *
+ * Success payload shape:
+ *   {
+ *     projectId:        string
+ *     name:             string
+ *     dueDate:          string     — project due date (ISO-8601)
+ *     startDate:        string     — creation date of the earliest task (ISO-8601),
+ *                                    or the project createdAt if no tasks exist
+ *     totalTasks:       number     — all tasks (completed + remaining)
+ *     completedTasks:   number
+ *     remainingTasks:   number
+ *     idealLinePercent: number     — % complete expected at this moment on a linear schedule
+ *     actualPercent:    number     — % actually complete
+ *     deltaDays:        number     — positive = ahead of pace; negative = behind
+ *     note:             string     — human-readable status summary
+ *   }
+ *
+ * Error response shape (always HTTP-200, typed JSON):
+ *   {
+ *     error: { code: "ProjectNotFound" | "NoDueDate"; message: string }
+ *   }
+ *
+ * Notes:
+ * - "Ideal line" is a naive linear model: (elapsedDays / totalDays) × 100.
+ *   The simplification is documented in the payload's `note` field.
+ * - `startDate` = creation date of the earliest non-dropped task; falls back
+ *   to project `createdAt` when the project has no tasks.
+ * - `deltaDays` is the gap between where the ideal line says we should be
+ *   and where we actually are, expressed in days of the project timeline.
+ *   Computed as: (actualPercent − idealLinePercent) / 100 × totalDays.
+ *
+ * @see #480
+ * @see src/resources/velocity.ts — rolling completion velocity
+ * @see src/domain/calendarWeeks.ts — week-boundary helpers (shared)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import type { ProjectId as ProjectIdType } from "../domain/ids.js";
+import { ProjectId as ProjectIdCtor } from "../domain/ids.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const BURNDOWN_URI_TEMPLATE = "omnifocus://burndown/{projectId}";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BurndownPayload {
+  projectId: string;
+  name: string;
+  dueDate: string;
+  startDate: string;
+  totalTasks: number;
+  completedTasks: number;
+  remainingTasks: number;
+  idealLinePercent: number;
+  actualPercent: number;
+  /** Positive = ahead of pace; negative = behind pace. */
+  deltaDays: number;
+  note: string;
+}
+
+export interface BurndownError {
+  error: { code: "ProjectNotFound" | "NoDueDate"; message: string };
+}
+
+export type BurndownResult = BurndownPayload | BurndownError;
+
+// ---------------------------------------------------------------------------
+// Helpers — pure, exported for testing
+// ---------------------------------------------------------------------------
+
+/** Round to two decimal places. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Build the burndown payload for one project.
+ *
+ * Returns a typed error object when the project is not found or has no due date.
+ * Never throws — callers can always serialize the return value directly.
+ */
+export async function buildBurndownPayload(
+  adapter: OmniFocusAdapter,
+  projectId: string,
+  now: Date = new Date(),
+): Promise<BurndownResult> {
+  // ── Project lookup ─────────────────────────────────────────────────────
+  let pid: ProjectIdType;
+  try {
+    pid = ProjectIdCtor.of(projectId);
+  } catch {
+    return {
+      error: { code: "ProjectNotFound", message: `Project not found: ${projectId}` },
+    };
+  }
+
+  const projects = await adapter.listProjects();
+  const project = projects.find((p) => String(p.id) === String(pid));
+  if (!project) {
+    return {
+      error: { code: "ProjectNotFound", message: `Project not found: ${projectId}` },
+    };
+  }
+
+  // ── Due-date guard ─────────────────────────────────────────────────────
+  if (!project.dueDate) {
+    return {
+      error: {
+        code: "NoDueDate",
+        message: `Project "${project.name}" has no due date — burndown requires a deadline.`,
+      },
+    };
+  }
+
+  // ── Task counts ────────────────────────────────────────────────────────
+  // Fetch all tasks in the project (completed + incomplete).
+  const [incompleteTasks, completedTasks] = await Promise.all([
+    adapter.listTasks({ completed: false }),
+    adapter.listTasks({ completed: true }),
+  ]);
+
+  const projectIdStr = String(project.id);
+  const projectIncomplete = incompleteTasks.filter(
+    (t) => !t.dropped && t.projectId !== null && String(t.projectId) === projectIdStr,
+  );
+  const projectCompleted = completedTasks.filter(
+    (t) => t.projectId !== null && String(t.projectId) === projectIdStr,
+  );
+
+  const totalTasks = projectIncomplete.length + projectCompleted.length;
+  const completedCount = projectCompleted.length;
+  const remainingCount = projectIncomplete.length;
+
+  // ── Start date ─────────────────────────────────────────────────────────
+  // Earliest task createdAt; fall back to project createdAt.
+  const allTasks = [...projectIncomplete, ...projectCompleted];
+  const firstTask = allTasks[0];
+  const startDate =
+    allTasks.length > 0 && firstTask !== undefined
+      ? allTasks.reduce(
+          (earliest, t) => (t.createdAt < earliest ? t.createdAt : earliest),
+          firstTask.createdAt,
+        )
+      : project.createdAt;
+
+  // ── Burndown math ──────────────────────────────────────────────────────
+  const startMs = new Date(startDate).getTime();
+  const dueMs = new Date(project.dueDate).getTime();
+  const nowMs = now.getTime();
+
+  const totalDays = Math.max(1, (dueMs - startMs) / 86_400_000);
+
+  // Clamp elapsed to [0, totalDays] — project may be overdue or not started yet.
+  const elapsedDays = Math.max(0, Math.min(totalDays, (nowMs - startMs) / 86_400_000));
+
+  const idealLinePercent = round2((elapsedDays / totalDays) * 100);
+  const actualPercent = totalTasks === 0 ? 100 : round2((completedCount / totalTasks) * 100);
+
+  // deltaDays: positive = ahead, negative = behind
+  const deltaDays = round2(((actualPercent - idealLinePercent) / 100) * totalDays);
+
+  // ── Human-readable status ──────────────────────────────────────────────
+  let note: string;
+  if (totalTasks === 0) {
+    note = "No tasks in project — burndown is trivially complete.";
+  } else if (deltaDays > 0) {
+    note = `Ahead of pace by ${deltaDays.toFixed(1)} day(s). Ideal: ${idealLinePercent.toFixed(1)}% done; actual: ${actualPercent.toFixed(1)}%.`;
+  } else if (deltaDays < 0) {
+    note = `Behind pace by ${Math.abs(deltaDays).toFixed(1)} day(s). Ideal: ${idealLinePercent.toFixed(1)}% done; actual: ${actualPercent.toFixed(1)}%.`;
+  } else {
+    note = `On pace. Ideal: ${idealLinePercent.toFixed(1)}%; actual: ${actualPercent.toFixed(1)}%.`;
+  }
+
+  // Append simplification caveat.
+  note +=
+    " (Ideal line is naive linear from earliest-task creation to project due date. " +
+    "Task weights and blockers are not modelled.)";
+
+  return {
+    projectId: projectIdStr,
+    name: project.name,
+    dueDate: project.dueDate,
+    startDate,
+    totalTasks,
+    completedTasks: completedCount,
+    remainingTasks: remainingCount,
+    idealLinePercent,
+    actualPercent,
+    deltaDays,
+    note,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerBurndownResource(server: McpServer, adapter: OmniFocusAdapter): void {
+  server.registerResource(
+    "omnifocus-burndown",
+    new ResourceTemplate(BURNDOWN_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Per-project burndown chart data — remaining vs completed tasks against a naive linear ideal line. " +
+        "Returns totalTasks, completedTasks, remainingTasks, idealLinePercent, actualPercent, and deltaDays " +
+        "(positive = ahead of pace; negative = behind). " +
+        "Requires the project to have a due date; returns a typed NoDueDate error otherwise. " +
+        "Returns ProjectNotFound when the projectId is unknown. " +
+        "Ideal line is a linear model from earliest-task creation to due date — task weights and blockers are not modelled. " +
+        "Pairs with omnifocus://velocity for macro-level and omnifocus://retrospective for qualitative review. " +
+        "Read-only.",
+      mimeType: "application/json",
+    },
+    async (uri, variables) => {
+      const vars = variables as Record<string, string | undefined>;
+      const projectId = vars.projectId ?? "";
+
+      const payload = await buildBurndownPayload(adapter, projectId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/resources/burndown.ts
+++ b/src/resources/burndown.ts
@@ -122,7 +122,7 @@ export async function buildBurndownPayload(
     return {
       error: {
         code: "NoDueDate",
-        message: `Project "${project.name}" has no due date — burndown requires a deadline.`,
+        message: `Project ${String(project.id)} has no due date — burndown requires a deadline.`,
       },
     };
   }

--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -112,9 +112,9 @@ function makeHarness() {
 // ---------------------------------------------------------------------------
 
 describe("registerOmniFocusResources — registration", () => {
-  it("registers exactly 15 resources", () => {
+  it("registers exactly 17 resources", () => {
     const { registered } = makeHarness();
-    expect(registered).toHaveLength(15);
+    expect(registered).toHaveLength(17);
   });
 
   it("registers omnifocus-snapshot with the correct URI", () => {

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -38,13 +38,17 @@ import type { ForecastService } from "../services/forecastService.js";
 import type { PerspectiveService } from "../services/perspectiveService.js";
 import type { ProjectService } from "../services/projectService.js";
 import type { ReviewService } from "../services/reviewService.js";
+import { registerBurndownResource } from "./burndown.js";
 import { registerRecentActivityResource } from "./recentActivity.js";
 import { registerRetrospectiveResource } from "./retrospective.js";
 import { registerTaxonomyAuditResource } from "./taxonomyAudit.js";
+import { registerVelocityResource } from "./velocity.js";
 
+export { BURNDOWN_URI_TEMPLATE } from "./burndown.js";
 export { RECENT_ACTIVITY_URI_TEMPLATE } from "./recentActivity.js";
 export { RETROSPECTIVE_URI_TEMPLATE } from "./retrospective.js";
 export { TAXONOMY_AUDIT_URI } from "./taxonomyAudit.js";
+export { VELOCITY_URI_TEMPLATE } from "./velocity.js";
 
 // ---------------------------------------------------------------------------
 // Dependency bundle
@@ -390,4 +394,10 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
 
   // ── omnifocus://taxonomy-audit ────────────────────────────────────────────
   registerTaxonomyAuditResource(server, adapter);
+
+  // ── omnifocus://velocity{?weeks} ─────────────────────────────────────────
+  registerVelocityResource(server, adapter);
+
+  // ── omnifocus://burndown/{projectId} ─────────────────────────────────────
+  registerBurndownResource(server, adapter);
 }

--- a/src/resources/recentActivity.ts
+++ b/src/resources/recentActivity.ts
@@ -146,7 +146,6 @@ export async function buildRecentActivityPayload(
   const tasksCompleted = completedTasks
     .filter((t) => t.completedAt !== null)
     .map((t) => {
-      // biome-ignore lint/style/noNonNullAssertion: filter above guarantees completedAt is set
       const completedAt = t.completedAt as string;
       const ageMs = new Date(completedAt).getTime() - new Date(t.createdAt).getTime();
       return {
@@ -167,7 +166,6 @@ export async function buildRecentActivityPayload(
       taskId: String(t.id),
       name: t.name,
       projectId: t.projectId !== null ? String(t.projectId) : null,
-      // biome-ignore lint/style/noNonNullAssertion: filter above guarantees droppedAt is set
       droppedAt: t.droppedAt as string,
     }))
     .sort((a, b) => (b.droppedAt > a.droppedAt ? 1 : b.droppedAt < a.droppedAt ? -1 : 0));
@@ -183,7 +181,6 @@ export async function buildRecentActivityPayload(
       taskId: String(t.id),
       name: t.name,
       projectId: t.projectId !== null ? String(t.projectId) : null,
-      // biome-ignore lint/style/noNonNullAssertion: filter above guarantees deferDate is set
       deferDate: t.deferDate as string,
     }))
     .sort((a, b) => (b.deferDate > a.deferDate ? 1 : b.deferDate < a.deferDate ? -1 : 0));

--- a/src/resources/velocity.test.ts
+++ b/src/resources/velocity.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the velocity resource.
+ *
+ * Covers:
+ * - parseWeeks: clamping, defaults, invalid inputs
+ * - buildVelocityPayload: empty state, weekly bucketing, rolling averages,
+ *   topClosingProjects ordering, window calculation
+ *
+ * Uses InMemoryAdapter — no live OmniFocus required.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import {
+  buildVelocityPayload,
+  parseWeeks,
+  VELOCITY_DEFAULT_WEEKS,
+  VELOCITY_MAX_WEEKS,
+} from "./velocity.js";
+
+// ---------------------------------------------------------------------------
+// parseWeeks
+// ---------------------------------------------------------------------------
+
+describe("parseWeeks", () => {
+  it("returns VELOCITY_DEFAULT_WEEKS for undefined", () => {
+    expect(parseWeeks(undefined)).toBe(VELOCITY_DEFAULT_WEEKS);
+  });
+
+  it("returns VELOCITY_DEFAULT_WEEKS for empty string", () => {
+    expect(parseWeeks("")).toBe(VELOCITY_DEFAULT_WEEKS);
+  });
+
+  it("returns VELOCITY_DEFAULT_WEEKS for non-numeric string", () => {
+    expect(parseWeeks("abc")).toBe(VELOCITY_DEFAULT_WEEKS);
+  });
+
+  it("returns VELOCITY_DEFAULT_WEEKS for negative number", () => {
+    expect(parseWeeks("-1")).toBe(VELOCITY_DEFAULT_WEEKS);
+  });
+
+  it("clamps 0 to 1", () => {
+    expect(parseWeeks("0")).toBe(1);
+  });
+
+  it("parses valid integer", () => {
+    expect(parseWeeks("4")).toBe(4);
+  });
+
+  it("rounds float to nearest integer", () => {
+    expect(parseWeeks("4.6")).toBe(5);
+  });
+
+  it("clamps to VELOCITY_MAX_WEEKS", () => {
+    expect(parseWeeks("9999")).toBe(VELOCITY_MAX_WEEKS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVelocityPayload — helpers
+// ---------------------------------------------------------------------------
+
+/** Monday-anchored ISO timestamp for a given week offset and weekday offset. */
+function weekIso(weeksAgo: number, daysOffset: number, now: Date): string {
+  const ms = now.getTime() - weeksAgo * 7 * 86_400_000 + daysOffset * 86_400_000;
+  return new Date(ms).toISOString();
+}
+
+// Fixed anchor: Monday 2026-04-27 noon UTC
+const NOW = new Date("2026-04-27T12:00:00.000Z");
+
+// ---------------------------------------------------------------------------
+// buildVelocityPayload — empty state
+// ---------------------------------------------------------------------------
+
+describe("buildVelocityPayload — empty state", () => {
+  it("returns correct week count for weeks=4", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildVelocityPayload(adapter, 4, NOW);
+    expect(payload.weeklyTotals).toHaveLength(4);
+  });
+
+  it("returns zero counts for all weeks when adapter is empty", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildVelocityPayload(adapter, 2, NOW);
+    for (const week of payload.weeklyTotals) {
+      expect(week.created).toBe(0);
+      expect(week.completed).toBe(0);
+      expect(week.dropped).toBe(0);
+      expect(week.netDelta).toBe(0);
+    }
+  });
+
+  it("returns empty topClosingProjects when no completions", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildVelocityPayload(adapter, 4, NOW);
+    expect(payload.topClosingProjects).toHaveLength(0);
+  });
+
+  it("includes rollingAverages for 4 and 8 windows when weeks=8", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildVelocityPayload(adapter, 8, NOW);
+    expect(payload.rollingAverages.map((r) => r.window)).toEqual([4, 8]);
+  });
+
+  it("omits 8-week rolling average when weeks < 8", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildVelocityPayload(adapter, 4, NOW);
+    expect(payload.rollingAverages.map((r) => r.window)).toEqual([4]);
+  });
+
+  it("omits all rolling averages when weeks < 4", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildVelocityPayload(adapter, 3, NOW);
+    expect(payload.rollingAverages).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVelocityPayload — weekly bucketing
+// ---------------------------------------------------------------------------
+
+describe("buildVelocityPayload — weekly bucketing", () => {
+  it("counts completed tasks in the correct week bucket", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "P" });
+
+    // Create and complete a task "this week" (0 weeks ago, day 0)
+    const taskId = await adapter.createTask({ name: "done-this-week", projectId: projId });
+    await adapter.completeTask(taskId, new Date(weekIso(0, 1, NOW)));
+
+    const payload = await buildVelocityPayload(adapter, 2, NOW);
+    const thisWeek = payload.weeklyTotals[
+      payload.weeklyTotals.length - 1
+    ] as (typeof payload.weeklyTotals)[0];
+    expect(thisWeek.completed).toBeGreaterThanOrEqual(1);
+  });
+
+  it("netDelta accounts for created, completed, and dropped", async () => {
+    const adapter = new InMemoryAdapter();
+    // 3 created, 1 completed, 1 dropped → netDelta = 3 - 1 - 1 = 1
+    // But InMemoryAdapter records createdAt=now for all tasks, so all fall
+    // in the current week. We just verify the formula.
+    const t1 = await adapter.createTask({ name: "t1" });
+    const t2 = await adapter.createTask({ name: "t2" });
+    const _t3 = await adapter.createTask({ name: "t3" });
+    await adapter.completeTask(t1, new Date(weekIso(0, 0, NOW)));
+    await adapter.dropTask(t2);
+
+    const payload = await buildVelocityPayload(adapter, 1, NOW);
+    const week = payload.weeklyTotals[0] as (typeof payload.weeklyTotals)[0];
+    expect(week.netDelta).toBe(week.created - week.completed - week.dropped);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVelocityPayload — rolling averages
+// ---------------------------------------------------------------------------
+
+describe("buildVelocityPayload — rolling averages", () => {
+  it("computes completedPerWeek as average of last 4 weeks", async () => {
+    const adapter = new InMemoryAdapter();
+    // Complete 4 tasks, one per week for the last 4 weeks.
+    // Because InMemoryAdapter sets completedAt = the Date we pass,
+    // we just check the payload sums correctly (may vary by week placement).
+    const payload = await buildVelocityPayload(adapter, 4, NOW);
+    for (const avg of payload.rollingAverages) {
+      const slice = payload.weeklyTotals.slice(-avg.window);
+      const expected =
+        Math.round((slice.reduce((s, w) => s + w.completed, 0) / avg.window) * 100) / 100;
+      expect(avg.completedPerWeek).toBe(expected);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVelocityPayload — topClosingProjects
+// ---------------------------------------------------------------------------
+
+describe("buildVelocityPayload — topClosingProjects", () => {
+  it("lists projects with completions in the trailing window", async () => {
+    const adapter = new InMemoryAdapter();
+    const pId = await adapter.createProject({ name: "Sprint 1" });
+    const t1 = await adapter.createTask({ name: "t1", projectId: pId });
+    const t2 = await adapter.createTask({ name: "t2", projectId: pId });
+    await adapter.completeTask(t1, new Date(weekIso(0, 0, NOW)));
+    await adapter.completeTask(t2, new Date(weekIso(0, 1, NOW)));
+
+    const payload = await buildVelocityPayload(adapter, 4, NOW);
+    expect(payload.topClosingProjects).toHaveLength(1);
+    const top = payload.topClosingProjects[0] as (typeof payload.topClosingProjects)[0];
+    expect(top.name).toBe("Sprint 1");
+    expect(top.closedThisWeek).toBe(2);
+  });
+
+  it("caps topClosingProjects at 5", async () => {
+    const adapter = new InMemoryAdapter();
+    for (let i = 0; i < 7; i++) {
+      const pId = await adapter.createProject({ name: `P${i}` });
+      const tId = await adapter.createTask({ name: `t${i}`, projectId: pId });
+      await adapter.completeTask(tId, new Date(weekIso(0, 0, NOW)));
+    }
+    const payload = await buildVelocityPayload(adapter, 4, NOW);
+    expect(payload.topClosingProjects.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildVelocityPayload — window field
+// ---------------------------------------------------------------------------
+
+describe("buildVelocityPayload — window field", () => {
+  it("window.from is earlier than window.to", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildVelocityPayload(adapter, 4, NOW);
+    expect(payload.window.from < payload.window.to).toBe(true);
+  });
+});

--- a/src/resources/velocity.ts
+++ b/src/resources/velocity.ts
@@ -1,0 +1,284 @@
+/**
+ * `omnifocus://velocity` MCP resource.
+ *
+ * Rolling completion/creation/drop velocity over configurable trailing weeks.
+ * Answers "am I getting better or worse?" as a complement to the retrospective
+ * (per-week snapshot) and burndown (per-project trajectory).
+ *
+ * URI: `omnifocus://velocity{?weeks}`
+ *   - `weeks` (optional, default 8, max 52): number of trailing weeks to include
+ *
+ * Payload shape:
+ *   {
+ *     window:          { from: string; to: string }
+ *     weeklyTotals:    { weekStart: string; created: number; completed: number;
+ *                        dropped: number; netDelta: number }[]
+ *     rollingAverages: { window: 4 | 8;
+ *                        completedPerWeek: number; createdPerWeek: number }[]
+ *     topClosingProjects: { projectId: string; name: string;
+ *                           closedThisWeek: number; closedTrailing4: number }[]
+ *   }
+ *
+ * Notes:
+ * - `netDelta` = created − completed − dropped (positive = backlog growing)
+ * - `topClosingProjects` reports top-5 projects by `closedThisWeek` (then
+ *   by `closedTrailing4` as tiebreaker). "This week" = the most recent week
+ *   in the requested range.
+ * - Rolling averages are computed only for windows ≤ requested weeks; if
+ *   `weeks < 8` the 8-week average is omitted.
+ * - Cached by the adapter-level LRU; no per-resource TTL override here
+ *   (see docs/adr/0006-read-cache-strategy.md). Historical task data
+ *   changes only when mutations occur, so invalidation covers freshness.
+ *
+ * @see #480
+ * @see src/resources/retrospective.ts — per-range sibling
+ * @see src/resources/burndown.ts — per-project trajectory
+ * @see src/domain/calendarWeeks.ts — week-boundary helpers
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import { isoWeekEnd, isoWeekStart, trailingWeekStarts } from "../domain/calendarWeeks.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const VELOCITY_URI_TEMPLATE = "omnifocus://velocity{?weeks}";
+
+export const VELOCITY_DEFAULT_WEEKS = 8;
+export const VELOCITY_MAX_WEEKS = 52;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WeeklyTotal {
+  weekStart: string;
+  created: number;
+  completed: number;
+  dropped: number;
+  /** created − completed − dropped; positive = backlog growing */
+  netDelta: number;
+}
+
+export interface RollingAverage {
+  window: 4 | 8;
+  completedPerWeek: number;
+  createdPerWeek: number;
+}
+
+export interface TopClosingProject {
+  projectId: string;
+  name: string;
+  closedThisWeek: number;
+  closedTrailing4: number;
+}
+
+export interface VelocityPayload {
+  window: { from: string; to: string };
+  weeklyTotals: WeeklyTotal[];
+  rollingAverages: RollingAverage[];
+  topClosingProjects: TopClosingProject[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — pure, exported for testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `weeks` URI variable. Returns a clamped integer in [1, VELOCITY_MAX_WEEKS].
+ * Defaults to VELOCITY_DEFAULT_WEEKS when the value is absent, non-numeric, or ≤ 0.
+ */
+export function parseWeeks(raw: string | undefined): number {
+  if (raw === undefined || raw === null || raw === "") return VELOCITY_DEFAULT_WEEKS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return VELOCITY_DEFAULT_WEEKS;
+  return Math.min(VELOCITY_MAX_WEEKS, Math.max(1, Math.round(n)));
+}
+
+/**
+ * Compute velocity payload from adapter data.
+ *
+ * Exported separately so unit tests can inject a mock adapter without
+ * spinning up an MCP server.
+ */
+export async function buildVelocityPayload(
+  adapter: OmniFocusAdapter,
+  weeks: number,
+  now: Date = new Date(),
+): Promise<VelocityPayload> {
+  // ── Determine time window ──────────────────────────────────────────────
+  const weekStarts = trailingWeekStarts(weeks, now);
+  // trailingWeekStarts always returns exactly `weeks` elements for weeks >= 1.
+  const windowFrom = weekStarts[0] as Date; // oldest Monday
+  // windowTo = exclusive end of the most recent week
+  const lastWeekStart = weekStarts[weekStarts.length - 1] as Date;
+  const windowTo = isoWeekEnd(lastWeekStart);
+
+  const windowFromIso = windowFrom.toISOString();
+  const windowToIso = windowTo.toISOString();
+
+  // ── Fetch data ─────────────────────────────────────────────────────────
+  // Three parallel fetches:
+  //  - incomplete tasks (includes dropped) — for created + dropped counts
+  //  - completed tasks since windowFrom — for completed counts
+  //  - projects — for topClosingProjects
+  const [incompleteTasks, completedTasks, projects] = await Promise.all([
+    adapter.listTasks({ completed: false }),
+    adapter.listTasks({ completed: true, completedSince: windowFromIso }),
+    adapter.listProjects(),
+  ]);
+
+  // Build a project name lookup
+  const projectNames = new Map<string, string>();
+  for (const p of projects) {
+    projectNames.set(String(p.id), p.name);
+  }
+
+  // ── Per-week bucketing ─────────────────────────────────────────────────
+  // For each week, count tasks whose relevant timestamp falls in [weekStart, weekEnd).
+
+  const weeklyTotals: WeeklyTotal[] = weekStarts.map((weekStart) => {
+    const weekEnd = isoWeekEnd(weekStart);
+    const weekStartIso = weekStart.toISOString();
+    const weekEndIso = weekEnd.toISOString();
+
+    // created: tasks whose createdAt falls in this week
+    const created = incompleteTasks.filter(
+      (t) => t.createdAt >= weekStartIso && t.createdAt < weekEndIso,
+    ).length;
+
+    // completed: tasks whose completedAt falls in this week
+    // (completedTasks only contains tasks completed since windowFrom; we
+    //  filter to this specific week using completedAt)
+    const completed = completedTasks.filter(
+      (t) => t.completedAt !== null && t.completedAt >= weekStartIso && t.completedAt < weekEndIso,
+    ).length;
+
+    // Also count completed tasks that were created before windowFrom but
+    // completed in this week (completedTasks has all completedSince windowFrom)
+    // The above already handles this since completedTasks includes all tasks
+    // completed since windowFrom regardless of creation date.
+
+    // dropped: tasks whose droppedAt falls in this week
+    const dropped = incompleteTasks.filter(
+      (t) =>
+        t.dropped &&
+        t.droppedAt !== null &&
+        t.droppedAt >= weekStartIso &&
+        t.droppedAt < weekEndIso,
+    ).length;
+
+    return {
+      weekStart: weekStartIso,
+      created,
+      completed,
+      dropped,
+      netDelta: created - completed - dropped,
+    };
+  });
+
+  // ── Rolling averages ───────────────────────────────────────────────────
+  const rollingAverages: RollingAverage[] = [];
+
+  for (const windowSize of [4, 8] as const) {
+    if (weeks < windowSize) continue;
+    const slice = weeklyTotals.slice(-windowSize);
+    const totalCompleted = slice.reduce((s, w) => s + w.completed, 0);
+    const totalCreated = slice.reduce((s, w) => s + w.created, 0);
+    rollingAverages.push({
+      window: windowSize,
+      completedPerWeek: Math.round((totalCompleted / windowSize) * 100) / 100,
+      createdPerWeek: Math.round((totalCreated / windowSize) * 100) / 100,
+    });
+  }
+
+  // ── Top closing projects ───────────────────────────────────────────────
+  // "Closing" = tasks completed in project. "This week" = most recent week.
+  // "Trailing 4" = last 4 weeks (or all weeks if fewer).
+  const thisWeekStart = isoWeekStart(lastWeekStart).toISOString();
+  const thisWeekEnd = isoWeekEnd(lastWeekStart).toISOString();
+
+  const trailing4Start = (weekStarts[Math.max(0, weekStarts.length - 4)] as Date).toISOString();
+
+  // Count completions per project per window
+  const completedThisWeekByProject = new Map<string, number>();
+  const completedTrailing4ByProject = new Map<string, number>();
+
+  for (const t of completedTasks) {
+    if (t.completedAt === null || t.projectId === null) continue;
+    const pid = String(t.projectId);
+
+    if (t.completedAt >= thisWeekStart && t.completedAt < thisWeekEnd) {
+      completedThisWeekByProject.set(pid, (completedThisWeekByProject.get(pid) ?? 0) + 1);
+    }
+    if (t.completedAt >= trailing4Start && t.completedAt < windowToIso) {
+      completedTrailing4ByProject.set(pid, (completedTrailing4ByProject.get(pid) ?? 0) + 1);
+    }
+  }
+
+  // Combine and sort: primary by closedThisWeek desc, secondary by closedTrailing4 desc
+  const allProjectIds = new Set([
+    ...completedThisWeekByProject.keys(),
+    ...completedTrailing4ByProject.keys(),
+  ]);
+
+  const topClosingProjects: TopClosingProject[] = Array.from(allProjectIds)
+    .map((pid) => ({
+      projectId: pid,
+      name: projectNames.get(pid) ?? pid,
+      closedThisWeek: completedThisWeekByProject.get(pid) ?? 0,
+      closedTrailing4: completedTrailing4ByProject.get(pid) ?? 0,
+    }))
+    .sort((a, b) =>
+      b.closedThisWeek !== a.closedThisWeek
+        ? b.closedThisWeek - a.closedThisWeek
+        : b.closedTrailing4 - a.closedTrailing4,
+    )
+    .slice(0, 5);
+
+  return {
+    window: { from: windowFromIso, to: windowToIso },
+    weeklyTotals,
+    rollingAverages,
+    topClosingProjects,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerVelocityResource(server: McpServer, adapter: OmniFocusAdapter): void {
+  server.registerResource(
+    "omnifocus-velocity",
+    new ResourceTemplate(VELOCITY_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Rolling task velocity over trailing weeks — created, completed, dropped, and net-delta per week, " +
+        "plus rolling 4-week and 8-week completion/creation averages and the top-5 highest-closing projects. " +
+        "Default window: 8 weeks; max: 52 weeks. " +
+        "Use to answer 'am I getting better or worse?' alongside omnifocus://retrospective (per-range) and omnifocus://burndown/{projectId} (per-project). " +
+        "Read-only.",
+      mimeType: "application/json",
+    },
+    async (_uri, variables) => {
+      const vars = variables as Record<string, string | undefined>;
+      const weeks = parseWeeks(vars.weeks);
+      const payload = await buildVelocityPayload(adapter, weeks);
+
+      const uri = `omnifocus://velocity?weeks=${weeks}`;
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `omnifocus://velocity{?weeks}` — rolling task velocity over trailing ISO weeks (default 8, max 52). Returns created/completed/dropped/netDelta per week, 4-week and 8-week rolling completion/creation averages, and top-5 highest-closing projects.
- Adds `omnifocus://burndown/{projectId}` — per-project burndown against a naive linear ideal line. Returns totalTasks, completedTasks, remainingTasks, idealLinePercent, actualPercent, deltaDays (positive = ahead, negative = behind), and a human-readable status note. Typed errors for `ProjectNotFound` and `NoDueDate`.
- Adds `src/domain/calendarWeeks.ts` — shared Monday-start ISO week helpers (`isoWeekStart`, `isoWeekEnd`, `weekBounds`, `trailingWeekStarts`), extracted per the issue's technical notes.
- Cleans up 3 stale `biome-ignore` suppression comments in `recentActivity.ts`.

## Test plan

- [ ] `src/domain/calendarWeeks.test.ts` — 10 tests covering week-boundary math
- [ ] `src/resources/velocity.test.ts` — 20 tests: parseWeeks clamping, empty state, weekly bucketing, rolling averages, topClosingProjects ordering, window field
- [ ] `src/resources/burndown.test.ts` — 11 tests: ProjectNotFound, NoDueDate, zero-task project, task counts, progress math (ahead/behind/at-start), output shape
- [ ] `src/resources/omnifocus.test.ts` — resource count updated 15→17

Closes #480