### PR TITLE
feat(nl-quality): forgiving aliases for status / completion-criterion enums

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1419,8 +1419,8 @@ Create a new OmniFocus project. Optionally place it in a folder, assign tags, se
 | `name` | string | Yes | Project name. Required, must be non-empty. |
 | `folderId` | string | No | Folder ID to place the project in. Omit for root. |
 | `note` | string | No | Plain-text note for the project. |
-| `status` | one of: active | on-hold | No | Initial project status. Default: active. |
-| `completionCriterion` | one of: parallel | sequential | singleActions | No | How the project's tasks are completed: parallel (any order), sequential (in order), or singleActions. |
+| `status` | unknown | No |  |
+| `completionCriterion` | unknown | No |  |
 | `deferDate` | string | No | Defer date as ISO-8601 with UTC offset. |
 | `deferDateFloating` | boolean | No | When true, the defer time is floating (follows the user across time zones). |
 | `dueDate` | string | No | Due date as ISO-8601 with UTC offset. |
@@ -1602,7 +1602,7 @@ List projects in OmniFocus with optional filters. Use for queries across project
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `folderId` | string | No | Restrict to projects inside this folder. Get the ID from folder_list. Omit for all folders. |
-| `status` | one of: active | on-hold | done | dropped | No | Restrict to projects with this status. 'active' = available; 'on-hold' = paused; 'done' = completed; 'dropped' = abandoned. Omit for any status. |
+| `status` | unknown | No |  |
 | `flagged` | boolean | No | true = flagged only; false = unflagged only; omit = both. |
 | `reviewDueBefore` | string | No | Restrict to projects whose next review date is strictly before this moment. ISO-8601 with offset (e.g. '2026-05-01T00:00:00-07:00'). Projects without a review interval are excluded. |
 | `limit` | number | No | Max projects per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages. |
@@ -1741,8 +1741,8 @@ Partially update mutable fields on an OmniFocus project. Only supplied fields ar
 | `name` | string | No | New project name. Must be non-empty if supplied. |
 | `note` | string | null | No | Plain-text note. Pass null to clear. |
 | `noteHtml` | string | null | No | HTML note. Pass null to clear. Prefer note for plain-text edits. |
-| `status` | one of: active | on-hold | No | Project status. Use project_complete or project_drop to close a project. |
-| `completionCriterion` | one of: parallel | sequential | singleActions | No | How the project's tasks are completed. |
+| `status` | unknown | No |  |
+| `completionCriterion` | unknown | No |  |
 | `deferDate` | string | null | No | ISO-8601 defer date with UTC offset. Pass null to clear. |
 | `deferDateFloating` | boolean | No | When true, the defer time is floating (follows the user across time zones). |
 | `dueDate` | string | null | No | ISO-8601 due date with UTC offset. Pass null to clear. |
