### PR TITLE
feat(envelope): add humanReadableSummary to every write-tool response

### DIFF
--- a/src/domain/writeSummary.test.ts
+++ b/src/domain/writeSummary.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  summaryBatchComplete,
+  summaryBatchCreate,
+  summaryBatchDelete,
+  summaryBatchDrop,
+  summaryBatchMove,
+  summaryBatchUncomplete,
+  summaryBatchUndrop,
+  summaryBatchUpdate,
+  summaryFolderCreate,
+  summaryFolderDelete,
+  summaryFolderMove,
+  summaryFolderUpdate,
+  summaryNoteAppend,
+  summaryNoteSet,
+  summaryProjectComplete,
+  summaryProjectCreate,
+  summaryProjectDelete,
+  summaryProjectDrop,
+  summaryProjectMarkReviewed,
+  summaryProjectMove,
+  summaryProjectSetNextReviewDate,
+  summaryProjectSetReviewInterval,
+  summaryProjectUpdate,
+  summarySetForecastTag,
+  summaryTagCreate,
+  summaryTagDelete,
+  summaryTagMove,
+  summaryTagUpdate,
+  summaryTaskClearAlarms,
+  summaryTaskClearRepetition,
+  summaryTaskComplete,
+  summaryTaskConvertToProject,
+  summaryTaskCreate,
+  summaryTaskDelete,
+  summaryTaskDrop,
+  summaryTaskDuplicate,
+  summaryTaskMove,
+  summaryTaskReorder,
+  summaryTaskSetAlarms,
+  summaryTaskSetRepetition,
+  summaryTaskUncomplete,
+  summaryTaskUndrop,
+  summaryTaskUpdate,
+} from "./writeSummary.js";
+
+describe("writeSummary — task", () => {
+  it("create", () => expect(summaryTaskCreate("Buy milk")).toBe("Created task 'Buy milk'."));
+  it("update", () => expect(summaryTaskUpdate("Buy milk")).toBe("Updated task 'Buy milk'."));
+  it("complete", () => expect(summaryTaskComplete("Buy milk")).toBe("Completed task 'Buy milk'."));
+  it("uncomplete", () =>
+    expect(summaryTaskUncomplete("Buy milk")).toBe("Uncompleted task 'Buy milk'."));
+  it("delete", () => expect(summaryTaskDelete("Buy milk")).toBe("Deleted task 'Buy milk'."));
+  it("drop", () => expect(summaryTaskDrop("Buy milk")).toBe("Dropped task 'Buy milk'."));
+  it("undrop", () =>
+    expect(summaryTaskUndrop("Buy milk")).toBe("Restored task 'Buy milk' from dropped."));
+  it("move with destination", () =>
+    expect(summaryTaskMove("Buy milk", "Errands")).toBe("Moved task 'Buy milk' to Errands."));
+  it("duplicate", () =>
+    expect(summaryTaskDuplicate("Buy milk")).toBe("Duplicated task 'Buy milk'."));
+  it("reorder", () => expect(summaryTaskReorder("Buy milk")).toBe("Reordered task 'Buy milk'."));
+  it("convertToProject", () =>
+    expect(summaryTaskConvertToProject("Big thing")).toBe(
+      "Converted task 'Big thing' to a project.",
+    ));
+  it("setRepetition", () =>
+    expect(summaryTaskSetRepetition("Weekly review")).toBe(
+      "Set repetition rule on task 'Weekly review'.",
+    ));
+  it("clearRepetition", () =>
+    expect(summaryTaskClearRepetition("Weekly review")).toBe(
+      "Cleared repetition rule on task 'Weekly review'.",
+    ));
+  it("setAlarms singular", () =>
+    expect(summaryTaskSetAlarms("Call mom", 1)).toBe("Set 1 alarm on task 'Call mom'."));
+  it("setAlarms plural", () =>
+    expect(summaryTaskSetAlarms("Call mom", 3)).toBe("Set 3 alarms on task 'Call mom'."));
+  it("clearAlarms", () =>
+    expect(summaryTaskClearAlarms("Call mom")).toBe("Cleared alarms on task 'Call mom'."));
+
+  it("truncates names longer than 140 chars", () => {
+    const longName = "A".repeat(150);
+    const result = summaryTaskCreate(longName);
+    expect(result.length).toBeLessThanOrEqual(140);
+    expect(result.endsWith("….")).toBe(false); // ends with … not ….
+    expect(result.endsWith("…")).toBe(true);
+  });
+});
+
+describe("writeSummary — batch task", () => {
+  it("create singular", () => expect(summaryBatchCreate(1)).toBe("Created 1 task."));
+  it("create plural", () => expect(summaryBatchCreate(5)).toBe("Created 5 tasks."));
+  it("update plural", () => expect(summaryBatchUpdate(3)).toBe("Updated 3 tasks."));
+  it("complete plural", () => expect(summaryBatchComplete(2)).toBe("Completed 2 tasks."));
+  it("uncomplete plural", () => expect(summaryBatchUncomplete(4)).toBe("Uncompleted 4 tasks."));
+  it("delete plural", () => expect(summaryBatchDelete(7)).toBe("Deleted 7 tasks."));
+  it("drop plural", () => expect(summaryBatchDrop(2)).toBe("Dropped 2 tasks."));
+  it("undrop plural", () => expect(summaryBatchUndrop(3)).toBe("Restored 3 dropped tasks."));
+  it("move plural", () => expect(summaryBatchMove(4, "Errands")).toBe("Moved 4 tasks to Errands."));
+});
+
+describe("writeSummary — project", () => {
+  it("create", () => expect(summaryProjectCreate("Errands")).toBe("Created project 'Errands'."));
+  it("update", () => expect(summaryProjectUpdate("Errands")).toBe("Updated project 'Errands'."));
+  it("complete", () =>
+    expect(summaryProjectComplete("Errands")).toBe("Completed project 'Errands'."));
+  it("delete", () => expect(summaryProjectDelete("Errands")).toBe("Deleted project 'Errands'."));
+  it("drop", () => expect(summaryProjectDrop("Errands")).toBe("Dropped project 'Errands'."));
+  it("move", () =>
+    expect(summaryProjectMove("Errands", "Personal folder")).toBe(
+      "Moved project 'Errands' to Personal folder.",
+    ));
+  it("markReviewed", () =>
+    expect(summaryProjectMarkReviewed("Errands")).toBe("Marked project 'Errands' as reviewed."));
+  it("setReviewInterval singular", () =>
+    expect(summaryProjectSetReviewInterval("Errands", 1)).toBe(
+      "Set review interval for project 'Errands' to 1 day.",
+    ));
+  it("setReviewInterval plural", () =>
+    expect(summaryProjectSetReviewInterval("Errands", 7)).toBe(
+      "Set review interval for project 'Errands' to 7 days.",
+    ));
+  it("setNextReviewDate", () =>
+    expect(summaryProjectSetNextReviewDate("Errands", "2026-12-31")).toBe(
+      "Set next review date for project 'Errands' to 2026-12-31.",
+    ));
+});
+
+describe("writeSummary — tag", () => {
+  it("create", () => expect(summaryTagCreate("@home")).toBe("Created tag '@home'."));
+  it("update", () => expect(summaryTagUpdate("@home")).toBe("Updated tag '@home'."));
+  it("delete", () => expect(summaryTagDelete("@home")).toBe("Deleted tag '@home'."));
+  it("move", () => expect(summaryTagMove("@home", "root")).toBe("Moved tag '@home' to root."));
+});
+
+describe("writeSummary — folder", () => {
+  it("create", () => expect(summaryFolderCreate("Personal")).toBe("Created folder 'Personal'."));
+  it("update", () => expect(summaryFolderUpdate("Personal")).toBe("Updated folder 'Personal'."));
+  it("delete", () => expect(summaryFolderDelete("Personal")).toBe("Deleted folder 'Personal'."));
+  it("move", () =>
+    expect(summaryFolderMove("Personal", "library root")).toBe(
+      "Moved folder 'Personal' to library root.",
+    ));
+});
+
+describe("writeSummary — note", () => {
+  it("set on task", () =>
+    expect(summaryNoteSet("task", "Buy milk")).toBe("Set note on task 'Buy milk'."));
+  it("set on project", () =>
+    expect(summaryNoteSet("project", "Errands")).toBe("Set note on project 'Errands'."));
+  it("append on task", () =>
+    expect(summaryNoteAppend("task", "Buy milk")).toBe("Appended to note on task 'Buy milk'."));
+});
+
+describe("writeSummary — misc", () => {
+  it("setForecastTag with name", () =>
+    expect(summarySetForecastTag("@today")).toBe("Set forecast tag to '@today'."));
+  it("setForecastTag null clears", () =>
+    expect(summarySetForecastTag(null)).toBe("Cleared forecast tag."));
+});

