### PR TITLE
chore(automation): post-merge-close workflow for direct-to-main commits

### DIFF
--- a/.github/workflows/post-merge-close.yml
+++ b/.github/workflows/post-merge-close.yml
@@ -1,0 +1,152 @@
+# Defense-in-depth board hygiene: when a commit lands directly on `main` whose
+# message contains a closes-keyword (`Closes #N`, `Fixes #N`, `Resolves #N`),
+# close the referenced issue and flip its project board Status → Done.
+#
+# # Why this exists
+#
+# `board-sync.yml` already flips on PR merge — that handles 99% of paths.
+# This workflow catches the residual cases where commits land on `main`
+# without going through a PR:
+#
+#   - Repo admin bypasses branch protection for a hotfix.
+#   - Migration / batch tooling pushes direct commits.
+#   - Historic direct-to-main commits predating branch protection.
+#
+# In normal operation it rarely fires — and that's the value: a quiet net
+# under the routine path.
+#
+# # Idempotency
+#
+# Every step is a no-op when applied twice:
+#   - Closing an already-closed issue is a no-op.
+#   - Flipping the board to Done when already Done is a no-op.
+#   - Removing a missing label is a no-op (`|| true`).
+# Re-runs (e.g. workflow restarts, replayed events) are safe.
+#
+# # Token requirement
+#
+# Project-board mutations on a *user-owned* Projects v2 board cannot be
+# performed by the default `GITHUB_TOKEN` — it lacks `project` scope. Add a
+# fine-grained PAT as the repo secret `PROJECT_TOKEN` with:
+#   - User permission "Projects: Read and write"
+#   - Repository permission "Issues: Read and write"
+# When the secret is missing the workflow short-circuits with a `::warning::`
+# rather than failing CI — that keeps the workflow benign on forks / fresh
+# clones where no PAT is provisioned.
+#
+# # Kill switch
+#
+# Set repo variable `AUTO_CLOSE_ENABLED=false` to disable without code
+# changes. The default (unset / anything-but-`true`) means the workflow
+# *runs but does nothing destructive* — see the `if:` guard on the job.
+#
+# Related: #517 (atomic-claim race), #520 (PR-merge close-out), this issue (#521).
+
+name: Post-merge close
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+
+jobs:
+  flip-closed-issues:
+    # Kill-switch: only run when the repo variable is explicitly true.
+    # Default (unset) is "off" so the workflow can land safely before the
+    # PAT is provisioned, and the operator opts in by setting the variable.
+    if: vars.AUTO_CLOSE_ENABLED == 'true'
+    runs-on: [self-hosted, macos]
+    steps:
+      - name: Check token
+        id: token
+        run: |
+          if [ -n "$GH_TOKEN" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PROJECT_TOKEN not set — skipping post-merge close."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.token.outputs.ok == 'true'
+
+      - name: Load project constants
+        if: steps.token.outputs.ok == 'true'
+        run: |
+          if [ ! -f scripts/_project-constants.sh ]; then
+            echo "::warning::scripts/_project-constants.sh not found (gitignored; must be present on the runner). Skipping."
+            exit 0
+          fi
+          # shellcheck source=../../scripts/_project-constants.sh
+          source scripts/_project-constants.sh
+          {
+            echo "PROJECT_ID=$PROJECT_ID"
+            echo "STATUS_FIELD=$F_STATUS"
+            echo "OPT_DONE=$STATUS_DONE"
+          } >> "$GITHUB_ENV"
+
+      - name: Extract closes-keyword issue numbers from pushed commits
+        id: parsed
+        if: steps.token.outputs.ok == 'true'
+        env:
+          # `commits` is the array of commits in this push (max 20 per push
+          # event; for larger force-pushes GitHub truncates and the rest are
+          # caught the next time someone touches them — acceptable for a
+          # safety net).
+          COMMITS_JSON: ${{ toJSON(github.event.commits) }}
+        run: |
+          # Pull every commit message, scan for closes-keywords, dedupe.
+          nums=$(printf '%s' "$COMMITS_JSON" \
+            | jq -r '.[].message' \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u \
+            | tr '\n' ' ')
+          echo "nums=$nums" >> "$GITHUB_OUTPUT"
+          echo "Closes-keyword references: ${nums:-<none>}"
+
+      - name: Close issue + flip board to Done for each reference
+        if: steps.token.outputs.ok == 'true' && steps.parsed.outputs.nums != ''
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          NUMS: ${{ steps.parsed.outputs.nums }}
+        run: |
+          # shellcheck disable=SC2016  # $o/$r/$n are GraphQL variables, not shell expansions
+          for n in $NUMS; do
+            # Skip silently if the issue doesn't exist (typo in commit message,
+            # or the number refers to something else like a PR in another repo).
+            if ! gh issue view "$n" --json state >/dev/null 2>&1; then
+              echo "#$n not found — skip"
+              continue
+            fi
+
+            # Close the issue if open. `gh issue close` is idempotent.
+            state=$(gh issue view "$n" --json state --jq .state)
+            if [ "$state" = "OPEN" ]; then
+              gh issue close "$n" --reason completed >/dev/null
+              echo "#$n closed"
+            fi
+
+            # Flip the board status to Done. Re-fetch the project item id
+            # because it isn't derivable from the issue number alone.
+            item=$(gh api graphql \
+              -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){issue(number:$n){projectItems(first:10){nodes{id project{id}}}}}}' \
+              -F o="$OWNER" -F r="$REPO" -F n="$n" \
+              --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id==\"$PROJECT_ID\") | .id" || true)
+            if [ -n "$item" ]; then
+              gh api graphql -f query="mutation{updateProjectV2ItemFieldValue(input:{projectId:\"$PROJECT_ID\",itemId:\"$item\",fieldId:\"$STATUS_FIELD\",value:{singleSelectOptionId:\"$OPT_DONE\"}}){projectV2Item{id}}}" >/dev/null
+              echo "#$n → Done"
+            else
+              echo "#$n not on project — skip board flip"
+            fi
+
+            # Strip the in-progress label if it lingered.
+            gh issue edit "$n" --remove-label "status: in-progress" 2>/dev/null || true
+          done


