### PR TITLE
fix(jxa): preserve projectId read when containingProject().class() throws (closes #673)

### DIFF
--- a/src/scripts/jxa/forecast_get.js
+++ b/src/scripts/jxa/forecast_get.js
@@ -48,10 +48,19 @@ function run(argv) {
   }
 
   function buildTask(task) {
+    // See task_get.js — `cp.class()` throws on real projects in OF 4.x (#673).
     let projectId = null;
     try {
       const cp = task.containingProject();
-      if (cp && cp.class() !== "document") projectId = cp.id();
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here */
+        }
+        if (!isDocument) projectId = cp.id();
+      }
     } catch (_e) {}
 
     let parentId = null;

--- a/src/scripts/jxa/perspective_evaluate.js
+++ b/src/scripts/jxa/perspective_evaluate.js
@@ -36,10 +36,19 @@ function run(argv) {
     }
 
     function buildTask(task) {
+      // See task_get.js — `cp.class()` throws on real projects in OF 4.x (#673).
       let projectId = null;
       try {
         const cp = task.containingProject();
-        if (cp && cp.class() !== "document") projectId = cp.id();
+        if (cp) {
+          let isDocument = false;
+          try {
+            isDocument = cp.class() === "document";
+          } catch (_classErr) {
+            /* OF 4.x: real projects throw here */
+          }
+          if (!isDocument) projectId = cp.id();
+        }
       } catch (_e) {}
 
       let parentId = null;

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -34,10 +34,21 @@ function run(argv) {
   }
 
   function buildTask(task) {
+    // See task_get.js — `cp.class()` throws on real projects in OF 4.x
+    // (#673). Treat a throw as "real project", a successful return as
+    // "document — skip".
     let projectId = null;
     try {
       const cp = task.containingProject();
-      if (cp && cp.class() !== "document") projectId = cp.id();
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here */
+        }
+        if (!isDocument) projectId = cp.id();
+      }
     } catch (_e) {}
 
     let parentId = null;

--- a/src/scripts/jxa/task_duplicate.js
+++ b/src/scripts/jxa/task_duplicate.js
@@ -37,9 +37,21 @@ function run(argv) {
     if (pt) {
       destContainer = pt;
     } else {
+      // See task_get.js — `cp.class()` throws on real projects in OF 4.x
+      // (#673), and the throw used to escape this if-condition unhandled,
+      // exiting the whole script with `JXA script failed (exit 1)`.
       const cp = source.containingProject();
-      if (cp && cp.class() !== "document") destContainer = cp;
-      else destContainer = doc;
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here */
+        }
+        destContainer = isDocument ? doc : cp;
+      } else {
+        destContainer = doc;
+      }
     }
   }
 

--- a/src/scripts/jxa/task_get.js
+++ b/src/scripts/jxa/task_get.js
@@ -29,10 +29,26 @@ function run(argv) {
   }
 
   function buildTask(task) {
+    // OmniFocus 4.x note (#673): on a real Project specifier returned by
+    // `task.containingProject()`, calling `.class()` throws "Can't convert
+    // types". Only the document responds to `.class()` successfully. So:
+    // treat a `.class()` throw as "is a real project", a successful return
+    // as "is something else (document) — skip". The previous one-liner
+    // (`cp.class() !== "document"`) let the throw escape the if-condition
+    // and the outer try/catch swallowed the whole block, leaving projectId
+    // null even when the task was correctly assigned to a project.
     let projectId = null;
     try {
       const cp = task.containingProject();
-      if (cp && cp.class() !== "document") projectId = cp.id();
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here — leave isDocument false */
+        }
+        if (!isDocument) projectId = cp.id();
+      }
     } catch (_e) {}
 
     let parentId = null;

--- a/src/scripts/jxa/task_get_many.js
+++ b/src/scripts/jxa/task_get_many.js
@@ -29,10 +29,19 @@ function run(argv) {
   }
 
   function buildTask(task) {
+    // See task_get.js — `cp.class()` throws on real projects in OF 4.x (#673).
     let projectId = null;
     try {
       const cp = task.containingProject();
-      if (cp && cp.class() !== "document") projectId = cp.id();
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here */
+        }
+        if (!isDocument) projectId = cp.id();
+      }
     } catch (_e) {}
 
     let parentId = null;

--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -35,10 +35,19 @@ function run(argv) {
   }
 
   function buildTask(task) {
+    // See task_get.js — `cp.class()` throws on real projects in OF 4.x (#673).
     let projectId = null;
     try {
       const cp = task.containingProject();
-      if (cp && cp.class() !== "document") projectId = cp.id();
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here */
+        }
+        if (!isDocument) projectId = cp.id();
+      }
     } catch (_e) {}
 
     let parentId = null;

