### PR TITLE
feat(nl-quality): add .describe() to inner fields in batch tool schemas

### DIFF
--- a/src/domain/noteFences.test.ts
+++ b/src/domain/noteFences.test.ts
@@ -130,6 +130,7 @@ describe("upsertFence", () => {
     const fields = { whom: "Alice", since: "2026-04-27T10:00:00-05:00" };
     const note = upsertFence("user note", "waiting-on", serializeFenceBody(fields));
     const m = findFence(note, "waiting-on");
+    // biome-ignore lint/style/noNonNullAssertion: findFence always returns a match here
     expect(parseFenceBody(m!.body)).toEqual(fields);
   });
 });

--- a/src/domain/repetitionGrammar.ts
+++ b/src/domain/repetitionGrammar.ts
@@ -392,7 +392,7 @@ function detectFrequency(text: string): FrequencyMatch | null {
  *   6. Otherwise emit `ok` with the normalized description.
  */
 export function parseRepetitionFromProse(prose: string): RepetitionParseResult {
-  if (!prose || !prose.trim()) {
+  if (!prose?.trim()) {
     return { kind: "error", reason: "no-repetition-detected" };
   }
 

--- a/src/scripts/jxa/window_get_state.js
+++ b/src/scripts/jxa/window_get_state.js
@@ -36,7 +36,7 @@ function run(_argv) {
   const focusContainerIds = [];
   try {
     const focus = w.focus();
-    if (focus && focus.length) {
+    if (focus?.length) {
       for (let i = 0; i < focus.length; i++) {
         try {
           focusContainerIds.push(String(focus[i].id()));

--- a/src/scripts/omnijs/perspective_create.js
+++ b/src/scripts/omnijs/perspective_create.js
@@ -90,7 +90,7 @@
       });
     }
   } catch (e) {
-    const msg = String(e && e.message ? e.message : e);
+    const msg = String(e?.message ? e.message : e);
     // OmniFocus rejects duplicate names with a recognisable message; surface
     // as VALIDATION_ERROR so the agent can react accordingly.
     if (msg.toLowerCase().indexOf("already") >= 0 || msg.toLowerCase().indexOf("duplicate") >= 0) {
@@ -128,13 +128,11 @@
     // Atomic rollback — the shell exists but the configure step failed, so
     // delete the shell so the user is never left with a malformed
     // perspective. If rollback also fails, surface both errors.
-    const configureMsg = String(e && e.message ? e.message : e);
+    const configureMsg = String(e?.message ? e.message : e);
     try {
       deleteObject(persp);
     } catch (rollbackErr) {
-      const rollbackMsg = String(
-        rollbackErr && rollbackErr.message ? rollbackErr.message : rollbackErr,
-      );
+      const rollbackMsg = String(rollbackErr?.message ? rollbackErr.message : rollbackErr);
       return JSON.stringify({
         error: {
           code: "SCRIPT_ERROR",

--- a/src/scripts/omnijs/perspective_delete.js
+++ b/src/scripts/omnijs/perspective_delete.js
@@ -33,7 +33,7 @@
     deleteObject(persp);
   } catch (e) {
     return JSON.stringify({
-      error: { code: "SCRIPT_ERROR", message: String(e && e.message ? e.message : e) },
+      error: { code: "SCRIPT_ERROR", message: String(e?.message ? e.message : e) },
     });
   }
 

--- a/src/scripts/omnijs/perspective_update.js
+++ b/src/scripts/omnijs/perspective_update.js
@@ -83,7 +83,7 @@
       persp.iconColor = Color.RGB(iconColor.r, iconColor.g, iconColor.b, iconColor.a);
     }
   } catch (e) {
-    const msg = String(e && e.message ? e.message : e);
+    const msg = String(e?.message ? e.message : e);
     if (msg.toLowerCase().indexOf("already") >= 0 || msg.toLowerCase().indexOf("duplicate") >= 0) {
       return JSON.stringify({
         error: { code: "VALIDATION_ERROR", message: `Duplicate perspective name: ${name}` },

--- a/src/tools/project/templateInstantiate.test.ts
+++ b/src/tools/project/templateInstantiate.test.ts
@@ -56,6 +56,7 @@ async function seedTemplate(
   let folder = folders.find((f) => f.name.toLowerCase() === folderName.toLowerCase());
   if (folder === undefined) {
     const folderId = await adapter.createFolder({ name: folderName });
+    // biome-ignore lint/style/noNonNullAssertion: folder was just created so it must exist
     folder = (await adapter.listFolders()).find((f) => f.id === folderId)!;
   }
   const note = buildProjectTemplateNote(

--- a/src/tools/task/batchAssign.ts
+++ b/src/tools/task/batchAssign.ts
@@ -68,9 +68,19 @@ const assignmentSchema = z
       .array(TagId.schema)
       .optional()
       .describe("Tag IDs to remove. Wins over addTagIds when the same ID appears in both."),
-    deferDate: z.string().datetime({ offset: true }).nullable().optional(),
-    dueDate: z.string().datetime({ offset: true }).nullable().optional(),
-    flagged: z.boolean().optional(),
+    deferDate: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional()
+      .describe("Defer date as ISO-8601 with offset. Null clears the date."),
+    dueDate: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional()
+      .describe("Due date as ISO-8601 with offset. Null clears the date."),
+    flagged: z.boolean().optional().describe("Flag or unflag the task."),
   })
   .refine(
     (a) =>

--- a/src/tools/task/batchCreate.ts
+++ b/src/tools/task/batchCreate.ts
@@ -41,16 +41,35 @@ const singleItemSchema = z
     parentTaskId: TaskId.schema
       .optional()
       .describe("Parent task ID for a subtask. Omit for inbox or project task."),
-    note: z.string().optional(),
-    flagged: z.boolean().optional(),
-    dueDate: z.string().datetime({ offset: true }).optional(),
-    dueDateFloating: z.boolean().optional(),
-    deferDate: z.string().datetime({ offset: true }).optional(),
-    deferDateFloating: z.boolean().optional(),
-    estimatedMinutes: z.number().int().positive().optional(),
-    tagIds: z.array(TagId.schema).optional(),
-    sequential: z.boolean().optional(),
-    completedByChildren: z.boolean().optional(),
+    note: z.string().optional().describe("Plain-text note."),
+    flagged: z.boolean().optional().describe("Flag the task."),
+    dueDate: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe("Due date as ISO-8601 with offset."),
+    dueDateFloating: z
+      .boolean()
+      .optional()
+      .describe("When true, the due time is floating (follows the user across time zones)."),
+    deferDate: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe("Defer date as ISO-8601 with offset."),
+    deferDateFloating: z
+      .boolean()
+      .optional()
+      .describe("When true, the defer time is floating (follows the user across time zones)."),
+    estimatedMinutes: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Estimated duration in minutes."),
+    tagIds: z.array(TagId.schema).optional().describe("Tag IDs to apply."),
+    sequential: z.boolean().optional().describe("If true, subtasks must be completed in order."),
+    completedByChildren: z.boolean().optional().describe("Complete when all subtasks complete."),
   })
   .refine((v) => !(v.projectId !== undefined && v.parentTaskId !== undefined), {
     message: "Supply at most one of projectId or parentTaskId",

--- a/src/tools/task/batchUpdate.ts
+++ b/src/tools/task/batchUpdate.ts
@@ -34,17 +34,39 @@ export const TASK_BATCH_UPDATE_DESCRIPTION =
 
 const patchSchema = z
   .object({
-    name: z.string().min(1).optional(),
-    note: z.string().nullable().optional(),
-    flagged: z.boolean().optional(),
-    dueDate: z.string().datetime({ offset: true }).nullable().optional(),
-    dueDateFloating: z.boolean().optional(),
-    deferDate: z.string().datetime({ offset: true }).nullable().optional(),
-    deferDateFloating: z.boolean().optional(),
-    estimatedMinutes: z.number().int().positive().nullable().optional(),
-    tagIds: z.array(TagId.schema).optional(),
-    sequential: z.boolean().optional(),
-    completedByChildren: z.boolean().optional(),
+    name: z.string().min(1).optional().describe("New task name."),
+    note: z.string().nullable().optional().describe("Plain-text note. Null clears the note."),
+    flagged: z.boolean().optional().describe("Flag or unflag the task."),
+    dueDate: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional()
+      .describe("Due date as ISO-8601 with offset. Null clears the date."),
+    dueDateFloating: z
+      .boolean()
+      .optional()
+      .describe("When true, the due time is floating (follows the user across time zones)."),
+    deferDate: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional()
+      .describe("Defer date as ISO-8601 with offset. Null clears the date."),
+    deferDateFloating: z
+      .boolean()
+      .optional()
+      .describe("When true, the defer time is floating (follows the user across time zones)."),
+    estimatedMinutes: z
+      .number()
+      .int()
+      .positive()
+      .nullable()
+      .optional()
+      .describe("Estimated duration in minutes. Null clears the estimate."),
+    tagIds: z.array(TagId.schema).optional().describe("Full replacement tag ID list."),
+    sequential: z.boolean().optional().describe("If true, subtasks must be completed in order."),
+    completedByChildren: z.boolean().optional().describe("Complete when all subtasks complete."),
   })
   .refine((p) => Object.keys(p).length > 0, {
     message: "Patch must contain at least one field",

--- a/src/tools/task/extractFromImage.ts
+++ b/src/tools/task/extractFromImage.ts
@@ -115,10 +115,18 @@ export const TASK_EXTRACT_FROM_IMAGE_DESCRIPTION =
  * prompt (#475) and other composers can accept either tool's output.
  */
 const proposedTaskSchema = z.object({
-  name: z.string().min(1),
-  note: z.string().optional(),
-  deferDate: z.string().datetime({ offset: true }).optional(),
-  dueDate: z.string().datetime({ offset: true }).optional(),
+  name: z.string().min(1).describe("Task name extracted from the image."),
+  note: z.string().optional().describe("Additional context or plain-text note for the task."),
+  deferDate: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("Defer date as ISO-8601 with offset, if detected in the image."),
+  dueDate: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .describe("Due date as ISO-8601 with offset, if detected in the image."),
 });
 
 const sourceSchema = z


### PR DESCRIPTION
## Summary

- Adds `.describe()` to all undescribed fields in `task_batch_create`, `task_batch_update`, `task_batch_assign`, and `task_extract_from_image` inner schemas
- Agents can now read field semantics directly from the schema instead of inferring from outer tool descriptions
- Also fixes pre-existing Biome lint warnings (`noNonNullAssertion`, `useOptionalChain`) in test helpers and JXA scripts

Closes #571

## Test plan

- [x] `pnpm lint` passes (0 errors, 1 warning)
- [x] `pnpm typecheck` passes
- [x] All 2949 tests pass
- [x] `verify-nl-quality` reports clean (36 enforced, 95 allowlisted)