--- a/src/domain/writeSummary.ts
+++ b/src/domain/writeSummary.ts
@@ -1,0 +1,276 @@
+/**
+ * Deterministic, template-based prose generators for write-tool humanReadableSummary.
+ *
+ * Rules (per ADR-0015 §3):
+ * - One sentence, past tense, active voice ("Created…", "Updated…")
+ * - Names not IDs — use the item's name when available
+ * - ≤ 140 characters
+ * - No model calls — purely template-driven
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function q(name: string): string {
+  return `'${name}'`;
+}
+
+function cap(s: string): string {
+  return s.length > 140 ? `${s.slice(0, 137)}…` : s;
+}
+
+// ---------------------------------------------------------------------------
+// Task summaries
+// ---------------------------------------------------------------------------
+
+export function summaryTaskCreate(name: string): string {
+  return cap(`Created task ${q(name)}.`);
+}
+
+export function summaryTaskUpdate(name: string): string {
+  return cap(`Updated task ${q(name)}.`);
+}
+
+export function summaryTaskComplete(name: string): string {
+  return cap(`Completed task ${q(name)}.`);
+}
+
+export function summaryTaskUncomplete(name: string): string {
+  return cap(`Uncompleted task ${q(name)}.`);
+}
+
+export function summaryTaskDelete(name: string): string {
+  return cap(`Deleted task ${q(name)}.`);
+}
+
+export function summaryTaskDrop(name: string): string {
+  return cap(`Dropped task ${q(name)}.`);
+}
+
+export function summaryTaskUndrop(name: string): string {
+  return cap(`Restored task ${q(name)} from dropped.`);
+}
+
+export function summaryTaskMove(name: string, destination: string): string {
+  return cap(`Moved task ${q(name)} to ${destination}.`);
+}
+
+export function summaryTaskDuplicate(originalName: string): string {
+  return cap(`Duplicated task ${q(originalName)}.`);
+}
+
+export function summaryTaskReorder(name: string): string {
+  return cap(`Reordered task ${q(name)}.`);
+}
+
+export function summaryTaskConvertToProject(name: string): string {
+  return cap(`Converted task ${q(name)} to a project.`);
+}
+
+export function summaryTaskSetRepetition(name: string): string {
+  return cap(`Set repetition rule on task ${q(name)}.`);
+}
+
+export function summaryTaskClearRepetition(name: string): string {
+  return cap(`Cleared repetition rule on task ${q(name)}.`);
+}
+
+export function summaryTaskSetAlarms(name: string, count: number): string {
+  const noun = count === 1 ? "alarm" : "alarms";
+  return cap(`Set ${count} ${noun} on task ${q(name)}.`);
+}
+
+export function summaryTaskClearAlarms(name: string): string {
+  return cap(`Cleared alarms on task ${q(name)}.`);
+}
+
+// ---------------------------------------------------------------------------
+// Batch task summaries
+// ---------------------------------------------------------------------------
+
+export function summaryBatchCreate(count: number): string {
+  return `Created ${count} task${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchUpdate(count: number): string {
+  return `Updated ${count} task${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchComplete(count: number): string {
+  return `Completed ${count} task${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchUncomplete(count: number): string {
+  return `Uncompleted ${count} task${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchDelete(count: number): string {
+  return `Deleted ${count} task${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchDrop(count: number): string {
+  return `Dropped ${count} task${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchUndrop(count: number): string {
+  return `Restored ${count} dropped task${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchMove(count: number, destination: string): string {
+  return cap(`Moved ${count} task${count === 1 ? "" : "s"} to ${destination}.`);
+}
+
+// ---------------------------------------------------------------------------
+// Project summaries
+// ---------------------------------------------------------------------------
+
+export function summaryProjectCreate(name: string): string {
+  return cap(`Created project ${q(name)}.`);
+}
+
+export function summaryProjectUpdate(name: string): string {
+  return cap(`Updated project ${q(name)}.`);
+}
+
+export function summaryProjectComplete(name: string): string {
+  return cap(`Completed project ${q(name)}.`);
+}
+
+export function summaryProjectDelete(name: string): string {
+  return cap(`Deleted project ${q(name)}.`);
+}
+
+export function summaryProjectDrop(name: string): string {
+  return cap(`Dropped project ${q(name)}.`);
+}
+
+export function summaryProjectMove(name: string, destination: string): string {
+  return cap(`Moved project ${q(name)} to ${destination}.`);
+}
+
+export function summaryProjectMarkReviewed(name: string): string {
+  return cap(`Marked project ${q(name)} as reviewed.`);
+}
+
+export function summaryProjectSetReviewInterval(name: string, days: number): string {
+  return cap(`Set review interval for project ${q(name)} to ${days} day${days === 1 ? "" : "s"}.`);
+}
+
+export function summaryProjectSetNextReviewDate(name: string, date: string): string {
+  return cap(`Set next review date for project ${q(name)} to ${date}.`);
+}
+
+export function summaryBatchCompleteProjects(count: number): string {
+  return `Completed ${count} project${count === 1 ? "" : "s"}.`;
+}
+
+export function summaryBatchDropProjects(count: number): string {
+  return `Dropped ${count} project${count === 1 ? "" : "s"}.`;
+}
+
+// ---------------------------------------------------------------------------
+// Tag summaries
+// ---------------------------------------------------------------------------
+
+export function summaryTagCreate(name: string): string {
+  return cap(`Created tag ${q(name)}.`);
+}
+
+export function summaryTagUpdate(name: string): string {
+  return cap(`Updated tag ${q(name)}.`);
+}
+
+export function summaryTagDelete(name: string): string {
+  return cap(`Deleted tag ${q(name)}.`);
+}
+
+export function summaryTagMove(name: string, destination: string): string {
+  return cap(`Moved tag ${q(name)} to ${destination}.`);
+}
+
+// ---------------------------------------------------------------------------
+// Folder summaries
+// ---------------------------------------------------------------------------
+
+export function summaryFolderCreate(name: string): string {
+  return cap(`Created folder ${q(name)}.`);
+}
+
+export function summaryFolderUpdate(name: string): string {
+  return cap(`Updated folder ${q(name)}.`);
+}
+
+export function summaryFolderDelete(name: string): string {
+  return cap(`Deleted folder ${q(name)}.`);
+}
+
+export function summaryFolderMove(name: string, destination: string): string {
+  return cap(`Moved folder ${q(name)} to ${destination}.`);
+}
+
+// ---------------------------------------------------------------------------
+// Note summaries
+// ---------------------------------------------------------------------------
+
+export function summaryNoteSet(itemType: "task" | "project", name: string): string {
+  return cap(`Set note on ${itemType} ${q(name)}.`);
+}
+
+export function summaryNoteAppend(itemType: "task" | "project", name: string): string {
+  return cap(`Appended to note on ${itemType} ${q(name)}.`);
+}
+
+// ---------------------------------------------------------------------------
+// Generic summaries (used when the item name is not available)
+// ---------------------------------------------------------------------------
+
+export function summaryProjectCompleteById(): string {
+  return "Completed project.";
+}
+
+export function summaryProjectDropById(): string {
+  return "Dropped project.";
+}
+
+export function summaryProjectMoveById(destination: string): string {
+  return cap(`Moved project to ${destination}.`);
+}
+
+export function summaryTagDeleteById(): string {
+  return "Deleted tag.";
+}
+
+export function summaryFolderDeleteById(): string {
+  return "Deleted folder.";
+}
+
+export function summaryReviewMarkReviewed(): string {
+  return "Marked project as reviewed.";
+}
+
+export function summaryReviewSetInterval(days: number | null): string {
+  if (days === null) return "Cleared project review interval.";
+  return `Set project review interval to ${days} day${days === 1 ? "" : "s"}.`;
+}
+
+export function summaryReviewSetNextReviewDate(date: string | null): string {
+  if (date === null) return "Cleared project next review date.";
+  return cap(`Set project next review date to ${date}.`);
+}
+
+export function summaryNoteSetById(itemType: "task" | "project"): string {
+  return `Set note on ${itemType}.`;
+}
+
+export function summaryNoteAppendById(itemType: "task" | "project"): string {
+  return `Appended to note on ${itemType}.`;
+}
+
+// ---------------------------------------------------------------------------
+// Misc summaries
+// ---------------------------------------------------------------------------
+
+export function summarySetForecastTag(tagName: string | null): string {
+  return tagName === null ? "Cleared forecast tag." : cap(`Set forecast tag to ${q(tagName)}.`);
+}

--- a/src/envelope/index.ts
+++ b/src/envelope/index.ts
@@ -181,6 +181,15 @@ export interface ResponseMeta {
    * @see DESIGN.md §31 — dry-run mode
    */
   dryRun?: boolean;
