### PR TITLE
fix(readme): drop tool-count from intents row (closes #645)

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ The server registers resources under the `omnifocus://` scheme. Resources are re
 | `omnifocus://overdue` | All overdue tasks sorted by dueDate ASC |
 | `omnifocus://flagged` | All flagged available tasks |
 | `omnifocus://review-due` | Projects with nextReviewDate ≤ today |
-| `omnifocus://intents` | User-phrase → tool-sequence map; "feel like 8 verbs, not 80 tools" |
+| `omnifocus://intents` | User-phrase → tool-sequence map: a small set of human-meaningful verbs that compose the full tool surface |
 | `omnifocus://stats` | Database-wide rollup: counts by project, tag, completion state |
 | `omnifocus://taxonomy-audit` | Structural audit — inconsistent tag/folder usage, orphans, drift signals |
 | `omnifocus://waiting-on` | Every task carrying a `waiting-on` fence, sorted by daysOverdue DESC |


### PR DESCRIPTION
## Summary

Closes #645. Restores green on \`./scripts/verify-no-tool-counts.sh\` after the regression I introduced in [#644](https://github.com/torsday/omnifocus-mcp/pull/644).

The intents-row description carried the literal string \`80 tools\` from #491's epic slogan; that matches the no-tool-counts pattern. Reworded to convey the same shape (a small verb set composing the full tool surface) without restating the count.

The CI no-tool-counts gate did flag this on #644 but auto-merge raced ahead because the gate isn't on the required-checks list. Filing as a separate concern would be #645.5 — out of scope here.

## Test plan

- [x] \`./scripts/verify-no-tool-counts.sh\` — clean
- [x] \`pnpm lint\` — clean
- [x] No code changes — README only