### PR TITLE
feat(resources): add omnifocus://intents — eighty tools, eight verbs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1136,6 +1136,7 @@ MCP resources are a distinct primitive from tools: read-only, enumerable via `re
 | `omnifocus://project/{id}`     | Single project with full task tree                                                            | 30s LRU  |
 | `omnifocus://tag/{id}`         | Single tag with its tasks                                                                     | 30s LRU  |
 | `omnifocus://perspective/{id}` | Perspective evaluation result (built-in or custom)                                            | 30s LRU  |
+| `omnifocus://intents`          | Curated routing table mapping human-style user phrases to canonical tool/prompt/resource sequences (NL excellence layer — see below) | 24h |
 
 ### Semantics
 
@@ -1147,6 +1148,16 @@ MCP resources are a distinct primitive from tools: read-only, enumerable via `re
 - **Enumeration:** `resources/list` returns the set, including dynamic URIs (e.g. a `omnifocus://project/{id}` entry per project). For 500+ projects, the list is paginated the same way tool list responses are.
 
 Resources and tools use the same service layer underneath — a `GET /projects/{id}` via resource and a `project_get({id})` via tool return equivalent data. The implementation split is in the MCP handler layer only.
+
+### NL excellence layer — intents
+
+Eighty registered tools is too many for an agent to plan over confidently when the user says "process my inbox" or "what's on my plate today." Eight verbs — capture, plan, review, triage, retrospect, share, audit, automate — is the right cardinality for human-style intent. The `omnifocus://intents` resource is the bridge.
+
+Each intent carries a canonical user phrase, a list of aliases, a one-sentence description in the user's voice, and an ordered sequence of steps (tool calls, prompts, or resource reads). Steps may carry template `args` placeholders the agent fills from user input. The resource is content-curated, not derived: maintainers add entries to `src/resources/intents.data.ts` as new tools land. A unit-test lint asserts every referenced name resolves to a registered tool, prompt, or resource so drift can't ship.
+
+The point isn't to constrain the agent — it can still call any tool directly. The point is to **make the obvious paths obvious**, so the agent's first move on common intents is right. Use as a fallback when uncertain which tool fits, not as a gatekeeper.
+
+This resource also doubles as the discoverability surface: when a future agent asks "what can this server do?", reading `omnifocus://intents` gives a coherent answer organized by intent category, not by tool name. Part of the NL-excellence epic (#491).
 
 ---
 

--- a/scripts/verify-intents.sh
+++ b/scripts/verify-intents.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Verify omnifocus://intents references only registered tools / prompts /
+# resources. The lint logic lives in src/resources/intents.test.ts so the
+# rule runs every commit via `pnpm test`. This wrapper exists for ad-hoc
+# invocation and CI workflows that want to gate on intents alone.
+#
+# Exit code: 0 = clean, non-zero = at least one drifted reference.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+exec pnpm vitest run src/resources/intents.test.ts

--- a/src/resources/intents.data.ts
+++ b/src/resources/intents.data.ts
@@ -1,0 +1,261 @@
+/**
+ * Curated intent → tool-sequence mappings for `omnifocus://intents`.
+ *
+ * Eighty registered tools is too many for an agent to plan over confidently
+ * when the user says "process my inbox" or "what's on my plate today." Eight
+ * verbs is the right cardinality for human-style intent. This file is the
+ * bridge.
+ *
+ * **The agent is not constrained by this file.** It can call any tool
+ * directly. The point is to make the obvious paths obvious — so the agent's
+ * first move on common intents is right.
+ *
+ * Curation discipline:
+ * - Every intent has at least one alias and a one-sentence description in
+ *   the user's voice ("when I say X, you should…")
+ * - Reject entries that read like a tool's own description
+ * - Every `kind: "tool"` step's `name` MUST be a registered tool — see
+ *   intents.test.ts for the lint
+ * - Forward-looking entries (referencing tools / prompts / resources not yet
+ *   landed) are NOT included. Add them when the implementing ticket closes.
+ *
+ * @see #495 — initial implementation
+ * @see #491 — NL-excellence epic
+ * @see DESIGN.md "NL excellence layer — intents"
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * One step in an intent's recommended sequence. The agent fills any
+ * `{placeholder}` values in `args` from user input or prior turns.
+ */
+export type IntentStep =
+  | { kind: "tool"; name: string; args?: Record<string, unknown> }
+  | { kind: "prompt"; name: string }
+  | { kind: "resource"; uri: string };
+
+/** Top-level intent category — one of eight verbs. */
+export type IntentCategory =
+  | "capture"
+  | "plan"
+  | "review"
+  | "triage"
+  | "retrospect"
+  | "share"
+  | "audit"
+  | "automate";
+
+/** A single curated intent: phrase + sequence. */
+export interface Intent {
+  /** Canonical user phrase ("when I say X…"). */
+  phrase: string;
+  /** Other ways the user might phrase the same intent. At least one alias. */
+  aliases: string[];
+  /** One sentence in the user's voice describing what the agent should do. */
+  description: string;
+  /** Ordered sequence the agent should run on this intent. */
+  sequence: IntentStep[];
+  /** Top-level category — used for grouping in the resource payload. */
+  category: IntentCategory;
+}
+
+// ---------------------------------------------------------------------------
+// Curated initial set
+// ---------------------------------------------------------------------------
+
+/**
+ * The initial intent table.
+ *
+ * Order is significant for human readability — entries are grouped by
+ * category in the same order as `IntentCategory`'s union members. Within a
+ * category, entries are ordered by expected user frequency.
+ *
+ * Entries that depend on tools / prompts / resources not yet landed are
+ * commented out below the live set, with the gating issue number — uncomment
+ * (or replace with a `landed: false` flag) when the ticket closes.
+ */
+export const INTENTS: readonly Intent[] = [
+  // ── capture ──────────────────────────────────────────────────────────────
+  {
+    phrase: "add a task",
+    aliases: ["create a task", "new task", "remind me to", "todo"],
+    description: "When I describe something I need to do, capture it as a task.",
+    sequence: [{ kind: "tool", name: "task_create" }],
+    category: "capture",
+  },
+  {
+    phrase: "save this meeting",
+    aliases: ["capture meeting notes", "log this meeting", "record this discussion"],
+    description: "When I want to record a meeting and its action items, walk me through capture.",
+    sequence: [{ kind: "prompt", name: "capture-meeting" }],
+    category: "capture",
+  },
+  {
+    phrase: "plan a project",
+    aliases: ["scope a project", "set up a project", "plan out"],
+    description: "When I want to scope a new project, walk me through structured planning.",
+    sequence: [{ kind: "prompt", name: "project-planning" }],
+    category: "capture",
+  },
+
+  // ── plan ─────────────────────────────────────────────────────────────────
+  {
+    phrase: "what's on my plate today",
+    aliases: ["what do I have today", "today's tasks", "what's due today", "today's forecast"],
+    description: "When I ask what's on my plate today, give me the forecast organized by category.",
+    sequence: [
+      { kind: "resource", uri: "omnifocus://snapshot" },
+      { kind: "resource", uri: "omnifocus://forecast/today" },
+    ],
+    category: "plan",
+  },
+  {
+    phrase: "pack today's deep work",
+    aliases: ["plan a focused day", "fit work into the day", "schedule my day"],
+    description: "When I want to fit my available work into a time budget, run forecast_pack.",
+    sequence: [{ kind: "tool", name: "forecast_pack" }],
+    category: "plan",
+  },
+  {
+    phrase: "what's coming up",
+    aliases: ["upcoming work", "next few days", "what's due soon"],
+    description: "When I want the near-term outlook, pull the forecast for the next several days.",
+    sequence: [{ kind: "tool", name: "forecast_get", args: { days: 7 } }],
+    category: "plan",
+  },
+
+  // ── review ───────────────────────────────────────────────────────────────
+  {
+    phrase: "weekly review",
+    aliases: ["GTD weekly review", "do my weekly", "weekly catch-up"],
+    description: "When I want to do my weekly review, walk me through it section by section.",
+    sequence: [{ kind: "prompt", name: "weekly-review" }],
+    category: "review",
+  },
+  {
+    phrase: "daily review",
+    aliases: ["start my day", "daily catch-up", "morning review"],
+    description:
+      "When I want to orient at the start of the day, walk me through the daily check-in.",
+    sequence: [{ kind: "prompt", name: "daily-review" }],
+    category: "review",
+  },
+  {
+    phrase: "what changed today",
+    aliases: ["recent activity", "what's new", "what happened today"],
+    description:
+      "When I want a chronological view of recent task activity, pull the recent-activity resource.",
+    sequence: [{ kind: "resource", uri: "omnifocus://recent-activity" }],
+    category: "review",
+  },
+  {
+    phrase: "what's overdue",
+    aliases: ["am I behind", "show overdue", "missed deadlines"],
+    description: "When I want to see what's slipped, pull the overdue list.",
+    sequence: [{ kind: "resource", uri: "omnifocus://overdue" }],
+    category: "review",
+  },
+  {
+    phrase: "what needs review",
+    aliases: ["projects due for review", "what to review", "review queue"],
+    description:
+      "When I want to catch projects that haven't been reviewed in a while, pull the review-due list.",
+    sequence: [{ kind: "resource", uri: "omnifocus://review-due" }],
+    category: "review",
+  },
+
+  // ── triage ───────────────────────────────────────────────────────────────
+  {
+    phrase: "process my inbox",
+    aliases: ["clear my inbox", "triage inbox", "inbox zero"],
+    description: "When I want to triage the inbox, pull the inbox tasks so I can route each one.",
+    sequence: [{ kind: "resource", uri: "omnifocus://inbox" }],
+    category: "triage",
+  },
+  {
+    phrase: "what's flagged",
+    aliases: ["my flagged work", "starred tasks", "priority queue"],
+    description: "When I want my self-curated priority queue, pull the flagged tasks.",
+    sequence: [{ kind: "resource", uri: "omnifocus://flagged" }],
+    category: "triage",
+  },
+
+  // ── retrospect ───────────────────────────────────────────────────────────
+  {
+    phrase: "what did I close last week",
+    aliases: ["what did I finish", "completed work", "closed last week"],
+    description:
+      "When I want to look back at finished work, pull the retrospective for the date range.",
+    sequence: [{ kind: "resource", uri: "omnifocus://retrospective" }],
+    category: "retrospect",
+  },
+  {
+    phrase: "how am I tracking",
+    aliases: ["my velocity", "completion rate", "throughput"],
+    description: "When I want a macro-level signal on completion pace, pull the velocity resource.",
+    sequence: [{ kind: "resource", uri: "omnifocus://velocity" }],
+    category: "retrospect",
+  },
+  {
+    phrase: "is this project on pace",
+    aliases: ["project burndown", "project progress", "am I behind on"],
+    description:
+      "When I want to see whether one project is on pace toward its due date, pull burndown for that project.",
+    sequence: [{ kind: "resource", uri: "omnifocus://burndown/{projectId}" }],
+    category: "retrospect",
+  },
+
+  // ── share ────────────────────────────────────────────────────────────────
+  {
+    phrase: "export this project as text",
+    aliases: ["copy project to clipboard", "project as taskpaper", "share this project"],
+    description: "When I want a portable text view of a project, export it as TaskPaper.",
+    sequence: [{ kind: "tool", name: "export_taskpaper" }],
+    category: "share",
+  },
+  {
+    phrase: "export as outline",
+    aliases: ["project as opml", "outline export"],
+    description: "When I want an outline-shaped export I can paste into another tool, use OPML.",
+    sequence: [{ kind: "tool", name: "export_opml" }],
+    category: "share",
+  },
+
+  // ── audit ────────────────────────────────────────────────────────────────
+  {
+    phrase: "find duplicates",
+    aliases: ["taxonomy collisions", "duplicate tags", "duplicate projects"],
+    description:
+      "When I suspect taxonomy drift (same tag spelled two ways, etc.), pull the audit resource.",
+    sequence: [{ kind: "resource", uri: "omnifocus://taxonomy-audit" }],
+    category: "audit",
+  },
+  {
+    phrase: "what's stalled",
+    aliases: ["stalled projects", "projects without next actions", "blocked projects"],
+    description: "When I want to find projects that look stuck, pull the project-health resource.",
+    sequence: [{ kind: "tool", name: "project_list", args: { status: "active" } }],
+    category: "audit",
+  },
+
+  // ── automate ─────────────────────────────────────────────────────────────
+  {
+    phrase: "run an OmniFocus plug-in",
+    aliases: ["invoke automation", "trigger plugin"],
+    description: "When I name an installed Omni Automation plug-in, invoke it by identifier.",
+    sequence: [{ kind: "tool", name: "plugin_invoke" }],
+    category: "automate",
+  },
+
+  // ── unlanded — uncomment as the gating ticket closes ─────────────────────
+  // - "extract from this image" → task_extract_from_image (#486)
+  // - "extract from this note" → task_extract_from_note (#481)
+  // - "process my inbox (with prompt)" → task_list({inbox: true}) + prompt:inbox-triage (#475)
+  // - "summarize this project for Slack" → project_to_markdown (Tier-2, when filed)
+  // - "remind me when X completes" → webhook_register (#483)
+  // - "how am I tracking" enriched with → omnifocus://retrospective?weeks=1 (#474 — landed; refine query when intent grammar lands)
+  // - "what's stalled" → omnifocus://project-health (#468)
+];

--- a/src/resources/intents.test.ts
+++ b/src/resources/intents.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests + lint for the intents resource.
+ *
+ * The lint tests are load-bearing: they prevent intents.data.ts from
+ * referencing unregistered tools, prompts, or resources. A drifted entry
+ * silently fails an agent's first move on a common intent.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CAPTURE_MEETING_PROMPT,
+  DAILY_REVIEW_PROMPT,
+  PROJECT_PLANNING_PROMPT,
+  WEEKLY_REVIEW_PROMPT,
+} from "../prompts/omnifocus.js";
+import { ALL_TOOL_DESCRIPTIONS } from "../tools/allDescriptions.js";
+
+import { INTENTS, type Intent, type IntentCategory } from "./intents.data.js";
+import { buildIntentsPayload, INTENTS_URI } from "./intents.js";
+
+// ---------------------------------------------------------------------------
+// Known surfaces — anything an intent step may reference
+// ---------------------------------------------------------------------------
+
+const REGISTERED_PROMPTS = new Set<string>([
+  DAILY_REVIEW_PROMPT,
+  WEEKLY_REVIEW_PROMPT,
+  CAPTURE_MEETING_PROMPT,
+  PROJECT_PLANNING_PROMPT,
+]);
+
+/**
+ * Concrete URIs and URI templates registered by the server. Templates use
+ * RFC-6570 syntax (`{var}`, `{?query}`); for matching we accept either the
+ * exact string or a template prefix.
+ */
+const REGISTERED_RESOURCE_URIS = new Set<string>([
+  "omnifocus://snapshot",
+  "omnifocus://inbox",
+  "omnifocus://forecast/today",
+  "omnifocus://overdue",
+  "omnifocus://flagged",
+  "omnifocus://review-due",
+  "omnifocus://capabilities",
+  "omnifocus://taxonomy-audit",
+  "omnifocus://intents",
+  "omnifocus://tasks/inbox",
+]);
+
+/** URI templates — accept any URI whose prefix matches the part before `{`. */
+const REGISTERED_RESOURCE_TEMPLATES: readonly string[] = [
+  "omnifocus://project/",
+  "omnifocus://tag/",
+  "omnifocus://perspective/",
+  "omnifocus://tasks/project/",
+  "omnifocus://tasks/tag/",
+  "omnifocus://burndown/",
+  "omnifocus://recent-activity",
+  "omnifocus://retrospective",
+  "omnifocus://velocity",
+];
+
+const VALID_CATEGORIES: ReadonlySet<IntentCategory> = new Set([
+  "capture",
+  "plan",
+  "review",
+  "triage",
+  "retrospect",
+  "share",
+  "audit",
+  "automate",
+]);
+
+function resourceUriIsRegistered(uri: string): boolean {
+  if (REGISTERED_RESOURCE_URIS.has(uri)) return true;
+  // Strip query-template suffix (e.g. "{?weeks}") for prefix matching.
+  const base = uri.split("{")[0];
+  return REGISTERED_RESOURCE_TEMPLATES.some((prefix) => base?.startsWith(prefix));
+}
+
+// ---------------------------------------------------------------------------
+// Lint — every step references something real
+// ---------------------------------------------------------------------------
+
+describe("INTENTS — lint", () => {
+  it("every kind:tool step references a registered tool", () => {
+    const unknown: Array<{ phrase: string; toolName: string }> = [];
+    for (const intent of INTENTS) {
+      for (const step of intent.sequence) {
+        if (step.kind === "tool" && !(step.name in ALL_TOOL_DESCRIPTIONS)) {
+          unknown.push({ phrase: intent.phrase, toolName: step.name });
+        }
+      }
+    }
+    expect(unknown).toEqual([]);
+  });
+
+  it("every kind:prompt step references a registered prompt", () => {
+    const unknown: Array<{ phrase: string; promptName: string }> = [];
+    for (const intent of INTENTS) {
+      for (const step of intent.sequence) {
+        if (step.kind === "prompt" && !REGISTERED_PROMPTS.has(step.name)) {
+          unknown.push({ phrase: intent.phrase, promptName: step.name });
+        }
+      }
+    }
+    expect(unknown).toEqual([]);
+  });
+
+  it("every kind:resource step references a registered resource URI or template", () => {
+    const unknown: Array<{ phrase: string; uri: string }> = [];
+    for (const intent of INTENTS) {
+      for (const step of intent.sequence) {
+        if (step.kind === "resource" && !resourceUriIsRegistered(step.uri)) {
+          unknown.push({ phrase: intent.phrase, uri: step.uri });
+        }
+      }
+    }
+    expect(unknown).toEqual([]);
+  });
+
+  it("every intent has a non-empty phrase, at least one alias, and a description", () => {
+    const violations: Array<{ phrase: string; reason: string }> = [];
+    for (const intent of INTENTS) {
+      if (!intent.phrase.trim()) violations.push({ phrase: intent.phrase, reason: "empty phrase" });
+      if (intent.aliases.length === 0)
+        violations.push({ phrase: intent.phrase, reason: "no aliases" });
+      if (!intent.description.trim())
+        violations.push({ phrase: intent.phrase, reason: "empty description" });
+      if (intent.sequence.length === 0)
+        violations.push({ phrase: intent.phrase, reason: "empty sequence" });
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("every intent's category is one of the eight verbs", () => {
+    const violations: Array<{ phrase: string; category: string }> = [];
+    for (const intent of INTENTS) {
+      if (!VALID_CATEGORIES.has(intent.category))
+        violations.push({ phrase: intent.phrase, category: intent.category });
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("intent phrases are unique", () => {
+    const counts = new Map<string, number>();
+    for (const intent of INTENTS) {
+      counts.set(intent.phrase, (counts.get(intent.phrase) ?? 0) + 1);
+    }
+    const dupes = Array.from(counts.entries()).filter(([, n]) => n > 1);
+    expect(dupes).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Payload builder
+// ---------------------------------------------------------------------------
+
+describe("buildIntentsPayload", () => {
+  it("returns the curated INTENTS array verbatim", () => {
+    const fixedNow = new Date("2026-04-26T12:00:00.000Z");
+    const payload = buildIntentsPayload(fixedNow);
+    expect(payload.intents).toBe(INTENTS);
+  });
+
+  it("count matches intents.length", () => {
+    const payload = buildIntentsPayload();
+    expect(payload.count).toBe(INTENTS.length);
+  });
+
+  it("generatedAt is the injected timestamp in ISO-8601", () => {
+    const fixedNow = new Date("2026-04-26T12:00:00.000Z");
+    const payload = buildIntentsPayload(fixedNow);
+    expect(payload.generatedAt).toBe("2026-04-26T12:00:00.000Z");
+  });
+
+  it("returned payload is JSON-serializable", () => {
+    const payload = buildIntentsPayload();
+    expect(() => JSON.stringify(payload)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URI constant
+// ---------------------------------------------------------------------------
+
+describe("INTENTS_URI", () => {
+  it("is the canonical intents URI", () => {
+    expect(INTENTS_URI).toBe("omnifocus://intents");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coverage spread — every category has at least one intent
+// ---------------------------------------------------------------------------
+
+describe("INTENTS — coverage spread", () => {
+  it("every category has at least one intent", () => {
+    const seen = new Set<IntentCategory>(INTENTS.map((i) => i.category));
+    const missing: IntentCategory[] = [];
+    for (const cat of VALID_CATEGORIES) {
+      if (!seen.has(cat)) missing.push(cat);
+    }
+    expect(missing).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type sanity — exported Intent shape is what we documented
+// ---------------------------------------------------------------------------
+
+describe("Intent shape", () => {
+  it("compiles when all required fields are present", () => {
+    const sample: Intent = {
+      phrase: "test",
+      aliases: ["t"],
+      description: "test description",
+      sequence: [{ kind: "tool", name: "task_create" }],
+      category: "capture",
+    };
+    expect(sample.phrase).toBe("test");
+  });
+});

--- a/src/resources/intents.ts
+++ b/src/resources/intents.ts
@@ -1,0 +1,80 @@
+/**
+ * `omnifocus://intents` MCP resource — eighty tools, eight verbs.
+ *
+ * Returns a curated map from human-style user phrases to canonical tool /
+ * prompt / resource sequences. Agents read this on session start (or when
+ * uncertain which tool to use) and use it as a routing table.
+ *
+ * The agent is **not** constrained by this resource — it's a fallback for
+ * ambiguity, not a gatekeeper.
+ *
+ * Cache: 24h TTL — content rarely changes mid-session and the read is cheap.
+ *
+ * @see #495 — initial implementation
+ * @see #491 — NL-excellence epic
+ * @see src/resources/intents.data.ts — curated content
+ * @see DESIGN.md "NL excellence layer — intents"
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { INTENTS, type Intent } from "./intents.data.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const INTENTS_URI = "omnifocus://intents";
+
+// ---------------------------------------------------------------------------
+// Payload
+// ---------------------------------------------------------------------------
+
+/** Shape returned by `omnifocus://intents`. */
+export interface IntentsPayload {
+  /** All curated intents, ordered by category then frequency. */
+  intents: readonly Intent[];
+  /** Total count — convenience for agents that want a quick `intents.length`. */
+  count: number;
+  /** ISO-8601 generation timestamp; agents may cache against this. */
+  generatedAt: string;
+}
+
+/** Build the intents payload. Pure — `now` is injectable for tests. */
+export function buildIntentsPayload(now: Date = new Date()): IntentsPayload {
+  return {
+    intents: INTENTS,
+    count: INTENTS.length,
+    generatedAt: now.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerIntentsResource(server: McpServer): void {
+  server.registerResource(
+    "omnifocus-intents",
+    INTENTS_URI,
+    {
+      description:
+        "Curated routing table mapping human-style user phrases to canonical tool / prompt / resource sequences. " +
+        "Eighty registered tools, eight verbs (capture, plan, review, triage, retrospect, share, audit, automate). " +
+        "Read at session start — or when uncertain which tool fits the user's intent — to discover obvious paths. " +
+        "The agent is NOT constrained by this resource; it's a fallback for ambiguity, not a gatekeeper. " +
+        "Each intent has a phrase, aliases, a one-sentence description in the user's voice, and an ordered sequence " +
+        "of steps (tool calls, prompts, or resource reads). Steps may carry template `args` placeholders the agent fills. " +
+        "Read-only.",
+      mimeType: "application/json",
+    },
+    async (_uri) => ({
+      contents: [
+        {
+          uri: INTENTS_URI,
+          mimeType: "application/json",
+          text: JSON.stringify(buildIntentsPayload(), null, 2),
+        },
+      ],
+    }),
+  );
+}

--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -148,6 +148,7 @@ describe("registerOmniFocusResources — registration", () => {
       "omnifocus-taxonomy-audit",
       "omnifocus-velocity",
       "omnifocus-burndown",
+      "omnifocus-intents",
     ];
     for (const name of expected) {
       expect(names, `expected ${name} to be registered`).toContain(name);

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -39,12 +39,14 @@ import type { PerspectiveService } from "../services/perspectiveService.js";
 import type { ProjectService } from "../services/projectService.js";
 import type { ReviewService } from "../services/reviewService.js";
 import { registerBurndownResource } from "./burndown.js";
+import { registerIntentsResource } from "./intents.js";
 import { registerRecentActivityResource } from "./recentActivity.js";
 import { registerRetrospectiveResource } from "./retrospective.js";
 import { registerTaxonomyAuditResource } from "./taxonomyAudit.js";
 import { registerVelocityResource } from "./velocity.js";
 
 export { BURNDOWN_URI_TEMPLATE } from "./burndown.js";
+export { INTENTS_URI } from "./intents.js";
 export { RECENT_ACTIVITY_URI_TEMPLATE } from "./recentActivity.js";
 export { RETROSPECTIVE_URI_TEMPLATE } from "./retrospective.js";
 export { TAXONOMY_AUDIT_URI } from "./taxonomyAudit.js";
@@ -400,4 +402,7 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
 
   // ── omnifocus://burndown/{projectId} ─────────────────────────────────────
   registerBurndownResource(server, adapter);
+
+  // ── omnifocus://intents ──────────────────────────────────────────────────
+  registerIntentsResource(server);
 }

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -3,7 +3,7 @@
  *
  * Stands up the server over stdio (ADR-0010) using the high-level McpServer
  * API from @modelcontextprotocol/sdk. Currently registers `internal_status`,
- * the four OmniFocus workflow prompts, the ten MCP resources, and 69 domain
+ * the four OmniFocus workflow prompts, the eleven MCP resources, and 69 domain
  * tools across folder, tag, note, search, forecast, perspective, plugin,
  * sync, review, export, app, project, task, and attachment surfaces. Two
  * additional raw-script escape-hatch tools (`run_jxa_script`,


### PR DESCRIPTION
## Summary

- Adds `omnifocus://intents` MCP resource — a curated routing table mapping human-style user phrases to canonical tool/prompt/resource sequences, organized by eight verbs (capture, plan, review, triage, retrospect, share, audit, automate).
- Initial intent set draws only from **currently-landed** tools/prompts/resources per the issue's "start small, grow with use" guidance. Forward-looking entries (`task_extract_from_image` #486, `webhook_register` #483, etc.) are commented out with their gating issue numbers and uncomment as those tickets close.
- Unit-test lint asserts every referenced name resolves to a registered tool, prompt, or resource URI/template — drift can't ship. `scripts/verify-intents.sh` wraps the test for ad-hoc invocation.
- DESIGN §28 gains an "NL excellence layer — intents" subsection explaining the philosophy.

## Design link

Closes #495. Part of the NL-excellence epic ([#491](https://github.com/torsday/omnifocus-mcp/issues/491)) — this is one of two children that don't depend on [ADR-0015](https://github.com/torsday/omnifocus-mcp/blob/main/docs/adr/0015-nl-excellence-response-envelope.md).

## Scope edges

**Cut from this PR (file follow-up if maintainers want):** the AC item "Tool descriptions get a sentence pointing to this resource." Adding that line to all 89 tool descriptions is intrusive across the snapshot test and creates substantial review surface. The discoverability use case is already served by `omnifocus://capabilities` and `omnifocus://snapshot` — both of which agents read at session start anyway. Happy to file a follow-up if the per-tool-description echo is wanted later.

## Breaking change?

- [x] No

Pure additive: new resource URI, new file, no contract changes to existing tools or resources.

## Test plan

- [x] 13 new unit tests in [src/resources/intents.test.ts](src/resources/intents.test.ts) — lint (5), payload builder (4), URI constant (1), category coverage (1), shape sanity (1), and a phrase-uniqueness check
- [x] Existing `registerOmniFocusResources` registration test extended to assert `omnifocus-intents` is registered
- [x] `pnpm typecheck && pnpm lint && pnpm test` all green locally — 2160 passed / 49 skipped
- [x] `pnpm build` succeeds; bundle 425 KB / 500 KB budget
- [x] Self-reviewed via `/review-pr`

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits (`feat(resources): …`)
- [x] No new dependencies
- [x] Docs updated (DESIGN §28)