### PR TITLE
fix(project): route createProject through OmniJS (per ADR-0019) + JXA status/move setter fixes

### DIFF
--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -20,17 +20,20 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 BUNDLE="dist/index.js"
-# 680 KiB. Bumped 660 → 680 KiB on 2026-04-29 alongside #483 slice 1
+# 700 KiB. Bumped 680 → 700 KiB on 2026-04-29 alongside #681
+# (project_create routed through OmniJS per ADR-0019: ~150 lines of
+# OmniJS plus the wrapper / typing / contracts entry). Measured 698477
+# bytes against the 696320 (680 KiB) ceiling — 2.1 KiB over. Bumping by
+# 20 KiB to leave headroom for the matching #680 createTask migration
+# (similar shape, similar cost). Previously 680 KiB alongside #483 slice 1
 # (webhooks: registry + register/list/delete tools + types + capability
-# resource integration + env-flag wiring per ADR-0016). The slice 1 surface
-# measured ~4.5 KiB over the 660 KiB ceiling; bumping by 20 KiB to leave
-# headroom for slice 2's cache-refresh diff observer and slice 3's HTTPS
-# delivery + retry / circuit-breaker code. Previously 660 KiB alongside
-# #485 slice 1 (decision-journal); 640 KiB alongside the final slice of
-# #484 (omnifocus://agenda); 625 KiB alongside #577 (perspective CRUD
-# slice B/C); 610 KiB alongside #570 (Example: sweep); 580 KiB alongside
-# #494; 540, 525, originally 500 KiB. Keep in sync with DESIGN §20.
-BUDGET=696320
+# resource integration + env-flag wiring per ADR-0016). Earlier: 660 KiB
+# alongside #485 slice 1 (decision-journal); 640 KiB alongside the final
+# slice of #484 (omnifocus://agenda); 625 KiB alongside #577 (perspective
+# CRUD slice B/C); 610 KiB alongside #570 (Example: sweep); 580 KiB
+# alongside #494; 540, 525, originally 500 KiB. Keep in sync with DESIGN
+# §20.
+BUDGET=716800
 
 if [ ! -f "$BUNDLE" ]; then
   echo "::error::$BUNDLE not found — run 'pnpm build' first." >&2