--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -46,10 +46,19 @@ function run(argv) {
   }
 
   function buildTask(task) {
+    // See task_get.js — `cp.class()` throws on real projects in OF 4.x (#673).
     let projectId = null;
     try {
       const cp = task.containingProject();
-      if (cp && cp.class() !== "document") projectId = cp.id();
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here */
+        }
+        if (!isDocument) projectId = cp.id();
+      }
     } catch (_e) {}
 
     let parentId = null;

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -35,10 +35,19 @@ function run(argv) {
   }
 
   function buildTask(task) {
+    // See task_get.js — `cp.class()` throws on real projects in OF 4.x (#673).
     let projectId = null;
     try {
       const cp = task.containingProject();
-      if (cp && cp.class() !== "document") projectId = cp.id();
+      if (cp) {
+        let isDocument = false;
+        try {
+          isDocument = cp.class() === "document";
+        } catch (_classErr) {
+          /* OF 4.x: real projects throw here */
+        }
+        if (!isDocument) projectId = cp.id();
+      }
     } catch (_e) {}
 
     let parentId = null;


### PR DESCRIPTION
## Summary

OmniFocus 4.x's JXA bridge throws `Can't convert types` when calling `.class()` on a real Project specifier returned by `task.containingProject()`. The buildTask helpers in 8 JXA scripts (and the `destContainer` resolver in `task_duplicate.js`) had a one-liner like:

```js
if (cp && cp.class() !== "document") projectId = cp.id();
```

Wrapped in a try/catch, the throw propagated up, the outer try swallowed the whole block, and `projectId` stayed `null` even when the task was correctly assigned to a project. In `task_duplicate.js`, where the same pattern wasn't wrapped at all, the throw caused the script to exit 1 entirely — the canonical `JXA script failed (exit 1) [task_duplicate]` symptom.

## Fix

Wrap the `.class()` call in a nested try/catch and treat a throw as "real project" (which OF 4.x reliably is) and a successful return of `"document"` as the only skip path. Verified empirically with a JXA diagnostic: `cp.id()` and `cp.name()` both succeed on a Project specifier even when `cp.class()` throws.

```js
let projectId = null;
try {
  const cp = task.containingProject();
  if (cp) {
    let isDocument = false;
    try {
      isDocument = cp.class() === "document";
    } catch (_classErr) {
      /* OF 4.x: real projects throw here */
    }
    if (!isDocument) projectId = cp.id();
  }
} catch (_e) {}
```

Applied to: `task_get.js` (canonical comment), `task_create.js`, `task_get_many.js`, `task_list.js`, `task_update.js`, `task_search.js`, `forecast_get.js`, `perspective_evaluate.js`, and `task_duplicate.js` (slightly different shape — uses `cp` as a destination container, not for reading projectId).

## Scope honesty

This fix flips **one** of the 15 originally-failing integration tests green (the canonical one named in #673's title): `createTask with projectId places the task in that project`. The other 14 failures from [run 25129921989](https://github.com/torsday/omnifocus-mcp/actions/runs/25129921989) do **not** share this root cause — they remain red after this fix:

- 7 task-side failures (moveTask, reorderTask ×4, duplicateTask ×3) likely share a different root cause around project lookups or test isolation
- 3 project-side failures (updateProject, listProjects filter, moveProject) likely share an analogous bug in project_create or project_get
- `tagId filter`, `listTags filter by parentId` — already filed as #675, sibling
- `createTask with unknown projectId throws NotFound` — already filed as #674, sibling
- `reorderTask — ValidationError when reference has different parent` — already filed as #676

#673's AC asked for cascading failures to flip — they don't, and reading the failures more carefully shows they're independent. Will file follow-up tickets for the still-failing clusters as part of the close-out.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` clean (3217 unit tests, no change)
- [x] `OMNIFOCUS_INTEGRATION=1 pnpm vitest run -t "createTask with projectId places the task"` — was failing, now passes locally
- [x] No regressions: re-ran the full integration suite locally, the failure list is the original 15 minus the one fixed. No new failures introduced.

## Why testing didn't catch this earlier

The JXA script layer has **zero unit test coverage** — Stryker's allowlist excludes `src/scripts/jxa/`, and the existing `JxaTransport.test.ts` mocks the bridge so the actual script code never runs in unit tests. The integration tests that DO exercise the scripts have been 100% red on every release tag since v1.0.0, but the integration workflow is configured advisory (skip-not-fail on missing runners), and `release.yml` doesn't gate on it. Will file a follow-up issue for the testing-coverage gap.

Closes #673