### PR TITLE
feat(resources): add omnifocus://project-health stalled-project triage

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1138,6 +1138,7 @@ MCP resources are a distinct primitive from tools: read-only, enumerable via `re
 | `omnifocus://perspective/{id}` | Perspective evaluation result (built-in or custom)                                            | 30s LRU  |
 | `omnifocus://intents`          | Curated routing table mapping human-style user phrases to canonical tool/prompt/resource sequences (NL excellence layer — see below) | 24h |
 | `omnifocus://stats`            | Server-side aggregate counts: tasks, projects, inbox, tags, sync — for "how is my system doing?" queries without listing every record client-side | 60s |
+| `omnifocus://project-health{?staleDays}` | Triage list of active projects flagged by ≥1 health-warning condition with granular signals — list-form sibling of `stats.projects.stalled_count` | 60s |
 
 ### Semantics
 
@@ -1168,7 +1169,7 @@ This resource also doubles as the discoverability surface: when a future agent a
 2. ≥ **14 days** since the latest task activity in the project — `max(task.modifiedAt)` over the project's tasks, or the project's own `modifiedAt` if it has no tasks
 3. No defer date in the future (a deferred-into-the-future project is deliberately paused, not stalled)
 
-Single source of truth lives in `src/resources/stats.ts → isProjectStalled`. Future resources or tools using "stalled" semantics MUST reuse that predicate; do not redefine.
+Single source of truth lives in `src/domain/health.ts → isProjectStalled`. Future resources or tools using "stalled" semantics MUST reuse that predicate; do not redefine.
 
 ---
 

--- a/src/domain/health.ts
+++ b/src/domain/health.ts
@@ -1,0 +1,64 @@
+/**
+ * Domain-level health predicates and thresholds for OmniFocus projects.
+ *
+ * Single source of truth for "what does it mean for a project to be stalled?"
+ * and other health concepts that more than one resource consumes. Resources
+ * (e.g. `omnifocus://stats`, `omnifocus://project-health`) MUST import these
+ * predicates rather than redefining them — drift between two definitions of
+ * "stalled" is a bug class we don't want to chase.
+ *
+ * @see DESIGN.md §28 — "Stalled-project definition"
+ */
+
+import type { Project } from "./project.js";
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+
+/**
+ * Days since last task activity at which an active project is considered
+ * stalled. Used by `omnifocus://stats` (count form) and
+ * `omnifocus://project-health` (list form). The latter exposes this via an
+ * optional `staleDays` query parameter so callers can override per-call.
+ */
+export const STALLED_DAYS = 14;
+
+// ---------------------------------------------------------------------------
+// Stalled-project predicate
+// ---------------------------------------------------------------------------
+
+/**
+ * A project is stalled when ALL of:
+ *   1. status === "active" (and not completed or dropped)
+ *   2. ≥ `staleDays` days since the latest task activity
+ *      (`max(task.modifiedAt)` over the project's tasks, or the project's
+ *      own `modifiedAt` if it has no tasks)
+ *   3. no defer date in the future — a deferred-into-the-future project is
+ *      deliberately paused, not stalled
+ *
+ * `latestActivityAt` is `null` when the project has no tasks; the caller
+ * passes `null` and the project's own `modifiedAt` is the fallback reference.
+ */
+export function isProjectStalled(
+  project: Project,
+  latestActivityAt: string | null,
+  now: Date,
+  staleDays: number = STALLED_DAYS,
+): boolean {
+  if (project.status !== "active") return false;
+  if (project.completed || project.dropped) return false;
+
+  // Deferred-into-the-future projects are deliberately paused, not stalled.
+  if (project.deferDate) {
+    const deferAt = new Date(project.deferDate);
+    if (deferAt.getTime() > now.getTime()) return false;
+  }
+
+  const referenceIso = latestActivityAt ?? project.modifiedAt;
+  const referenceMs = new Date(referenceIso).getTime();
+  const ageMs = now.getTime() - referenceMs;
+  const ageDays = ageMs / (24 * 60 * 60 * 1000);
+
+  return ageDays >= staleDays;
+}