--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -48,6 +48,7 @@ import {
   type PerspectiveEvaluateScriptResult,
   type PerspectiveGetScriptResult,
   type PerspectiveUpdateScriptResult,
+  type ProjectCreateScriptResult,
   type TaskBatchMoveScriptResult,
   type TaskConvertToProjectScriptResult,
   type TaskMoveScriptResult,
@@ -65,6 +66,7 @@ import perspectiveEvaluateDryRunScript from "../../scripts/omnijs/perspective_ev
 import perspectiveGetScript from "../../scripts/omnijs/perspective_get.js";
 import perspectiveUpdateScript from "../../scripts/omnijs/perspective_update.js";
 import pluginInvokeScript from "../../scripts/omnijs/plugin_invoke.js";
+import projectCreateScript from "../../scripts/omnijs/project_create.js";
 import taskBatchMoveScript from "../../scripts/omnijs/task_batch_move.js";
 import taskClearAlarmsScript from "../../scripts/omnijs/task_clear_alarms.js";
 import taskConvertToProjectScript from "../../scripts/omnijs/task_convert_to_project.js";
@@ -338,8 +340,40 @@ export class OmniJsTransport implements OmniFocusAdapter {
   async getProjectsMany(_ids: ProjectId[]): Promise<(Project | null)[]> {
     return notYetWired("getProjectsMany");
   }
-  async createProject(_input: CreateProjectInput): Promise<ProjectId> {
-    return notYetWired("createProject");
+  async createProject(input: CreateProjectInput): Promise<ProjectId> {
+    // Routes through OmniJS per ADR-0019: JXA's `Project(props) + push()`
+    // returns a transient specifier ID that doesn't match OmniFocus's
+    // persistent `id.primaryKey`, so subsequent OmniJS-routed operations
+    // (moveTask, reorderTask, etc.) fail to resolve the project.
+    // OmniJS's `new Project(name, position)` returns IDs both transports
+    // accept.
+    const result = await runOmniJsScript<ProjectCreateScriptResult>(
+      projectCreateScript,
+      {
+        name: input.name,
+        folderId: input.folderId ?? null,
+        note: input.note ?? null,
+        deferDate: input.deferDate ?? null,
+        dueDate: input.dueDate ?? null,
+        estimatedMinutes: input.estimatedMinutes ?? null,
+        flagged: input.flagged ?? false,
+        status: input.status ?? null,
+        completionCriterion: input.completionCriterion ?? null,
+        reviewIntervalDays: input.reviewIntervalDays ?? null,
+      },
+      { ...this.runOpts, scriptName: "project_create" },
+    );
+    if (isScriptError(result)) {
+      if (result.error.code === "NOT_FOUND") {
+        throw new NotFound(result.error.message, {
+          details: { transport: "omnijs", scriptName: "project_create" },
+        });
+      }
+      throw new ValidationError(result.error.message, {
+        details: { transport: "omnijs", scriptName: "project_create" },
+      });
+    }
+    return ProjectIdCtor.of(result.project.id);
   }
   async updateProject(_id: ProjectId, _patch: UpdateProjectInput): Promise<void> {
     return notYetWired("updateProject");

--- a/src/adapter/router.test.ts
+++ b/src/adapter/router.test.ts
@@ -307,6 +307,7 @@ describe("TransportRouter — table integrity", () => {
       "clearTaskAlarms", // Task.notifications mutation is OmniJS-only (#461)
       "convertTaskToProject", // OmniJS-only: Database.convertTasksToProjects()
       "createCustomPerspective", // OmniJS-only: rule-tree write + atomic rollback contract (#577)
+      "createProject", // ADR-0019: persistent id.primaryKey from creation, interoperable with both transports
       "deleteCustomPerspective", // OmniJS deleteObject — JXA cannot delete custom perspectives (#523)
       "evaluateCustomPerspective",
       "evaluatePerspectiveRules", // OmniJS-only: temp-perspective lifecycle + walk (#659)

--- a/src/adapter/router.ts
+++ b/src/adapter/router.ts
@@ -117,7 +117,10 @@ export const ROUTING_TABLE: Readonly<Record<AdapterMethod, TransportName>> = Obj
   listProjects: "jxa",
   getProject: "jxa",
   getProjectsMany: "jxa",
-  createProject: "jxa",
+  // Per ADR-0019: routes through OmniJS so the returned id is a persistent
+  // primaryKey interoperable with both transports (vs JXA's transient
+  // specifier IDs that can't be resolved by OmniJS-routed downstream ops).
+  createProject: "omnijs",
   updateProject: "jxa",
   completeProject: "jxa",
   batchCompleteProjects: "jxa",

--- a/src/scripts/contracts.ts
+++ b/src/scripts/contracts.ts
@@ -17,6 +17,7 @@
  */
 
 import type { BatchOutcome } from "../domain/batch.js";
+import type { Project } from "../domain/project.js";
 import type { Task } from "../domain/task.js";
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,17 @@ export type TaskBatchMoveScriptResult = RawBatchScriptResult | ScriptErrorEnvelo
 export type TaskConvertToProjectScriptResult =
   | { projectId: string }
   | ScriptErrorEnvelope<"NOT_FOUND" | "VALIDATION" | "CONVERSION_FAILED">;
+
+/**
+ * Result type for `project_create.js` (OmniJS).
+ *
+ * Per ADR-0019, project creation routes through OmniJS so the returned
+ * `id.primaryKey` is a persistent identifier interoperable with both
+ * transports (vs JXA's transient specifier IDs).
+ */
+export type ProjectCreateScriptResult =
+  | { project: Project }
+  | ScriptErrorEnvelope<"NOT_FOUND" | "VALIDATION">;
 
 /** Result type for `app_window_new.js` and `app_window_new_tab.js`. */
 export type AppWindowNewScriptResult =

--- a/src/scripts/jxa/project_create.js
+++ b/src/scripts/jxa/project_create.js
@@ -172,7 +172,12 @@ function run(argv) {
   if (args.estimatedMinutes != null) props.estimatedMinutes = args.estimatedMinutes;
   if (args.flagged != null) props.flagged = args.flagged;
   if (args.status != null) {
-    props.status = args.status === "on-hold" ? "on hold" : args.status;
+    // OmniFocus 4.8.8+ requires the " status" suffix on assignment values
+    // (without it the assignment silently no-ops on `on hold`). Same as the
+    // fix in project_update.js. Note: createProject now routes through
+    // OmniJS per ADR-0019, so this JXA path is effectively dead code; the
+    // fix is here for defense in depth in case the routing flips back.
+    props.status = args.status === "on-hold" ? "on hold status" : "active status";
   }
 
   // OmniFocus 4.x rejects `doc.make({ new: "project", withProperties })` with

--- a/src/scripts/jxa/project_move.js
+++ b/src/scripts/jxa/project_move.js
@@ -25,7 +25,18 @@ function run(argv) {
   if (!target) throw new Error(`Project not found: ${args.id}`);
 
   if (args.folderId) {
-    const folder = ofApp.defaultDocument.folders.byId(args.folderId);
+    // Resolve via flattenedFolders iteration (top-level `folders` excludes
+    // nested ones; `byId(...)` returns a lazy specifier whose subsequent
+    // `.projects.end` is nil — same JXA quirk as #674's lookupOrThrow).
+    // Mirroring the same iteration the project lookup above uses.
+    const allFolders = ofApp.defaultDocument.flattenedFolders();
+    let folder = null;
+    for (let i = 0; i < allFolders.length; i++) {
+      if (allFolders[i].id() === args.folderId) {
+        folder = allFolders[i];
+        break;
+      }
+    }
     if (!folder) throw new Error(`Folder not found: ${args.folderId}`);
     target.move({ to: folder.projects.end });
   } else {

--- a/src/scripts/jxa/project_update.js
+++ b/src/scripts/jxa/project_update.js
@@ -180,7 +180,14 @@ function run(argv) {
     target.deferDate = args.deferDate ? new Date(args.deferDate) : null;
   if (args.dueDate !== undefined) target.dueDate = args.dueDate ? new Date(args.dueDate) : null;
   if (args.status !== undefined) {
-    const jxaStatus = args.status === "on-hold" ? "on hold" : args.status;
+    // OmniFocus 4.8.8+ silently no-ops `target.status = "on hold"` (without
+    // the " status" suffix). The verbose form is required for assignment
+    // even though reads return the verbose form too. Map both wire values
+    // to their suffixed JXA equivalents. Note: only "active" and "on-hold"
+    // are valid here — the wire contract excludes "done" / "dropped",
+    // which JXA refuses anyway and which use markComplete / markDropped
+    // verbs instead.
+    const jxaStatus = args.status === "on-hold" ? "on hold status" : "active status";
     target.status = jxaStatus;
   }
   if (args.folderId !== undefined) {

--- a/src/scripts/omnijs/project_create.d.ts
+++ b/src/scripts/omnijs/project_create.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `project_create.js`.
+ * @see src/scripts/jxa/task_list.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/omnijs/project_create.js
+++ b/src/scripts/omnijs/project_create.js
@@ -1,0 +1,159 @@
+/**
+ * OmniJS: create a new project.
+ *
+ * Routes through OmniJS rather than JXA per ADR-0019: JXA's
+ * `Project(props) + push()` returns a transient specifier ID that doesn't
+ * match OmniFocus's persistent `id.primaryKey`, so subsequent OmniJS-routed
+ * operations (moveTask, reorderTask, etc.) fail to resolve the project.
+ * OmniJS's `new Project(name, position)` returns a project whose
+ * `id.primaryKey` is interoperable with both transports.
+ *
+ * Args injected as `globalThis.__args`:
+ *   {
+ *     name: string,
+ *     folderId?: string|null,
+ *     note?: string|null,
+ *     deferDate?: string|null,    // ISO-8601-with-offset
+ *     dueDate?: string|null,      // ISO-8601-with-offset
+ *     estimatedMinutes?: number|null,
+ *     flagged?: boolean,
+ *     status?: "active" | "on-hold" | "done" | "dropped" | null,
+ *     completionCriterion?: "parallel" | "sequential" | "singleActions" | null,
+ *     reviewIntervalDays?: number|null,
+ *     nextReviewDate?: string|null,  // ISO-8601-with-offset
+ *   }
+ *
+ * Returns JSON: { project: Project } where Project mirrors the JXA build shape.
+ *
+ * @see src/adapter/omnijs/OmniJsTransport.ts — caller
+ * @see src/domain/project.ts — Project domain type
+ * @see docs/adr/0019-cross-transport-id-interoperability.md — routing rationale
+ */
+(() => {
+  const args = globalThis.__args;
+
+  if (!args.name || args.name.trim() === "") {
+    return JSON.stringify({
+      error: { code: "VALIDATION", message: "name is required and cannot be empty" },
+    });
+  }
+
+  // Resolve placement: a Folder, or the library root.
+  // The folder is itself a `Section` with `.beginning` / `.ending` as
+  // ChildInsertionLocation values — `folder.children.ending` does NOT place
+  // the project inside the folder (verified empirically: the project lands
+  // at the library root with `folder.children.ending`, in the folder with
+  // `folder.ending`).
+  let position;
+  if (args.folderId != null) {
+    const folder = flattenedFolders.filter((f) => f.id.primaryKey === args.folderId)[0];
+    if (!folder) {
+      return JSON.stringify({
+        error: { code: "NOT_FOUND", message: `Folder not found: ${args.folderId}` },
+      });
+    }
+    position = folder.ending;
+  } else {
+    position = library.ending;
+  }
+
+  // `new Project(name, position)` is the canonical OmniJS create — produces
+  // a real persistent id.primaryKey.
+  const proj = new Project(args.name, position);
+
+  // Set props post-construction. OmniJS exposes them as plain assignments.
+  if (args.note != null) proj.note = args.note;
+  if (args.deferDate != null) proj.deferDate = new Date(args.deferDate);
+  if (args.dueDate != null) proj.dueDate = new Date(args.dueDate);
+  if (args.estimatedMinutes != null) proj.estimatedMinutes = args.estimatedMinutes;
+  if (args.flagged != null) proj.flagged = args.flagged;
+  if (args.status != null) {
+    // Map the wire-stable status enum to the OmniJS Project.Status constants.
+    // Wire: "active" | "on-hold" | "done" | "dropped"
+    const statusMap = {
+      active: Project.Status.Active,
+      "on-hold": Project.Status.OnHold,
+      done: Project.Status.Done,
+      dropped: Project.Status.Dropped,
+    };
+    const target = statusMap[args.status];
+    if (target !== undefined) proj.status = target;
+  }
+  if (args.completionCriterion != null) {
+    if (args.completionCriterion === "sequential") proj.sequential = true;
+    else if (args.completionCriterion === "singleActions") {
+      // singleActions: containsSingletonActions=true means project completes
+      // when all its singleton actions complete (or via the singleton flag).
+      proj.containsSingletonActions = true;
+    }
+    // "parallel" is the default — sequential=false, containsSingletonActions=false.
+  }
+  if (args.reviewIntervalDays != null) {
+    // OmniJS Project.reviewInterval takes a `Project.ReviewInterval` value
+    // constructed via `{ steps, unit }`. Days is the canonical unit here.
+    proj.reviewInterval = { steps: args.reviewIntervalDays, unit: "day" };
+  }
+  if (args.nextReviewDate != null) {
+    proj.nextReviewDate = new Date(args.nextReviewDate);
+  }
+
+  // Build the response Project — mirrors src/scripts/jxa/project_create.js's
+  // buildProject shape so the wire format is identical regardless of transport.
+  function statusToWire(s) {
+    if (s === Project.Status.Active) return "active";
+    if (s === Project.Status.OnHold) return "on-hold";
+    if (s === Project.Status.Done) return "done";
+    if (s === Project.Status.Dropped) return "dropped";
+    return "active";
+  }
+
+  function completionCriterionToWire(p) {
+    if (p.containsSingletonActions) return "singleActions";
+    if (p.sequential) return "sequential";
+    return "parallel";
+  }
+
+  function isoOrNull(d) {
+    return d ? d.toISOString() : null;
+  }
+
+  const status = statusToWire(proj.status);
+  const folderIdOut =
+    proj.parentFolder !== null && proj.parentFolder !== undefined
+      ? proj.parentFolder.id.primaryKey
+      : null;
+  // Project-level tags live on `proj.task.tags` (OmniJS models the project as
+  // a wrapping task; tags are owned by that inner task object).
+  const tagIdsOut = proj.task ? proj.task.tags.map((t) => t.id.primaryKey) : [];
+
+  return JSON.stringify({
+    project: {
+      id: proj.id.primaryKey,
+      name: proj.name,
+      note: proj.note || null,
+      noteHtml: null, // OmniJS doesn't expose noteHtml on Project; same as JXA's degraded path.
+      folderId: folderIdOut,
+      tagIds: tagIdsOut,
+      status: status,
+      completionCriterion: completionCriterionToWire(proj),
+      deferDate: isoOrNull(proj.deferDate),
+      dueDate: isoOrNull(proj.dueDate),
+      estimatedMinutes: proj.estimatedMinutes ?? null,
+      flagged: proj.flagged ?? false,
+      reviewIntervalDays:
+        proj.reviewInterval && proj.reviewInterval.steps != null ? proj.reviewInterval.steps : null,
+      nextReviewDate: isoOrNull(proj.nextReviewDate),
+      lastReviewDate: isoOrNull(proj.lastReviewDate),
+      completed: status === "done",
+      completedAt: isoOrNull(proj.task ? proj.task.completionDate : null),
+      dropped: status === "dropped",
+      droppedAt: isoOrNull(proj.task ? proj.task.dropDate : null),
+      taskCount: proj.flattenedTasks ? proj.flattenedTasks.length : 0,
+      completedTaskCount: proj.flattenedTasks
+        ? proj.flattenedTasks.filter((t) => t.completed).length
+        : 0,
+      createdAt: isoOrNull(proj.added) || new Date().toISOString(),
+      modifiedAt: isoOrNull(proj.modified) || new Date().toISOString(),
+    },
+  });
+})();


### PR DESCRIPTION
## Summary

Per [ADR-0019](docs/adr/0019-cross-transport-id-interoperability.md), route `createProject` through OmniJS so the returned ID is a persistent `id.primaryKey` both transports can resolve. Plus two pre-existing JXA bugs surfaced during investigation: status setter requires the `" status"` suffix, and folder lookup uses the lazy-specifier `byId()` pattern (same flavor as #674).

## Changes

1. **Route `createProject` → OmniJS.** New [`src/scripts/omnijs/project_create.js`](src/scripts/omnijs/project_create.js) mirrors the JXA props-set surface; wired through `OmniJsTransport.createProject` with the standard `isScriptError` + `NotFound`/`ValidationError` mapping. Adds `ProjectCreateScriptResult` to `src/scripts/contracts.ts`.
2. **Fix JXA `project_update.js` status setter.** OmniFocus 4.8.8+ silently no-ops `target.status = "on hold"` — the verbose form `"on hold status"` is required. Empirically verified with diagnostic probes against live OF.
3. **Fix JXA `project_move.js` folder lookup.** `ofApp.defaultDocument.folders.byId(...)` returns a lazy specifier whose `.projects.end` is nil; switch to `flattenedFolders` iteration matching the existing project lookup pattern in the same script.

## Scope honesty: 1 of 3 named tests fixed

Investigation surfaced that the 3 #681 tests had distinct root causes:

| Test | Status | Root cause |
|---|---|---|
| `updateProject applies a patch` | ✅ now passes | Status-setter suffix bug (fixed) |
| `listProjects filters by status` | ❌ still fails | **Test-isolation issue, not a code bug.** Pre-existing real user data plus accumulated mcp-fixture residue pollutes `listProjects({status:"on-hold"})`. Test needs to filter to just-created fixtures. |
| `moveProject to a different folder` | ❌ still fails | **JXA `target.move()` silently no-ops on OmniJS-created projects.** The folder-lookup fix gets past "nil container," but the move itself doesn't take. Same write-fails-on-fresh-OmniJS-object pattern as the status-setter bug, but `target.move()` has no working JXA syntax — needs OmniJS routing. |

Will reopen #681 post-merge for the remaining two failures (per the repo's multi-slice pattern: `Closes #N` + reopen for follow-up work).

## Bundle budget

Bumped 680 → 700 KiB. The new OmniJS script (~150 lines) plus contracts/wiring measured 2.1 KiB over the 680 ceiling. Bumping by 20 KiB to leave headroom for the matching #680 createTask migration which has similar shape.

## Testing

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3219 passed (the existing router-table test got a `createProject` entry)
- [x] `OMNIFOCUS_INTEGRATION=1 pnpm test:integration` — `updateProject applies a patch` flips green; `listProjects filters by folderId` (previously passing) stays green; `moveProject` and `listProjects filters by status` still fail per the table above
- [x] Self-reviewed via `/review-pr`

Closes #681