### PR TITLE
fix(omnijs): bundle script loading via static imports — fixes ENOENT in dist

### DIFF
--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -27,7 +27,6 @@
  * @see src/adapter/omnijs/scriptRunner.ts
  */
 
-import { join } from "node:path";
 import type { Folder } from "../../domain/folder.js";
 import type { FolderId, ProjectId, TagId, TaskId } from "../../domain/ids.js";
 import { TagId as TagIdCtor, TaskId as TaskIdCtor } from "../../domain/ids.js";
@@ -42,6 +41,13 @@ import {
   type TaskBatchMoveScriptResult,
   type TaskMoveScriptResult,
 } from "../../scripts/contracts.js";
+import forecastGetTagScript from "../../scripts/omnijs/forecast_get_tag.js";
+import forecastSetTagScript from "../../scripts/omnijs/forecast_set_tag.js";
+import perspectiveEvaluateScript from "../../scripts/omnijs/perspective_evaluate.js";
+import pluginInvokeScript from "../../scripts/omnijs/plugin_invoke.js";
+import taskBatchMoveScript from "../../scripts/omnijs/task_batch_move.js";
+import taskMoveScript from "../../scripts/omnijs/task_move.js";
+import taskReorderScript from "../../scripts/omnijs/task_reorder.js";
 import type {
   CreateFolderInput,
   CreateProjectInput,
@@ -140,9 +146,7 @@ export class OmniJsTransport implements OmniFocusAdapter {
     // JXA's task.move() fails with error 9 ("Replacement not supported") in
     // OmniFocus 4.x. Database.moveTasks() in OmniJS performs genuine reparenting
     // while preserving the task's persistent ID — hence this routes to OmniJS.
-    const script = await import("node:fs/promises").then((fs) =>
-      fs.readFile(join(import.meta.dirname, "../../scripts/omnijs/task_move.js"), "utf8"),
-    );
+    const script = taskMoveScript;
     const result = await runOmniJsScript<TaskMoveScriptResult>(
       script,
       {
@@ -166,9 +170,7 @@ export class OmniJsTransport implements OmniFocusAdapter {
   async batchMoveTasks(
     items: Array<{ id: TaskId; destination: { projectId?: ProjectId; parentId?: TaskId } }>,
   ): Promise<import("../../domain/batch.js").BatchOutcome<TaskId>> {
-    const script = await import("node:fs/promises").then((fs) =>
-      fs.readFile(join(import.meta.dirname, "../../scripts/omnijs/task_batch_move.js"), "utf8"),
-    );
+    const script = taskBatchMoveScript;
     const raw = await runOmniJsScript<TaskBatchMoveScriptResult>(
       script,
       {
@@ -188,9 +190,7 @@ export class OmniJsTransport implements OmniFocusAdapter {
     return mapBatchScriptResult(raw, TaskIdCtor.of);
   }
   async reorderTask(id: TaskId, position: TaskPosition): Promise<void> {
-    const script = await import("node:fs/promises").then((fs) =>
-      fs.readFile(join(import.meta.dirname, "../../scripts/omnijs/task_reorder.js"), "utf8"),
-    );
+    const script = taskReorderScript;
 
     let payload: {
       id: TaskId;
@@ -393,9 +393,7 @@ export class OmniJsTransport implements OmniFocusAdapter {
   }
 
   async getForecastTag(): Promise<{ tagId: TagId | null }> {
-    const script = await import("node:fs/promises").then((fs) =>
-      fs.readFile(join(import.meta.dirname, "../../scripts/omnijs/forecast_get_tag.js"), "utf8"),
-    );
+    const script = forecastGetTagScript;
     const result = await runOmniJsScript<
       { tagId: string | null } | { error: { code: string; message: string } }
     >(script, {}, { ...this.runOpts, scriptName: "forecast_get_tag" });
@@ -410,9 +408,7 @@ export class OmniJsTransport implements OmniFocusAdapter {
   }
 
   async setForecastTag(tagId: TagId | null): Promise<{ tagId: TagId | null }> {
-    const script = await import("node:fs/promises").then((fs) =>
-      fs.readFile(join(import.meta.dirname, "../../scripts/omnijs/forecast_set_tag.js"), "utf8"),
-    );
+    const script = forecastSetTagScript;
     const result = await runOmniJsScript<
       { tagId: string | null } | { error: { code: string; message: string } }
     >(script, { tagId }, { ...this.runOpts, scriptName: "forecast_set_tag" });
@@ -482,9 +478,7 @@ export class OmniJsTransport implements OmniFocusAdapter {
   // -- Plug-in invocation (wired) -------------------------------------------
 
   async pluginInvoke(input: PluginInvokeInput): Promise<PluginInvokeResult> {
-    const script = await import("node:fs/promises").then((fs) =>
-      fs.readFile(join(import.meta.dirname, "../../scripts/omnijs/plugin_invoke.js"), "utf8"),
-    );
+    const script = pluginInvokeScript;
     return runOmniJsScript<PluginInvokeResult>(
       script,
       { identifier: input.identifier, arg: input.arg ?? null },
@@ -508,12 +502,7 @@ export class OmniJsTransport implements OmniFocusAdapter {
   async evaluateCustomPerspective(
     identifier: string,
   ): Promise<import("../../domain/task.js").Task[]> {
-    const script = await import("node:fs/promises").then((fs) =>
-      fs.readFile(
-        join(import.meta.dirname, "../../scripts/omnijs/perspective_evaluate.js"),
-        "utf8",
-      ),
-    );
+    const script = perspectiveEvaluateScript;
     const result = await runOmniJsScript<PerspectiveEvaluateScriptResult>(
       script,
       { identifier },

--- a/src/scripts/omnijs/forecast_get_tag.d.ts
+++ b/src/scripts/omnijs/forecast_get_tag.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `forecast_get_tag.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/omnijs/forecast_set_tag.d.ts
+++ b/src/scripts/omnijs/forecast_set_tag.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `forecast_set_tag.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/omnijs/perspective_evaluate.d.ts
+++ b/src/scripts/omnijs/perspective_evaluate.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `perspective_evaluate.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/omnijs/plugin_invoke.d.ts
+++ b/src/scripts/omnijs/plugin_invoke.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `plugin_invoke.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/omnijs/task_batch_move.d.ts
+++ b/src/scripts/omnijs/task_batch_move.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_batch_move.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/omnijs/task_move.d.ts
+++ b/src/scripts/omnijs/task_move.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `task_move.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;


### PR DESCRIPTION
## Summary

Seven OmniJS scripts loaded via `fs.readFile(join(import.meta.dirname, ...))` failed with `ENOENT` in the bundled dist build. Migrate to static imports that hit the existing `scriptInlinerPlugin` loader. Closes #531.

## Affected tools (all 7 broken in dist)

`forecast_get_tag`, `forecast_set_tag`, `task_move`, `task_batch_move`, `task_reorder`, `plugin_invoke`, `evaluateCustomPerspective`.

## Fix

- 6 new `.d.ts` shims under `src/scripts/omnijs/` (mirroring `src/scripts/jxa/*.d.ts`).
- 7 `fs.readFile(...)` blocks → static `import xScript from "../../scripts/omnijs/X.js"`.
- Drop the now-unused `node:path` import.

The `scriptInlinerPlugin` already matched `src/scripts/**` — JXA scripts have shipped this way since the start; OmniJS scripts just hadn't migrated.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 2160 / 2160 pass (was 2147; new tests landed since #529)
- [x] `pnpm build` succeeds; bundle grew slightly because scripts now embed inline
- [ ] Manual smoke: `forecast_get_tag` / `forecast_set_tag` (verified locally pre-merge)

## Risk

Low. Mechanical migration to a pattern already in production for ~80 JXA scripts. The script-inliner regex already covered the OmniJS path; we just stopped circumventing it.