### PR TITLE
feat(perspective): rule input schema with disjointness + strict-shape refinements

### DIFF
--- a/src/domain/perspectiveRules.test.ts
+++ b/src/domain/perspectiveRules.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for the strict input-side rule schema (#577 slice A).
+ *
+ * Coverage:
+ *  - Atom disjointness: reject mixed action shapes; accept single-predicate atoms.
+ *  - Strict shape: reject unknown keys (no `unknown` carrier on inputs).
+ *  - Id-list validation: tag/focus/search lists must be non-empty and contain
+ *    no empty strings.
+ *  - Recursive aggregates: arbitrarily-deep aggregate nesting is accepted.
+ *  - Disabled wrappers: round-trip through a single rule.
+ *  - Cross-cutting: empty atom (no action keys) is accepted as a degenerate
+ *    pass-through atom (per AC: "at most one").
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ACTION_KEYS,
+  countActionKeys,
+  PerspectiveRuleAtomInputSchema,
+  PerspectiveRuleInputSchema,
+} from "./perspectiveRules.js";
+
+// ---------------------------------------------------------------------------
+// countActionKeys
+// ---------------------------------------------------------------------------
+
+describe("countActionKeys", () => {
+  it("returns 0 for an empty atom", () => {
+    expect(countActionKeys({})).toBe(0);
+  });
+
+  it("counts each action key exactly once", () => {
+    expect(countActionKeys({ actionStatus: "flagged" })).toBe(1);
+    expect(countActionKeys({ actionStatus: "flagged", actionHasNoProject: true })).toBe(2);
+  });
+
+  it("treats `undefined` values as not set", () => {
+    // Cast through unknown — exactOptionalPropertyTypes forbids assigning
+    // `undefined` literally, but the runtime check must still tolerate it
+    // (real callers can land here via destructured rest, etc).
+    expect(
+      countActionKeys({ actionStatus: undefined } as unknown as Parameters<
+        typeof countActionKeys
+      >[0]),
+    ).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PerspectiveRuleAtomInputSchema — disjointness
+// ---------------------------------------------------------------------------
+
+describe("PerspectiveRuleAtomInputSchema — disjointness", () => {
+  it("accepts an atom with exactly one action key", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({ actionStatus: "flagged" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts an empty atom (zero action keys; degenerate pass-through)", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({});
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an atom with two action keys and names both in the error", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({
+      actionStatus: "flagged",
+      actionHasNoProject: true,
+    });
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const message = r.error.issues[0]?.message ?? "";
+    expect(message).toContain("at most one action predicate");
+    expect(message).toContain("actionStatus");
+    expect(message).toContain("actionHasNoProject");
+  });
+
+  it("rejects an atom with three action keys", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({
+      actionStatus: "flagged",
+      actionHasNoProject: true,
+      actionAvailability: "remaining",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("ACTION_KEYS covers every documented predicate", () => {
+    // Sanity check: if a new predicate is added to PerspectiveRuleAtom, the
+    // ACTION_KEYS list must be extended too — otherwise the disjointness
+    // refine silently misses it. This test catches that drift.
+    expect(ACTION_KEYS.length).toBe(11);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PerspectiveRuleAtomInputSchema — strict / unknown keys
+// ---------------------------------------------------------------------------
+
+describe("PerspectiveRuleAtomInputSchema — strict shape", () => {
+  it("rejects an unknown carrier key", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({
+      actionStatus: "flagged",
+      // Output schema permits this; input does not.
+      unknown: { someFutureKey: 42 },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects an unrecognized top-level key", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({
+      actionStatus: "flagged",
+      typo: "value",
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PerspectiveRuleAtomInputSchema — id-list validation
+// ---------------------------------------------------------------------------
+
+describe("PerspectiveRuleAtomInputSchema — id lists", () => {
+  it("accepts a non-empty tag list", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({
+      actionHasAllOfTags: ["tag-1", "tag-2"],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an empty tag list", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({ actionHasAllOfTags: [] });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects an empty string id inside the tag list", () => {
+    const r = PerspectiveRuleAtomInputSchema.safeParse({
+      actionHasAnyOfTags: ["tag-1", ""],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("validates actionWithinFocus as a non-empty id list", () => {
+    expect(
+      PerspectiveRuleAtomInputSchema.safeParse({ actionWithinFocus: ["proj-1"] }).success,
+    ).toBe(true);
+    expect(PerspectiveRuleAtomInputSchema.safeParse({ actionWithinFocus: [] }).success).toBe(false);
+    expect(PerspectiveRuleAtomInputSchema.safeParse({ actionWithinFocus: [""] }).success).toBe(
+      false,
+    );
+  });
+
+  it("validates actionMatchingSearch as a non-empty string list", () => {
+    expect(
+      PerspectiveRuleAtomInputSchema.safeParse({ actionMatchingSearch: ["dentist"] }).success,
+    ).toBe(true);
+    expect(PerspectiveRuleAtomInputSchema.safeParse({ actionMatchingSearch: [] }).success).toBe(
+      false,
+    );
+    expect(PerspectiveRuleAtomInputSchema.safeParse({ actionMatchingSearch: [""] }).success).toBe(
+      false,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PerspectiveRuleInputSchema — recursive aggregates
+// ---------------------------------------------------------------------------
+
+describe("PerspectiveRuleInputSchema — aggregates", () => {
+  it("accepts a flat aggregate over single-predicate atoms", () => {
+    const tree = {
+      aggregateType: "all" as const,
+      aggregateRules: [{ actionStatus: "flagged" as const }, { actionHasNoProject: true }],
+    };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(true);
+  });
+
+  it("accepts a deeply-nested aggregate (3 levels)", () => {
+    const tree = {
+      aggregateType: "all" as const,
+      aggregateRules: [
+        {
+          aggregateType: "any" as const,
+          aggregateRules: [
+            { actionStatus: "flagged" as const },
+            {
+              aggregateType: "none" as const,
+              aggregateRules: [{ actionHasDueDate: true }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(true);
+  });
+
+  it("rejects an aggregate with an unknown key", () => {
+    const tree = {
+      aggregateType: "all",
+      aggregateRules: [],
+      bogus: "value",
+    };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(false);
+  });
+
+  it("rejects an aggregate whose child violates the disjointness rule", () => {
+    const tree = {
+      aggregateType: "all" as const,
+      aggregateRules: [{ actionStatus: "flagged", actionHasNoProject: true }],
+    };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(false);
+  });
+
+  it("rejects an unknown aggregateType", () => {
+    const tree = { aggregateType: "xor", aggregateRules: [] };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PerspectiveRuleInputSchema — disabled wrappers
+// ---------------------------------------------------------------------------
+
+describe("PerspectiveRuleInputSchema — disabled wrappers", () => {
+  it("accepts a disabled-rule wrapper around an atom", () => {
+    const tree = { disabledRule: { actionStatus: "flagged" as const } };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(true);
+  });
+
+  it("accepts a disabled-rule wrapper around an aggregate", () => {
+    const tree = {
+      disabledRule: { aggregateType: "any" as const, aggregateRules: [] },
+    };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(true);
+  });
+
+  it("rejects a disabled-rule wrapper with extra keys", () => {
+    const tree = {
+      disabledRule: { actionStatus: "flagged" as const },
+      extra: "value",
+    };
+    expect(PerspectiveRuleInputSchema.safeParse(tree).success).toBe(false);
+  });
+});

--- a/src/domain/perspectiveRules.ts
+++ b/src/domain/perspectiveRules.ts
@@ -1,0 +1,166 @@
+/**
+ * Strict *input* schema for custom-perspective rule trees, used by
+ * `perspective_create` and `perspective_update` (#577).
+ *
+ * Why a separate module from `perspective.ts`:
+ * - `perspective.ts` defines the **output** schemas used by `perspective_get`
+ *   and the OmniJS read-side serialization (#523/#569). Output is permissive:
+ *   it tolerates `unknown` carrier keys for forward compatibility and accepts
+ *   atoms that combine multiple action* predicates (because OmniFocus on disk
+ *   may emit those combinations even when the agent shouldn't author them).
+ * - This module defines the **input** schema. Input is stricter:
+ *   - Atom-key disjointness refinement: an atom may set **at most one** of
+ *     the action* predicates. Use a `RuleAggregate` with `aggregateType: "all"`
+ *     to AND multiple predicates — that's the canonical authoring shape and
+ *     it round-trips through OmniJS without surprises.
+ *   - Tag-id and focus-id arrays must be non-empty, and each entry must be a
+ *     non-empty string. An empty list is a degenerate filter that OmniFocus
+ *     evaluates inconsistently across versions; reject it at the boundary.
+ *   - No `unknown` carrier key. Forward compatibility is a read concern;
+ *     letting the agent write arbitrary keys breaks the schema contract.
+ *
+ * The TypeScript *types* (`PerspectiveRule`, `PerspectiveRuleAtom`,
+ * `PerspectiveRuleAggregate`, `PerspectiveRuleDisabled`) are reused as-is from
+ * `perspective.ts`. Only the runtime validation differs.
+ *
+ * @see #577 — perspective_create + perspective_update
+ * @see src/domain/perspective.ts — output-side schemas (PerspectiveRuleSchema)
+ */
+
+import { z } from "zod";
+import type {
+  PerspectiveAggregation,
+  PerspectiveRule,
+  PerspectiveRuleAggregate,
+  PerspectiveRuleAtom,
+  PerspectiveRuleDisabled,
+} from "./perspective.js";
+
+// ---------------------------------------------------------------------------
+// Action-key inventory — single source of truth for the disjointness refine.
+// ---------------------------------------------------------------------------
+
+/**
+ * Every key on `PerspectiveRuleAtom` that represents an action predicate.
+ * Listed explicitly (rather than computed from `keyof`) so adding a new
+ * predicate forces an intentional update of the disjointness rule.
+ */
+export const ACTION_KEYS = [
+  "actionAvailability",
+  "actionStatus",
+  "actionHasAllOfTags",
+  "actionHasAnyOfTags",
+  "actionHasNoProject",
+  "actionHasDueDate",
+  "actionHasDeferDate",
+  "actionIsLeaf",
+  "actionIsProject",
+  "actionMatchingSearch",
+  "actionWithinFocus",
+] as const satisfies readonly (keyof PerspectiveRuleAtom)[];
+
+export type ActionKey = (typeof ACTION_KEYS)[number];
+
+/**
+ * Returns the count of action-predicate keys actually set on an atom.
+ * Used by the disjointness refinement and by tests so the same definition of
+ * "set" applies in both places.
+ */
+export function countActionKeys(atom: PerspectiveRuleAtom): number {
+  let n = 0;
+  for (const k of ACTION_KEYS) {
+    if (atom[k] !== undefined) n += 1;
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Atom field schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Non-empty string-id list. Each entry must itself be a non-empty string —
+ * a bare `""` would silently match no records, and empty arrays are
+ * inconsistently evaluated across OmniFocus versions.
+ */
+const NonEmptyIdList = z
+  .array(z.string().min(1, "id must be non-empty"))
+  .min(1, "list must contain at least one id");
+
+const AggregationInputSchema = z.enum(["all", "any", "none"]);
+
+// ---------------------------------------------------------------------------
+// Atom input schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Base atom — every action predicate is optional. The disjointness rule is
+ * applied as a `.superRefine` below so violations carry a precise path.
+ *
+ * `.strict()` rejects unknown keys — agents can't smuggle `unknown` carrier
+ * data into a write payload.
+ */
+const PerspectiveRuleAtomBaseSchema = z
+  .object({
+    actionAvailability: z
+      .enum(["available", "remaining", "completed", "dropped", "firstAvailable"])
+      .optional(),
+    actionStatus: z.enum(["flagged", "due"]).optional(),
+    actionHasAllOfTags: NonEmptyIdList.optional(),
+    actionHasAnyOfTags: NonEmptyIdList.optional(),
+    actionHasNoProject: z.boolean().optional(),
+    actionHasDueDate: z.boolean().optional(),
+    actionHasDeferDate: z.boolean().optional(),
+    actionIsLeaf: z.boolean().optional(),
+    actionIsProject: z.boolean().optional(),
+    actionMatchingSearch: z.array(z.string().min(1)).min(1).optional(),
+    actionWithinFocus: NonEmptyIdList.optional(),
+  })
+  .strict();
+
+export const PerspectiveRuleAtomInputSchema: z.ZodType<PerspectiveRuleAtom> =
+  PerspectiveRuleAtomBaseSchema.superRefine((atom, ctx) => {
+    const count = countActionKeys(atom as PerspectiveRuleAtom);
+    if (count > 1) {
+      const setKeys = ACTION_KEYS.filter((k) => (atom as PerspectiveRuleAtom)[k] !== undefined);
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `Rule atom must set at most one action predicate; got ${count} (${setKeys.join(", ")}). ` +
+          "Combine predicates by wrapping atoms in a RuleAggregate with " +
+          'aggregateType: "all" / "any" / "none" instead.',
+        path: [],
+      });
+    }
+  }) as z.ZodType<PerspectiveRuleAtom>;
+
+// ---------------------------------------------------------------------------
+// Recursive rule input schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursive discriminated union: `RuleAtom | RuleAggregate | RuleDisabled`.
+ *
+ * The atom branch goes last in the union so Zod tries the structurally
+ * distinctive branches (`aggregateType` for aggregate, `disabledRule` for
+ * disabled) first. Without that ordering, an atom with no action keys would
+ * also match the empty aggregate shape and produce confusing errors.
+ */
+export const PerspectiveRuleInputSchema: z.ZodType<PerspectiveRule> = z.lazy(() =>
+  z.union([
+    z
+      .object({
+        aggregateType: AggregationInputSchema,
+        aggregateRules: z.array(PerspectiveRuleInputSchema),
+      })
+      .strict() as z.ZodType<PerspectiveRuleAggregate>,
+    z
+      .object({ disabledRule: PerspectiveRuleInputSchema })
+      .strict() as z.ZodType<PerspectiveRuleDisabled>,
+    PerspectiveRuleAtomInputSchema,
+  ]),
+);
+
+// Re-export the aggregation type so callers writing input payloads do not
+// need to import from both modules.
+export type { PerspectiveAggregation };


### PR DESCRIPTION
Closes #619
Refs #577

## Summary

Slice A of 3 for #577 (perspective_create + perspective_update). Adds the strict input-side rule schema; the actual create/update tools land in slice B (#617) and slice C (#618).

\`src/domain/perspectiveRules.ts\` exports:

| Export | Purpose |
|---|---|
| \`PerspectiveRuleAtomInputSchema\` | Strict atom with disjointness refine (≤1 action predicate per atom) |
| \`PerspectiveRuleInputSchema\` | Recursive union: aggregate \| disabled \| atom |
| \`ACTION_KEYS\` | Single source of truth for predicate inventory |
| \`countActionKeys\` | Used by the refine and exposed for tests |

**Why a separate module from \`perspective.ts\`:** the existing schemas there round-trip what OmniFocus emits on disk — permissive about the \`unknown\` carrier key (forward compat) and atoms that combine multiple predicates. Inputs are stricter: agents shouldn't smuggle unknown keys into writes, and combined predicates should be expressed via \`RuleAggregate\` so the resulting tree round-trips through OmniJS without surprises.

The TypeScript *types* are reused as-is from \`perspective.ts\`; only the runtime validation differs.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 2909 pass / 49 skip (23 new tests covering disjointness, strict shape, id-list rules, deep aggregates, disabled wrappers)
- [x] \`pnpm run docs:check\` clean

Follow-ups #617 (perspective_create) and #618 (perspective_update) close out #577 once they merge.