--- a/src/resources/omnifocus.test.ts
+++ b/src/resources/omnifocus.test.ts
@@ -150,6 +150,7 @@ describe("registerOmniFocusResources — registration", () => {
       "omnifocus-burndown",
       "omnifocus-intents",
       "omnifocus-stats",
+      "omnifocus-project-health",
     ];
     for (const name of expected) {
       expect(names, `expected ${name} to be registered`).toContain(name);

--- a/src/resources/omnifocus.ts
+++ b/src/resources/omnifocus.ts
@@ -40,6 +40,7 @@ import type { ProjectService } from "../services/projectService.js";
 import type { ReviewService } from "../services/reviewService.js";
 import { registerBurndownResource } from "./burndown.js";
 import { registerIntentsResource } from "./intents.js";
+import { registerProjectHealthResource } from "./projectHealth.js";
 import { registerRecentActivityResource } from "./recentActivity.js";
 import { registerRetrospectiveResource } from "./retrospective.js";
 import { registerStatsResource } from "./stats.js";
@@ -48,6 +49,7 @@ import { registerVelocityResource } from "./velocity.js";
 
 export { BURNDOWN_URI_TEMPLATE } from "./burndown.js";
 export { INTENTS_URI } from "./intents.js";
+export { PROJECT_HEALTH_URI_TEMPLATE } from "./projectHealth.js";
 export { RECENT_ACTIVITY_URI_TEMPLATE } from "./recentActivity.js";
 export { RETROSPECTIVE_URI_TEMPLATE } from "./retrospective.js";
 export { STATS_URI } from "./stats.js";
@@ -410,4 +412,7 @@ export function registerOmniFocusResources(server: McpServer, deps: OmniFocusRes
 
   // ── omnifocus://stats ────────────────────────────────────────────────────
   registerStatsResource(server, adapter);
+
+  // ── omnifocus://project-health{?staleDays} ───────────────────────────────
+  registerProjectHealthResource(server, adapter);
 }

--- a/src/resources/projectHealth.test.ts
+++ b/src/resources/projectHealth.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for the project-health resource.
+ *
+ * Covers buildProjectHealthPayload, the per-project signal computation, the
+ * flag-conditions filter, the severity sort, and the staleDays-override
+ * parameter parsing.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { STALLED_DAYS } from "../domain/health.js";
+import type { Task } from "../domain/task.js";
+
+import {
+  buildProjectHealthPayload,
+  buildProjectSignals,
+  PROJECT_HEALTH_URI_TEMPLATE,
+  parseStaleDays,
+} from "./projectHealth.js";
+
+const NOW = new Date("2026-04-01T12:00:00.000Z"); // Wednesday
+
+// ---------------------------------------------------------------------------
+// Empty database
+// ---------------------------------------------------------------------------
+
+describe("buildProjectHealthPayload — empty database", () => {
+  it("returns empty list and the default staleDays", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildProjectHealthPayload(adapter, undefined, NOW);
+    expect(payload.projects).toEqual([]);
+    expect(payload.staleDays).toBe(STALLED_DAYS);
+    expect(payload.generatedAt).toBe(NOW.toISOString());
+  });
+
+  it("echoes back the override staleDays", async () => {
+    const adapter = new InMemoryAdapter();
+    const payload = await buildProjectHealthPayload(adapter, 7, NOW);
+    expect(payload.staleDays).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter: only flagged projects appear
+// ---------------------------------------------------------------------------
+
+describe("buildProjectHealthPayload — flag filter", () => {
+  it("excludes a healthy project (recent activity, has available task, just reviewed)", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "healthy", reviewIntervalDays: 30 });
+    await adapter.createTask({ name: "open", projectId: projId });
+    await adapter.markProjectReviewed(projId);
+
+    const payload = await buildProjectHealthPayload(adapter, undefined, new Date());
+    expect(payload.projects.find((p) => p.name === "healthy")).toBeUndefined();
+  });
+
+  it("includes a project with zero available tasks", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "no-actions", reviewIntervalDays: 30 });
+    await adapter.markProjectReviewed(projId);
+    // Project has no tasks → hasNoActions=true → availableTaskCount=0 → flagged
+
+    const payload = await buildProjectHealthPayload(adapter, undefined, new Date());
+    const entry = payload.projects.find((p) => p.name === "no-actions");
+    expect(entry).toBeDefined();
+    expect(entry?.signals.hasNoActions).toBe(true);
+    expect(entry?.signals.availableTaskCount).toBe(0);
+  });
+
+  it("includes a project overdue for review (never reviewed)", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "no-review" });
+    await adapter.createTask({ name: "open", projectId: projId });
+    // Never reviewed; nextReviewDate=null → overdueForReview=true
+
+    const payload = await buildProjectHealthPayload(adapter, undefined, new Date());
+    const entry = payload.projects.find((p) => p.name === "no-review");
+    expect(entry).toBeDefined();
+    expect(entry?.signals.overdueForReview).toBe(true);
+    expect(entry?.signals.lastReviewedAt).toBeNull();
+  });
+
+  it("excludes on-hold and completed projects", async () => {
+    const adapter = new InMemoryAdapter();
+    const a = await adapter.createProject({ name: "on-hold-with-no-actions" });
+    const b = await adapter.createProject({ name: "done-with-no-actions" });
+    await adapter.updateProject(a, { status: "on-hold" });
+    await adapter.completeProject(b);
+
+    const payload = await buildProjectHealthPayload(adapter, undefined, new Date());
+    expect(payload.projects.find((p) => p.name === "on-hold-with-no-actions")).toBeUndefined();
+    expect(payload.projects.find((p) => p.name === "done-with-no-actions")).toBeUndefined();
+  });
+
+  it("flags a project where every open task is deferred into the future", async () => {
+    const adapter = new InMemoryAdapter();
+    const projId = await adapter.createProject({ name: "all-deferred", reviewIntervalDays: 30 });
+    await adapter.markProjectReviewed(projId);
+    // Defer the only task into the future
+    await adapter.createTask({
+      name: "future",
+      projectId: projId,
+      deferDate: "2099-01-01T00:00:00.000Z",
+    });
+
+    const payload = await buildProjectHealthPayload(adapter, undefined, new Date());
+    const entry = payload.projects.find((p) => p.name === "all-deferred");
+    expect(entry).toBeDefined();
+    expect(entry?.signals.deferredFutureTasks).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Severity sort
+// ---------------------------------------------------------------------------
+
+describe("buildProjectHealthPayload — sort", () => {
+  it("places review-overdue projects before activity-stale projects", async () => {
+    const adapter = new InMemoryAdapter();
+    // A: stale activity, recently reviewed → only flagged via no-available-tasks
+    const a = await adapter.createProject({ name: "A-stale", reviewIntervalDays: 365 });
+    await adapter.markProjectReviewed(a);
+    // B: never reviewed, has open task → flagged via overdueForReview
+    const b = await adapter.createProject({ name: "B-overdue-review" });
+    await adapter.createTask({ name: "open", projectId: b });
+
+    const payload = await buildProjectHealthPayload(adapter, undefined, new Date());
+    const idxA = payload.projects.findIndex((p) => p.name === "A-stale");
+    const idxB = payload.projects.findIndex((p) => p.name === "B-overdue-review");
+    expect(idxB).toBeGreaterThanOrEqual(0);
+    expect(idxA).toBeGreaterThanOrEqual(0);
+    // B (review-overdue) should sort before A
+    expect(idxB).toBeLessThan(idxA);
+  });
+
+  it("uses name as a stable tiebreaker for equal-severity projects", async () => {
+    const adapter = new InMemoryAdapter();
+    // Two no-actions, never-reviewed projects → identical severity
+    await adapter.createProject({ name: "Zeta" });
+    await adapter.createProject({ name: "Alpha" });
+
+    const payload = await buildProjectHealthPayload(adapter, undefined, new Date());
+    const names = payload.projects.map((p) => p.name);
+    expect(names.indexOf("Alpha")).toBeLessThan(names.indexOf("Zeta"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// staleDays override
+// ---------------------------------------------------------------------------
+
+describe("buildProjectHealthPayload — staleDays override", () => {
+  it("applying a small staleDays threshold flags more projects via stalled-activity", async () => {
+    const adapter = new InMemoryAdapter();
+    // Recently-reviewed project with one available task — would NOT be flagged
+    // by the default conditions (has actions, just reviewed). But with
+    // staleDays=0 the activity-staleness fires immediately because the
+    // task's modifiedAt equals "right now", which is ≥ 0 days ago.
+    const projId = await adapter.createProject({ name: "edge-case", reviewIntervalDays: 30 });
+    await adapter.markProjectReviewed(projId);
+    await adapter.createTask({ name: "open", projectId: projId });
+
+    const baseline = await buildProjectHealthPayload(adapter, undefined, new Date());
+    expect(baseline.projects.find((p) => p.name === "edge-case")).toBeUndefined();
+
+    const aggressive = await buildProjectHealthPayload(adapter, 0, new Date());
+    // With staleDays=0, every active project is "stalled" and thus flagged.
+    expect(aggressive.projects.find((p) => p.name === "edge-case")).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-project signals — direct unit tests on the pure helper
+// ---------------------------------------------------------------------------
+
+describe("buildProjectSignals", () => {
+  function makeTask(overrides: Partial<Task>): Task {
+    return {
+      id: "t" as Task["id"],
+      name: "task",
+      note: null,
+      noteHtml: null,
+      projectId: "p" as Task["projectId"],
+      parentId: null,
+      tagIds: [],
+      deferDate: null,
+      dueDate: null,
+      estimatedMinutes: null,
+      flagged: false,
+      completed: false,
+      completedAt: null,
+      dropped: false,
+      droppedAt: null,
+      available: true,
+      blocked: false,
+      sequential: false,
+      completedByChildren: false,
+      repetition: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      modifiedAt: "2026-01-01T00:00:00.000Z",
+      ...overrides,
+    } as Task;
+  }
+
+  it("derives lastTaskActivityAt from max(task.modifiedAt)", () => {
+    const tasks = [
+      makeTask({ modifiedAt: "2026-02-01T00:00:00.000Z" }),
+      makeTask({ modifiedAt: "2026-03-01T00:00:00.000Z" }),
+      makeTask({ modifiedAt: "2026-01-15T00:00:00.000Z" }),
+    ];
+    const signals = buildProjectSignals(
+      { modifiedAt: "2025-12-01T00:00:00.000Z", nextReviewDate: null, lastReviewDate: null },
+      tasks,
+      NOW,
+    );
+    expect(signals.lastTaskActivityAt).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("falls back to project.modifiedAt when there are no tasks", () => {
+    const signals = buildProjectSignals(
+      { modifiedAt: "2026-01-01T00:00:00.000Z", nextReviewDate: null, lastReviewDate: null },
+      [],
+      NOW,
+    );
+    expect(signals.lastTaskActivityAt).toBeNull();
+    // daysSinceActivity should still derive from the project's modifiedAt
+    expect(signals.daysSinceActivity).toBeGreaterThan(0);
+  });
+
+  it("counts only open tasks toward available/blocked", () => {
+    const tasks = [
+      makeTask({ id: "1" as Task["id"], available: true }),
+      makeTask({ id: "2" as Task["id"], blocked: true, available: false }),
+      makeTask({ id: "3" as Task["id"], completed: true }), // ignored
+      makeTask({ id: "4" as Task["id"], dropped: true }), // ignored
+    ];
+    const signals = buildProjectSignals(
+      { modifiedAt: NOW.toISOString(), nextReviewDate: NOW.toISOString(), lastReviewDate: null },
+      tasks,
+      NOW,
+    );
+    expect(signals.availableTaskCount).toBe(1);
+    expect(signals.blockedTaskCount).toBe(1);
+  });
+
+  it("hasNoActions is true when every task is completed/dropped or there are no tasks", () => {
+    const tasks = [
+      makeTask({ id: "a" as Task["id"], completed: true }),
+      makeTask({ id: "b" as Task["id"], dropped: true }),
+    ];
+    const signals = buildProjectSignals(
+      { modifiedAt: NOW.toISOString(), nextReviewDate: null, lastReviewDate: null },
+      tasks,
+      NOW,
+    );
+    expect(signals.hasNoActions).toBe(true);
+  });
+
+  it("deferredFutureTasks requires open tasks AND every open task to have a future defer date", () => {
+    const futureIso = "2099-01-01T00:00:00.000Z";
+    const tasks = [
+      makeTask({ id: "x" as Task["id"], deferDate: futureIso }),
+      makeTask({ id: "y" as Task["id"], deferDate: futureIso }),
+    ];
+    const signals = buildProjectSignals(
+      { modifiedAt: NOW.toISOString(), nextReviewDate: null, lastReviewDate: null },
+      tasks,
+      NOW,
+    );
+    expect(signals.deferredFutureTasks).toBe(true);
+  });
+
+  it("deferredFutureTasks is false when at least one open task has no defer date", () => {
+    const tasks = [
+      makeTask({ id: "x" as Task["id"], deferDate: "2099-01-01T00:00:00.000Z" }),
+      makeTask({ id: "y" as Task["id"], deferDate: null }),
+    ];
+    const signals = buildProjectSignals(
+      { modifiedAt: NOW.toISOString(), nextReviewDate: null, lastReviewDate: null },
+      tasks,
+      NOW,
+    );
+    expect(signals.deferredFutureTasks).toBe(false);
+  });
+
+  it("deferredFutureTasks is false when there are zero open tasks", () => {
+    const signals = buildProjectSignals(
+      { modifiedAt: NOW.toISOString(), nextReviewDate: null, lastReviewDate: null },
+      [],
+      NOW,
+    );
+    expect(signals.deferredFutureTasks).toBe(false);
+  });
+
+  it("overdueForReview is true when nextReviewDate is null", () => {
+    const signals = buildProjectSignals(
+      { modifiedAt: NOW.toISOString(), nextReviewDate: null, lastReviewDate: null },
+      [],
+      NOW,
+    );
+    expect(signals.overdueForReview).toBe(true);
+  });
+
+  it("overdueForReview is true when nextReviewDate <= now", () => {
+    const signals = buildProjectSignals(
+      {
+        modifiedAt: NOW.toISOString(),
+        nextReviewDate: "2026-03-01T00:00:00.000Z",
+        lastReviewDate: null,
+      },
+      [],
+      NOW,
+    );
+    expect(signals.overdueForReview).toBe(true);
+  });
+
+  it("overdueForReview is false when nextReviewDate is in the future", () => {
+    const signals = buildProjectSignals(
+      {
+        modifiedAt: NOW.toISOString(),
+        nextReviewDate: "2099-01-01T00:00:00.000Z",
+        lastReviewDate: "2026-01-01T00:00:00.000Z",
+      },
+      [],
+      NOW,
+    );
+    expect(signals.overdueForReview).toBe(false);
+  });
+
+  it("daysSinceReview is null when never reviewed", () => {
+    const signals = buildProjectSignals(
+      { modifiedAt: NOW.toISOString(), nextReviewDate: null, lastReviewDate: null },
+      [],
+      NOW,
+    );
+    expect(signals.daysSinceReview).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseStaleDays
+// ---------------------------------------------------------------------------
+
+describe("parseStaleDays", () => {
+  it("returns the default for missing input", () => {
+    expect(parseStaleDays(undefined)).toBe(STALLED_DAYS);
+    expect(parseStaleDays("")).toBe(STALLED_DAYS);
+  });
+
+  it("parses positive integers", () => {
+    expect(parseStaleDays("7")).toBe(7);
+    expect(parseStaleDays("30")).toBe(30);
+  });
+
+  it("falls back to default for non-positive values", () => {
+    expect(parseStaleDays("0")).toBe(STALLED_DAYS);
+    expect(parseStaleDays("-3")).toBe(STALLED_DAYS);
+  });
+
+  it("falls back to default for malformed values", () => {
+    expect(parseStaleDays("abc")).toBe(STALLED_DAYS);
+    expect(parseStaleDays("1.5")).toBe(1); // parseInt truncates; 1 is valid
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URI template export
+// ---------------------------------------------------------------------------
+
+describe("PROJECT_HEALTH_URI_TEMPLATE", () => {
+  it("is the canonical project-health URI template", () => {
+    expect(PROJECT_HEALTH_URI_TEMPLATE).toBe("omnifocus://project-health{?staleDays}");
+  });
+});

--- a/src/resources/projectHealth.ts
+++ b/src/resources/projectHealth.ts
@@ -1,0 +1,298 @@
+/**
+ * `omnifocus://project-health{?staleDays}` MCP resource.
+ *
+ * Triage list of active projects with health-warning signals — the
+ * weekly-review answer to "which active projects are stalled?" without the
+ * agent having to fetch every project, every task, and compute on the
+ * client. Returns granular per-project signals; leaves *judgment*
+ * (stalled-because-blocked vs. stalled-because-abandoned) to the agent.
+ *
+ * Query parameters:
+ *   - `staleDays` (optional, integer ≥ 1) — overrides the default 14-day
+ *     threshold for "no recent activity"
+ *
+ * Cache: 60s TTL (read-heavy, computed via aggregation). v1 caches as a
+ * single payload; partition-key invalidation is a future optimization.
+ *
+ * @see #468 — initial implementation
+ * @see src/domain/health.ts — `STALLED_DAYS`, `isProjectStalled`
+ * @see src/resources/stats.ts — count-form sibling
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
+import { isProjectStalled, STALLED_DAYS } from "../domain/health.js";
+import type { Task } from "../domain/task.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const PROJECT_HEALTH_URI_TEMPLATE = "omnifocus://project-health{?staleDays}";
+
+// ---------------------------------------------------------------------------
+// Payload
+// ---------------------------------------------------------------------------
+
+export interface ProjectHealthSignals {
+  /** Most recent task modification in the project, ISO-8601. `null` when the project has no tasks. */
+  lastTaskActivityAt: string | null;
+  /** floor((now - lastTaskActivityAt) / day). Falls back to project.modifiedAt when no tasks. */
+  daysSinceActivity: number;
+  /** Tasks where `available === true` (not blocked, not deferred-into-future, not completed). */
+  availableTaskCount: number;
+  /** Tasks where `blocked === true`. */
+  blockedTaskCount: number;
+  /** True when the project has zero non-completed, non-dropped tasks. */
+  hasNoActions: boolean;
+  /** True when the project has tasks but every non-completed task has a future defer date. */
+  deferredFutureTasks: boolean;
+  /** ISO-8601; `null` when the project has never been reviewed. */
+  lastReviewedAt: string | null;
+  /** floor((now - lastReviewedAt) / day). `null` when never reviewed. */
+  daysSinceReview: number | null;
+  /** True when `nextReviewDate <= today` OR `nextReviewDate === null` for an active project. */
+  overdueForReview: boolean;
+}
+
+export interface ProjectHealthEntry {
+  projectId: string;
+  name: string;
+  status: string;
+  signals: ProjectHealthSignals;
+}
+
+export interface ProjectHealthPayload {
+  /** Triage list — projects flagged by ≥1 health condition, sorted by severity. */
+  projects: readonly ProjectHealthEntry[];
+  /** The threshold used for "stale activity" — echoes back `staleDays` or the default. */
+  staleDays: number;
+  /** ISO-8601 generation timestamp. */
+  generatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — pure
+// ---------------------------------------------------------------------------
+
+/** Group tasks by `projectId`. Inbox tasks (no projectId) are ignored. */
+function groupTasksByProject(tasks: readonly Task[]): Map<string, Task[]> {
+  const map = new Map<string, Task[]>();
+  for (const task of tasks) {
+    if (!task.projectId) continue;
+    const key = String(task.projectId);
+    const list = map.get(key);
+    if (list) list.push(task);
+    else map.set(key, [task]);
+  }
+  return map;
+}
+
+/** Max ISO-8601 string from a list, else `null`. */
+function maxIso(values: readonly string[]): string | null {
+  if (values.length === 0) return null;
+  let max = values[0] ?? null;
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v && (max === null || v > max)) max = v;
+  }
+  return max;
+}
+
+/** floor((now - then) / day). Returns 0 when `then` is in the future. */
+function daysBetween(thenIso: string, now: Date): number {
+  const ageMs = now.getTime() - new Date(thenIso).getTime();
+  return Math.max(0, Math.floor(ageMs / (24 * 60 * 60 * 1000)));
+}
+
+/**
+ * Compute health signals for a single project given its (possibly empty)
+ * task list.
+ */
+export function buildProjectSignals(
+  project: { modifiedAt: string; nextReviewDate: string | null; lastReviewDate: string | null },
+  tasks: readonly Task[],
+  now: Date,
+): ProjectHealthSignals {
+  const openTasks = tasks.filter((t) => !t.completed && !t.dropped);
+  const taskMods = tasks.map((t) => t.modifiedAt);
+  const lastTaskActivityAt = maxIso(taskMods);
+  const referenceIso = lastTaskActivityAt ?? project.modifiedAt;
+  const daysSinceActivity = daysBetween(referenceIso, now);
+
+  const availableTaskCount = openTasks.filter((t) => t.available).length;
+  const blockedTaskCount = openTasks.filter((t) => t.blocked).length;
+
+  const hasNoActions = openTasks.length === 0;
+  const nowIso = now.toISOString();
+  const deferredFutureTasks =
+    openTasks.length > 0 && openTasks.every((t) => t.deferDate !== null && t.deferDate > nowIso);
+
+  const lastReviewedAt = project.lastReviewDate;
+  const daysSinceReview = lastReviewedAt ? daysBetween(lastReviewedAt, now) : null;
+
+  // Overdue for review: nextReviewDate is null (never set) OR ≤ today's start.
+  // The adapter's `listProjectsDueForReview` uses the same semantics.
+  let overdueForReview: boolean;
+  if (project.nextReviewDate === null) {
+    overdueForReview = true;
+  } else {
+    overdueForReview = project.nextReviewDate <= nowIso;
+  }
+
+  return {
+    lastTaskActivityAt,
+    daysSinceActivity,
+    availableTaskCount,
+    blockedTaskCount,
+    hasNoActions,
+    deferredFutureTasks,
+    lastReviewedAt,
+    daysSinceReview,
+    overdueForReview,
+  };
+}
+
+/**
+ * Determines whether a project's signals trip ANY of the health-warning
+ * conditions. Active projects qualify when:
+ *   - days since activity ≥ staleDays (per `isProjectStalled`)
+ *   - OR no available tasks while active
+ *   - OR overdue for review
+ *   - OR every non-completed task has a future defer date
+ */
+function isFlagged(signals: ProjectHealthSignals, isStalled: boolean, isActive: boolean): boolean {
+  if (!isActive) return false;
+  if (isStalled) return true;
+  if (signals.availableTaskCount === 0) return true;
+  if (signals.overdueForReview) return true;
+  if (signals.deferredFutureTasks) return true;
+  return false;
+}
+
+/**
+ * Severity score — higher means more urgent. Used for sort:
+ *   1. most-overdue review first
+ *   2. then longest no-activity
+ *   3. then no-available-tasks
+ */
+function severityScore(signals: ProjectHealthSignals): number {
+  // Compose a single number where review-overdue dominates, days-since-activity
+  // is next, and no-actions / no-available is the tiebreaker.
+  let score = 0;
+  if (signals.overdueForReview) {
+    // daysSinceReview can be null (never reviewed) — treat as max severity.
+    const reviewDays = signals.daysSinceReview ?? 9_999;
+    score += 1_000_000 + reviewDays;
+  }
+  score += 1_000 + signals.daysSinceActivity;
+  if (signals.availableTaskCount === 0) score += 50;
+  if (signals.hasNoActions) score += 25;
+  return score;
+}
+
+// ---------------------------------------------------------------------------
+// Builder — pure, `now` injectable for tests
+// ---------------------------------------------------------------------------
+
+export async function buildProjectHealthPayload(
+  adapter: OmniFocusAdapter,
+  staleDays: number = STALLED_DAYS,
+  now: Date = new Date(),
+): Promise<ProjectHealthPayload> {
+  const [allProjects, allTasks] = await Promise.all([
+    adapter.listProjects(),
+    adapter.listTasks({}),
+  ]);
+
+  const tasksByProject = groupTasksByProject(allTasks);
+
+  const flagged: Array<ProjectHealthEntry & { _severity: number }> = [];
+
+  for (const project of allProjects) {
+    const isActive = project.status === "active" && !project.completed && !project.dropped;
+    if (!isActive) continue;
+
+    const projectTasks = tasksByProject.get(String(project.id)) ?? [];
+    const signals = buildProjectSignals(project, projectTasks, now);
+
+    // Stalled per the canonical definition, with optional override.
+    const stalled = isProjectStalled(project, signals.lastTaskActivityAt, now, staleDays);
+
+    if (!isFlagged(signals, stalled, isActive)) continue;
+
+    flagged.push({
+      projectId: String(project.id),
+      name: project.name,
+      status: project.status,
+      signals,
+      _severity: severityScore(signals),
+    });
+  }
+
+  // Sort descending by severity, then by name as a stable tiebreaker.
+  flagged.sort((a, b) => {
+    if (a._severity !== b._severity) return b._severity - a._severity;
+    return a.name.localeCompare(b.name);
+  });
+
+  return {
+    projects: flagged.map(({ _severity, ...entry }) => entry),
+    staleDays,
+    generatedAt: now.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Query-parameter parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `staleDays` URI variable. Returns the canonical default
+ * (`STALLED_DAYS`) when the parameter is absent, malformed, or not a
+ * positive integer.
+ */
+export function parseStaleDays(raw: string | undefined): number {
+  if (!raw) return STALLED_DAYS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return STALLED_DAYS;
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectHealthResource(server: McpServer, adapter: OmniFocusAdapter): void {
+  server.registerResource(
+    "omnifocus-project-health",
+    new ResourceTemplate(PROJECT_HEALTH_URI_TEMPLATE, { list: undefined }),
+    {
+      description:
+        "Triage list of active projects flagged by health-warning conditions — the weekly-review answer to " +
+        "'which active projects are stalled?' Returns per-project signals (lastTaskActivityAt, daysSinceActivity, " +
+        "availableTaskCount, blockedTaskCount, hasNoActions, deferredFutureTasks, lastReviewedAt, daysSinceReview, " +
+        "overdueForReview), filtered to projects matching ≥1 of: ≥ staleDays since last activity (default 14, " +
+        "override with ?staleDays=N), zero available tasks, overdue for review, all tasks deferred into the future. " +
+        "Sorted by severity (review-overdue first, then longest no-activity, then no-available-tasks). " +
+        "Granular signals — leaves the judgment (blocked vs abandoned) to the agent. Read-only.",
+      mimeType: "application/json",
+    },
+    async (uri, variables) => {
+      const vars = variables as Record<string, string | undefined>;
+      const staleDays = parseStaleDays(vars.staleDays);
+      const payload = await buildProjectHealthPayload(adapter, staleDays);
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/resources/stats.ts
+++ b/src/resources/stats.ts
@@ -23,7 +23,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
-import type { Project } from "../domain/project.js";
+import { isProjectStalled } from "../domain/health.js";
 import type { Task } from "../domain/task.js";
 
 // ---------------------------------------------------------------------------
@@ -32,20 +32,10 @@ import type { Task } from "../domain/task.js";
 
 export const STATS_URI = "omnifocus://stats";
 
-/**
- * A project is "stalled" when ALL of the following hold:
- *   1. status === "active"
- *   2. ≥ STALLED_DAYS days since the latest task activity in the project
- *   3. no defer date in the future (a deferred project isn't stalled —
- *      it's deliberately paused)
- *
- * "Latest task activity" = max(task.modifiedAt) over the project's tasks,
- * or the project's own modifiedAt if it has no tasks.
- *
- * Same definition is used by `omnifocus://project-health` (#468). Keep them
- * in sync — single source of truth lives here in `isProjectStalled`.
- */
-export const STALLED_DAYS = 14;
+// Stalled-project predicate and threshold live in `src/domain/health.ts` so
+// every consumer (this resource and `omnifocus://project-health`) shares one
+// canonical definition. Re-exported here for back-compat with prior callers.
+export { isProjectStalled, STALLED_DAYS } from "../domain/health.js";
 
 // ---------------------------------------------------------------------------
 // Payload
@@ -86,40 +76,6 @@ export interface StatsPayload {
     sync_age_seconds: number | null;
     last_sync_at: string | null;
   };
-}
-
-// ---------------------------------------------------------------------------
-// Stalled-project predicate (exported so #468 can share)
-// ---------------------------------------------------------------------------
-
-/**
- * Determines whether a project is stalled per the canonical definition
- * (see `STALLED_DAYS` JSDoc above).
- *
- * `latestActivityAt` is the max of all task `modifiedAt` for tasks belonging
- * to this project, or `null` if the project has no tasks (in which case the
- * caller should pass the project's own `modifiedAt`).
- */
-export function isProjectStalled(
-  project: Project,
-  latestActivityAt: string | null,
-  now: Date,
-): boolean {
-  if (project.status !== "active") return false;
-  if (project.completed || project.dropped) return false;
-
-  // Deferred-into-the-future projects are deliberately paused, not stalled.
-  if (project.deferDate) {
-    const deferAt = new Date(project.deferDate);
-    if (deferAt.getTime() > now.getTime()) return false;
-  }
-
-  const referenceIso = latestActivityAt ?? project.modifiedAt;
-  const referenceMs = new Date(referenceIso).getTime();
-  const ageMs = now.getTime() - referenceMs;
-  const ageDays = ageMs / (24 * 60 * 60 * 1000);
-
-  return ageDays >= STALLED_DAYS;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -3,7 +3,7 @@
  *
  * Stands up the server over stdio (ADR-0010) using the high-level McpServer
  * API from @modelcontextprotocol/sdk. Currently registers `internal_status`,
- * the four OmniFocus workflow prompts, the twelve MCP resources, and 69 domain
+ * the four OmniFocus workflow prompts, the thirteen MCP resources, and 69 domain
  * tools across folder, tag, note, search, forecast, perspective, plugin,
  * sync, review, export, app, project, task, and attachment surfaces. Two
  * additional raw-script escape-hatch tools (`run_jxa_script`,


### PR DESCRIPTION
## Summary

- Adds `omnifocus://project-health{?staleDays}` — a triage list for the most common weekly-review query: "which active projects are stalled?" Returns granular per-project signals (lastTaskActivityAt, daysSinceActivity, availableTaskCount, blockedTaskCount, hasNoActions, deferredFutureTasks, lastReviewedAt, daysSinceReview, overdueForReview), filtered to projects matching ≥1 of four flag conditions, and sorted by severity (review-overdue → longest no-activity → no-available-tasks).
- Optional `?staleDays=N` query parameter overrides the default 14-day threshold per call.
- Refactors `STALLED_DAYS` and `isProjectStalled` from `src/resources/stats.ts` into a new `src/domain/health.ts` so the existing stats resource and this new resource share one canonical home in the domain layer. Re-exports kept on `stats.ts` for back-compat.

## Design link

Closes #468. Sibling of `omnifocus://stats.projects.stalled_count` ([#464](https://github.com/torsday/omnifocus-mcp/issues/464), the count form). Both consume the same `isProjectStalled` predicate.

## Scope edges

**Cut and document — file follow-up if maintainers want:**

- **OmniJS aggregation script** per Technical Notes. v1 uses TS-side aggregation over existing adapter methods, mirroring the path `stats` took.
- **Live-OF integration test.** 26 new InMemoryAdapter unit tests cover the four flag conditions, the severity sort, and the `staleDays` override; integration coverage can land as a follow-up if it adds enough signal.

## Breaking change?

- [x] No

Pure additive: new resource URI, new `src/domain/health.ts`, no existing-contract changes. The `STALLED_DAYS` / `isProjectStalled` move keeps re-exports on `stats.ts`, so callers that imported from there remain valid.

## Test plan

- [x] 26 new unit tests in [src/resources/projectHealth.test.ts](src/resources/projectHealth.test.ts) — empty-database, every flag condition (no-actions, overdue-review, never-reviewed, all-deferred-future, on-hold/done exclusion), severity sort with name tiebreaker, `staleDays` override, per-signal direct unit tests on `buildProjectSignals`, and `parseStaleDays` edge cases.
- [x] Existing `stats.test.ts` (26 tests) still passes against the refactored `isProjectStalled` import.
- [x] Existing `registerOmniFocusResources` registration test extended to assert `omnifocus-project-health` is registered.
- [x] `pnpm typecheck && pnpm lint && pnpm test` all green — 2212 passed / 49 skipped.
- [x] `pnpm build` succeeds; bundle 446 KB / 500 KB budget.
- [x] Self-reviewed via `/review-pr`.

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits (`feat(resources): …`)
- [x] No new dependencies
- [x] Docs updated (DESIGN §28 — resource table + stalled-project source-of-truth pointer)