### PR TITLE
chore(release): skip prepublishOnly in CI publish step via --ignore-scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,11 @@ jobs:
         # above) and a public repo (we are public). With Trusted Publishing
         # configured on npm, no NODE_AUTH_TOKEN is needed — the npm CLI
         # auto-detects the OIDC environment.
-        run: pnpm publish --access public --no-git-checks --provenance
+        # --ignore-scripts skips prepublishOnly (typecheck/lint/test/build)
+        # because those already ran as explicit steps above; running them again
+        # on the same runner is redundant and caused repeated release failures
+        # when lint errors were caught at publish time instead of the gate steps.
+        run: pnpm publish --access public --no-git-checks --provenance --ignore-scripts
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary

- Adds `--ignore-scripts` to the `pnpm publish` call in `release.yml`
- Prevents `prepublishOnly` (typecheck/lint/test/build) from re-running after those exact steps already passed as explicit workflow gates
- Keeps `prepublishOnly` intact as a safeguard for local `pnpm publish` invocations

Closes #613.

## Issue

Implements [#613 — fix(release): skip redundant prepublishOnly checks when publishing from CI](https://github.com/torsday/omnifocus-mcp/issues/613). During the v1.1.0 release, lint errors surfaced inside `prepublishOnly` after all gate steps had already passed, requiring three tag-delete-retag cycles.

## Breaking change?
- [x] No

## Test plan
- [x] One-line diff, no logic change
- [x] Self-reviewed: only the publish command changes; all pre-publish gates remain
- [x] CI will verify the workflow file is valid on this PR