### PR TITLE
feat(nl-quality): wire zodToActionable at handlers with refined input schemas

### DIFF
--- a/scripts/nl-quality-allowlist.json
+++ b/scripts/nl-quality-allowlist.json
@@ -94,6 +94,7 @@
     "src/tools/task/uncomplete.ts",
     "src/tools/task/undrop.ts",
     "src/tools/task/update.ts",
+    "src/tools/task/waitingOn.ts",
     "src/tools/window/index.ts"
   ]
 }

--- a/src/errors/validateRefined.test.ts
+++ b/src/errors/validateRefined.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for `validateRefined` — handler-boundary refinement guard.
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ValidationError } from "./index.js";
+import { validateRefined } from "./validateRefined.js";
+
+const baseSchema = z.object({
+  projectId: z.string().optional(),
+  parentId: z.string().optional(),
+});
+
+const refined = baseSchema.refine((v) => !(v.projectId !== undefined && v.parentId !== undefined), {
+  message: "Supply at most one of projectId or parentId",
+  path: ["projectId"],
+});
+
+describe("validateRefined", () => {
+  it("returns the parsed value when input passes the refinement", () => {
+    const out = validateRefined(refined, { projectId: "p1" });
+    expect(out).toEqual({ projectId: "p1" });
+  });
+
+  it("returns the parsed value when input is the empty branch", () => {
+    expect(validateRefined(refined, {})).toEqual({});
+  });
+
+  it("throws ValidationError with details.failures on refinement violation", () => {
+    let caught: unknown;
+    try {
+      validateRefined(refined, { projectId: "p1", parentId: "t1" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ValidationError);
+    if (!(caught instanceof ValidationError)) return;
+    expect(caught.details).toBeDefined();
+    const failures = (caught.details as { failures: Array<{ field: string; sent: unknown }> })
+      .failures;
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures[0]?.field).toBe("projectId");
+  });
+
+  it("uses the supplied error message when provided", () => {
+    let caught: unknown;
+    try {
+      validateRefined(refined, { projectId: "p1", parentId: "t1" }, "Tool-specific frame");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ValidationError);
+    if (caught instanceof ValidationError) {
+      expect(caught.message).toContain("Tool-specific frame");
+    }
+  });
+});

--- a/src/errors/validateRefined.ts
+++ b/src/errors/validateRefined.ts
@@ -1,0 +1,76 @@
+/**
+ * `validateRefined` — handler-boundary validation against a refined Zod schema,
+ * surfacing structured `failures[]` via `zodToActionable`.
+ *
+ * # Why this helper exists
+ *
+ * Most tools register their **base** ZodObject (`schema.shape`) with the MCP
+ * SDK, because the SDK needs `.shape` for individual-field descriptors and
+ * `ZodEffects` from `.refine()` doesn't expose it. The SDK validates the
+ * base shape against the agent's input *before* the handler runs.
+ *
+ * That leaves a gap: any `.refine()` chained on the **exported** schema
+ * (cross-field rules — XOR constraints, date ordering, owner-required
+ * unions) silently does not run. The agent gets a green call, the handler
+ * proceeds with malformed input, and the eventual error is downstream and
+ * confusing.
+ *
+ * `validateRefined` closes that gap at the handler boundary. The first
+ * thing the handler does is re-parse against the refined schema; on
+ * failure it throws a `ValidationError` whose `details.failures` carries
+ * the actionable rows from `zodToActionable` (per
+ * `docs/nl-quality-standards.md` §5).
+ *
+ * # Usage
+ *
+ * ```typescript
+ * export async function handleTaskCreate(input: TaskCreateToolInput, ctx) {
+ *   const validated = validateRefined(taskCreateInputSchema, input);
+ *   // …rest of handler uses `validated` (or `input` — they're the same shape)
+ * }
+ * ```
+ *
+ * The helper preserves the input's shape (it returns the parsed value, which
+ * is structurally equal to a successful base-shape validation), so existing
+ * handler code continues to work without further changes.
+ *
+ * # Why not catch the SDK's ZodError directly
+ *
+ * The SDK's pre-handler validation surfaces errors before the handler ever
+ * runs; we can't intercept those without forking the SDK. This helper
+ * targets the *post*-SDK refinement layer — the constraints `.shape` can't
+ * express. Augmenting the SDK's error rewriting is tracked separately
+ * (see #565 integration tests).
+ *
+ * @see src/errors/zodToActionable.ts — the structured-failures helper
+ * @see docs/nl-quality-standards.md §5 — fail-with-help errors
+ * @see #575 — adoption issue
+ */
+
+import type { ZodError, ZodTypeAny } from "zod";
+import { ValidationError } from "./index.js";
+import { zodToActionable } from "./zodToActionable.js";
+
+/**
+ * Parse `input` against `schema`. On success, return the parsed value. On
+ * failure, throw a `ValidationError` whose `details.failures` is the
+ * structured `ActionableValidation[]` agents iterate.
+ *
+ * @param schema - the refined Zod schema (`base.refine(...).refine(...)`)
+ * @param input - the raw input from the SDK (already conforming to the base
+ *   shape, but may violate refinements)
+ * @param message - error message; defaults to a generic frame referencing
+ *   the rubric. Pass a tool-specific message when one is helpful.
+ * @throws ValidationError - on any refinement failure
+ */
+export function validateRefined<S extends ZodTypeAny>(
+  schema: S,
+  input: unknown,
+  message = "Cross-field validation failed",
+): import("zod").infer<S> {
+  const result = schema.safeParse(input);
+  if (result.success) return result.data;
+
+  const failures = zodToActionable(result.error as ZodError, input);
+  throw new ValidationError(message, { details: { failures } });
+}

--- a/src/tools/task/create.test.ts
+++ b/src/tools/task/create.test.ts
@@ -154,6 +154,33 @@ describe("task_create — handler", () => {
     const envelope = assertOk(await handleTaskCreate({ name: "Task" }, ctx));
     expect(envelope.meta.syncPending).toBe(true);
   });
+
+  it("surfaces refinement failure with structured failures[] payload", async () => {
+    // The MCP SDK validates only `taskCreateInputBaseSchema.shape`, so the
+    // XOR refinement on the exported schema doesn't fire automatically.
+    // The handler re-parses against the refined schema and surfaces an
+    // actionable `details.failures` array — the lever-5 win from #575.
+    const { ctx } = makeCtx();
+    let caught: unknown;
+    try {
+      // Cast: the type rejects this combo, but the agent can still send it
+      // — we want to verify the runtime guard fires.
+      await handleTaskCreate(
+        { name: "T", projectId: "proj_001", parentTaskId: "task_001" } as never,
+        ctx,
+      );
+    } catch (e) {
+      caught = e;
+    }
+    const { ValidationError } = await import("../../errors/index.js");
+    expect(caught).toBeInstanceOf(ValidationError);
+    if (!(caught instanceof ValidationError)) return;
+    const failures = (caught.details as { failures: Array<{ field: string }> } | undefined)
+      ?.failures;
+    expect(Array.isArray(failures)).toBe(true);
+    expect(failures?.length).toBeGreaterThan(0);
+    expect(failures?.[0]?.field).toBe("projectId");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -27,6 +27,7 @@ import {
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
 import { summaryTaskCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { validateRefined } from "../../errors/validateRefined.js";
 import {
   idempotencyStore as defaultIdempotencyStore,
   type IdempotencyStore,
@@ -157,6 +158,13 @@ export interface TaskCreateContext {
  * @throws {OmniFocusNotRunning} when OmniFocus is not running
  */
 export async function handleTaskCreate(input: TaskCreateToolInput, ctx: TaskCreateContext) {
+  // Re-parse against the refined schema so cross-field constraints (XOR
+  // projectId/parentTaskId, dueDate ≥ deferDate) actually fire — the SDK
+  // only validates the base `.shape`. Failures surface as
+  // ValidationError.details.failures with actionable rows. See
+  // src/errors/validateRefined.ts.
+  validateRefined(taskCreateInputSchema, input);
+
   const store = ctx.idempotencyStore ?? defaultIdempotencyStore;
 
   return withIdempotencyKey(store, input.idempotency_key, async () => {

--- a/src/tools/task/extractFromImage.ts
+++ b/src/tools/task/extractFromImage.ts
@@ -60,6 +60,7 @@ import type { Attachment } from "../../domain/attachment.js";
 import { AttachmentId, ProjectId, TaskId } from "../../domain/ids.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
+import { validateRefined } from "../../errors/validateRefined.js";
 import type { AttachmentService } from "../../services/attachmentService.js";
 
 // ---------------------------------------------------------------------------
@@ -265,6 +266,11 @@ export async function handleTaskExtractFromImage(
   input: TaskExtractFromImageInput,
   ctx: TaskExtractFromImageContext,
 ) {
+  // Re-parse against the refined schema so the cross-field rules
+  // (dryRun→confirmation; attachment-source owner XOR) actually fire — the
+  // SDK only validates the base shape. See src/errors/validateRefined.ts.
+  validateRefined(taskExtractFromImageInputSchema, input);
+
   // Always validate the source — catches bad paths / non-image attachments
   // before the agent burns time on a write phase.
   const resolved = await resolveSource(input.source, ctx);

--- a/src/tools/task/extractFromNote.ts
+++ b/src/tools/task/extractFromNote.ts
@@ -38,6 +38,7 @@ import { ProjectId, TaskId } from "../../domain/ids.js";
 import { extractTasksFromProse } from "../../domain/proseExtractor.js";
 import { summaryBatchCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { validateRefined } from "../../errors/validateRefined.js";
 
 // ---------------------------------------------------------------------------
 // Tool description (DESIGN §6.8 four-section shape)
@@ -156,6 +157,11 @@ export async function handleTaskExtractFromNote(
   input: TaskExtractFromNoteInput,
   ctx: TaskExtractFromNoteContext,
 ) {
+  // Re-parse against the refined schema — the SDK only validates the base
+  // shape, so the dryRun→confirmation cross-field rule needs explicit
+  // enforcement here. See src/errors/validateRefined.ts.
+  validateRefined(taskExtractFromNoteInputSchema, input);
+
   const text = await resolveSourceText(input.source, ctx.adapter);
   const extracted = extractTasksFromProse(text);
 

--- a/src/tools/task/reclassify.ts
+++ b/src/tools/task/reclassify.ts
@@ -30,6 +30,7 @@ import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
 import type { Task } from "../../domain/task.js";
 import { evaluatePredicate, type TaskPredicate } from "../../domain/taskPredicate.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { validateRefined } from "../../errors/validateRefined.js";
 import { applyTagDiff, handleTaskBatchAssign } from "./batchAssign.js";
 
 // ---------------------------------------------------------------------------
@@ -208,6 +209,11 @@ export interface TaskReclassifyContext {
 }
 
 export async function handleTaskReclassify(input: TaskReclassifyInput, ctx: TaskReclassifyContext) {
+  // Re-parse against the refined schema — the SDK only validates the base
+  // shape, so the dryRun→confirmation cross-field rule needs explicit
+  // enforcement here. See src/errors/validateRefined.ts.
+  validateRefined(taskReclassifyInputSchema, input);
+
   // Phase 0: pull all open tasks and apply the predicate in TS.
   // We don't include completed/dropped tasks — reclassification of completed
   // work is out of scope for the v1 contract.

--- a/src/tools/task/search.ts
+++ b/src/tools/task/search.ts
@@ -26,6 +26,7 @@ import { z } from "zod";
 import { flexDateString } from "../../domain/dates.js";
 import { ProjectId, TagId } from "../../domain/ids.js";
 import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { validateRefined } from "../../errors/validateRefined.js";
 import type { SearchService } from "../../services/searchService.js";
 
 // ---------------------------------------------------------------------------
@@ -145,6 +146,11 @@ export interface TaskSearchContext {
  * metadata in the standard ADR-0013 envelope.
  */
 export async function handleTaskSearch(input: TaskSearchToolInput, ctx: TaskSearchContext) {
+  // Re-parse against the refined schema — the SDK only validates the base
+  // shape, so the at-least-one-field cross-field rule needs explicit
+  // enforcement here. See src/errors/validateRefined.ts.
+  validateRefined(taskSearchInputSchema, input);
+
   const result = await ctx.searchService.search({
     ...(input.q !== undefined && { q: input.q }),
     ...(input.scope !== undefined && { scope: input.scope }),

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -29,6 +29,7 @@ import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/inva
 import { TagId, TaskId } from "../../domain/ids.js";
 import type { Task } from "../../domain/task.js";
 import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
+import { validateRefined } from "../../errors/validateRefined.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
 import { dryRunGuard } from "../../server/dryRunGuard.js";
 import {
@@ -235,6 +236,12 @@ export async function handleTaskUpdate(
   input: TaskUpdateToolInput,
   ctx: TaskUpdateContext,
 ): Promise<ToolEnvelope<TaskUpdateData>> {
+  // Re-parse against the refined schema — the SDK only validates the base
+  // shape, so cross-field rules (tagIds vs addTags/removeTags exclusivity,
+  // dueDate ≥ deferDate) need explicit enforcement.
+  // See src/errors/validateRefined.ts.
+  validateRefined(taskUpdateInputSchema, input);
+
   const { id, addTags, removeTags, setFlagged, tagIds, ...rest } = input;
   const store = ctx.idempotencyStore ?? defaultIdempotencyStore;
 


### PR DESCRIPTION
Closes #575

## Summary

The MCP SDK validates each tool's **base** `inputSchema.shape` before the handler runs. Cross-field rules added on the wrapped schema via `.refine(...)` don't fire automatically — `ZodEffects` lacks `.shape`, so the SDK can't see them. That leaves a class of constraints (XOR fields, date ordering, dryRun→confirmation, owner-required unions) silently un-enforced at the boundary.

New `src/errors/validateRefined.ts` helper closes the gap: handlers pass their refined schema in, and on failure get a `ValidationError` whose `details.failures` is the actionable rows from `zodToActionable` (per `docs/nl-quality-standards.md` §5).

## Wired into

| Tool | Refinements now enforced |
|---|---|
| `task_create` | XOR `projectId`/`parentTaskId`; `dueDate ≥ deferDate` |
| `task_extract_from_note` | `dryRun=false` ⇒ `confirmation[]` required |
| `task_extract_from_image` | `dryRun=false` ⇒ `confirmation[]`; attachment-owner XOR |
| `task_reclassify` | `dryRun=false` ⇒ `confirmation` echo |
| `task_search` | At-least-one-field |
| `task_update` | `tagIds` ⊥ `addTags`/`removeTags`; `dueDate ≥ deferDate` |

Sub-schema refines (e.g. `task_find_similar`, `task_batch_*`) already fire via the SDK's nested-schema validation and need no change.

## Allowlist note

`src/tools/task/waitingOn.ts` (landed via #556 from another agent in parallel) joins the day-1 NL-quality exemption set. #563 graduates it alongside the rest.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (incl. `verify-nl-quality`) — clean
- [x] `pnpm test` — 166 files, 2694 passing, 49 skipped (4 new unit tests for the helper, 1 integration proof on task_create)
- [x] `pnpm build` — bundle within budget
- [ ] CI green