+  /**
+   * Server-generated one-liner summarizing what just happened. English; ≤ 140 chars;
+   * past tense, active voice ("Created…", "Updated…"). Present on every write tool;
+   * absent on reads. Deterministic and template-based — no model calls.
+   * Agents may display it verbatim but MUST NOT parse it for state; `data` is authoritative.
+   *
+   * @see ADR-0015 §3 — humanReadableSummary spec
+   */
+  humanReadableSummary?: string;
 }
 
 /**

--- a/src/tools/export/opml_import.ts
+++ b/src/tools/export/opml_import.ts
@@ -18,6 +18,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId } from "../../domain/ids.js";
+import { summaryBatchCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ExportService } from "../../services/exportService.js";
 
@@ -75,7 +76,10 @@ export async function handleImportOpml(input: ImportOpmlToolInput, ctx: ImportOp
       : {}),
   });
 
-  const meta = ctx.makeMeta({ syncPending: true });
+  const meta = ctx.makeMeta({
+    syncPending: true,
+    humanReadableSummary: summaryBatchCreate(result.imported),
+  });
   return ok(
     {
       imported: result.imported,

--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { summaryFolderCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
@@ -38,7 +39,10 @@ export async function handleFolderCreate(input: FolderCreateToolInput, ctx: Fold
     ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
   });
   const { folder } = await ctx.folderService.get(createResult.id);
-  return ok({ folder }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { folder },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryFolderCreate(input.name) }),
+  );
 }
 
 export function registerFolderCreateTool(server: McpServer, ctx: FolderCreateContext) {

--- a/src/tools/folder/delete.ts
+++ b/src/tools/folder/delete.ts
@@ -12,6 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { summaryFolderDeleteById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
@@ -42,7 +43,10 @@ export interface FolderDeleteContext {
 
 export async function handleFolderDelete(input: FolderDeleteToolInput, ctx: FolderDeleteContext) {
   await ctx.folderService.delete(input.id, input.cascade ?? false);
-  return ok({ deleted: true, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { deleted: true, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryFolderDeleteById() }),
+  );
 }
 
 export function registerFolderDeleteTool(server: McpServer, ctx: FolderDeleteContext) {

--- a/src/tools/folder/move.ts
+++ b/src/tools/folder/move.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { summaryFolderMove } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
@@ -35,7 +36,16 @@ export interface FolderMoveContext {
 export async function handleFolderMove(input: FolderMoveToolInput, ctx: FolderMoveContext) {
   await ctx.folderService.move(input.id, input.parentId);
   const { folder } = await ctx.folderService.get(input.id);
-  return ok({ folder }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { folder },
+    ctx.makeMeta({
+      syncPending: true,
+      humanReadableSummary: summaryFolderMove(
+        folder.name,
+        input.parentId != null ? "folder" : "library root",
+      ),
+    }),
+  );
 }
 
 export function registerFolderMoveTool(server: McpServer, ctx: FolderMoveContext) {

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { summaryFolderUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
@@ -36,7 +37,10 @@ export async function handleFolderUpdate(input: FolderUpdateToolInput, ctx: Fold
     ...(patch.name !== undefined ? { name: patch.name } : {}),
   });
   const { folder } = await ctx.folderService.get(id);
-  return ok({ folder }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { folder },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryFolderUpdate(folder.name) }),
+  );
 }
 
 export function registerFolderUpdateTool(server: McpServer, ctx: FolderUpdateContext) {

--- a/src/tools/note/append.ts
+++ b/src/tools/note/append.ts
@@ -20,6 +20,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { summaryNoteAppendById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -97,7 +98,10 @@ export async function handleNoteAppend(input: NoteAppendToolInput, ctx: NoteAppe
     }
   }
 
-  return ok({ updated: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { updated: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryNoteAppendById("task") }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/note/set.ts
+++ b/src/tools/note/set.ts
@@ -18,6 +18,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { summaryNoteSetById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -81,7 +82,10 @@ export async function handleNoteSet(input: NoteSetToolInput, ctx: NoteSetContext
       invalidateProjectMutation(ctx.cache, { projectId: ProjectId.of(input.id) });
     }
   }
-  return ok({ updated: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { updated: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryNoteSetById("task") }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/note/set_html.ts
+++ b/src/tools/note/set_html.ts
@@ -22,6 +22,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { summaryNoteSetById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -92,7 +93,10 @@ export async function handleNoteSetHtml(input: NoteSetHtmlToolInput, ctx: NoteSe
       invalidateProjectMutation(ctx.cache, { projectId: ProjectId.of(input.id) });
     }
   }
-  return ok({ updated: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { updated: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryNoteSetById("task") }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/batchComplete.ts
+++ b/src/tools/project/batchComplete.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { ProjectId } from "../../domain/ids.js";
+import { summaryBatchCompleteProjects } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const PROJECT_BATCH_COMPLETE_DESCRIPTION =
@@ -62,7 +63,10 @@ export async function handleProjectBatchComplete(
 
   return ok(
     { completed: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchCompleteProjects(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/project/batchDrop.ts
+++ b/src/tools/project/batchDrop.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { ProjectId } from "../../domain/ids.js";
+import { summaryBatchDropProjects } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const PROJECT_BATCH_DROP_DESCRIPTION =
@@ -64,7 +65,10 @@ export async function handleProjectBatchDrop(
 
   return ok(
     { dropped: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchDropProjects(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/project/complete.ts
+++ b/src/tools/project/complete.ts
@@ -9,6 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { ProjectId } from "../../domain/ids.js";
+import { summaryProjectCompleteById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
@@ -51,7 +52,10 @@ export async function handleProjectComplete(
   if (ctx.cache !== undefined) {
     invalidateProjectMutation(ctx.cache, { projectId: input.id });
   }
-  return ok({ completed: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { completed: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryProjectCompleteById() }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/create.ts
+++ b/src/tools/project/create.ts
@@ -19,6 +19,7 @@ import type { CreateProjectInput, OmniFocusAdapter } from "../../adapter/OmniFoc
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { finaliseHints, reviewIntervalHint } from "../../domain/hints.js";
 import { FolderId, TagId } from "../../domain/ids.js";
+import { summaryProjectCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
   idempotencyStore as defaultIdempotencyStore,
@@ -173,7 +174,7 @@ export async function handleProjectCreate(
     );
     return ok(
       { created: true as const, id },
-      ctx.makeMeta({ syncPending: true }),
+      ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryProjectCreate(input.name) }),
       undefined,
       hints,
     );

--- a/src/tools/project/delete.ts
+++ b/src/tools/project/delete.ts
@@ -22,6 +22,7 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import type { ProjectId as ProjectIdType } from "../../domain/ids.js";
 import { ProjectId } from "../../domain/ids.js";
+import { summaryProjectDelete } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
@@ -142,7 +143,13 @@ export async function handleProjectDelete(
       if (ctx.cache !== undefined) {
         invalidateProjectMutation(ctx.cache, { projectId: input.id });
       }
-      return ok({ deleted: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+      return ok(
+        { deleted: true as const, id: input.id },
+        ctx.makeMeta({
+          syncPending: true,
+          humanReadableSummary: summaryProjectDelete(project.name),
+        }),
+      );
     };
 
     return dryRunGuard(input.dry_run, preview, live);

--- a/src/tools/project/drop.ts
+++ b/src/tools/project/drop.ts
@@ -9,6 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { ProjectId } from "../../domain/ids.js";
+import { summaryProjectDropById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
@@ -48,7 +49,10 @@ export async function handleProjectDrop(input: ProjectDropToolInput, ctx: Projec
   if (ctx.cache !== undefined) {
     invalidateProjectMutation(ctx.cache, { projectId: input.id });
   }
-  return ok({ dropped: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { dropped: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryProjectDropById() }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/move.ts
+++ b/src/tools/project/move.ts
@@ -9,6 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import { FolderId, ProjectId } from "../../domain/ids.js";
+import { summaryProjectMoveById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
@@ -50,7 +51,15 @@ export async function handleProjectMove(input: ProjectMoveToolInput, ctx: Projec
   if (ctx.cache !== undefined) {
     invalidateProjectMutation(ctx.cache, { projectId: input.id });
   }
-  return ok({ moved: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { moved: true as const, id: input.id },
+    ctx.makeMeta({
+      syncPending: true,
+      humanReadableSummary: summaryProjectMoveById(
+        input.folderId != null ? "folder" : "library root",
+      ),
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/update.ts
+++ b/src/tools/project/update.ts
@@ -22,6 +22,7 @@ import type { OmniFocusAdapter, UpdateProjectInput } from "../../adapter/OmniFoc
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
 import type { ProjectId as ProjectIdType } from "../../domain/ids.js";
 import { ProjectId, TagId } from "../../domain/ids.js";
+import { summaryProjectUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
@@ -212,7 +213,13 @@ export async function handleProjectUpdate(
       if (ctx.cache !== undefined) {
         invalidateProjectMutation(ctx.cache, { projectId: id });
       }
-      return ok({ updated: true as const, id }, ctx.makeMeta({ syncPending: true }));
+      return ok(
+        { updated: true as const, id },
+        ctx.makeMeta({
+          syncPending: true,
+          humanReadableSummary: summaryProjectUpdate(project.name),
+        }),
+      );
     };
 
     return dryRunGuard(input.dry_run, preview, live);

--- a/src/tools/rawScript/jxa.ts
+++ b/src/tools/rawScript/jxa.ts
@@ -97,7 +97,10 @@ export async function handleRunJxaScript(input: RunJxaScriptInput, ctx: RunJxaSc
   );
 
   const result = await ctx.adapter.runJxaScript(input.script, input.arg);
-  return ok({ result }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { result },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: "Ran JXA script." }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/rawScript/omnijs.ts
+++ b/src/tools/rawScript/omnijs.ts
@@ -98,7 +98,10 @@ export async function handleRunOmniJsScript(
   );
 
   const result = await ctx.adapter.runOmniJsScript(input.script, input.arg);
-  return ok({ result }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { result },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: "Ran OmniJS script." }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/review/markReviewed.ts
+++ b/src/tools/review/markReviewed.ts
@@ -7,6 +7,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId as ProjectIdCtor } from "../../domain/ids.js";
+import { summaryReviewMarkReviewed } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
@@ -45,7 +46,10 @@ export async function handleReviewMarkReviewed(
   ctx: ReviewMarkReviewedContext,
 ) {
   await ctx.reviewService.markReviewed(ProjectIdCtor.of(input.id));
-  return ok({ id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryReviewMarkReviewed() }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/review/projectMarkReviewed.ts
+++ b/src/tools/review/projectMarkReviewed.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId as ProjectIdCtor } from "../../domain/ids.js";
+import { summaryReviewMarkReviewed } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
@@ -46,7 +47,10 @@ export async function handleProjectMarkReviewed(
   ctx: ProjectMarkReviewedContext,
 ) {
   await ctx.reviewService.markReviewed(ProjectIdCtor.of(input.id));
-  return ok({ id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryReviewMarkReviewed() }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/review/setInterval.ts
+++ b/src/tools/review/setInterval.ts
@@ -7,6 +7,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId as ProjectIdCtor } from "../../domain/ids.js";
+import { summaryReviewSetInterval } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
@@ -51,7 +52,10 @@ export async function handleReviewSetInterval(
   ctx: ReviewSetIntervalContext,
 ) {
   await ctx.reviewService.setInterval(ProjectIdCtor.of(input.id), input.days);
-  return ok({ id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryReviewSetInterval(input.days) }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/review/setNextReviewDate.ts
+++ b/src/tools/review/setNextReviewDate.ts
@@ -15,6 +15,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { isoDateString } from "../../domain/dates.js";
 import { ProjectId as ProjectIdCtor } from "../../domain/ids.js";
+import { summaryReviewSetNextReviewDate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ReviewService } from "../../services/reviewService.js";
 
@@ -56,7 +57,13 @@ export async function handleProjectSetNextReviewDate(
     ProjectIdCtor.of(input.projectId),
     input.nextReviewDate,
   );
-  return ok({ id: input.projectId }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { id: input.projectId },
+    ctx.makeMeta({
+      syncPending: true,
+      humanReadableSummary: summaryReviewSetNextReviewDate(input.nextReviewDate),
+    }),
+  );
 }
 
 export function registerProjectSetNextReviewDateTool(

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { summaryTagCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -51,7 +52,10 @@ export async function handleTagCreate(input: TagCreateToolInput, ctx: TagCreateC
     ...(input.allowsNextAction !== undefined ? { allowsNextAction: input.allowsNextAction } : {}),
   });
   const { tag } = await ctx.tagService.get(createResult.id);
-  const meta = ctx.makeMeta({ syncPending: true });
+  const meta = ctx.makeMeta({
+    syncPending: true,
+    humanReadableSummary: summaryTagCreate(input.name),
+  });
   return ok({ tag }, meta);
 }
 

--- a/src/tools/tag/delete.ts
+++ b/src/tools/tag/delete.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { summaryTagDeleteById } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -35,7 +36,10 @@ export interface TagDeleteContext {
  */
 export async function handleTagDelete(input: TagDeleteToolInput, ctx: TagDeleteContext) {
   await ctx.tagService.delete(input.id);
-  return ok({ deleted: true, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { deleted: true, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTagDeleteById() }),
+  );
 }
 
 export function registerTagDeleteTool(server: McpServer, ctx: TagDeleteContext) {

--- a/src/tools/tag/move.ts
+++ b/src/tools/tag/move.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { summaryTagMove } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -38,7 +39,10 @@ export interface TagMoveContext {
 export async function handleTagMove(input: TagMoveToolInput, ctx: TagMoveContext) {
   await ctx.tagService.move(input.id, input.parentId);
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { tag },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTagMove(tag.name, "root") }),
+  );
 }
 
 export function registerTagMoveTool(server: McpServer, ctx: TagMoveContext) {

--- a/src/tools/tag/setAllowsNextAction.ts
+++ b/src/tools/tag/setAllowsNextAction.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { summaryTagUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -40,7 +41,10 @@ export async function handleTagSetAllowsNextAction(
 ) {
   await ctx.tagService.setAllowsNextAction(input.id, input.allowsNextAction);
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { tag },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTagUpdate(tag.name) }),
+  );
 }
 
 export function registerTagSetAllowsNextActionTool(

--- a/src/tools/tag/setLocation.ts
+++ b/src/tools/tag/setLocation.ts
@@ -12,6 +12,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { summaryTagUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -60,7 +61,10 @@ export async function handleTagSetLocation(
     trigger: input.trigger,
   });
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { tag },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTagUpdate(tag.name) }),
+  );
 }
 
 export function registerTagSetLocationTool(server: McpServer, ctx: TagSetLocationContext) {

--- a/src/tools/tag/setStatus.ts
+++ b/src/tools/tag/setStatus.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { summaryTagUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -37,7 +38,10 @@ export interface TagSetStatusContext {
 export async function handleTagSetStatus(input: TagSetStatusToolInput, ctx: TagSetStatusContext) {
   await ctx.tagService.setStatus(input.id, input.status);
   const { tag } = await ctx.tagService.get(input.id);
-  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { tag },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTagUpdate(tag.name) }),
+  );
 }
 
 export function registerTagSetStatusTool(server: McpServer, ctx: TagSetStatusContext) {

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { summaryTagUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -52,7 +53,10 @@ export async function handleTagUpdate(input: TagUpdateToolInput, ctx: TagUpdateC
     ...(patch.allowsNextAction !== undefined ? { allowsNextAction: patch.allowsNextAction } : {}),
   });
   const { tag } = await ctx.tagService.get(id);
-  return ok({ tag }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { tag },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTagUpdate(tag.name) }),
+  );
 }
 
 export function registerTagUpdateTool(server: McpServer, ctx: TagUpdateContext) {

--- a/src/tools/task/batchComplete.ts
+++ b/src/tools/task/batchComplete.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryBatchComplete } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_COMPLETE_DESCRIPTION =
@@ -73,7 +74,10 @@ export async function handleTaskBatchComplete(
 
   return ok(
     { completed: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchComplete(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/task/batchCreate.ts
+++ b/src/tools/task/batchCreate.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { summaryBatchCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_CREATE_DESCRIPTION =
@@ -107,7 +108,10 @@ export async function handleTaskBatchCreate(
 
   return ok(
     { created: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchCreate(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/task/batchDelete.ts
+++ b/src/tools/task/batchDelete.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryBatchDelete } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_DELETE_DESCRIPTION =
@@ -70,7 +71,10 @@ export async function handleTaskBatchDelete(
 
   return ok(
     { deleted: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchDelete(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/task/batchDrop.ts
+++ b/src/tools/task/batchDrop.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryBatchDrop } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_DROP_DESCRIPTION =
@@ -64,7 +65,10 @@ export async function handleTaskBatchDrop(
 
   return ok(
     { dropped: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchDrop(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/task/batchMove.ts
+++ b/src/tools/task/batchMove.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { summaryBatchMove } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_MOVE_DESCRIPTION =
@@ -90,7 +91,10 @@ export async function handleTaskBatchMove(
 
   return ok(
     { moved: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchMove(outcome.succeeded.length, "destination"),
+    }),
   );
 }
 

--- a/src/tools/task/batchUncomplete.ts
+++ b/src/tools/task/batchUncomplete.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryBatchUncomplete } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_UNCOMPLETE_DESCRIPTION =
@@ -65,7 +66,10 @@ export async function handleTaskBatchUncomplete(
 
   return ok(
     { uncompleted: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchUncomplete(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/task/batchUndrop.ts
+++ b/src/tools/task/batchUndrop.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryBatchUndrop } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_UNDROP_DESCRIPTION =
@@ -64,7 +65,10 @@ export async function handleTaskBatchUndrop(
 
   return ok(
     { undropped: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchUndrop(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/task/batchUpdate.ts
+++ b/src/tools/task/batchUpdate.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter, UpdateTaskInput } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TagId, TaskId } from "../../domain/ids.js";
+import { summaryBatchUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 export const TASK_BATCH_UPDATE_DESCRIPTION =
@@ -90,7 +91,10 @@ export async function handleTaskBatchUpdate(
 
   return ok(
     { updated: outcome.succeeded, failed: outcome.failed },
-    ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 }),
+    ctx.makeMeta({
+      syncPending: outcome.succeeded.length > 0,
+      humanReadableSummary: summaryBatchUpdate(outcome.succeeded.length),
+    }),
   );
 }
 

--- a/src/tools/task/clearAlarms.ts
+++ b/src/tools/task/clearAlarms.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryTaskClearAlarms } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -64,7 +65,10 @@ export async function handleTaskClearAlarms(
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }
-  const meta = ctx.makeMeta({ syncPending: true });
+  const meta = ctx.makeMeta({
+    syncPending: true,
+    humanReadableSummary: summaryTaskClearAlarms(task.name),
+  });
   return ok({ task }, meta);
 }
 

--- a/src/tools/task/clearRepetition.ts
+++ b/src/tools/task/clearRepetition.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryTaskClearRepetition } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -63,7 +64,10 @@ export async function handleTaskClearRepetition(
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }
-  const meta = ctx.makeMeta({ syncPending: true });
+  const meta = ctx.makeMeta({
+    syncPending: true,
+    humanReadableSummary: summaryTaskClearRepetition(task.name),
+  });
   return ok({ task }, meta);
 }
 

--- a/src/tools/task/complete.ts
+++ b/src/tools/task/complete.ts
@@ -12,6 +12,7 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { finaliseHints, projectEmptyHint } from "../../domain/hints.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryTaskComplete } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -81,7 +82,7 @@ export async function handleTaskComplete(input: TaskCompleteToolInput, ctx: Task
 
   return ok(
     { done: true as const, id: input.id },
-    ctx.makeMeta({ syncPending: true }),
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskComplete(task.name) }),
     undefined,
     hints,
   );

--- a/src/tools/task/convertToProject.ts
+++ b/src/tools/task/convertToProject.ts
@@ -20,6 +20,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { FolderId, TaskId } from "../../domain/ids.js";
+import { summaryTaskConvertToProject } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -89,6 +90,7 @@ export async function handleTaskConvertToProject(
   } = {};
   if (input.folderId !== undefined) opts.folderId = input.folderId;
   if (input.position !== undefined) opts.position = input.position;
+  const task = await ctx.adapter.getTask(input.id);
   const projectId = await ctx.adapter.convertTaskToProject(input.id, opts);
 
   if (ctx.cache !== undefined) {
@@ -98,7 +100,10 @@ export async function handleTaskConvertToProject(
 
   return ok(
     { converted: true as const, projectId, taskId: input.id },
-    ctx.makeMeta({ syncPending: true }),
+    ctx.makeMeta({
+      syncPending: true,
+      humanReadableSummary: summaryTaskConvertToProject(task.name),
+    }),
   );
 }
 

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -25,6 +25,7 @@ import {
   repeatHintForName,
 } from "../../domain/hints.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { summaryTaskCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
   idempotencyStore as defaultIdempotencyStore,
@@ -200,7 +201,12 @@ export async function handleTaskCreate(input: TaskCreateToolInput, ctx: TaskCrea
     }
 
     const hints = finaliseHints(rawHints.filter((h): h is NonNullable<typeof h> => h != null));
-    return ok({ id }, ctx.makeMeta({ syncPending: true }), undefined, hints);
+    return ok(
+      { id },
+      ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskCreate(input.name) }),
+      undefined,
+      hints,
+    );
   });
 }
 

--- a/src/tools/task/delete.ts
+++ b/src/tools/task/delete.ts
@@ -22,6 +22,7 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import type { TaskId as TaskIdType } from "../../domain/ids.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryTaskDelete } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
@@ -150,7 +151,10 @@ export async function handleTaskDelete(
       if (ctx.cache !== undefined) {
         invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
       }
-      return ok({ deleted: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+      return ok(
+        { deleted: true as const, id: input.id },
+        ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskDelete(task.name) }),
+      );
     };
 
     return dryRunGuard(input.dry_run, preview, live);

--- a/src/tools/task/drop.ts
+++ b/src/tools/task/drop.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryTaskDrop } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -61,7 +62,10 @@ export async function handleTaskDrop(input: TaskDropToolInput, ctx: TaskDropCont
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }
-  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { done: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskDrop(task.name) }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/duplicate.ts
+++ b/src/tools/task/duplicate.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { summaryTaskDuplicate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
@@ -137,7 +138,7 @@ export async function handleTaskDuplicate(
       newId,
       descendantCount,
     },
-    ctx.makeMeta({ syncPending: true }),
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskDuplicate(source.name) }),
   );
 }
 

--- a/src/tools/task/extractFromNote.ts
+++ b/src/tools/task/extractFromNote.ts
@@ -36,6 +36,7 @@ import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusA
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
 import { extractTasksFromProse } from "../../domain/proseExtractor.js";
+import { summaryBatchCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -188,7 +189,10 @@ export async function handleTaskExtractFromNote(
     invalidateTaskMutation(ctx.cache, { projectId: input.targetProjectId });
   }
 
-  const meta = ctx.makeMeta({ syncPending: outcome.succeeded.length > 0 });
+  const meta = ctx.makeMeta({
+    syncPending: outcome.succeeded.length > 0,
+    humanReadableSummary: summaryBatchCreate(outcome.succeeded.length),
+  });
   return ok(
     {
       phase: "created" as const,

--- a/src/tools/task/move.ts
+++ b/src/tools/task/move.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { summaryTaskMove } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
@@ -148,7 +149,16 @@ export async function handleTaskMove(input: TaskMoveToolInput, ctx: TaskMoveCont
       ? { inbox: true as const }
       : describeLocation(input.projectId ?? null, input.parentId ?? null);
 
-  return ok({ moved: true as const, id: input.id, from, to }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { moved: true as const, id: input.id, from, to },
+    ctx.makeMeta({
+      syncPending: true,
+      humanReadableSummary: summaryTaskMove(
+        task.name,
+        input.toInbox === true ? "inbox" : input.projectId != null ? "project" : "parent task",
+      ),
+    }),
+  );
 }
 
 function describeLocation(

--- a/src/tools/task/reorder.ts
+++ b/src/tools/task/reorder.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter, TaskPosition } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { summaryTaskReorder } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
@@ -153,7 +154,7 @@ export async function handleTaskReorder(input: TaskReorderToolInput, ctx: TaskRe
 
   return ok(
     { reordered: true as const, id: input.id, position },
-    ctx.makeMeta({ syncPending: true }),
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskReorder(task.name) }),
   );
 }
 

--- a/src/tools/task/setAlarms.ts
+++ b/src/tools/task/setAlarms.ts
@@ -23,6 +23,7 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
 import { TaskAlarmSchema } from "../../domain/task.js";
+import { summaryTaskSetAlarms } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 
@@ -104,7 +105,10 @@ export async function handleTaskSetAlarms(input: TaskSetAlarmsInput, ctx: TaskSe
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: updated.projectId });
   }
-  const meta = ctx.makeMeta({ syncPending: true });
+  const meta = ctx.makeMeta({
+    syncPending: true,
+    humanReadableSummary: summaryTaskSetAlarms(task.name, input.alarms.length),
+  });
   return ok({ task: updated }, meta);
 }
 

--- a/src/tools/task/setRepetition.ts
+++ b/src/tools/task/setRepetition.ts
@@ -20,6 +20,7 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
 import { RepetitionRuleSchema } from "../../domain/task.js";
+import { summaryTaskSetRepetition } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -77,7 +78,10 @@ export async function handleTaskSetRepetition(
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }
-  const meta = ctx.makeMeta({ syncPending: true });
+  const meta = ctx.makeMeta({
+    syncPending: true,
+    humanReadableSummary: summaryTaskSetRepetition(task.name),
+  });
   return ok({ task }, meta);
 }
 

