### PR TITLE
chore(lint): remove stale biome suppression in templateSave.test.ts (closes #641)

### DIFF
--- a/src/tools/project/templateSave.test.ts
+++ b/src/tools/project/templateSave.test.ts
@@ -164,11 +164,7 @@ describe("project_template_save — handler", () => {
   it("propagates NotFound when the source project does not exist", async () => {
     const { ctx } = makeCtx();
     await expect(
-      handleProjectTemplateSave(
-        // biome-ignore lint/suspicious/noExplicitAny: deliberately invalid id for the negative test
-        { projectId: "project_999999" as any, templateName: "T1" },
-        ctx,
-      ),
+      handleProjectTemplateSave({ projectId: "project_999999" as any, templateName: "T1" }, ctx),
     ).rejects.toBeInstanceOf(NotFound);
   });
 


### PR DESCRIPTION
## Summary

Closes [#641](https://github.com/torsday/omnifocus-mcp/issues/641).

The \`// biome-ignore lint/suspicious/noExplicitAny\` comment at \`src/tools/project/templateSave.test.ts:168\` was suppressing a rule biome no longer flags in that context — turning the suppression itself into a \`suppressions/unused\` warning. Every \`pnpm lint\` run for several cycles emitted this single warning, masking signal on any genuine new warning.

Removed. \`pnpm lint\` now exits clean (zero warnings).

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 3016 passed, 51 skipped (no behavior change)
- [x] \`pnpm lint\` — **clean for the first time this session**
- [x] \`pnpm build\` + bundle gate — 641877/655360 bytes