### PR TITLE
feat(envelope): add hints[] array to ok responses (ADR-0015)

### DIFF
--- a/src/domain/hints.test.ts
+++ b/src/domain/hints.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for src/domain/hints.ts
+ *
+ * Covers: builder helpers, capHints, filterHintsBySeverity, finaliseHints,
+ * and each per-tool detector (repeatHintForName, estimateHintForDue,
+ * inboxGrowthHint, reviewIntervalHint, projectEmptyHint).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  capHints,
+  considerAlternativeHint,
+  estimateHintForDue,
+  filterHintsBySeverity,
+  finaliseHints,
+  inboxGrowthHint,
+  missingDetailHint,
+  nextNaturalStepHint,
+  projectEmptyHint,
+  repeatHintForName,
+  reviewIntervalHint,
+  staleDataHint,
+  wouldConflictHint,
+} from "./hints.js";
+
+// ---------------------------------------------------------------------------
+// Builder helpers
+// ---------------------------------------------------------------------------
+
+describe("hint builders", () => {
+  it("missingDetailHint sets kind and reason", () => {
+    const h = missingDetailHint("No estimate.");
+    expect(h.kind).toBe("missing-detail");
+    expect(h.reason).toBe("No estimate.");
+    expect(h.severity).toBeUndefined();
+  });
+
+  it("wouldConflictHint carries severity warn", () => {
+    const h = wouldConflictHint("Conflict.", { severity: "warn" });
+    expect(h.kind).toBe("would-conflict");
+    expect(h.severity).toBe("warn");
+  });
+
+  it("nextNaturalStepHint carries suggestedTool and suggestedArgs", () => {
+    const h = nextNaturalStepHint("Follow-up.", {
+      suggestedTool: "task_set_repetition",
+      suggestedArgs: { id: "t1" },
+    });
+    expect(h.kind).toBe("next-natural-step");
+    expect(h.suggestedTool).toBe("task_set_repetition");
+    expect(h.suggestedArgs).toEqual({ id: "t1" });
+  });
+
+  it("considerAlternativeHint", () => {
+    expect(considerAlternativeHint("Alt.").kind).toBe("consider-alternative");
+  });
+
+  it("staleDataHint", () => {
+    expect(staleDataHint("Stale.").kind).toBe("stale-data");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capHints
+// ---------------------------------------------------------------------------
+
+describe("capHints", () => {
+  it("returns all hints when under cap", () => {
+    const hints = [missingDetailHint("a"), missingDetailHint("b")];
+    expect(capHints(hints, 3)).toHaveLength(2);
+  });
+
+  it("truncates to max when over cap", () => {
+    const hints = Array.from({ length: 5 }, (_, i) => missingDetailHint(`hint ${i}`));
+    expect(capHints(hints, 3)).toHaveLength(3);
+  });
+
+  it("prefers warn-severity hints over info when capping", () => {
+    const info1 = missingDetailHint("info 1", { severity: "info" });
+    const info2 = missingDetailHint("info 2", { severity: "info" });
+    const warn = wouldConflictHint("warn!", { severity: "warn" });
+    const info3 = missingDetailHint("info 3", { severity: "info" });
+    const result = capHints([info1, info2, warn, info3], 2);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(warn);
+  });
+
+  it("respects default cap of 3", () => {
+    const hints = Array.from({ length: 6 }, (_, i) => missingDetailHint(`h ${i}`));
+    expect(capHints(hints)).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterHintsBySeverity
+// ---------------------------------------------------------------------------
+
+describe("filterHintsBySeverity", () => {
+  const original = process.env.OMNIFOCUS_HINT_LEVEL;
+
+  beforeEach(() => {
+    delete process.env.OMNIFOCUS_HINT_LEVEL;
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.OMNIFOCUS_HINT_LEVEL;
+    } else {
+      process.env.OMNIFOCUS_HINT_LEVEL = original;
+    }
+  });
+
+  it("returns all hints when env is unset", () => {
+    const hints = [missingDetailHint("a"), wouldConflictHint("b", { severity: "warn" })];
+    expect(filterHintsBySeverity(hints)).toHaveLength(2);
+  });
+
+  it("strips info hints when OMNIFOCUS_HINT_LEVEL=warn", () => {
+    process.env.OMNIFOCUS_HINT_LEVEL = "warn";
+    const hints = [
+      missingDetailHint("info hint", { severity: "info" }),
+      wouldConflictHint("warn hint", { severity: "warn" }),
+    ];
+    const result = filterHintsBySeverity(hints);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.kind).toBe("would-conflict");
+  });
+
+  it("treats hints with no severity as info", () => {
+    process.env.OMNIFOCUS_HINT_LEVEL = "warn";
+    const hints = [missingDetailHint("no severity")]; // severity undefined → treated as info
+    expect(filterHintsBySeverity(hints)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// finaliseHints
+// ---------------------------------------------------------------------------
+
+describe("finaliseHints", () => {
+  it("returns undefined for empty array", () => {
+    expect(finaliseHints([])).toBeUndefined();
+  });
+
+  it("returns undefined when all hints filtered out", () => {
+    const original = process.env.OMNIFOCUS_HINT_LEVEL;
+    process.env.OMNIFOCUS_HINT_LEVEL = "warn";
+    try {
+      const hints = [missingDetailHint("info only")];
+      expect(finaliseHints(hints)).toBeUndefined();
+    } finally {
+      if (original === undefined) delete process.env.OMNIFOCUS_HINT_LEVEL;
+      else process.env.OMNIFOCUS_HINT_LEVEL = original;
+    }
+  });
+
+  it("caps to 3 by default", () => {
+    const hints = Array.from({ length: 5 }, (_, i) => missingDetailHint(`h ${i}`));
+    expect(finaliseHints(hints)).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-tool detectors
+// ---------------------------------------------------------------------------
+
+describe("repeatHintForName", () => {
+  it("returns undefined for non-recurring names", () => {
+    expect(repeatHintForName("t1", "Buy groceries")).toBeUndefined();
+    expect(repeatHintForName("t1", "Check email")).toBeUndefined();
+  });
+
+  it("fires for 'weekly' cue", () => {
+    const h = repeatHintForName("t1", "Weekly team sync");
+    expect(h).not.toBeUndefined();
+    expect(h?.kind).toBe("next-natural-step");
+    expect(h?.suggestedTool).toBe("task_set_repetition");
+    expect(h?.suggestedArgs).toEqual({ id: "t1" });
+  });
+
+  it("fires for 'daily' cue", () => {
+    expect(repeatHintForName("t1", "Daily standup")).not.toBeUndefined();
+  });
+
+  it("fires for 'every week' cue", () => {
+    expect(repeatHintForName("t1", "Review goals every week")).not.toBeUndefined();
+  });
+
+  it("fires for 'every Monday' cue", () => {
+    expect(repeatHintForName("t1", "Send report every Monday")).not.toBeUndefined();
+  });
+
+  it("is case-insensitive", () => {
+    expect(repeatHintForName("t1", "WEEKLY REVIEW")).not.toBeUndefined();
+  });
+});
+
+describe("estimateHintForDue", () => {
+  it("returns undefined when no due date", () => {
+    expect(estimateHintForDue("t1", undefined, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when estimate already set", () => {
+    expect(estimateHintForDue("t1", "2026-05-01T09:00:00+00:00", 30)).toBeUndefined();
+  });
+
+  it("fires when due date set and no estimate", () => {
+    const h = estimateHintForDue("t1", "2026-05-01T09:00:00+00:00", undefined);
+    expect(h).not.toBeUndefined();
+    expect(h?.kind).toBe("missing-detail");
+    expect(h?.suggestedTool).toBe("task_update");
+    expect(h?.suggestedArgs).toEqual({ id: "t1" });
+  });
+});
+
+describe("inboxGrowthHint", () => {
+  it("returns undefined below threshold", () => {
+    expect(inboxGrowthHint(4)).toBeUndefined();
+    expect(inboxGrowthHint(0)).toBeUndefined();
+  });
+
+  it("fires at exactly the threshold (default 5)", () => {
+    const h = inboxGrowthHint(5);
+    expect(h).not.toBeUndefined();
+    expect(h?.kind).toBe("consider-alternative");
+    expect(h?.reason).toContain("5");
+  });
+
+  it("fires above threshold", () => {
+    expect(inboxGrowthHint(10)).not.toBeUndefined();
+  });
+
+  it("respects custom threshold", () => {
+    expect(inboxGrowthHint(3, 10)).toBeUndefined();
+    expect(inboxGrowthHint(10, 10)).not.toBeUndefined();
+  });
+});
+
+describe("reviewIntervalHint", () => {
+  it("returns undefined when review interval is already set", () => {
+    expect(reviewIntervalHint("p1", 7)).toBeUndefined();
+    expect(reviewIntervalHint("p1", 14)).toBeUndefined();
+  });
+
+  it("fires when no review interval", () => {
+    const h = reviewIntervalHint("p1", undefined);
+    expect(h).not.toBeUndefined();
+    expect(h?.kind).toBe("next-natural-step");
+    expect(h?.suggestedTool).toBe("project_update");
+    expect(h?.suggestedArgs).toMatchObject({ id: "p1", reviewIntervalDays: 7 });
+  });
+});
+
+describe("projectEmptyHint", () => {
+  it("always returns a hint with the project name", () => {
+    const h = projectEmptyHint("p1", "Errands");
+    expect(h.kind).toBe("next-natural-step");
+    expect(h.reason).toContain("Errands");
+    expect(h.suggestedTool).toBe("project_complete");
+    expect(h.suggestedArgs).toEqual({ id: "p1" });
+  });
+});

--- a/src/domain/hints.ts
+++ b/src/domain/hints.ts
@@ -1,0 +1,229 @@
+/**
+ * Hint type and helpers for the `hints[]` array on `ok` responses.
+ *
+ * Per ADR-0015, every `ToolSuccess` envelope may carry an optional `hints[]`
+ * array — server-suggested follow-ups that let tools share domain knowledge
+ * with the agent without making the advice mandatory.
+ *
+ * **Emission policy:**
+ * - Hints are opt-in per tool; tools that have nothing useful to say omit
+ *   the field entirely (not `[]`).
+ * - Hints are opt-in per call site — the same tool may hint on some inputs
+ *   and not others.
+ * - Cap: ≤ 3 hints per response. `capHints` enforces this and picks
+ *   highest-severity entries when the list exceeds the cap.
+ * - Severity gate: when `OMNIFOCUS_HINT_LEVEL=warn`, only `severity: "warn"`
+ *   hints are emitted. See `filterHintsBySeverity`.
+ *
+ * @see docs/adr/0015-nl-excellence-response-envelope.md — shape decision
+ * @see src/envelope/index.ts — ToolSuccess.hints field
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Closed discriminator for hint categories.
+ * New kinds are a minor-version addition per ADR-0011.
+ */
+export type HintKind =
+  /** A follow-up read would enrich the picture beyond what the response already shows. */
+  | "missing-detail"
+  /** A likely-next mutation would conflict with current state. */
+  | "would-conflict"
+  /** A tool that commonly follows this one; the agent may auto-route. */
+  | "next-natural-step"
+  /** A better-fitting tool exists for what the agent likely wants next. */
+  | "consider-alternative"
+  /** The agent is operating on a cached or stale view; refresh recommended. */
+  | "stale-data";
+
+/**
+ * A single hint on an `ok` response.
+ *
+ * Agents are not required to act on hints; ignoring them has zero side effects.
+ * When `suggestedTool` is present, the agent may pre-populate a follow-up call
+ * with `suggestedArgs` to reduce round-trips.
+ */
+export interface Hint {
+  /** Closed category discriminator — agents switch on this. */
+  kind: HintKind;
+  /** Human-readable one-sentence explanation. Agent may quote. */
+  reason: string;
+  /** Canonical tool name the agent could invoke as a follow-up. */
+  suggestedTool?: string;
+  /** Partial args for `suggestedTool`; the agent fills in the rest. */
+  suggestedArgs?: Record<string, unknown>;
+  /**
+   * Advisory importance. Defaults to `"info"`.
+   * `"warn"` means ignoring is risky but not blocking.
+   */
+  severity?: "info" | "warn";
+}
+
+// ---------------------------------------------------------------------------
+// Builder helpers
+// ---------------------------------------------------------------------------
+
+/** Build a `missing-detail` hint. */
+export function missingDetailHint(
+  reason: string,
+  opts: Pick<Hint, "suggestedTool" | "suggestedArgs" | "severity"> = {},
+): Hint {
+  return { kind: "missing-detail", reason, ...opts };
+}
+
+/** Build a `would-conflict` hint. */
+export function wouldConflictHint(
+  reason: string,
+  opts: Pick<Hint, "suggestedTool" | "suggestedArgs" | "severity"> = {},
+): Hint {
+  return { kind: "would-conflict", reason, ...opts };
+}
+
+/** Build a `next-natural-step` hint. */
+export function nextNaturalStepHint(
+  reason: string,
+  opts: Pick<Hint, "suggestedTool" | "suggestedArgs" | "severity"> = {},
+): Hint {
+  return { kind: "next-natural-step", reason, ...opts };
+}
+
+/** Build a `consider-alternative` hint. */
+export function considerAlternativeHint(
+  reason: string,
+  opts: Pick<Hint, "suggestedTool" | "suggestedArgs" | "severity"> = {},
+): Hint {
+  return { kind: "consider-alternative", reason, ...opts };
+}
+
+/** Build a `stale-data` hint. */
+export function staleDataHint(
+  reason: string,
+  opts: Pick<Hint, "suggestedTool" | "suggestedArgs" | "severity"> = {},
+): Hint {
+  return { kind: "stale-data", reason, ...opts };
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/** Soft cap: keep at most `max` hints, preferring `"warn"` severity over `"info"`. */
+export function capHints(hints: Hint[], max = 3): Hint[] {
+  if (hints.length <= max) return hints;
+  // Warn-severity hints are higher priority; stable sort by severity
+  const sorted = [...hints].sort((a, b) => {
+    const aW = (a.severity ?? "info") === "warn" ? 0 : 1;
+    const bW = (b.severity ?? "info") === "warn" ? 0 : 1;
+    return aW - bW;
+  });
+  return sorted.slice(0, max);
+}
+
+/**
+ * When `OMNIFOCUS_HINT_LEVEL=warn`, strip `"info"` hints so the array
+ * only surfaces actionable warnings. Default (any other value / unset):
+ * return all hints unchanged.
+ */
+export function filterHintsBySeverity(hints: Hint[]): Hint[] {
+  if (process.env.OMNIFOCUS_HINT_LEVEL === "warn") {
+    return hints.filter((h) => (h.severity ?? "info") === "warn");
+  }
+  return hints;
+}
+
+/**
+ * Convenience: apply both the severity gate and the soft cap.
+ * Call this at every hint-emitting tool site before passing to `ok()`.
+ */
+export function finaliseHints(hints: Hint[], max = 3): Hint[] | undefined {
+  const filtered = filterHintsBySeverity(hints);
+  const capped = capHints(filtered, max);
+  return capped.length > 0 ? capped : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Per-tool hint detectors (pure, unit-testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex for recurring-event cues in a task name.
+ * Matches: "daily", "weekly", "monthly", "every day/week/month/Tuesday/…"
+ */
+const REPETITION_CUE_RE =
+  /\b(daily|weekly|monthly|every\s+(day|week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday|weekday|weekend))\b/i;
+
+/**
+ * Return a `next-natural-step` hint toward `task_set_repetition` if the task
+ * name contains a recurrence cue.
+ */
+export function repeatHintForName(taskId: string, name: string): Hint | undefined {
+  if (!REPETITION_CUE_RE.test(name)) return undefined;
+  return nextNaturalStepHint(
+    "Task name contains a recurrence cue — setting a repetition rule keeps it rescheduled automatically.",
+    { suggestedTool: "task_set_repetition", suggestedArgs: { id: taskId }, severity: "info" },
+  );
+}
+
+/**
+ * Return a `missing-detail` hint if a due date was set but no time estimate.
+ */
+export function estimateHintForDue(
+  taskId: string,
+  dueDate: string | undefined,
+  estimatedMinutes: number | undefined,
+): Hint | undefined {
+  if (dueDate === undefined || estimatedMinutes !== undefined) return undefined;
+  return missingDetailHint(
+    "Task has a due date but no time estimate — an estimate helps schedule the task accurately.",
+    { suggestedTool: "task_update", suggestedArgs: { id: taskId }, severity: "info" },
+  );
+}
+
+/**
+ * Return a `consider-alternative` hint if the inbox now contains `count`
+ * unrouted tasks (>= the `threshold`, default 5).
+ */
+export function inboxGrowthHint(count: number, threshold = 5): Hint | undefined {
+  if (count < threshold) return undefined;
+  return considerAlternativeHint(
+    `Inbox now has ${count} unrouted tasks — consider triaging to keep your inbox clear.`,
+    { suggestedTool: "task_list", suggestedArgs: { inbox: true }, severity: "info" },
+  );
+}
+
+/**
+ * Return a `next-natural-step` hint toward `review_set_interval` if the
+ * project was created without a review interval.
+ */
+export function reviewIntervalHint(
+  projectId: string,
+  reviewIntervalDays: number | undefined,
+): Hint | undefined {
+  if (reviewIntervalDays !== undefined) return undefined;
+  return nextNaturalStepHint(
+    "Project has no review interval — setting one ensures it surfaces in regular review.",
+    {
+      suggestedTool: "project_update",
+      suggestedArgs: { id: projectId, reviewIntervalDays: 7 },
+      severity: "info",
+    },
+  );
+}
+
+/**
+ * Return a `next-natural-step` hint if the project just hit zero remaining
+ * (non-completed, non-dropped) tasks after a completion.
+ */
+export function projectEmptyHint(projectId: string, projectName: string): Hint {
+  return nextNaturalStepHint(
+    `Project '${projectName}' now has no remaining tasks — consider completing or reviewing the project.`,
+    {
+      suggestedTool: "project_complete",
+      suggestedArgs: { id: projectId },
+      severity: "info",
+    },
+  );
+}

--- a/src/envelope/index.ts
+++ b/src/envelope/index.ts
@@ -16,7 +16,10 @@
  * @see docs/adr/0013-tool-response-envelope.md — public contract for this shape
  */
 
+import type { Hint } from "../domain/hints.js";
 import type { OmniFocusError, SerializedError } from "../errors/index.js";
+
+export type { Hint } from "../domain/hints.js";
 
 // ---------------------------------------------------------------------------
 // Public contract — Warning
@@ -196,6 +199,12 @@ export interface ToolSuccess<T> {
   data: T;
   meta: ResponseMeta;
   pagination?: Pagination;
+  /**
+   * Optional server-suggested follow-ups. Purely advisory — the agent is
+   * free to ignore them with zero side effects. Absent (not `[]`) when the
+   * tool has no hints to offer. See ADR-0015 and `src/domain/hints.ts`.
+   */
+  hints?: Hint[];
 }
 
 /** Failure envelope — the shape every tool returns on error. */
@@ -219,9 +228,24 @@ export type ToolEnvelope<T> = ToolSuccess<T> | ToolError;
  * @param pagination — optional pagination block for list-shaped responses
  * @returns a `ToolSuccess<T>` matching the ADR-0013 contract
  */
-export function ok<T>(data: T, meta: ResponseMeta, pagination?: Pagination): ToolSuccess<T> {
+/**
+ * Wrap a success payload in the standard envelope.
+ *
+ * @param data — tool-specific payload
+ * @param meta — request-scoped metadata from the handler harness
+ * @param pagination — optional pagination block for list-shaped responses
+ * @param hints — optional server-suggested follow-ups (see ADR-0015)
+ * @returns a `ToolSuccess<T>` matching the ADR-0013/ADR-0015 contract
+ */
+export function ok<T>(
+  data: T,
+  meta: ResponseMeta,
+  pagination?: Pagination,
+  hints?: Hint[],
+): ToolSuccess<T> {
   const envelope: ToolSuccess<T> = { data, meta };
   if (pagination !== undefined) envelope.pagination = pagination;
+  if (hints !== undefined && hints.length > 0) envelope.hints = hints;
   return envelope;
 }
 

--- a/src/tools/project/create.ts
+++ b/src/tools/project/create.ts
@@ -17,6 +17,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { CreateProjectInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { finaliseHints, reviewIntervalHint } from "../../domain/hints.js";
 import { FolderId, TagId } from "../../domain/ids.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
@@ -165,7 +166,17 @@ export async function handleProjectCreate(
       invalidateProjectMutation(ctx.cache, { projectId: id });
     }
 
-    return ok({ created: true as const, id }, ctx.makeMeta({ syncPending: true }));
+    const hints = finaliseHints(
+      [reviewIntervalHint(id, input.reviewIntervalDays)].filter(
+        (h): h is NonNullable<typeof h> => h != null,
+      ),
+    );
+    return ok(
+      { created: true as const, id },
+      ctx.makeMeta({ syncPending: true }),
+      undefined,
+      hints,
+    );
   });
 }
 

--- a/src/tools/task/complete.ts
+++ b/src/tools/task/complete.ts
@@ -10,6 +10,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
+import { finaliseHints, projectEmptyHint } from "../../domain/hints.js";
 import { TaskId } from "../../domain/ids.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
@@ -60,7 +61,30 @@ export async function handleTaskComplete(input: TaskCompleteToolInput, ctx: Task
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }
-  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+
+  // Hint: if the parent project now has no remaining tasks, suggest completing it.
+  let hints: ReturnType<typeof finaliseHints>;
+  if (task.projectId !== null) {
+    try {
+      const remaining = await ctx.adapter.listTasks({
+        projectId: task.projectId,
+        completed: false,
+      });
+      if (remaining.length === 0) {
+        const project = await ctx.adapter.getProject(task.projectId);
+        hints = finaliseHints([projectEmptyHint(task.projectId, project.name)]);
+      }
+    } catch {
+      // Hint fetch failure never blocks the response.
+    }
+  }
+
+  return ok(
+    { done: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true }),
+    undefined,
+    hints,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -18,6 +18,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
+import {
+  estimateHintForDue,
+  finaliseHints,
+  inboxGrowthHint,
+  repeatHintForName,
+} from "../../domain/hints.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
@@ -176,7 +182,25 @@ export async function handleTaskCreate(input: TaskCreateToolInput, ctx: TaskCrea
         ...(input.projectId !== undefined && { projectId: input.projectId }),
       });
     }
-    return ok({ id }, ctx.makeMeta({ syncPending: true }));
+
+    // Collect advisory hints — all are best-effort; failures are suppressed.
+    const rawHints = [
+      repeatHintForName(id, input.name),
+      estimateHintForDue(id, input.dueDate, input.estimatedMinutes),
+    ];
+
+    // Inbox-count hint: only when task lands in inbox (no project, no parent).
+    if (input.projectId === undefined && input.parentTaskId === undefined) {
+      try {
+        const inboxTasks = await ctx.adapter.listTasks({ inbox: true, completed: false });
+        rawHints.push(inboxGrowthHint(inboxTasks.length));
+      } catch {
+        // Hint fetch failure never blocks the response.
+      }
+    }
+
+    const hints = finaliseHints(rawHints.filter((h): h is NonNullable<typeof h> => h != null));
+    return ok({ id }, ctx.makeMeta({ syncPending: true }), undefined, hints);
   });
 }
 


### PR DESCRIPTION
## Summary

- Adds `hints?: Hint[]` to `ToolSuccess<T>` and the `ok()` helper (4th optional param) per ADR-0015
- Introduces `src/domain/hints.ts`: discriminated `Hint` union (5 kinds), builder helpers, `capHints`/`filterHintsBySeverity`/`finaliseHints` utilities, and per-tool pure detectors
- Wires hint emission into `task_create` (repeat-cue, missing-estimate, inbox-growth), `task_complete` (project-empty), and `project_create` (review-interval)
- Full unit test coverage in `src/domain/hints.test.ts` (31 tests)

Closes #492

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no violations
- [x] `pnpm test` — 2332 passed, 49 skipped (integration/e2e gated)
- [x] Existing tool tests (`task_create`, `task_complete`, `project_create`) still pass