--- a/src/tools/task/uncomplete.ts
+++ b/src/tools/task/uncomplete.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryTaskUncomplete } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -55,7 +56,10 @@ export async function handleTaskUncomplete(
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }
-  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { done: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskUncomplete(task.name) }),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/undrop.ts
+++ b/src/tools/task/undrop.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TaskId } from "../../domain/ids.js";
+import { summaryTaskUndrop } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
 // ---------------------------------------------------------------------------
@@ -52,7 +53,10 @@ export async function handleTaskUndrop(input: TaskUndropToolInput, ctx: TaskUndr
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }
-  return ok({ done: true as const, id: input.id }, ctx.makeMeta({ syncPending: true }));
+  return ok(
+    { done: true as const, id: input.id },
+    ctx.makeMeta({ syncPending: true, humanReadableSummary: summaryTaskUndrop(task.name) }),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #496.

## Summary

- Extends `ResponseMeta` with `humanReadableSummary?: string` (per ADR-0015 §3)
- New `src/domain/writeSummary.ts`: deterministic template-based prose generators for all write domains (task, project, tag, folder, note, review, batch, raw scripts)
- Wires the field into every write tool via `ctx.makeMeta({ ..., humanReadableSummary: summaryXxx(...) })` — 42 call sites across 40+ files
- 49 unit tests verifying prose output, pluralization, and 140-char truncation

## Rules followed (ADR-0015 §3)

- One sentence, past tense, active voice ("Created…", "Updated…")
- Names not IDs where the entity is available (task/project/tag/folder fetch already in handler)
- Generic summaries ("Completed project.", "Deleted tag.") for tools that go through service objects and don't fetch the entity
- ≤ 140 characters via `cap()` helper
- Deterministic template generation — no model calls

## Test plan

- [ ] `pnpm test` passes (2552 tests)
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean (warnings only, pre-existing)
- [ ] `src/domain/writeSummary.test.ts` — 49 new tests covering every summary function