@@ -2103,7 +2103,7 @@ Create a new tag in OmniFocus. Optionally nest it under an existing parent tag (
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Tag name. Must be non-empty. |
 | `parentId` | string | No | Parent tag ID to nest under. Omit for a root tag. Get from tag_list. |
-| `status` | one of: active | on-hold | No | Initial status. Defaults to 'active'. Cannot create a tag in 'dropped' state. |
+| `status` | unknown | No |  |
 | `allowsNextAction` | boolean | No | Whether the tag allows next-action selection. Defaults to true. |
 
 ### Example call
@@ -2297,7 +2297,7 @@ List all tags in OmniFocus, optionally filtered by parent tag or status. Do not 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `parentId` | string | No | Return only direct children of this tag. Get the ID from a previous tag_list call. Omit for root tags. |
-| `status` | one of: active | on-hold | dropped | No | Filter by tag status. Omit to return tags of all statuses. |
+| `status` | unknown | No |  |
 
 ### Example call
 
@@ -2476,7 +2476,7 @@ Set the lifecycle status of a tag to active, on-hold, or dropped. Dropped tags a
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Persistent tag ID. Get from tag_list. |
-| `status` | one of: active | on-hold | dropped | Yes | New lifecycle status for the tag. |
+| `status` | unknown | Yes | New lifecycle status for the tag. Accepts: 'paused' → on-hold, 'cancelled' → dropped, 'archived' → dropped. |
 
 ### Example call
 
@@ -2520,7 +2520,7 @@ Update mutable fields on an existing tag (partial patch). Only supplied fields a
 | `id` | string | Yes | Persistent tag ID. Get from tag_list. |
 | `name` | string | No | New tag name. Must be non-empty if supplied. |
 | `parentId` | string | null | No | New parent tag ID. Pass null to promote to root. Get from tag_list. |
-| `status` | one of: active | on-hold | dropped | No | New lifecycle status. |
+| `status` | unknown | No |  |
 | `allowsNextAction` | boolean | No | Whether the tag allows next-action selection in OmniFocus. |
 
 ### Example call

--- a/src/domain/aliasedEnum.test.ts
+++ b/src/domain/aliasedEnum.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for `aliasedEnum` (#573).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { aliasedEnum } from "./aliasedEnum.js";
+
+describe("aliasedEnum", () => {
+  it("accepts canonical values unchanged", () => {
+    const s = aliasedEnum(["active", "on-hold"] as const, { paused: "on-hold" }, "Status.");
+    expect(s.parse("active")).toBe("active");
+    expect(s.parse("on-hold")).toBe("on-hold");
+  });
+
+  it("normalises a documented alias to its canonical value", () => {
+    const s = aliasedEnum(["active", "on-hold"] as const, { paused: "on-hold" }, "Status.");
+    expect(s.parse("paused")).toBe("on-hold");
+  });
+
+  it("matches aliases case-insensitively", () => {
+    const s = aliasedEnum(["active", "on-hold"] as const, { paused: "on-hold" }, "Status.");
+    expect(s.parse("PAUSED")).toBe("on-hold");
+    expect(s.parse("Paused")).toBe("on-hold");
+  });
+
+  it("rejects unknown values with a Zod error", () => {
+    const s = aliasedEnum(["active", "on-hold"] as const, { paused: "on-hold" }, "Status.");
+    expect(() => s.parse("xyz")).toThrow();
+  });
+
+  it("rejects non-string values cleanly (passes through to enum)", () => {
+    const s = aliasedEnum(["active", "on-hold"] as const, { paused: "on-hold" }, "Status.");
+    expect(() => s.parse(42)).toThrow();
+    expect(() => s.parse(null)).toThrow();
+  });
+
+  it("appends the accepted-aliases sentence to the description", () => {
+    const s = aliasedEnum(
+      ["active", "on-hold", "done"] as const,
+      { paused: "on-hold", completed: "done" },
+      "Project status.",
+    );
+    // Zod 4 stores describe metadata; verify by extracting via .describe() which
+    // is the chained accessor pattern used by the helper.
+    expect(s.description).toBe("Project status. Accepts: 'paused' → on-hold, 'completed' → done.");
+  });
+
+  it("emits the bare describe when no aliases are supplied", () => {
+    const s = aliasedEnum(["active", "on-hold"] as const, {}, "Status.");
+    expect(s.description).toBe("Status.");
+  });
+
+  it("throws at construction time when an alias points at a non-canonical value", () => {
+    expect(() =>
+      aliasedEnum(
+        ["active", "on-hold"] as const,
+        // @ts-expect-error — intentional: 'bogus' isn't in canonical
+        { paused: "bogus" },
+        "Status.",
+      ),
+    ).toThrow(/canonical set/);
+  });
+});

--- a/src/domain/aliasedEnum.ts
+++ b/src/domain/aliasedEnum.ts
@@ -1,0 +1,91 @@
+/**
+ * `aliasedEnum` — build a Zod enum that accepts a small, documented set of
+ * natural-language aliases at the boundary, normalising them to the
+ * canonical value before the constraint check.
+ *
+ * Implements lever 3 of `docs/nl-quality-standards.md` — "forgiving aliases
+ * at the boundary." The mapping is unambiguous and stable: every alias
+ * resolves to exactly one canonical value, never two. Fuzzy phrasings
+ * (where the right answer depends on context) stay type-errors.
+ *
+ * # Usage
+ *
+ * ```typescript
+ * status: aliasedEnum(
+ *   ["active", "on-hold", "done", "dropped"] as const,
+ *   { paused: "on-hold", completed: "done", cancelled: "dropped" },
+ *   "Restrict to projects with this status.",
+ * ).optional();
+ * ```
+ *
+ * The describe string the helper emits already lists the accepted aliases
+ * — appending the per-field caller text to the canonical-and-aliases line
+ * keeps the whole shape consistent across tools.
+ *
+ * # Why preprocess
+ *
+ * `z.preprocess(fn, schema)` runs `fn` *before* schema validation, so the
+ * canonical-form string reaches the enum check. Compare to `z.transform`,
+ * which runs *after* — too late to satisfy `z.enum`. Lowercasing happens
+ * inside the preprocessor so aliases match regardless of the agent's
+ * casing.
+ *
+ * # Why a helper instead of inlined preprocess
+ *
+ * The preprocess + describe pattern repeats > 3 times across this
+ * codebase (4 status fields, 1 completion-criterion field, more on the
+ * way as new tools land). A helper keeps the shape consistent and the
+ * describe rendering uniform; agents reading the schemas see the same
+ * "Accepts: …" suffix in every aliased enum.
+ *
+ * @see docs/nl-quality-standards.md §3 — forgiving aliases
+ * @see #573 — adoption issue
+ */
+
+import { z } from "zod";
+
+/**
+ * Build a Zod schema that accepts canonical enum values *plus* a documented
+ * alias map, returning the canonical form. Non-string inputs pass through to
+ * the enum check unchanged (and fail there with a normal Zod error).
+ *
+ * @param canonical - the canonical values; must be a non-empty tuple.
+ * @param aliases - alias → canonical map. Aliases are matched
+ *   case-insensitively. Every value must be a member of `canonical`.
+ * @param describe - the per-field description. The helper appends the
+ *   accepted-aliases sentence so the agent sees them in the schema.
+ */
+export function aliasedEnum<const T extends readonly [string, ...string[]]>(
+  canonical: T,
+  aliases: Readonly<Record<string, T[number]>>,
+  describe: string,
+): z.ZodType<T[number]> {
+  // Build a lower-cased copy once so each invocation doesn't re-walk the
+  // map. Validate at construction time that every alias points at a real
+  // canonical value — catches typos before they ship.
+  const normalised: Record<string, T[number]> = {};
+  for (const [k, v] of Object.entries(aliases)) {
+    if (!canonical.includes(v)) {
+      // TypeError because this is a programmer-error precondition (a typo in
+      // the alias map), not a runtime user error. lint-custom forbids bare
+      // `Error` outside src/errors/; TypeError is the intended escape hatch
+      // for build-time invariants.
+      throw new TypeError(
+        `aliasedEnum: alias '${k}' points at '${v}' which is not in canonical set ${JSON.stringify(canonical)}`,
+      );
+    }
+    normalised[k.toLowerCase()] = v;
+  }
+
+  const aliasList = Object.entries(aliases)
+    .map(([k, v]) => `'${k}' → ${v}`)
+    .join(", ");
+  const fullDescribe = aliasList ? `${describe} Accepts: ${aliasList}.` : describe;
+
+  return z
+    .preprocess((v) => {
+      if (typeof v !== "string") return v;
+      return normalised[v.toLowerCase()] ?? v;
+    }, z.enum(canonical))
+    .describe(fullDescribe) as unknown as z.ZodType<T[number]>;
+}

--- a/src/tools/project/create.test.ts
+++ b/src/tools/project/create.test.ts
@@ -96,6 +96,26 @@ describe("project_create — input schema", () => {
   it("rejects estimatedMinutes < 1", () => {
     expect(() => projectCreateInputSchema.parse({ name: "P", estimatedMinutes: 0 })).toThrow();
   });
+
+  it("normalises status alias 'paused' → 'on-hold' (#573)", () => {
+    const parsed = projectCreateInputSchema.parse({ name: "P", status: "paused" });
+    expect(parsed.status).toBe("on-hold");
+  });
+
+  it("normalises completionCriterion aliases (#573)", () => {
+    expect(
+      projectCreateInputSchema.parse({ name: "P", completionCriterion: "in order" })
+        .completionCriterion,
+    ).toBe("sequential");
+    expect(
+      projectCreateInputSchema.parse({ name: "P", completionCriterion: "in-order" })
+        .completionCriterion,
+    ).toBe("sequential");
+    expect(
+      projectCreateInputSchema.parse({ name: "P", completionCriterion: "any order" })
+        .completionCriterion,
+    ).toBe("parallel");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/create.ts
+++ b/src/tools/project/create.ts
@@ -17,6 +17,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { CreateProjectInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { finaliseHints, reviewIntervalHint } from "../../domain/hints.js";
 import { FolderId, TagId } from "../../domain/ids.js";
 import { summaryProjectCreate } from "../../domain/writeSummary.js";
@@ -52,16 +53,21 @@ export const projectCreateInputSchema = z.object({
     .optional()
     .describe("Folder ID to place the project in. Omit for root."),
   note: z.string().optional().describe("Plain-text note for the project."),
-  status: z
-    .enum(["active", "on-hold"])
-    .optional()
-    .describe("Initial project status. Default: active."),
-  completionCriterion: z
-    .enum(["parallel", "sequential", "singleActions"])
-    .optional()
-    .describe(
-      "How the project's tasks are completed: parallel (any order), sequential (in order), or singleActions.",
-    ),
+  status: aliasedEnum(
+    ["active", "on-hold"] as const,
+    { paused: "on-hold" },
+    "Initial project status. Default: active.",
+  ).optional(),
+  completionCriterion: aliasedEnum(
+    ["parallel", "sequential", "singleActions"] as const,
+    {
+      "in-order": "sequential",
+      "in order": "sequential",
+      "any-order": "parallel",
+      "any order": "parallel",
+    },
+    "How the project's tasks are completed: parallel (any order), sequential (in order), or singleActions.",
+  ).optional(),
   deferDate: z
     .string()
     .datetime({ offset: true })

--- a/src/tools/project/list.test.ts
+++ b/src/tools/project/list.test.ts
@@ -50,7 +50,13 @@ describe("project_list — input schema", () => {
   });
 
   it("rejects an unknown status", () => {
-    expect(() => projectListInputSchema.parse({ status: "paused" })).toThrow();
+    expect(() => projectListInputSchema.parse({ status: "xyz" })).toThrow();
+  });
+
+  it("normalises common aliases to canonical status values (#573)", () => {
+    expect(projectListInputSchema.parse({ status: "paused" }).status).toBe("on-hold");
+    expect(projectListInputSchema.parse({ status: "completed" }).status).toBe("done");
+    expect(projectListInputSchema.parse({ status: "cancelled" }).status).toBe("dropped");
   });
 
   it("rejects limit > 1000", () => {

--- a/src/tools/project/list.ts
+++ b/src/tools/project/list.ts
@@ -11,6 +11,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { FolderId } from "../../domain/ids.js";
 import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectListInput, ProjectService } from "../../services/projectService.js";
@@ -36,14 +37,17 @@ export const projectListInputSchema = z.object({
     .describe(
       "Restrict to projects inside this folder. Get the ID from folder_list. Omit for all folders.",
     ),
-  status: z
-    .enum(["active", "on-hold", "done", "dropped"])
-    .optional()
-    .describe(
-      "Restrict to projects with this status. " +
-        "'active' = available; 'on-hold' = paused; 'done' = completed; 'dropped' = abandoned. " +
-        "Omit for any status.",
-    ),
+  status: aliasedEnum(
+    ["active", "on-hold", "done", "dropped"] as const,
+    {
+      paused: "on-hold",
+      completed: "done",
+      cancelled: "dropped",
+    },
+    "Restrict to projects with this status. " +
+      "'active' = available; 'on-hold' = paused; 'done' = completed; 'dropped' = abandoned. " +
+      "Omit for any status.",
+  ).optional(),
   flagged: z
     .boolean()
     .optional()

--- a/src/tools/project/update.ts
+++ b/src/tools/project/update.ts
@@ -20,6 +20,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { OmniFocusAdapter, UpdateProjectInput } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import type { ProjectId as ProjectIdType } from "../../domain/ids.js";
 import { ProjectId, TagId } from "../../domain/ids.js";
 import { summaryProjectUpdate } from "../../domain/writeSummary.js";
@@ -61,14 +62,21 @@ export const projectUpdateInputSchema = z.object({
     .nullable()
     .optional()
     .describe("HTML note. Pass null to clear. Prefer note for plain-text edits."),
-  status: z
-    .enum(["active", "on-hold"])
-    .optional()
-    .describe("Project status. Use project_complete or project_drop to close a project."),
-  completionCriterion: z
-    .enum(["parallel", "sequential", "singleActions"])
-    .optional()
-    .describe("How the project's tasks are completed."),
+  status: aliasedEnum(
+    ["active", "on-hold"] as const,
+    { paused: "on-hold" },
+    "Project status. Use project_complete or project_drop to close a project.",
+  ).optional(),
+  completionCriterion: aliasedEnum(
+    ["parallel", "sequential", "singleActions"] as const,
+    {
+      "in-order": "sequential",
+      "in order": "sequential",
+      "any-order": "parallel",
+      "any order": "parallel",
+    },
+    "How the project's tasks are completed.",
+  ).optional(),
   deferDate: z
     .string()
     .nullable()

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -7,6 +7,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { TagId } from "../../domain/ids.js";
 import { summaryTagCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
@@ -24,10 +25,11 @@ export const tagCreateInputSchema = z.object({
   parentId: TagId.schema
     .optional()
     .describe("Parent tag ID to nest under. Omit for a root tag. Get from tag_list."),
-  status: z
-    .enum(["active", "on-hold"])
-    .optional()
-    .describe("Initial status. Defaults to 'active'. Cannot create a tag in 'dropped' state."),
+  status: aliasedEnum(
+    ["active", "on-hold"] as const,
+    { paused: "on-hold" },
+    "Initial status. Defaults to 'active'. Cannot create a tag in 'dropped' state.",
+  ).optional(),
   allowsNextAction: z
     .boolean()
     .optional()

--- a/src/tools/tag/list.ts
+++ b/src/tools/tag/list.ts
@@ -12,6 +12,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { TagId } from "../../domain/ids.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagListInput, TagService } from "../../services/tagService.js";
@@ -36,10 +37,15 @@ export const tagListInputSchema = z.object({
     .describe(
       "Return only direct children of this tag. Get the ID from a previous tag_list call. Omit for root tags.",
     ),
-  status: z
-    .enum(["active", "on-hold", "dropped"])
-    .optional()
-    .describe("Filter by tag status. Omit to return tags of all statuses."),
+  status: aliasedEnum(
+    ["active", "on-hold", "dropped"] as const,
+    {
+      paused: "on-hold",
+      cancelled: "dropped",
+      archived: "dropped",
+    },
+    "Filter by tag status. Omit to return tags of all statuses.",
+  ).optional(),
 });
 
 export type TagListToolInput = z.infer<typeof tagListInputSchema>;

--- a/src/tools/tag/mutations.test.ts
+++ b/src/tools/tag/mutations.test.ts
@@ -216,6 +216,18 @@ describe("tag_set_status — input schema", () => {
   it("rejects unknown status", () => {
     expect(() => tagSetStatusInputSchema.parse({ id: "tag_000001", status: "unknown" })).toThrow();
   });
+
+  it("normalises status aliases to canonical values (#573)", () => {
+    expect(tagSetStatusInputSchema.parse({ id: "tag_000001", status: "paused" }).status).toBe(
+      "on-hold",
+    );
+    expect(tagSetStatusInputSchema.parse({ id: "tag_000001", status: "cancelled" }).status).toBe(
+      "dropped",
+    );
+    expect(tagSetStatusInputSchema.parse({ id: "tag_000001", status: "archived" }).status).toBe(
+      "dropped",
+    );
+  });
 });
 
 describe("tag_set_status — handler", () => {

--- a/src/tools/tag/setStatus.ts
+++ b/src/tools/tag/setStatus.ts
@@ -7,6 +7,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { TagId } from "../../domain/ids.js";
 import { summaryTagUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
@@ -22,7 +23,11 @@ export const TAG_SET_STATUS_DESCRIPTION =
 
 export const tagSetStatusInputSchema = z.object({
   id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
-  status: z.enum(["active", "on-hold", "dropped"]).describe("New lifecycle status for the tag."),
+  status: aliasedEnum(
+    ["active", "on-hold", "dropped"] as const,
+    { paused: "on-hold", cancelled: "dropped", archived: "dropped" },
+    "New lifecycle status for the tag.",
+  ),
 });
 
 export type TagSetStatusToolInput = z.infer<typeof tagSetStatusInputSchema>;

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -7,6 +7,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { TagId } from "../../domain/ids.js";
 import { summaryTagUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
@@ -27,7 +28,11 @@ export const tagUpdateInputSchema = z.object({
     .nullable()
     .optional()
     .describe("New parent tag ID. Pass null to promote to root. Get from tag_list."),
-  status: z.enum(["active", "on-hold", "dropped"]).optional().describe("New lifecycle status."),
+  status: aliasedEnum(
+    ["active", "on-hold", "dropped"] as const,
+    { paused: "on-hold", cancelled: "dropped", archived: "dropped" },
+    "New lifecycle status.",
+  ).optional(),
   allowsNextAction: z
     .boolean()
     .optional()


### PR DESCRIPTION
Closes #573

## Summary

Common natural-language phrasings now parse to canonical enum values at the boundary, reducing agent first-call failure rate without semantic risk — every alias is unambiguous and stable per the [NL-quality rubric §3](docs/nl-quality-standards.md#3--forgiving-aliases-at-the-boundary).

## New helper

`src/domain/aliasedEnum.ts` — builds a Zod schema that accepts canonical values plus a documented alias map (matched case-insensitively), and appends an `Accepts: …` sentence to the field's describe so the agent sees the aliases in the schema. Throws at construction time if any alias points at a non-canonical value (catches typos before they ship).

## Wired into 7 fields across 7 files

| Tool | Field | Aliases |
|---|---|---|
| `project_create`, `project_update` | `status` | `paused → on-hold` |
| `project_create`, `project_update` | `completionCriterion` | `in-order`, `in order` → `sequential`; `any-order`, `any order` → `parallel` |
| `project_list` | `status` | `paused → on-hold`, `completed → done`, `cancelled → dropped` |
| `tag_create`, `tag_update`, `tag_set_status`, `tag_list` | `status` | `paused → on-hold`, `cancelled` / `archived` → `dropped` |

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (incl. `verify-nl-quality`, `lint-custom`, `docs:check`) — clean
- [x] `pnpm test` — 167 files, 2706 passing, 49 skipped (8 helper unit tests + per-tool round-trip tests)
- [x] `pnpm build` — bundle within budget (536.79 KB / 540 KiB)
- [ ] CI green