### PR TITLE
chore(scripts): update file-issue.sh --model enum to canonical 4-tier names

### DIFF
--- a/scripts/file-issue.sh
+++ b/scripts/file-issue.sh
@@ -16,7 +16,7 @@
 #   --size        XS|S|M|L|XL
 #   --phase       M0|M1|M2|M3|M4|M5|v1
 #   --domain      "<comma-separated list>"        — e.g. "task,tag"
-#   --model       opus|sonnet
+#   --model       sonnet-low|opus-med|opus-high|opus-1m-max
 #
 # Optional flags:
 #   --risk        high|medium                     — omit for low/none
@@ -39,7 +39,7 @@
 #     --title "feat(tags): implement create_tag tool" \
 #     --body-file /tmp/body.md \
 #     --type feature --priority P1 --size M --phase M1 \
-#     --domain tag --model opus
+#     --domain tag --model opus-med
 # =============================================================================
 set -euo pipefail
 
@@ -93,14 +93,14 @@ done
 [ -n "$SIZE" ]       || die "--size required"
 [ -n "$PHASE" ]      || die "--phase required"
 [ -n "$DOMAIN" ]     || die "--domain required (at least one)"
-[ -n "$MODEL" ]      || die "--model required (opus|sonnet)"
+[ -n "$MODEL" ]      || die "--model required (sonnet-low|opus-med|opus-high|opus-1m-max)"
 
 # Enumerations — fail fast on typos rather than producing a half-wired issue
 case "$TYPE"     in feature|bug|chore|refactor|perf|docs|test|infra|spike|epic) ;; *) die "--type invalid: $TYPE" ;; esac
 case "$PRIORITY" in P0|P1|P2|P3) ;;                          *) die "--priority invalid: $PRIORITY" ;; esac
 case "$SIZE"     in XS|S|M|L|XL) ;;                          *) die "--size invalid: $SIZE" ;; esac
 case "$PHASE"    in M0|M1|M2|M3|M4|M5|v1) ;;                 *) die "--phase invalid: $PHASE" ;; esac
-case "$MODEL"    in opus|sonnet) ;;                          *) die "--model invalid: $MODEL" ;; esac
+case "$MODEL"    in sonnet-low|opus-med|opus-high|opus-1m-max) ;; *) die "--model invalid: $MODEL (use sonnet-low|opus-med|opus-high|opus-1m-max — see ~/.claude/skills/shared/model-tiers.md)" ;; esac
 if [ -n "$RISK" ]; then
   case "$RISK" in high|medium) ;; *) die "--risk invalid: $RISK (use high|medium or omit)" ;; esac
 fi


### PR DESCRIPTION
## Summary

- Update `scripts/file-issue.sh`'s `--model` enum from legacy `opus|sonnet` to the canonical 4-tier scheme (`sonnet-low|opus-med|opus-high|opus-1m-max`) per [`~/.claude/skills/shared/model-tiers.md`](https://github.com/torsday/dotfiles).
- Update the error message and the doc-comment example to match.
- Label-assembly line is unchanged — with the new enum values, `LABELS=...,model: $MODEL` produces the correct repo label (`model: opus-med`, etc.) since the repo has only those four `model:` labels.

## Why

The repo migrated to the 4-tier scheme but `file-issue.sh` was never updated. Every `/issue` invocation through the filer has been failing for a while with `could not add label: 'model: opus' not found`, forcing fall-through to bare `gh issue create` which can't do atomic project-board placement.

Caught while filing #670 and #673–#676 in the current session — bypassed the filer for all five.

## Compatibility

The legacy `opus`/`sonnet` values are **deliberately dropped** (not aliased). Any leftover automation passing them now fails loudly rather than silently filing un-tier'd issues. Per global CLAUDE.md, repos that haven't migrated may keep legacy labels; this repo has fully migrated.

## Test plan

- [x] `bash -n scripts/file-issue.sh` clean
- [x] `shellcheck` clean (pre-existing SC2016/SC2153 unrelated to this diff)
- [ ] Next time someone files an issue via `/issue`, the filer should succeed and place the issue on the project board atomically — verifiable on next use