### PR TITLE
docs(clients): add OpenCode and Pi setup guides (#559)

### DIFF
--- a/docs/clients/opencode.md
+++ b/docs/clients/opencode.md
@@ -1,0 +1,124 @@
+# OpenCode — omnifocus-mcp setup
+
+Adds omnifocus-mcp as a local MCP server in [OpenCode](https://opencode.ai), the open-source terminal agent by SST.
+
+## Prerequisites
+
+- macOS 13 (Ventura) or later
+- OmniFocus 3.15+ or OmniFocus 4.x
+- Node.js 24 or newer (`node --version`)
+- OpenCode installed (`opencode --version`)
+
+## One-time install
+
+```bash
+npm install -g @torsday/omnifocus-mcp
+```
+
+Verify the binary is available:
+
+```bash
+omnifocus-mcp --version
+```
+
+## Configuration
+
+OpenCode reads MCP server definitions from `~/.config/opencode/opencode.json` (global) or a project-local `opencode.json` in the working directory. Add an entry under `"mcp"`:
+
+```json
+{
+  "mcp": {
+    "omnifocus": {
+      "type": "local",
+      "command": ["omnifocus-mcp"],
+      "environment": {
+        "OMNIFOCUS_LOG_LEVEL": "info"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+If the file does not exist, create it. If it does exist, merge the `"mcp"` key — don't replace other server entries.
+
+The `"type": "local"` field is required for stdio servers. The `"command"` array takes the executable name followed by any arguments (none required for omnifocus-mcp).
+
+## Verify
+
+Restart OpenCode (it reads the config at startup), then ask:
+
+> Use the `internal_status` tool and tell me what it returns.
+
+A healthy response surfaces a JSON object with `status: "ok"`, `ofVersion`, and `transport`. If no tools are found, see [Troubleshooting](#troubleshooting).
+
+## Grant macOS Automation permission
+
+On the first call that touches OmniFocus, macOS prompts:
+
+> "**OpenCode** (or your terminal) wants access to control **OmniFocus**."
+
+Click **OK**. If denied by mistake:
+
+**System Settings → Privacy & Security → Automation → [your terminal app] → OmniFocus** ✓
+
+Because OpenCode is a terminal application, the Automation permission typically attaches to the terminal emulator (Terminal.app, iTerm2, Ghostty, etc.) that launched OpenCode — not to OpenCode itself. Look for that process in the Automation list if the permission prompt doesn't appear.
+
+## Environment variables
+
+Pass environment variables via the `"environment"` map in the config:
+
+```json
+{
+  "mcp": {
+    "omnifocus": {
+      "type": "local",
+      "command": ["omnifocus-mcp"],
+      "environment": {
+        "OMNIFOCUS_LOG_LEVEL": "debug",
+        "OMNIFOCUS_ALLOW_RAW_SCRIPT": "1"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OMNIFOCUS_LOG_LEVEL` | `info` | Log verbosity: `trace` / `debug` / `info` / `warn` / `error` |
+| `OMNIFOCUS_CACHE_TTL_MS` | `30000` | Read-cache TTL in milliseconds |
+| `OMNIFOCUS_ALLOW_RAW_SCRIPT` | — | Set to `1` to enable `run_jxa_script` / `run_omnijs_script` escape hatches |
+
+Full reference: [README — Environment variables](../../README.md#environment-variables).
+
+## Troubleshooting
+
+### No tools surfaced / "tool not found"
+
+The server failed to start. Run it manually to check for startup errors:
+
+```bash
+omnifocus-mcp 2>&1 | head -20
+```
+
+A clean start logs `server started` on stderr. Restart OpenCode after fixing any errors.
+
+### "OmniFocus is not running"
+
+The server drives a running OmniFocus process via AppleScript. Open OmniFocus before or during the session.
+
+### "Automation permission denied"
+
+The permission is sticky once denied. Re-grant it at:
+
+**System Settings → Privacy & Security → Automation → [your terminal] → OmniFocus** ✓
+
+### Config changes not picked up
+
+OpenCode reads the config at startup. After editing `opencode.json`, exit and re-launch OpenCode.
+
+## Related
+
+- [Generic stdio client setup](./generic-stdio.md) — the underlying stdio transport contract
+- [README — Trust & security](../../README.md) — what data leaves the machine (none) and how the server is sandboxed

--- a/docs/clients/pi.md
+++ b/docs/clients/pi.md
@@ -1,0 +1,33 @@
+# Pi (pi.ai) — omnifocus-mcp compatibility
+
+[Pi](https://pi.ai) is a conversational AI assistant by Inflection AI. This page records its current MCP compatibility status so you don't spend time chasing a setup that doesn't exist yet.
+
+## Current status: not supported
+
+Pi does not support the Model Context Protocol as of mid-2025. The consumer-facing app has no mechanism to connect to external tool servers — MCP or otherwise. There is no known bridge or proxy approach that adds MCP support to Pi.
+
+Pi's tool surface is limited to:
+
+- Web browsing via curated Discover Feeds
+- Voice interaction
+- A preference graph that personalises conversation style
+
+It does not support code execution, calendar or app integrations, or custom tool servers.
+
+## What to use instead
+
+If you want an AI assistant that connects to omnifocus-mcp, use any of the clients in this directory:
+
+| Client | Setup guide |
+|---|---|
+| Claude Code (CLI) | [claude-code.md](./claude-code.md) |
+| Claude Desktop | [claude-desktop.md](./claude-desktop.md) |
+| OpenCode | [opencode.md](./opencode.md) |
+| OpenAI Codex CLI | [codex.md](./codex.md) |
+| Any other MCP-compatible stdio client | [generic-stdio.md](./generic-stdio.md) |
+
+## Tracking MCP support in Pi
+
+Inflection has published MCP servers for their enterprise products (Inflection for Business), but those are servers *for* Claude and ChatGPT to call — they do not give Pi itself the ability to call external MCP servers.
+
+Watch [pi.ai/updates](https://pi.ai) and [Inflection's engineering blog](https://inflection.ai) for announcements. If support ships, the setup will follow the [generic stdio pattern](./generic-stdio.md) — `command: omnifocus-mcp`, no required args.


### PR DESCRIPTION
## Summary

- **OpenCode** ([opencode.md](docs/clients/opencode.md)): full setup worksheet covering `opencode.json` config format, macOS Automation permission caveats (permission attaches to the terminal, not OpenCode itself), env var reference, and troubleshooting. Follows the same structure as `claude-code.md` and `codex.md`.
- **Pi** ([pi.md](docs/clients/pi.md)): honest compatibility note — pi.ai does not support MCP as of mid-2025, no bridge exists. Redirects to supported clients and tells users what to watch for if Pi support ships.

Closes #559.

## Issue
Implements [#559 — docs: document OpenCode and Pi in docs/clients/](https://github.com/torsday/omnifocus-mcp/issues/559).

## Breaking change?
- [x] No

## Test plan
- [x] No code changes — docs only
- [x] OpenCode config format verified against opencode.ai/docs
- [x] Pi MCP status verified — not supported as of mid-2025
- [x] Self-reviewed for accuracy and consistency with existing client docs