### PR TITLE
fix(release): lift HOMEBREW_TAP_TOKEN to job-level env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
     permissions:
       contents: write   # needed to create a GitHub Release
       id-token: write   # needed for npm provenance (and future OIDC publish)
+    env:
+      # Lifted to the job level so the Homebrew step's `if: env.X != ''`
+      # conditional can read it. Step-level env is not in scope for the
+      # same step's `if:` expression — that pattern silently skipped the
+      # Homebrew formula update through every release before #670.
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
     steps:
       - uses: actions/checkout@v6
@@ -119,12 +125,10 @@ jobs:
       - name: Update Homebrew tap formula
         # Patches torsday/homebrew-tap/Formula/omnifocus-mcp.rb with the new
         # version + sha256 so `brew upgrade torsday/tap/omnifocus-mcp` works
-        # immediately after the npm publish settles.
-        # Requires a PAT (HOMEBREW_TAP_TOKEN) with contents:write on the tap
-        # repo — store it in Settings → Secrets → Actions.
+        # immediately after the npm publish settles. Requires the
+        # HOMEBREW_TAP_TOKEN repo secret (PAT with contents:write on the tap
+        # repo) — wired in via the job-level env block above.
         if: env.HOMEBREW_TAP_TOKEN != ''
-        env:
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           bash scripts/update-homebrew-formula.sh "$VERSION"


### PR DESCRIPTION
## Summary

Fix the long-standing bug where the Update Homebrew tap formula step in `release.yml` silently skipped on every release since v1.0.0, leaving the `torsday/homebrew-tap` formula stuck at v1.0.2 through both v1.1.0 and v1.2.0.

## Root cause

The step had:

```yaml
- name: Update Homebrew tap formula
  if: env.HOMEBREW_TAP_TOKEN != ''
  env:
    HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
  run: ...
```

GitHub Actions evaluates `if:` **before** the step's own `env:` block runs, so the conditional always saw `HOMEBREW_TAP_TOKEN` as unset — even after the secret was added to the repo today. The step was unreachable by design.

## Fix

Lift the env block to the job level so it's in scope when the `if:` is evaluated:

```yaml
jobs:
  release:
    env:
      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
    steps:
      - name: Update Homebrew tap formula
        if: env.HOMEBREW_TAP_TOKEN != ''
        run: ...
```

The `if:` is preserved (with the same shape) so forks / setups without the secret still skip cleanly rather than failing the publish.

## Verification

- `actionlint .github/workflows/release.yml` clean.
- The script itself is idempotent: `update-homebrew-formula.sh` exits 0 with `formula content unchanged` when the formula already matches, so the next release will exercise the corrected step safely even though the formula is currently at v1.2.0 (manually patched today).

## Notes for v1.2.0 specifically

The tap formula was manually patched to v1.2.0 today as part of [#670](https://github.com/torsday/omnifocus-mcp/issues/670) ([torsday/homebrew-tap@4e67828](https://github.com/torsday/homebrew-tap/commit/4e67828)). `brew update && brew upgrade torsday/tap/omnifocus-mcp` works for v1.2.0 already; this PR ensures the next release doesn't need a manual patch.

## Test plan

- [x] `actionlint` clean
- [x] Diff is minimal (9+/5−)
- [ ] Next release tag publish runs the Homebrew step (verifiable post-merge on the next release)

Closes #670