### PR TITLE
chore(automation): enforce PR-required-for-main at GitHub layer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Inherited from [`coding.md`](https://github.com/torsday/llm_prompts/blob/main/co
 ## Workflow
 
 1. **Understand the task.** Open the issue, read the linked DESIGN / SPEC / ADR section.
-2. **Work on a branch.** Never commit to `main` directly.
+2. **Work on a branch. All commits to `main` go through a PR — no exceptions.** GitHub branch protection enforces this for everyone, including administrators; a direct push is rejected at the GitHub layer.
 3. **Follow the patterns.** See [`DESIGN.md §26`](./DESIGN.md#26-example-tool--reference-implementation-for-task_list) for the reference implementation every tool follows.
 4. **Test before opening a PR.**
    - `pnpm typecheck` — zero errors


### PR DESCRIPTION
## Summary

- Enables `enforce_admins=true` on `main` branch protection so administrators (including the repo owner) cannot bypass the PR requirement with a direct push
- Updates CONTRIBUTING.md workflow step to name the enforcement mechanism explicitly, so contributors and automated tools understand that a direct push is rejected at the GitHub layer — not just a guideline

Closes #520.

## Issue

Implements [#520 — chore(automation): require PRs for all commits to main; forbid direct push](https://github.com/torsday/omnifocus-mcp/issues/520).

Branch protection already had `required_pull_request_reviews` with 0 required reviewers and `required_status_checks` (`build (Node 24)`). The gap was `enforce_admins: false`, which let the repo owner bypass those rules with a direct push.

## Breaking change?
- [x] No

## Test plan
- [x] `gh api repos/torsday/omnifocus-mcp/branches/main/protection` confirms `enforce_admins.enabled: true`
- [x] Self-reviewed via /review-pr
- [x] No new dependencies
- [x] Existing tests pass (2471 passed locally)