### PR DESCRIPTION
Closes #521

## Summary

Adds `.github/workflows/post-merge-close.yml` — a defense-in-depth net for project-board drift. When a commit lands directly on `main` with a closes-keyword in its message (`Closes #N` / `Fixes #N` / `Resolves #N`), the workflow closes the referenced issue and flips the project board Status → Done.

`board-sync.yml` already handles the routine PR-merge path. This workflow catches the residual cases:
- Repo admin bypassing branch protection for a hotfix.
- Migration / batch tooling pushing direct commits.
- Historic direct-to-main commits predating branch protection.

In normal operation it rarely fires — that's the value: a quiet net under the routine path.

## Properties
- **Idempotent.** Closing an already-closed issue is a no-op; flipping Done→Done is a no-op; missing-label removal is `|| true`. Re-runs are safe.
- **Kill-switch.** Gated by `vars.AUTO_CLOSE_ENABLED == 'true'`. Default (unset / anything else) means the workflow runs but does nothing destructive — opt-in by setting the variable when ready.
- **Token-aware.** Short-circuits with a `::warning::` when `PROJECT_TOKEN` isn't set, so the workflow lands safely before the PAT is provisioned and stays benign on forks / fresh clones.
- **Doesn't fire on non-default branches.** Trigger is `push: branches: [main]`.

## Test plan
- [x] `actionlint .github/workflows/post-merge-close.yml` — no errors
- [x] `pnpm lint` (incl. `docs:check`, `verify-no-tool-counts`) — clean
- [x] `pnpm test` — 157 files, 2567 passing, 49 skipped
- [ ] CI green (actionlint + shellcheck workflows)
- [ ] Manual smoke (post-merge): set `vars.AUTO_CLOSE_ENABLED=true`, push a deliberate direct-to-main commit referencing a test issue, verify board flip within ~1 minute.