### PR TITLE
chore(nl-quality): add rubric, zodToActionable helper, contributing template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,46 @@ Inherited from [`coding.md`](https://github.com/torsday/llm_prompts/blob/main/co
 - Every public method has a docblock with `@param` / `@returns` / `@throws`
 - **Don't restate the tool count in prose.** Living docs describe the shape of the tool surface (domains, verbs, patterns), not the integer count. The live count lives at `omnifocus://capabilities` and `internal_status` at runtime, plus `docs/tools.md` (auto-generated). See DESIGN.md §6.8.1 — `scripts/verify-no-tool-counts.sh` enforces this in CI.
 
+## Tool descriptions and NL quality
+
+Every MCP tool description, input schema, and validation error gets read by an agent and decides whether the agent's first attempt at a call lands. The full rubric is [`docs/nl-quality-standards.md`](./docs/nl-quality-standards.md) — five levers (schema descriptions, worked examples, forgiving aliases, round-trip readability, fail-with-help errors). Use the checklist at the bottom of that doc at PR review time.
+
+### Tool description template
+
+New tool descriptions follow the four-section shape (`DESIGN.md §6.8`, enforced by `descriptionShape.ts`) plus a worked example. Keep the description concatenated as a single string constant — concise, readable, scannable:
+
+```typescript
+export const NOUN_VERB_DESCRIPTION =
+  // What it does — opening sentence, present tense.
+  "<One-sentence summary of the tool's purpose>. " +
+  // When NOT to use — disambiguates from sibling tools.
+  "Do NOT use for <out-of-scope case> — prefer <other_tool> instead. " +
+  // Returns — names the shape so the agent can plan its next call.
+  "Returns <data shape, including pagination if applicable>. " +
+  // Side effects — read-only / mutates / triggers a sync / safe to retry.
+  "<Read-only; safe to retry> | <Mutates; triggers a sync; idempotent on `clientToken`>. " +
+  // Worked example — one representative call.
+  'Example: { "<field>": "<value>" }';
+```
+
+Every Zod input field carries a `.describe(...)` of one sentence under ~120 chars, naming what the field controls and where to obtain a valid value when relevant.
+
+### Validation errors
+
+Tool handlers that validate input through Zod catch `ZodError` at the boundary and rewrite it via [`zodToActionable`](./src/errors/zodToActionable.ts) so each failure carries `{ field, sent, expected, examples? }`. Don't let raw Zod messages reach the client — the agent has to translate "expected int, received number" before it can fix the call, and the translation step is where loops happen.
+
+```typescript
+import { ValidationError } from "../../errors/index.js";
+import { zodToActionable } from "../../errors/zodToActionable.js";
+
+const parsed = inputSchema.safeParse(rawInput);
+if (!parsed.success) {
+  throw new ValidationError("Invalid <tool_name> input", {
+    details: { failures: zodToActionable(parsed.error, rawInput) },
+  });
+}
+```
+
 ## Workflow
 
 1. **Understand the task.** Open the issue, read the linked DESIGN / SPEC / ADR section.
@@ -58,7 +98,8 @@ Inherited from [`coding.md`](https://github.com/torsday/llm_prompts/blob/main/co
 - [ ] Integration tests pass (if adapter changes)
 - [ ] No stdout output (check via integration test)
 - [ ] Response envelope + typed error used
-- [ ] Tool description matches the what/when-not/returns/side-effects shape
+- [ ] Tool description matches the what/when-not/returns/side-effects shape and ends with an `Example:` line ([NL-quality rubric](./docs/nl-quality-standards.md))
+- [ ] Validation errors use `zodToActionable` so failures carry `{ field, sent, expected }`
 - [ ] No user content (task names, notes, tags) interpolated into metadata fields (`suggestion`, `message`, `warnings`)
 ```
 

--- a/docs/nl-quality-standards.md
+++ b/docs/nl-quality-standards.md
@@ -1,0 +1,317 @@
+# NL-quality standards
+
+**Status:** Foundation. Per-tool audit, lint enforcement, and integration tests
+land in follow-ups (see [#489](https://github.com/torsday/omnifocus-mcp/issues/489)).
+
+This rubric is the floor every MCP tool in this server must meet. It exists
+because *natural-language quality at the agent ↔ MCP boundary isn't automatic*:
+the agent generates prose, we receive structured input validated against Zod,
+and the surface-side levers below decide whether the agent's first translation
+of "due tomorrow at 9 in EST" lands a task or a 400.
+
+The five levers are independent and additive — a tool can score well on three
+and still fail an agent's first attempt because of the other two. Score every
+new tool against all five before opening a PR; new tools that fall short of
+the floor block merge.
+
+> **What this is not.** This rubric is downstream of [ADR-0013] (envelope
+> shape) and [ADR-0015] (NL-excellence — `hints`, `clarification`,
+> `humanReadableSummary`). Those decide what shape the response takes; this
+> rubric decides whether each individual tool description, schema, and error
+> message is something an agent can act on without a round-trip.
+
+[ADR-0013]: ./adr/0013-tool-response-envelope.md
+[ADR-0015]: ./adr/0015-nl-excellence-response-envelope.md
+
+---
+
+## The five levers
+
+| # | Lever | What it controls |
+|---|---|---|
+| 1 | Schema descriptions | Whether the agent knows what each field means without a fetch |
+| 2 | Worked examples | Whether the agent's first attempt is closer to a working call |
+| 3 | Forgiving aliases | Whether common natural-language phrasings parse |
+| 4 | Round-trip readability | Whether the agent can describe the response in one sentence |
+| 5 | Fail-with-help errors | Whether a 400 tells the agent how to fix the call |
+
+Each lever has a rule, an existing pattern in this codebase, and a way to
+verify. The rule is the bar; the pattern shows what passes; the verification
+is how a follow-up audit (or future lint) catches drift.
+
+---
+
+## 1 · Schema descriptions
+
+Every Zod input field carries a `.describe(...)` string. The agent reads these
+as part of the tool's input schema; a field with no `.describe(...)` shows up
+as a typed slot with no semantic hint, and the agent has to guess from the
+field name.
+
+**Rule.** Every field in `inputSchema.shape` has `.describe(...)`. The string
+is one sentence (under ~120 chars), explains what the field controls, and
+points at how to obtain it when relevant.
+
+**Pattern in this codebase.** [`src/tools/task/get.ts:31`][get-ts] —
+
+```typescript
+export const taskGetInputSchema = z.object({
+  id: TaskId.schema.describe(
+    "Persistent ID of the task to fetch. Get from task_list or task_get_many.",
+  ),
+  includeSubtasks: z
+    .boolean()
+    .optional()
+    .describe("Include direct subtasks in the response. Default true."),
+});
+```
+
+The `id` description tells the agent both *what* the field is and *where to
+look* for a valid value. `includeSubtasks` notes the default — the agent
+doesn't have to guess whether to send `true` to opt in or out.
+
+**Anti-pattern.** A bare `z.string()` with no `.describe()`, or a description
+that just restates the field name (`name: z.string().describe("name")`).
+
+**Verification.** A future lint job (tracked in the follow-up issue for
+`scripts/verify-nl-quality.sh`) walks every tool's input schema AST and fails
+CI on any field lacking `.describe(...)`. Until that lands, the audit
+follow-up scores each tool by hand.
+
+[get-ts]: ../src/tools/task/get.ts
+
+---
+
+## 2 · Worked examples in tool descriptions
+
+The four-section description shape ([DESIGN.md §6.8][design-68], enforced by
+[`descriptionShape.ts`][shape-ts]) is the structural floor. The NL-quality
+extension on top of it is: include 1–2 worked examples in the description
+itself, so the agent's first attempt at composing arguments has a concrete
+template to follow.
+
+**Rule.** A tool description, after the four required sections (what / when
+not / returns / side effects), includes at least one `Example:` line showing
+a representative call.
+
+**Pattern.** Compose the example into the description constant directly:
+
+```typescript
+export const TASK_LIST_DESCRIPTION =
+  "List OmniFocus tasks under a flat-paginated cursor. " +
+  "Use to walk a project, a tag, or the inbox. " +
+  "Do NOT use to fetch a single known task — prefer task_get. " +
+  "Returns up to limit tasks plus an opaque pagination cursor. " +
+  "Read-only; safe to retry. " +
+  'Example: { "filter": { "projectId": "p123" }, "limit": 50 }';
+```
+
+A worked example pinned to the description costs one line and saves a wrong
+first attempt. Examples should pick representative shapes — for tools with
+several modes (e.g. by-project vs. by-tag vs. inbox), include a short example
+per mode.
+
+**Anti-pattern.** Listing every option in the description as if it were a
+manpage. The example should be a *call you'd actually make*, not an
+exhaustive flag listing.
+
+**Verification.** A follow-up lint check enforces "every `*_DESCRIPTION`
+constant contains the substring `Example:`". The audit follow-up grades
+existing descriptions and adds examples where missing.
+
+[design-68]: ../DESIGN.md#68-tool-description-standard
+[shape-ts]: ../src/tools/descriptionShape.ts
+
+---
+
+## 3 · Forgiving aliases at the boundary
+
+Schemas should accept the common natural-language phrasings an agent or user
+will produce, where the mapping is unambiguous and stable. This is the
+"normalize at the door" pattern: the canonical internal value is one thing,
+but the schema accepts a small, documented set of aliases and rewrites them
+before validation.
+
+**Rule.** When a field has a small, stable set of canonical values (priority
+levels, statuses, frequencies) AND there is an obvious natural-language
+phrasing (`"high"` → `"P1"`, `"weekly"` → fixed-frequency 1-week schedule),
+the schema accepts the alias.
+
+**Pattern.** Use a Zod `preprocess` or `transform` step that normalizes
+before the constraint check:
+
+```typescript
+const priorityAlias = z
+  .union([z.enum(["P0", "P1", "P2", "P3"]), z.string()])
+  .transform((v, ctx) => {
+    const map: Record<string, "P0" | "P1" | "P2" | "P3"> = {
+      P0: "P0",
+      P1: "P1",
+      P2: "P2",
+      P3: "P3",
+      critical: "P0",
+      high: "P1",
+      medium: "P2",
+      low: "P3",
+    };
+    const normal = map[v.toLowerCase?.() ?? v];
+    if (!normal) {
+      ctx.addIssue({ code: "custom", message: "unknown priority alias" });
+      return z.NEVER;
+    }
+    return normal;
+  });
+```
+
+Document the accepted aliases in the field's `.describe(...)` so the agent
+sees them in the schema. *Never* invent aliases that aren't unambiguous —
+"due tuesday" is ambiguous (next tuesday? this tuesday?), so it stays a
+type-error rather than a silent misinterpretation.
+
+**Anti-pattern.** Accepting `"urgent"` as a stand-in for `"P0"` without
+documenting it; or accepting fuzzy date phrasings the agent might mean
+either of two things by.
+
+**Verification.** Aliases are tested as part of each tool's unit suite. The
+audit follow-up identifies fields that should accept aliases but currently
+don't.
+
+---
+
+## 4 · Round-trip readability
+
+The response envelope ([ADR-0013][adr-0013]) decides the *shape*; this lever
+decides whether what comes back is *describable in one sentence*. An agent
+that has to compose a task summary from `data` gets it right more often when
+IDs come paired with names, dates carry timezones, and numeric fields have
+units in the schema description.
+
+**Rule.** Every entity in `data.*` carries enough context that an agent can
+restate the response without a follow-up read:
+
+- IDs travel with the corresponding name (e.g. `{ id, name }` for projects,
+  tags, folders inside a Task response, not bare `projectId`).
+- Dates are ISO-8601 with offset ([ADR-0007]). Never bare local time.
+- Counts and durations name their unit in the field description (`"durationMs"`,
+  `"itemCount"`).
+- Empty results are an empty array, never `null` or `undefined` (`tags: []`,
+  not omitted).
+
+**Pattern.** [ADR-0015]'s `humanReadableSummary` is the explicit form of this
+rule for write tools — every write returns a server-generated one-liner. For
+read tools, the rule applies to the data shape itself.
+
+**Anti-pattern.** Returning `{ projectId: "p123" }` without the project name;
+returning `{ due: "2026-04-27T15:00:00" }` without an offset; returning
+`{ count: 50 }` without a unit.
+
+**Verification.** Spot-checked in the per-tool audit; no automated lint
+(shape decisions are too contextual). The mutation-response contract in
+[CONTRIBUTING.md][contrib] already enforces "return the full updated entity"
+for writes — this lever extends that principle to reads.
+
+[adr-0013]: ./adr/0013-tool-response-envelope.md
+[ADR-0007]: ./adr/0007-dates-iso8601-with-offset.md
+[ADR-0015]: ./adr/0015-nl-excellence-response-envelope.md
+[contrib]: ../CONTRIBUTING.md
+
+---
+
+## 5 · Fail-with-help error messages
+
+Default Zod messages — `"Invalid input: expected int, received number"`,
+`"Invalid option"` — are jargon. An agent reading them has to translate
+"expected int" into "send a whole number, not 3.5" before it can fix the
+call. The translation step is unreliable; some agents loop on the same wrong
+input, others give up and surface the raw error to the user.
+
+**Rule.** Every tool handler that validates input through Zod catches
+`ZodError` at the boundary and rewrites it into the structured shape:
+
+```typescript
+{
+  field: string;        // dotted path: "tags[0].name"
+  sent: unknown;        // what the agent sent
+  expected: string;     // one-sentence description of what was expected
+  examples?: unknown[]; // 1+ valid examples the agent can copy
+}
+```
+
+The rewritten failures live in `ValidationError.details.failures`. Agents
+read this and patch their input without another round-trip; humans read it
+and see exactly which field needs which value.
+
+**Pattern.** Use [`zodToActionable`][zta-ts] at the tool-handler boundary:
+
+```typescript
+import { ZodError } from "zod";
+import { ValidationError } from "../../errors/index.js";
+import { zodToActionable } from "../../errors/zodToActionable.js";
+
+export async function handleTaskCreate(rawInput: unknown, ctx: TaskCreateContext) {
+  const parsed = taskCreateInputSchema.safeParse(rawInput);
+  if (!parsed.success) {
+    throw new ValidationError("Invalid task_create input", {
+      details: { failures: zodToActionable(parsed.error, rawInput) },
+    });
+  }
+  // ... happy path
+}
+```
+
+The helper handles every Zod 4 issue code (`invalid_type`, `invalid_value`,
+`invalid_format`, `too_small`, `too_big`, `unrecognized_keys`,
+`invalid_union`, `not_multiple_of`, `custom`) and produces examples for
+common string formats (datetime, email, UUID, …) automatically.
+
+**Anti-pattern.** Throwing a bare `ValidationError("invalid input")` and
+losing the per-field detail; or letting the raw `ZodError` propagate and
+forcing the agent to parse Zod's own message format.
+
+**Verification.** `zodToActionable` is unit-tested against every Zod 4 issue
+code. A follow-up integration test ([#489][489] AC) seeds 5–10 deliberately-bad
+inputs across diverse tools and asserts each error response carries the
+structured `failures` array.
+
+[zta-ts]: ../src/errors/zodToActionable.ts
+[489]: https://github.com/torsday/omnifocus-mcp/issues/489
+
+---
+
+## Tool-quality checklist (use at PR review)
+
+Apply this to every new tool and every tool you touch. A "no" on any line
+is a blocker, not a nit:
+
+- [ ] Description follows the four-section shape (DESIGN.md §6.8) — `checkDescriptionShape` passes
+- [ ] Description ends with at least one `Example:` line of a representative call
+- [ ] Every Zod input field has `.describe(...)` — one sentence, under ~120 chars
+- [ ] Aliases accepted at the boundary for fields with stable canonical sets, documented in `.describe(...)`
+- [ ] Response shape includes IDs paired with names, ISO-8601 dates with offset, units on counts/durations
+- [ ] Handler catches `ZodError` and uses `zodToActionable` to populate `ValidationError.details.failures`
+- [ ] Unit tests cover one happy path, one validation failure, one boundary error rewriting
+
+The non-NL invariants from CONTRIBUTING.md ("typed errors only", "no user
+content in metadata", "response envelope") still apply. This rubric is
+strictly additive.
+
+---
+
+## Why these five and not others
+
+The levers are picked because each one fails *silently* — an agent gets a
+worse-than-necessary first attempt and you don't notice unless you measure
+the per-tool first-call success rate. Things that fail loudly (wrong tool
+called, missing required field, transport error) don't need a rubric; the
+agent surfaces those immediately. The levers above are the silent failure
+modes specific to NL-driven tool use.
+
+What's *not* on the list and why:
+
+- **Number of tools** — discussed extensively in [DESIGN.md §6.8.1][design-681];
+  not an NL-quality concern, separately governed.
+- **Streaming / progress reporting** — orthogonal; ADR scope, not lever.
+- **Tool composition / orchestration** — emergent from individual tool
+  quality plus the agent's reasoning; the levers above are inputs to that.
+
+[design-681]: ../DESIGN.md#681-tool-count-policy-478

--- a/src/errors/zodToActionable.test.ts
+++ b/src/errors/zodToActionable.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { zodToActionable } from "./zodToActionable.js";
+
+/**
+ * Each test pairs a schema with a deliberately-bad input, then asserts on
+ * the `ActionableValidation[]` output. The schema is the contract under
+ * test; never call private helpers directly — Zod 4's issue shapes are
+ * what we're translating, and the surface we care about is what handlers
+ * will pass in.
+ */
+function fail<T>(schema: z.ZodType<T>, input: unknown) {
+  const result = schema.safeParse(input);
+  if (result.success) throw new Error("expected schema to reject input");
+  return zodToActionable(result.error, input);
+}
+
+describe("zodToActionable — primitive type errors", () => {
+  it("we map invalid_type with a one-sentence expected", () => {
+    const schema = z.object({ count: z.number() });
+    const out = fail(schema, { count: "three" });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      field: "count",
+      sent: "three",
+      expected: "number",
+    });
+  });
+
+  it("we report the missing field as undefined sent", () => {
+    const schema = z.object({ count: z.number() });
+    const out = fail(schema, {});
+    expect(out[0]).toMatchObject({
+      field: "count",
+      sent: undefined,
+      expected: "number",
+    });
+  });
+
+  it("we keep the path in dotted/bracketed form", () => {
+    const schema = z.object({
+      project: z.object({ tags: z.array(z.object({ name: z.string() })) }),
+    });
+    const out = fail(schema, { project: { tags: [{ name: "ok" }, { name: 42 }] } });
+    expect(out[0]?.field).toBe("project.tags[1].name");
+  });
+});
+
+describe("zodToActionable — enums and literals", () => {
+  it("we list enum choices and surface the first three as examples", () => {
+    const schema = z.object({ priority: z.enum(["P0", "P1", "P2", "P3"]) });
+    const out = fail(schema, { priority: "urgent" });
+    expect(out[0]?.field).toBe("priority");
+    expect(out[0]?.sent).toBe("urgent");
+    expect(out[0]?.expected).toContain('"P0"');
+    expect(out[0]?.expected).toContain('"P3"');
+    expect(out[0]?.examples).toEqual(["P0", "P1", "P2"]);
+  });
+
+  it("we trim very long enum lists in the expected text", () => {
+    const big = Array.from({ length: 12 }, (_, i) => `v${i}`) as [string, ...string[]];
+    const schema = z.object({ k: z.enum(big) });
+    const out = fail(schema, { k: "missing" });
+    expect(out[0]?.expected).toContain("more)");
+    expect(out[0]?.expected).not.toContain('"v11"');
+  });
+});
+
+describe("zodToActionable — string format errors", () => {
+  it("we translate datetime to actionable ISO-8601 examples", () => {
+    const schema = z.object({ due: z.string().datetime({ offset: true }) });
+    const out = fail(schema, { due: "next tuesday" });
+    expect(out[0]?.field).toBe("due");
+    expect(out[0]?.sent).toBe("next tuesday");
+    expect(out[0]?.expected).toMatch(/ISO-8601 datetime/);
+    expect(out[0]?.examples?.[0]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("we translate email format with a usable example", () => {
+    const schema = z.object({ contact: z.string().email() });
+    const out = fail(schema, { contact: "not-email" });
+    expect(out[0]?.expected).toBe("email address");
+    expect(out[0]?.examples).toEqual(["user@example.com"]);
+  });
+
+  it("we fall back gracefully on unknown formats", () => {
+    // A custom check with a format we don't have a mapping for.
+    const schema = z.object({ slug: z.string().regex(/^[a-z]+$/) });
+    const out = fail(schema, { slug: "Has-Caps" });
+    expect(out[0]?.expected).toMatch(/regex|format/);
+  });
+});
+
+describe("zodToActionable — bounds", () => {
+  it("we describe array max with item-pluralized text", () => {
+    const schema = z.object({ tags: z.array(z.string()).max(5) });
+    const out = fail(schema, { tags: ["a", "b", "c", "d", "e", "f"] });
+    expect(out[0]?.expected).toMatch(/array/);
+    expect(out[0]?.expected).toMatch(/≤ 5/);
+  });
+
+  it("we describe number min", () => {
+    const schema = z.object({ count: z.number().min(1) });
+    const out = fail(schema, { count: 0 });
+    expect(out[0]?.expected).toMatch(/≥ 1/);
+  });
+
+  it("we describe string min with character pluralization", () => {
+    const schema = z.object({ name: z.string().min(1) });
+    const out = fail(schema, { name: "" });
+    expect(out[0]?.expected).toBe("string with ≥ 1 character");
+  });
+
+  it("we keep singular vs plural readable", () => {
+    const schema = z.object({ items: z.array(z.string()).min(1) });
+    const out = fail(schema, { items: [] });
+    expect(out[0]?.expected).toBe("array with ≥ 1 item");
+  });
+});
+
+describe("zodToActionable — unrecognized keys", () => {
+  it("we emit one row per stray key so the agent can drop each individually", () => {
+    const schema = z.strictObject({ id: z.string() });
+    const out = fail(schema, { id: "abc", extra1: 1, extra2: 2 });
+    expect(out).toHaveLength(2);
+    const fields = out.map((r) => r.field).sort();
+    expect(fields).toEqual(["extra1", "extra2"]);
+    for (const r of out) {
+      expect(r.expected).toMatch(/not part of the schema/);
+    }
+  });
+
+  it("we keep the parent path on nested unrecognized keys", () => {
+    const schema = z.object({ project: z.strictObject({ name: z.string() }) });
+    const out = fail(schema, { project: { name: "p", extra: 1 } });
+    expect(out[0]?.field).toBe("project.extra");
+    expect(out[0]?.sent).toBe(1);
+  });
+});
+
+describe("zodToActionable — input plucking", () => {
+  it("we set sent=undefined when no input is provided", () => {
+    const schema = z.object({ count: z.number() });
+    const result = schema.safeParse({ count: "x" });
+    if (result.success) throw new Error("expected failure");
+    const out = zodToActionable(result.error);
+    expect(out[0]?.sent).toBeUndefined();
+  });
+
+  it("we tolerate missing intermediate parents on deep paths", () => {
+    // The schema asks for project.tags but the input has no .project at all.
+    const schema = z.object({
+      project: z.object({ tags: z.array(z.string()) }),
+    });
+    const out = fail(schema, {});
+    expect(out[0]?.sent).toBeUndefined();
+    expect(out[0]?.field).toBe("project");
+  });
+});
+
+describe("zodToActionable — multi-issue inputs", () => {
+  it("we return one row per Zod issue, preserving order", () => {
+    const schema = z.object({
+      priority: z.enum(["P0", "P1"]),
+      count: z.number(),
+      tags: z.array(z.string()).max(2),
+    });
+    const out = fail(schema, {
+      priority: "urgent",
+      count: "three",
+      tags: ["a", "b", "c"],
+    });
+    expect(out).toHaveLength(3);
+    expect(out.map((r) => r.field)).toEqual(["priority", "count", "tags"]);
+  });
+
+  it("we degenerate to an empty array on a ZodError with no issues", () => {
+    // Construct a synthetic empty ZodError. Zod won't normally produce one,
+    // but the helper must not crash if it ever sees one.
+    const schema = z.object({ a: z.string() });
+    const result = schema.safeParse({ a: "ok" });
+    if (!result.success) throw new Error("expected success in this fixture");
+    // Build a fresh ZodError with no issues using the public constructor.
+    const zerr = new z.ZodError([]);
+    expect(zodToActionable(zerr)).toEqual([]);
+  });
+});
+
+describe("zodToActionable — output integrates with ValidationError", () => {
+  it("the failures array round-trips through JSON.stringify untouched", () => {
+    const schema = z.object({ name: z.string().min(1) });
+    const out = fail(schema, { name: "" });
+    const json = JSON.parse(JSON.stringify(out)) as typeof out;
+    expect(json[0]?.field).toBe("name");
+    expect(json[0]?.expected).toMatch(/character/);
+  });
+});

--- a/src/errors/zodToActionable.ts
+++ b/src/errors/zodToActionable.ts
@@ -1,0 +1,303 @@
+/**
+ * Convert a `ZodError` into an array of agent-actionable validation failures.
+ *
+ * Default Zod messages ("Invalid input: expected int, received number") are
+ * jargon. An agent reading them has to translate before it can fix its input.
+ * This helper produces the structured shape every read of `ValidationError.details`
+ * gets: `{ field, sent, expected, examples? }`. Stable enough to switch on,
+ * specific enough to repair the call without another round-trip.
+ *
+ * The result is intended for `ValidationError.details.failures` — uniform across
+ * every tool boundary. See `docs/nl-quality-standards.md` for the lever this
+ * helper implements.
+ *
+ * @see docs/nl-quality-standards.md — fail-with-help error messages
+ * @see DESIGN.md §6.7 — error taxonomy (`OF_VALIDATION`)
+ */
+
+import type { ZodError } from "zod";
+import type { $ZodIssue } from "zod/v4/core";
+
+/**
+ * One field-level validation failure. Agents iterate over these and patch
+ * their input before retrying.
+ */
+export interface ActionableValidation {
+  /** Dotted path to the offending field, e.g. `"tags[0].name"`. `<root>` for top-level. */
+  field: string;
+  /** The value that was sent. Undefined when the field was missing. */
+  sent: unknown;
+  /** One-sentence description of what would have been accepted. */
+  expected: string;
+  /** Concrete valid values an agent can copy. Omitted when no useful examples exist. */
+  examples?: unknown[];
+}
+
+/**
+ * Render a Zod path to a dotted/bracketed string an agent can read.
+ * Empty path → `<root>` so callers can still match on `field`.
+ */
+function renderPath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) return "<root>";
+  let out = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      out += `[${segment}]`;
+    } else {
+      out += out === "" ? String(segment) : `.${String(segment)}`;
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk `input` along `path` and return the value at that location, or
+ * `undefined` if the path doesn't resolve. Tolerant of missing parents.
+ */
+function pluck(input: unknown, path: ReadonlyArray<PropertyKey>): unknown {
+  let cursor: unknown = input;
+  for (const segment of path) {
+    if (cursor === null || cursor === undefined) return undefined;
+    if (typeof cursor === "object") {
+      cursor = (cursor as Record<PropertyKey, unknown>)[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return cursor;
+}
+
+/**
+ * Format a small list of values for an `expected:` string. Trims long lists
+ * and quotes strings so the agent can see boundaries clearly.
+ */
+function formatChoices(values: ReadonlyArray<unknown>, max = 6): string {
+  const head = values.slice(0, max);
+  const rendered = head.map((v) => (typeof v === "string" ? `"${v}"` : String(v)));
+  if (values.length > max) rendered.push(`… (${values.length - max} more)`);
+  return rendered.join(" | ");
+}
+
+/**
+ * Map an `invalid_format` issue (datetime, email, uuid, etc.) to a
+ * human-friendly expected/example pair. Falls back to the format name itself
+ * for formats we don't recognize — still better than `pattern: /…/`.
+ */
+function describeFormat(format: string): { expected: string; examples?: unknown[] } {
+  switch (format) {
+    case "datetime":
+      return {
+        expected: "ISO-8601 datetime, UTC (Z) or with offset",
+        examples: ["2025-03-01T09:00:00Z", "2025-03-01T09:00:00-05:00"],
+      };
+    case "date":
+      return { expected: "ISO-8601 date (YYYY-MM-DD)", examples: ["2025-03-01"] };
+    case "time":
+      return { expected: "ISO-8601 time (HH:MM:SS)", examples: ["09:00:00"] };
+    case "email":
+      return { expected: "email address", examples: ["user@example.com"] };
+    case "url":
+      return { expected: "absolute URL", examples: ["https://example.com/path"] };
+    case "uuid":
+      return { expected: "UUID v4", examples: ["3fa85f64-5717-4562-b3fc-2c963f66afa6"] };
+    case "ipv4":
+      return { expected: "IPv4 address", examples: ["192.0.2.42"] };
+    case "ipv6":
+      return { expected: "IPv6 address", examples: ["2001:db8::1"] };
+    case "regex":
+      return { expected: "string matching the schema's regex" };
+    default:
+      return { expected: `string in "${format}" format` };
+  }
+}
+
+/**
+ * Format a numeric/array/string bound. Uses `inclusive` to pick the right
+ * comparator and `origin` to pluralize the unit ("≥ 1 character", "≥ 1 item").
+ */
+function describeBound(
+  side: "min" | "max",
+  bound: number,
+  inclusive: boolean,
+  origin: string | undefined,
+): string {
+  const cmp = side === "min" ? (inclusive ? "≥" : ">") : inclusive ? "≤" : "<";
+  switch (origin) {
+    case "string":
+      return `string with ${cmp} ${bound} character${bound === 1 ? "" : "s"}`;
+    case "array":
+      return `array with ${cmp} ${bound} item${bound === 1 ? "" : "s"}`;
+    case "set":
+      return `set with ${cmp} ${bound} member${bound === 1 ? "" : "s"}`;
+    default:
+      return `value ${cmp} ${bound}`;
+  }
+}
+
+/**
+ * Map a single Zod issue to one or more `ActionableValidation` rows. Most
+ * issues map 1-to-1; `unrecognized_keys` and `invalid_union` may fan out.
+ */
+function issueToActionable(issue: $ZodIssue, rootInput: unknown): ActionableValidation[] {
+  const sentAt = (path: ReadonlyArray<PropertyKey>) =>
+    rootInput === undefined ? undefined : pluck(rootInput, path);
+
+  switch (issue.code) {
+    case "invalid_type": {
+      // Zod 4 surfaces `format` for refined string types (e.g. "email")
+      // alongside `invalid_format`; for raw types, `expected` is enough.
+      const expected = issue.expected;
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected: `${expected}`,
+        },
+      ];
+    }
+
+    case "invalid_value": {
+      const values = issue.values;
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected: `one of: ${formatChoices(values)}`,
+          ...(values.length > 0 && { examples: values.slice(0, 3) }),
+        },
+      ];
+    }
+
+    case "invalid_format": {
+      const desc = describeFormat(issue.format);
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected: desc.expected,
+          ...(desc.examples && { examples: desc.examples }),
+        },
+      ];
+    }
+
+    case "too_small": {
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected: describeBound(
+            "min",
+            Number(issue.minimum),
+            issue.inclusive ?? true,
+            issue.origin,
+          ),
+        },
+      ];
+    }
+
+    case "too_big": {
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected: describeBound(
+            "max",
+            Number(issue.maximum),
+            issue.inclusive ?? true,
+            issue.origin,
+          ),
+        },
+      ];
+    }
+
+    case "unrecognized_keys": {
+      // Path points at the parent object; offending keys live in `keys`.
+      // Emit one row per stray key so the agent can drop them individually.
+      const parentField = renderPath(issue.path);
+      return issue.keys.map((key) => ({
+        field: parentField === "<root>" ? key : `${parentField}.${key}`,
+        sent: pluck(rootInput, [...issue.path, key]),
+        expected: "key is not part of the schema; remove it",
+      }));
+    }
+
+    case "not_multiple_of": {
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected: `multiple of ${String(issue.divisor)}`,
+        },
+      ];
+    }
+
+    case "invalid_union": {
+      // Pick the deepest issue from each branch — usually the one that got
+      // furthest. If a branch only has top-level issues, take its first.
+      const branchSummaries: ActionableValidation[] = [];
+      for (const branch of issue.errors) {
+        const deepest = branch.slice().sort((a, b) => b.path.length - a.path.length)[0];
+        if (deepest !== undefined) {
+          branchSummaries.push(...issueToActionable(deepest, rootInput));
+        }
+      }
+      if (branchSummaries.length === 0) {
+        return [
+          {
+            field: renderPath(issue.path),
+            sent: sentAt(issue.path),
+            expected: "value matching one of the schema's accepted shapes",
+          },
+        ];
+      }
+      // Collapse to one row pointing at the parent path with combined options.
+      const expected = `one of: ${branchSummaries.map((b) => b.expected).join("; or ")}`;
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected,
+        },
+      ];
+    }
+
+    default: {
+      // `custom` and any other future code falls through here.
+      return [
+        {
+          field: renderPath(issue.path),
+          sent: sentAt(issue.path),
+          expected: issue.message || `value satisfying schema constraint "${String(issue.code)}"`,
+        },
+      ];
+    }
+  }
+}
+
+/**
+ * Convert a `ZodError` into an array of `ActionableValidation` rows.
+ *
+ * @param zodError - The error produced by `schema.parse(...)` /
+ *                   `schema.safeParse(...).error`.
+ * @param input    - Original input. Optional; when provided, each row's
+ *                   `sent` is populated by walking the issue path. Without it,
+ *                   `sent` is `undefined` (still useful — `field` and
+ *                   `expected` carry most of the signal).
+ * @returns        One row per offending field. May be empty only if the
+ *                 input `zodError.issues` is empty (degenerate).
+ *
+ * @example
+ *   const result = schema.safeParse(input);
+ *   if (!result.success) {
+ *     throw new ValidationError("Invalid input", {
+ *       details: { failures: zodToActionable(result.error, input) },
+ *     });
+ *   }
+ */
+export function zodToActionable(zodError: ZodError, input?: unknown): ActionableValidation[] {
+  const out: ActionableValidation[] = [];
+  for (const issue of zodError.issues) {
+    out.push(...issueToActionable(issue, input));
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- New rubric `docs/nl-quality-standards.md` documents five NL-quality levers (schema descriptions, worked examples, forgiving aliases, round-trip readability, fail-with-help errors) every tool must reach
- New helper `src/errors/zodToActionable.ts` rewrites Zod 4 `ZodError` into `{ field, sent, expected, examples? }` rows for `ValidationError.details.failures` — covers every Zod 4 issue code, 19 unit tests
- CONTRIBUTING gains a "Tool descriptions and NL quality" section with the description template, a `zodToActionable` adoption snippet, and two new PR-template checklist lines

Closes #489.

Foundation only — no per-tool description changes, no lint script, no integration tests in this PR. Those are split into:

- [#563](https://github.com/torsday/omnifocus-mcp/issues/563) — per-tool audit + remediation against the rubric (1M-context work)
- [#564](https://github.com/torsday/omnifocus-mcp/issues/564) — `scripts/verify-nl-quality.sh` lint script + meta-lint.yml wiring
- [#565](https://github.com/torsday/omnifocus-mcp/issues/565) — integration tests for boundary error rewriting

Splitting the slice keeps this PR reviewable in one sitting and gives the audit pass the full 1M context it needs.

## Design link

- New: [`docs/nl-quality-standards.md`](docs/nl-quality-standards.md)
- Cross-references: [`DESIGN.md §6.7`](DESIGN.md#67-error-taxonomy) (error taxonomy), [`DESIGN.md §6.8`](DESIGN.md#68-tool-description-standard) (4-section description shape), [ADR-0013](docs/adr/0013-tool-response-envelope.md) (envelope), [ADR-0015](docs/adr/0015-nl-excellence-response-envelope.md) (NL-excellence envelope additions)

## Breaking change?

No. New file `src/errors/zodToActionable.ts` is an additive helper, not yet wired into any tool handler — adoption is per-tool in #563. Public surface unchanged.

## Test plan

- [x] Unit tests cover happy + edge + error — 19 new tests, all Zod 4 issue codes
- [x] No stdout output — no I/O in the helper
- [x] Response envelope + typed error used — output feeds `ValidationError.details`
- [x] Tool description matches the what/when-not/returns/side-effects shape and ends with an `Example:` line — no new tools in this PR
- [x] Validation errors use `zodToActionable` so failures carry `{ field, sent, expected }` — N/A in this PR (helper landing only); adoption tracked in #563
- [x] No user content (task names, notes, tags) interpolated into metadata fields — `sent`/`field` carry agent input, not OmniFocus DB content; goes into `error.details.failures` (structured payload), not message strings
