### PR TITLE
infra(release): add Homebrew tap formula and auto-update on release (#561)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,16 @@ jobs:
         with:
           body: ${{ steps.notes.outputs.notes }}
           make_latest: true
+
+      - name: Update Homebrew tap formula
+        # Patches torsday/homebrew-tap/Formula/omnifocus-mcp.rb with the new
+        # version + sha256 so `brew upgrade torsday/tap/omnifocus-mcp` works
+        # immediately after the npm publish settles.
+        # Requires a PAT (HOMEBREW_TAP_TOKEN) with contents:write on the tap
+        # repo — store it in Settings → Secrets → Actions.
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          bash scripts/update-homebrew-formula.sh "$VERSION"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The server is built to a single-user local-first standard: no network surface, n
 
 1. **Install**
    ```bash
+   # Homebrew (no Node required)
+   brew install torsday/tap/omnifocus-mcp
+
+   # or npm
    npm install -g @torsday/omnifocus-mcp
    ```
 
@@ -715,6 +719,12 @@ Track open issues and future enhancements on the [**GitHub Project board**](http
 
 ## Install
 
+**Homebrew** (recommended for non-Node users):
+```bash
+brew install torsday/tap/omnifocus-mcp
+```
+
+**npm** (recommended if you already have Node 24+):
 ```bash
 # Global install
 npm install -g @torsday/omnifocus-mcp

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# update-homebrew-formula.sh — update the omnifocus-mcp Homebrew formula in
+# torsday/homebrew-tap after an npm publish.
+#
+# Usage (called from release.yml after `pnpm publish`):
+#   bash scripts/update-homebrew-formula.sh <version>
+#
+# Required env:
+#   HOMEBREW_TAP_TOKEN — GitHub PAT with contents:write on torsday/homebrew-tap
+#
+# Exits nonzero on any error so the release job fails loudly rather than
+# silently shipping a stale formula.
+
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version>}"
+PKG="@torsday/omnifocus-mcp"
+TARBALL_URL="https://registry.npmjs.org/${PKG}/-/omnifocus-mcp-${VERSION}.tgz"
+FORMULA_PATH="Formula/omnifocus-mcp.rb"
+TAP_REPO="torsday/homebrew-tap"
+
+echo "==> Fetching tarball for ${PKG}@${VERSION}…"
+
+# Retry up to 5 times — npm CDN occasionally takes a moment after publish.
+for attempt in 1 2 3 4 5; do
+  if curl -fsSL "$TARBALL_URL" -o /tmp/omnifocus-mcp.tgz 2>/dev/null; then
+    break
+  fi
+  if [ "$attempt" -eq 5 ]; then
+    echo "ERROR: tarball not available after 5 attempts: $TARBALL_URL" >&2
+    exit 1
+  fi
+  echo "  attempt $attempt failed; waiting 15s…"
+  sleep 15
+done
+
+SHA256=$(sha256sum /tmp/omnifocus-mcp.tgz | awk '{print $1}')
+echo "    sha256: $SHA256"
+
+echo "==> Fetching current formula from ${TAP_REPO}…"
+CURRENT=$(gh api "repos/${TAP_REPO}/contents/${FORMULA_PATH}" \
+  --header "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+  --jq '{sha: .sha, content: (.content | gsub("\n";"") | @base64d)}')
+CURRENT_SHA=$(echo "$CURRENT" | python3 -c "import sys,json; print(json.load(sys.stdin)['sha'])")
+CURRENT_CONTENT=$(echo "$CURRENT" | python3 -c "import sys,json; print(json.load(sys.stdin)['content'])")
+
+echo "==> Patching formula to version ${VERSION}…"
+NEW_CONTENT=$(echo "$CURRENT_CONTENT" \
+  | sed "s|omnifocus-mcp-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.tgz|omnifocus-mcp-${VERSION}.tgz|g" \
+  | sed "s|sha256 \"[a-f0-9]\{64\}\"|sha256 \"${SHA256}\"|g" \
+  | sed "s|version \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"|version \"${VERSION}\"|g")
+
+if [ "$NEW_CONTENT" = "$CURRENT_CONTENT" ]; then
+  echo "WARNING: formula content unchanged — nothing to commit (already at ${VERSION}?)" >&2
+  exit 0
+fi
+
+ENCODED=$(echo "$NEW_CONTENT" | base64 | tr -d '\n')
+
+echo "==> Committing updated formula to ${TAP_REPO}…"
+gh api "repos/${TAP_REPO}/contents/${FORMULA_PATH}" \
+  --method PUT \
+  --header "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+  -f message="chore: bump omnifocus-mcp to ${VERSION}" \
+  -f content="$ENCODED" \
+  -f sha="$CURRENT_SHA" \
+  --jq '"committed: " + .commit.sha'
+
+echo "==> Done — formula updated to ${VERSION}."


### PR DESCRIPTION
## Summary

- Adds `Formula/omnifocus-mcp.rb` to [torsday/homebrew-tap](https://github.com/torsday/homebrew-tap) — users can now `brew install torsday/tap/omnifocus-mcp`
- Adds `scripts/update-homebrew-formula.sh` — patches the tap formula (version + sha256) after each npm publish
- Wires the script into `.github/workflows/release.yml` behind `HOMEBREW_TAP_TOKEN` secret (step is a no-op if the secret isn't set, so existing releases are unaffected)
- Updates README quick-start and Install sections to document `brew install` alongside `npm install`

Closes #561.

## Issue
Implements [#561 — Add Homebrew tap formula for omnifocus-mcp](https://github.com/torsday/omnifocus-mcp/issues/561).

## Manual step required
Add a `HOMEBREW_TAP_TOKEN` secret to this repo (Settings → Secrets → Actions) with a PAT that has `contents:write` on `torsday/homebrew-tap`. The release workflow update step is gated on `env.HOMEBREW_TAP_TOKEN != ''` and is a complete no-op until the secret is set.

## Breaking change?
- [x] No

## Test plan
- [x] Formula committed to torsday/homebrew-tap — verifiable at https://github.com/torsday/homebrew-tap/blob/main/Formula/omnifocus-mcp.rb
- [x] `update-homebrew-formula.sh` has `set -euo pipefail`; retry loop; loud failure on bad version
- [x] `pnpm tsc --noEmit` clean
- [x] Self-reviewed