### PR TITLE
feat(project): add project_template_delete tool

### DIFF
--- a/src/errors/nl-quality-integration.test.ts
+++ b/src/errors/nl-quality-integration.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Integration tests: zodToActionable boundary error rewriting across real tool schemas.
+ *
+ * Verifies that bad inputs against live tool schemas produce structured
+ * `failures[]` rows that agents can iterate to fix their call without
+ * another round-trip. The contract: every ValidationError carries
+ * `details.failures[]` where each row has `field`, `sent`, and `expected`,
+ * plus `examples` where the format or enum set makes it useful.
+ *
+ * @see src/errors/zodToActionable.ts — the rewriting helper
+ * @see docs/nl-quality-standards.md §5 — fail-with-help errors
+ * @see #565 — this test file
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ZodError } from "zod";
+import { noteSetInputSchema as noteSetInputBaseSchema } from "../tools/note/set.js";
+import { taskBatchAssignInputSchema } from "../tools/task/batchAssign.js";
+import { taskBatchCreateInputBaseSchema } from "../tools/task/batchCreate.js";
+import { taskBatchUpdateInputBaseSchema } from "../tools/task/batchUpdate.js";
+import { taskListInputSchema as taskListInputBaseSchema } from "../tools/task/list.js";
+import { ValidationError } from "./index.js";
+import { validateRefined } from "./validateRefined.js";
+import { type ActionableValidation, zodToActionable } from "./zodToActionable.js";
+
+// ---------------------------------------------------------------------------
+// Helper: parse a schema with bad input, assert ZodError, run zodToActionable.
+// ---------------------------------------------------------------------------
+
+function parseFailures(
+  schema: { safeParse(v: unknown): { success: boolean; error?: ZodError } },
+  input: unknown,
+): ActionableValidation[] {
+  const result = schema.safeParse(input);
+  if (result.success) throw new Error("Expected parse to fail, but it succeeded");
+  return zodToActionable(result.error as ZodError, input);
+}
+
+function assertFailure(failures: ActionableValidation[]): void {
+  expect(failures.length).toBeGreaterThan(0);
+  for (const f of failures) {
+    expect(f).toHaveProperty("field");
+    expect(f).toHaveProperty("sent");
+    expect(f).toHaveProperty("expected");
+    expect(typeof f.field).toBe("string");
+    expect(typeof f.expected).toBe("string");
+    expect(f.field.length).toBeGreaterThan(0);
+    expect(f.expected.length).toBeGreaterThan(0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Missing required field — task_batch_create: name omitted
+// ---------------------------------------------------------------------------
+
+describe("missing required field — task_batch_create items[0].name", () => {
+  it("produces a failure with field=items[0].name and sent=undefined", () => {
+    const failures = parseFailures(taskBatchCreateInputBaseSchema, {
+      items: [{ note: "no name supplied" }],
+    });
+    assertFailure(failures);
+    const nameFail = failures.find((f) => f.field === "items[0].name");
+    expect(nameFail).toBeDefined();
+    expect(nameFail?.sent).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wrong type on an array field — tagIds must be an array, not a string
+// ---------------------------------------------------------------------------
+
+describe("wrong type on array — task_batch_create items[0].tagIds", () => {
+  it("surfaces invalid_type for tagIds sent as a string", () => {
+    const failures = parseFailures(taskBatchCreateInputBaseSchema, {
+      items: [{ name: "Task A", tagIds: "not-an-array" }],
+    });
+    assertFailure(failures);
+    const tagFail = failures.find((f) => f.field === "items[0].tagIds");
+    expect(tagFail).toBeDefined();
+    expect(tagFail?.sent).toBe("not-an-array");
+    expect(tagFail?.expected).toMatch(/array/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bare local-time datetime (no offset) — task_batch_create dueDate
+// ---------------------------------------------------------------------------
+
+describe("bare local-time datetime — task_batch_create items[0].dueDate", () => {
+  it("rejects a datetime with no UTC offset and provides ISO-8601 examples", () => {
+    const failures = parseFailures(taskBatchCreateInputBaseSchema, {
+      items: [{ name: "Task B", dueDate: "2025-03-01T10:00:00" }],
+    });
+    assertFailure(failures);
+    const dateFail = failures.find((f) => f.field === "items[0].dueDate");
+    expect(dateFail).toBeDefined();
+    expect(dateFail?.sent).toBe("2025-03-01T10:00:00");
+    expect(dateFail?.expected).toMatch(/ISO-8601|datetime|offset/i);
+    expect(dateFail?.examples).toBeDefined();
+    expect(Array.isArray(dateFail?.examples)).toBe(true);
+    expect(dateFail?.examples?.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Out-of-bound numeric — task_list limit: -1 (below min of 1)
+// ---------------------------------------------------------------------------
+
+describe("out-of-bound numeric — task_list limit below minimum", () => {
+  it("reports too_small with a ≥ 1 expected message", () => {
+    const failures = parseFailures(taskListInputBaseSchema, { limit: -1 });
+    assertFailure(failures);
+    const limitFail = failures.find((f) => f.field === "limit");
+    expect(limitFail).toBeDefined();
+    expect(limitFail?.sent).toBe(-1);
+    expect(limitFail?.expected).toMatch(/≥\s*1|at least 1/i);
+  });
+
+  it("reports too_big with a ≤ 1000 expected message for limit: 99999", () => {
+    const failures = parseFailures(taskListInputBaseSchema, { limit: 99999 });
+    assertFailure(failures);
+    const limitFail = failures.find((f) => f.field === "limit");
+    expect(limitFail).toBeDefined();
+    expect(limitFail?.sent).toBe(99999);
+    expect(limitFail?.expected).toMatch(/≤\s*1000|at most 1000/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Out-of-bound numeric — task_batch_update estimatedMinutes: 0 (must be positive)
+// ---------------------------------------------------------------------------
+
+describe("out-of-bound numeric — task_batch_update estimatedMinutes not positive", () => {
+  it("rejects estimatedMinutes: 0 and reports a bound failure", () => {
+    const failures = parseFailures(taskBatchUpdateInputBaseSchema, {
+      items: [{ id: "abc123def456", patch: { estimatedMinutes: 0 } }],
+    });
+    assertFailure(failures);
+    const estFail = failures.find((f) => f.field.includes("estimatedMinutes"));
+    expect(estFail).toBeDefined();
+    expect(estFail?.sent).toBe(0);
+    expect(estFail?.expected).toMatch(/>\s*0|≥\s*1|positive/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enum mismatch — note_set targetKind: "folder" (not in "task" | "project")
+// ---------------------------------------------------------------------------
+
+describe("enum mismatch — note_set targetKind", () => {
+  it("lists accepted values and surfaces the bad value in sent", () => {
+    const failures = parseFailures(noteSetInputBaseSchema, {
+      targetId: "abc123def456",
+      targetKind: "folder",
+      content: "some note",
+    });
+    assertFailure(failures);
+    const kindFail = failures.find((f) => f.field === "targetKind");
+    expect(kindFail).toBeDefined();
+    expect(kindFail?.sent).toBe("folder");
+    expect(kindFail?.expected).toMatch(/task|project/i);
+    expect(kindFail?.examples).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bad ID format — task_batch_assign taskId that is not valid alphanumeric
+// ---------------------------------------------------------------------------
+
+describe("bad ID format — task_batch_assign taskId with spaces", () => {
+  it("rejects a taskId containing spaces and reports the offending value", () => {
+    const failures = parseFailures(taskBatchAssignInputSchema, {
+      assignments: [{ taskId: "bad id here", flagged: true }],
+    });
+    assertFailure(failures);
+    const idFail = failures.find((f) => f.field === "assignments[0].taskId");
+    expect(idFail).toBeDefined();
+    expect(String(idFail?.sent)).toContain("bad id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty batch — task_batch_create items must have ≥ 1 item
+// ---------------------------------------------------------------------------
+
+describe("empty batch — task_batch_create items array empty", () => {
+  it("reports a too_small failure on items[]", () => {
+    const failures = parseFailures(taskBatchCreateInputBaseSchema, { items: [] });
+    assertFailure(failures);
+    const itemsFail = failures.find((f) => f.field === "items");
+    expect(itemsFail).toBeDefined();
+    expect(itemsFail?.expected).toMatch(/≥\s*1|at least 1/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-field refinement — validateRefined path (task_batch_assign assignment with no fields set)
+// The base schema accepts the object; the refinement rejects it.
+// We test through validateRefined directly since the SDK strips this guard.
+// ---------------------------------------------------------------------------
+
+describe("cross-field refinement via validateRefined — task_batch_assign empty assignment", () => {
+  it("throws ValidationError with details.failures when no field is set on an assignment", () => {
+    let caught: unknown;
+    try {
+      validateRefined(taskBatchAssignInputSchema, {
+        assignments: [{ taskId: "abc123def456" }],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ValidationError);
+    if (!(caught instanceof ValidationError)) return;
+    expect(caught.code).toBe("OF_VALIDATION");
+    const details = caught.details as { failures?: ActionableValidation[] } | undefined;
+    expect(details?.failures).toBeDefined();
+    expect(Array.isArray(details?.failures)).toBe(true);
+    expect((details?.failures ?? []).length).toBeGreaterThan(0);
+    const failure = details?.failures?.[0];
+    expect(failure).toHaveProperty("field");
+    expect(failure).toHaveProperty("expected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Envelope shape sanity — every failure row has the required keys
+// ---------------------------------------------------------------------------
+
+describe("envelope shape contract — all failure rows are well-formed", () => {
+  const badInputCases: Array<[string, typeof taskBatchCreateInputBaseSchema, unknown]> = [
+    ["missing name", taskBatchCreateInputBaseSchema, { items: [{ flagged: true }] }],
+    [
+      "wrong type for flagged",
+      taskBatchCreateInputBaseSchema,
+      { items: [{ name: "T", flagged: "yes" }] },
+    ],
+    [
+      "bad deferDate",
+      taskBatchCreateInputBaseSchema,
+      { items: [{ name: "T", deferDate: "not-a-date" }] },
+    ],
+  ];
+
+  for (const [label, schema, input] of badInputCases) {
+    it(`${label}: every row has field + sent + expected`, () => {
+      const failures = parseFailures(schema, input);
+      expect(failures.length).toBeGreaterThan(0);
+      for (const f of failures) {
+        expect(f).toHaveProperty("field");
+        expect(f).toHaveProperty("sent");
+        expect(f).toHaveProperty("expected");
+        if (f.examples !== undefined) {
+          expect(Array.isArray(f.examples)).toBe(true);
+        }
+      }
+    });
+  }
+});

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -114,6 +114,7 @@ import { registerProjectGetManyTool } from "../tools/project/getMany.js";
 import { registerProjectListTool } from "../tools/project/list.js";
 import { registerProjectMoveTool } from "../tools/project/move.js";
 import { registerProjectMoveDescribeTool } from "../tools/project/moveDescribe.js";
+import { registerProjectTemplateDeleteTool } from "../tools/project/templateDelete.js";
 import { registerProjectTemplateInstantiateTool } from "../tools/project/templateInstantiate.js";
 import { registerProjectTemplateListTool } from "../tools/project/templateList.js";
 import { registerProjectTemplateSaveTool } from "../tools/project/templateSave.js";
@@ -465,6 +466,7 @@ export async function startServer(): Promise<void> {
   };
   registerProjectTemplateSaveTool(server, projectTemplateCtx);
   registerProjectTemplateListTool(server, projectTemplateCtx);
+  registerProjectTemplateDeleteTool(server, projectTemplateCtx);
   registerProjectTemplateInstantiateTool(server, projectTemplateCtx);
 
   // Project describe tools.

--- a/src/tools/project/templateDelete.test.ts
+++ b/src/tools/project/templateDelete.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for `project_template_delete`.
+ *
+ * Covers: schema validation, TemplateNotFoundError when folder absent,
+ * TemplateNotFoundError when template absent, successful delete, case-insensitive
+ * match, ignores non-template projects with same name, cache invalidation,
+ * meta.syncPending, registration name.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
+import { type InvalidationScope, OmniFocusLruCache } from "../../cache/lruCache.js";
+import type { ResponseMeta } from "../../envelope/index.js";
+import {
+  handleProjectTemplateDelete,
+  projectTemplateDeleteInputSchema,
+  registerProjectTemplateDeleteTool,
+  TemplateNotFoundError,
+} from "./templateDelete.js";
+import { handleProjectTemplateSave } from "./templateSave.js";
+
+function recordScopes(cache: OmniFocusLruCache): InvalidationScope[] {
+  const scopes: InvalidationScope[] = [];
+  cache.on("cache.invalidated", (e: { scopes: InvalidationScope[] }) => {
+    scopes.push(...e.scopes);
+  });
+  return scopes;
+}
+
+const BASE_META: ResponseMeta = {
+  correlationId: "test-cid",
+  durationMs: 1,
+  cacheHit: false,
+  transport: "memory",
+  ofVersion: "test",
+};
+
+function makeCtx(templatesFolderName = "Templates") {
+  const adapter = new InMemoryAdapter();
+  const makeMeta = (partial: Partial<ResponseMeta> = {}): ResponseMeta => ({
+    ...BASE_META,
+    ...partial,
+  });
+  return { adapter, ctx: { adapter, makeMeta, templatesFolderName } };
+}
+
+async function saveTemplate(
+  adapter: InMemoryAdapter,
+  ctx: ReturnType<typeof makeCtx>["ctx"],
+  templateName: string,
+) {
+  const sourceId = await adapter.createProject({ name: `Source for ${templateName}` });
+  await handleProjectTemplateSave({ projectId: sourceId, templateName }, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+describe("project_template_delete — input schema", () => {
+  it("requires templateName", () => {
+    expect(() => projectTemplateDeleteInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects an empty templateName", () => {
+    expect(() => projectTemplateDeleteInputSchema.parse({ templateName: "" })).toThrow();
+  });
+
+  it("accepts a valid templateName", () => {
+    const parsed = projectTemplateDeleteInputSchema.parse({ templateName: "Client onboarding" });
+    expect(parsed.templateName).toBe("Client onboarding");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — TemplateNotFoundError
+// ---------------------------------------------------------------------------
+
+describe("project_template_delete — TemplateNotFoundError", () => {
+  it("throws when the Templates folder does not exist", async () => {
+    const { ctx } = makeCtx();
+    await expect(handleProjectTemplateDelete({ templateName: "T1" }, ctx)).rejects.toBeInstanceOf(
+      TemplateNotFoundError,
+    );
+  });
+
+  it("throws when the folder exists but no matching template is found", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createFolder({ name: "Templates" });
+    await expect(
+      handleProjectTemplateDelete({ templateName: "Nonexistent" }, ctx),
+    ).rejects.toBeInstanceOf(TemplateNotFoundError);
+  });
+
+  it("throws when only a non-template project with that name exists (no fence)", async () => {
+    const { ctx, adapter } = makeCtx();
+    const folderId = await adapter.createFolder({ name: "Templates" });
+    await adapter.createProject({ name: "Client onboarding", folderId });
+    await expect(
+      handleProjectTemplateDelete({ templateName: "Client onboarding" }, ctx),
+    ).rejects.toBeInstanceOf(TemplateNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — successful delete
+// ---------------------------------------------------------------------------
+
+describe("project_template_delete — successful delete", () => {
+  it("returns { deleted: true, templateName } on success", async () => {
+    const { ctx, adapter } = makeCtx();
+    await saveTemplate(adapter, ctx, "Client onboarding");
+
+    const result = await handleProjectTemplateDelete({ templateName: "Client onboarding" }, ctx);
+    expect(result.data.deleted).toBe(true);
+    expect(result.data.templateName).toBe("Client onboarding");
+  });
+
+  it("actually removes the template from the folder", async () => {
+    const { ctx, adapter } = makeCtx();
+    await saveTemplate(adapter, ctx, "T1");
+
+    await handleProjectTemplateDelete({ templateName: "T1" }, ctx);
+
+    const folders = await adapter.listFolders();
+    const folder = folders.find((f) => f.name.toLowerCase() === "templates");
+    const remaining = folder ? await adapter.listProjects({ folderId: folder.id }) : [];
+    expect(remaining.map((p) => p.name)).not.toContain("T1");
+  });
+
+  it("a second delete call throws TemplateNotFoundError (idempotency: no silent success)", async () => {
+    const { ctx, adapter } = makeCtx();
+    await saveTemplate(adapter, ctx, "T1");
+
+    await handleProjectTemplateDelete({ templateName: "T1" }, ctx);
+    await expect(handleProjectTemplateDelete({ templateName: "T1" }, ctx)).rejects.toBeInstanceOf(
+      TemplateNotFoundError,
+    );
+  });
+
+  it("matches template name case-insensitively", async () => {
+    const { ctx, adapter } = makeCtx();
+    await saveTemplate(adapter, ctx, "Client Onboarding");
+
+    const result = await handleProjectTemplateDelete({ templateName: "client onboarding" }, ctx);
+    expect(result.data.deleted).toBe(true);
+  });
+
+  it("sets meta.syncPending = true", async () => {
+    const { ctx, adapter } = makeCtx();
+    await saveTemplate(adapter, ctx, "T1");
+
+    const result = await handleProjectTemplateDelete({ templateName: "T1" }, ctx);
+    expect(result.meta.syncPending).toBe(true);
+  });
+
+  it("respects a custom templates folder name", async () => {
+    const { ctx, adapter } = makeCtx("My Templates");
+    await saveTemplate(adapter, ctx, "T1");
+
+    const result = await handleProjectTemplateDelete({ templateName: "T1" }, ctx);
+    expect(result.data.deleted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache invalidation
+// ---------------------------------------------------------------------------
+
+describe("project_template_delete — cache invalidation", () => {
+  it("emits project:${templateId} after deletion", async () => {
+    const { ctx: base, adapter } = makeCtx();
+    const cache = new OmniFocusLruCache();
+    const scopes = recordScopes(cache);
+    await saveTemplate(adapter, base, "T1");
+
+    const folders = await adapter.listFolders();
+    const folder = folders.find((f) => f.name.toLowerCase() === "templates");
+    const projects = folder ? await adapter.listProjects({ folderId: folder.id }) : [];
+    const templateId = projects[0]?.id;
+
+    await handleProjectTemplateDelete({ templateName: "T1" }, { ...base, cache });
+
+    expect(scopes).toContain(`project:${templateId}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+describe("project_template_delete — registration", () => {
+  it("registers under canonical tool name", () => {
+    const registerTool = vi.fn();
+    const server = {
+      registerTool,
+    } as unknown as Parameters<typeof registerProjectTemplateDeleteTool>[0];
+    const { ctx } = makeCtx();
+    registerProjectTemplateDeleteTool(server, ctx);
+    expect(registerTool.mock.calls[0]?.[0]).toBe("project_template_delete");
+  });
+});

--- a/src/tools/project/templateDelete.ts
+++ b/src/tools/project/templateDelete.ts
@@ -1,0 +1,135 @@
+/**
+ * `project_template_delete` MCP tool — remove a saved project template by name.
+ *
+ * Completes the template CRUD surface started by `project_template_save` and
+ * `project_template_list`. Locates the named template under the configured
+ * Templates folder (case-insensitive), deletes it, and returns
+ * `{ deleted: true, templateName }`. A missing template is always a typed
+ * `TemplateNotFoundError` — the caller should know whether their delete
+ * actually removed something.
+ *
+ * @see #588 — feature spec
+ * @see src/tools/project/templateSave.ts — sibling write tool
+ * @see src/tools/project/templateList.ts — sibling read tool
+ * @see src/domain/projectTemplates.ts — fence parser
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/invalidation.js";
+import { parseProjectTemplateMeta } from "../../domain/projectTemplates.js";
+import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { NotFound } from "../../errors/index.js";
+
+// ---------------------------------------------------------------------------
+// Tool description
+// ---------------------------------------------------------------------------
+
+export const PROJECT_TEMPLATE_DELETE_DESCRIPTION =
+  "Delete a saved project template by name from the Templates folder. " +
+  "Returns { deleted: true, templateName } on success. " +
+  "Returns TemplateNotFoundError when no matching template exists — " +
+  "callers can distinguish 'deleted' from 'never existed'. " +
+  "Side effects: removes the template project; sets meta.syncPending = true. " +
+  "Do NOT use to delete ordinary projects — call project_delete. " +
+  'Example: { templateName: "Client onboarding" }.';
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const projectTemplateDeleteInputSchema = z.object({
+  templateName: z
+    .string()
+    .min(1)
+    .describe(
+      "Name of the template to delete. Matched case-insensitively within the Templates folder.",
+    ),
+});
+
+export type ProjectTemplateDeleteToolInput = z.infer<typeof projectTemplateDeleteInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class TemplateNotFoundError extends NotFound {
+  constructor(name: string) {
+    super(`No template named "${name}" was found in the Templates folder.`, {
+      details: { templateName: name },
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+export interface ProjectTemplateDeleteContext {
+  adapter: OmniFocusAdapter;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+  cache?: InvalidatingCache;
+  /** Folder name used to hold templates. Resolved from `OMNIFOCUS_TEMPLATES_FOLDER_NAME`. */
+  templatesFolderName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleProjectTemplateDelete(
+  input: ProjectTemplateDeleteToolInput,
+  ctx: ProjectTemplateDeleteContext,
+) {
+  const folders = await ctx.adapter.listFolders();
+  const key = ctx.templatesFolderName.toLowerCase();
+  const templatesFolder = folders.find((f) => f.name.toLowerCase() === key);
+
+  if (templatesFolder === undefined) {
+    throw new TemplateNotFoundError(input.templateName);
+  }
+
+  const projects = await ctx.adapter.listProjects({ folderId: templatesFolder.id });
+  const nameKey = input.templateName.toLowerCase();
+  const match = projects.find((p) => {
+    if (p.name.toLowerCase() !== nameKey) return false;
+    return parseProjectTemplateMeta(p.note) !== undefined;
+  });
+
+  if (match === undefined) {
+    throw new TemplateNotFoundError(input.templateName);
+  }
+
+  await ctx.adapter.deleteProject(match.id);
+
+  if (ctx.cache !== undefined) {
+    invalidateProjectMutation(ctx.cache, { projectId: match.id });
+  }
+
+  return ok(
+    { deleted: true as const, templateName: input.templateName },
+    ctx.makeMeta({ syncPending: true }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerProjectTemplateDeleteTool(
+  server: McpServer,
+  ctx: ProjectTemplateDeleteContext,
+) {
+  return server.registerTool(
+    "project_template_delete",
+    {
+      description: PROJECT_TEMPLATE_DELETE_DESCRIPTION,
+      inputSchema: projectTemplateDeleteInputSchema.shape,
+    },
+    async (args: ProjectTemplateDeleteToolInput) => {
+      const envelope = await handleProjectTemplateDelete(args, ctx);
+      return toolResponse(envelope);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `project_template_delete` tool — completes template CRUD alongside `project_template_save` and `project_template_list`
- Accepts `{ templateName }`, matches case-insensitively, only deletes projects with a valid template fence (ignores plain projects with same name)
- Returns `TemplateNotFoundError` on a second delete — callers can distinguish "deleted" from "never existed"
- Wired into `mcpServer.ts`; `nl-quality` enforced count bumped from 36 → 37

Closes #588

## Test plan

- [x] 14 unit tests: schema validation, TemplateNotFoundError cases, successful delete, case-insensitive match, idempotency, syncPending, cache invalidation, registration name
- [x] Full suite: 2976 passed
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean