### PR TITLE
fix(jxa): map -1728 byId-miss to typed NotFound at the runner boundary

### DIFF
--- a/src/adapter/jxa/scriptRunner.test.ts
+++ b/src/adapter/jxa/scriptRunner.test.ts
@@ -200,6 +200,29 @@ describe("runJxaScript — error taxonomy: NotFound", () => {
     const spawner = fakeSpawner({ exitCode: 1, stderr: "OF_NOT_FOUND: project abc" });
     await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
   });
+
+  // #674: OmniFocus's native missing-id surface. JXA's `byId(...)` returns a
+  // lazy specifier; the lookup fires on the first method call and throws
+  // `Can't get object. (-1728)`. Without this mapping, every JXA-routed
+  // mutation that takes a target id (project, task, folder, tag) returned
+  // opaque ScriptError instead of typed NotFound — surfaced live by the
+  // integration suite which has been red since v1.0.0 on the `createTask
+  // with an unknown projectId throws NotFound` contract.
+  it("maps 'Error: Can't get object. (-1728)' to NotFound (JXA byId miss)", async () => {
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "execution error: Error: Error: Can't get object. (-1728)",
+    });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
+
+  it("maps the bare error code (-1728) without the prose to NotFound", async () => {
+    const spawner = fakeSpawner({
+      exitCode: 1,
+      stderr: "OmniFocus got an error: AppleEvent failed (-1728)",
+    });
+    await expect(runJxaScript("s", {}, { spawner })).rejects.toBeInstanceOf(NotFound);
+  });
 });
 
 describe("runJxaScript — error taxonomy: ValidationError", () => {

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -265,7 +265,21 @@ function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
   // Covers: `Task not found: abc`, `Project not found: xyz`,
   //         `Folder not found: ...`, `Tag not found: ...`, `Parent X not found: ...`,
   //         `OF_NOT_FOUND: parent task abc` (batch scripts).
-  if (/\bnot found\b/i.test(stderr) || /^OF_NOT_FOUND\b/m.test(stderr)) {
+  //
+  // Also maps OmniFocus's native missing-id error (#674): JXA's `byId(...)`
+  // returns a *lazy* specifier that's always truthy, so guards like
+  // `if (!byIdResult) throw "X not found"` are dead code. The actual lookup
+  // fires on the next method call (e.g. `.id()` or `.tasks.push(...)`) and
+  // throws `Error: Can't get object. (-1728)` (errAENoSuchObject). Any
+  // JXA-routed mutation that takes a target id surfaces this on a missing
+  // lookup. Without this regex, callers got opaque ScriptError instead of
+  // typed NotFound.
+  if (
+    /\bnot found\b/i.test(stderr) ||
+    /^OF_NOT_FOUND\b/m.test(stderr) ||
+    /Can['’]t get object\.?\s*\(-1728\)/i.test(stderr) ||
+    /\(-1728\)/.test(stderr)
+  ) {
     return new NotFound(stderr, {
       details: {
         transport: "jxa",

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -195,15 +195,28 @@ function run(argv) {
   // The working pattern mirrors the inbox-task fix in #275 and the
   // project/folder/tag fix in #319: construct a specifier via the class name
   // and push it onto the target collection.
+  // JXA's `byId(...)` returns a lazy specifier that's always truthy; the
+  // actual lookup happens on the first method call (#674). Force it early
+  // by calling `.id()` so a missing target produces a structured
+  // "X not found: <id>" message that the classifier maps to NotFound, not
+  // an opaque "Can't get object. (-1728)" surfaced as ScriptError.
   let newTask;
   if (args.parentId) {
     const parent = ofApp.defaultDocument.flattenedTasks.byId(args.parentId);
-    if (!parent) throw new Error(`Parent task not found: ${args.parentId}`);
+    try {
+      parent.id();
+    } catch (_e) {
+      throw new Error(`Parent task not found: ${args.parentId}`);
+    }
     newTask = ofApp.Task(props);
     parent.tasks.push(newTask);
   } else if (args.projectId) {
     const proj = ofApp.defaultDocument.flattenedProjects.byId(args.projectId);
-    if (!proj) throw new Error(`Project not found: ${args.projectId}`);
+    try {
+      proj.id();
+    } catch (_e) {
+      throw new Error(`Project not found: ${args.projectId}`);
+    }
     newTask = ofApp.Task(props);
     proj.tasks.push(newTask);
   } else {


### PR DESCRIPTION
## Summary

Restores the typed-error contract on the JXA path: missing-target lookups now reject with a typed `NotFound` instead of opaque `ScriptError: JXA script failed (exit 1)`.

## Root cause

JXA's `flattenedX.byId(<userInput>)` returns a *lazy specifier* that's always truthy. Code like

```js
const proj = ofApp.defaultDocument.flattenedProjects.byId(args.projectId);
if (!proj) throw new Error(`Project not found: ${args.projectId}`);  // dead code!
proj.tasks.push(newTask);  // <-- this throws "Can't get object. (-1728)"
```

is dead code on the `if (!proj)` line — the lookup actually fires on the next method call (`.tasks.push(...)`) and throws `Error: Can't get object. (-1728)` (`errAENoSuchObject`). That stderr signature didn't match the existing `\bnot found\b` regex in `classifyJxaStderr`, so the runner fell through to a generic `ScriptError`. Every caller's `instanceof NotFound` check silently broke.

The same dead-code pattern exists at ~17 call sites across the JXA scripts (project_move, project_update, task_move, task_duplicate, task_reorder, etc.) — not just task_create.

## Fix

**Two-part, defense-in-depth:**

1. **Classifier (broad coverage)** — extend the NotFound branch in [`classifyJxaStderr`](src/adapter/jxa/scriptRunner.ts) to match `Can't get object. (-1728)` and bare `(-1728)`. One change, covers every JXA-routed mutation that takes a target id. Two new unit tests pin both stderr shapes.
2. **`task_create.js` (clean error message)** — force the lookup early via `.id()` inside try/catch so the canonical case produces a structured `Project not found: <id>` / `Parent task not found: <id>` message rather than the opaque "Can't get object" string. Per-script fixes elsewhere can land as follow-ups; the classifier alone makes every caller's `instanceof NotFound` work.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3219 passed (+2 new in `scriptRunner.test.ts`)
- [x] `OMNIFOCUS_INTEGRATION=1 pnpm test:integration` — `createTask with an unknown projectId throws NotFound` now passes locally (was failing on every release tag since v1.0.0). Integration suite went 14 → 13 failures.

## Why this didn't ship before

Stryker's allowlist excludes `src/scripts/jxa/`, so JXA scripts have no unit-test coverage. Unit tests for the runner mock the spawner so the `(-1728)` stderr never appears in fixtures. Only the integration suite saw it — which has been red on every tag since v1.0.0 without blocking releases. See [#679](https://github.com/torsday/omnifocus-mcp/issues/679) for the structural-gap follow-up.

Closes #674