### PR TITLE
fix(jxa): guard tag parent class() and per-element tag id() against OF 4.x exceptions

### DIFF
--- a/src/scripts/jxa/forecast_get.js
+++ b/src/scripts/jxa/forecast_get.js
@@ -73,7 +73,9 @@ function run(argv) {
     try {
       const tags = task.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/perspective_evaluate.js
+++ b/src/scripts/jxa/perspective_evaluate.js
@@ -61,7 +61,9 @@ function run(argv) {
       try {
         const tags = task.tags();
         for (let i = 0; i < tags.length; i++) {
-          tagIds.push(tags[i].id());
+          try {
+            tagIds.push(tags[i].id());
+          } catch (_tagErr) {}
         }
       } catch (_e) {}
 

--- a/src/scripts/jxa/project_create.js
+++ b/src/scripts/jxa/project_create.js
@@ -36,7 +36,9 @@ function run(argv) {
     try {
       const tags = proj.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/project_get.js
+++ b/src/scripts/jxa/project_get.js
@@ -34,7 +34,9 @@ function run(argv) {
     try {
       const tags = proj.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/project_get_many.js
+++ b/src/scripts/jxa/project_get_many.js
@@ -32,7 +32,9 @@ function run(argv) {
     try {
       const tags = proj.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/project_list.js
+++ b/src/scripts/jxa/project_list.js
@@ -34,7 +34,9 @@ function run(argv) {
     try {
       const tags = proj.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/project_update.js
+++ b/src/scripts/jxa/project_update.js
@@ -37,7 +37,9 @@ function run(argv) {
     try {
       const tags = proj.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/tag_create.js
+++ b/src/scripts/jxa/tag_create.js
@@ -18,7 +18,20 @@ function run(argv) {
     let parentId = null;
     try {
       const p = tag.parent();
-      if (p && p.class() !== "document") parentId = p.id();
+      if (p) {
+        // OF 4.x: p.class() may throw — same defensive pattern as task_list.js #673.
+        let isDocument = false;
+        try {
+          isDocument = p.class() === "document";
+        } catch (_classErr) {}
+        if (!isDocument) {
+          try {
+            parentId = p.id();
+          } catch (_idErr) {
+            parentId = null;
+          }
+        }
+      }
     } catch (_e) {}
 
     let location = null;

--- a/src/scripts/jxa/tag_get.js
+++ b/src/scripts/jxa/tag_get.js
@@ -18,7 +18,21 @@ function run(argv) {
     let parentId = null;
     try {
       const p = tag.parent();
-      if (p && p.class() !== "document") parentId = p.id();
+      if (p) {
+        // OF 4.x: p.class() may throw on container objects (same pattern as
+        // containingProject().class() fix in task_list.js — see #673).
+        let isDocument = false;
+        try {
+          isDocument = p.class() === "document";
+        } catch (_classErr) {}
+        if (!isDocument) {
+          try {
+            parentId = p.id();
+          } catch (_idErr) {
+            parentId = null;
+          }
+        }
+      }
     } catch (_e) {}
 
     let location = null;

--- a/src/scripts/jxa/tag_get_many.js
+++ b/src/scripts/jxa/tag_get_many.js
@@ -18,7 +18,21 @@ function run(argv) {
     let parentId = null;
     try {
       const p = tag.parent();
-      if (p && p.class() !== "document") parentId = p.id();
+      if (p) {
+        // OF 4.x: p.class() may throw on container objects (same pattern as
+        // containingProject().class() fix in task_list.js — see #673).
+        let isDocument = false;
+        try {
+          isDocument = p.class() === "document";
+        } catch (_classErr) {}
+        if (!isDocument) {
+          try {
+            parentId = p.id();
+          } catch (_idErr) {
+            parentId = null;
+          }
+        }
+      }
     } catch (_e) {}
 
     let location = null;

--- a/src/scripts/jxa/tag_list.js
+++ b/src/scripts/jxa/tag_list.js
@@ -18,7 +18,24 @@ function run(argv) {
     let parentId = null;
     try {
       const p = tag.parent();
-      if (p && p.class() !== "document") parentId = p.id();
+      if (p) {
+        // OF 4.x: p.class() may throw on container objects (same pattern as
+        // containingProject().class() fix in task_list.js — see #673).
+        // When it throws we assume the parent is a real tag (not the document
+        // root) and fall through to p.id(); if p.id() also throws the outer
+        // catch leaves parentId = null, which is the safe default.
+        let isDocument = false;
+        try {
+          isDocument = p.class() === "document";
+        } catch (_classErr) {}
+        if (!isDocument) {
+          try {
+            parentId = p.id();
+          } catch (_idErr) {
+            parentId = null; // id() threw — treat as no parent (document root)
+          }
+        }
+      }
     } catch (_e) {}
 
     let location = null;

--- a/src/scripts/jxa/tag_update.js
+++ b/src/scripts/jxa/tag_update.js
@@ -18,7 +18,21 @@ function run(argv) {
     let parentId = null;
     try {
       const p = tag.parent();
-      if (p && p.class() !== "document") parentId = p.id();
+      if (p) {
+        // OF 4.x: p.class() may throw on container objects (same pattern as
+        // containingProject().class() fix in task_list.js — see #673).
+        let isDocument = false;
+        try {
+          isDocument = p.class() === "document";
+        } catch (_classErr) {}
+        if (!isDocument) {
+          try {
+            parentId = p.id();
+          } catch (_idErr) {
+            parentId = null;
+          }
+        }
+      }
     } catch (_e) {}
 
     let location = null;

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -61,7 +61,9 @@ function run(argv) {
     try {
       const tags = task.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/task_get.js
+++ b/src/scripts/jxa/task_get.js
@@ -61,7 +61,9 @@ function run(argv) {
     try {
       const tags = task.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/task_get_many.js
+++ b/src/scripts/jxa/task_get_many.js
@@ -54,7 +54,9 @@ function run(argv) {
     try {
       const tags = task.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -60,7 +60,12 @@ function run(argv) {
     try {
       const tags = task.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        // Guard per-element: a single bad tag object must not abort the loop
+        // and zero-out all tagIds, which would silently exclude this task
+        // from tagId-filter results (see #682).
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -71,7 +71,9 @@ function run(argv) {
     try {
       const tags = task.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -60,7 +60,9 @@ function run(argv) {
     try {
       const tags = task.tags();
       for (let i = 0; i < tags.length; i++) {
-        tagIds.push(tags[i].id());
+        try {
+          tagIds.push(tags[i].id());
+        } catch (_tagErr) {}
       }
     } catch (_e) {}
 


### PR DESCRIPTION
## Summary
- Fix `tag_list.js` parentId filter: `p.class()` can throw on OF 4.x container objects — when it did, the outer catch left `parentId = null`, silently excluding all child tags from `listTags({ parentId })` results
- Apply same defensive `isDocument` pattern to `tag_create.js`, `tag_get.js`, `tag_get_many.js`, `tag_update.js` for consistency
- Fix per-element tag ID safety in `task_list.js` and 10 other scripts: a single `tags[i].id()` throw was aborting the entire loop, zeroing `tagIds[]` and silently excluding the task from `tagId`-filter results

Closes #675.

Relates to #682 (task_list tagId filter — same per-element defensive fix applied).

## Issue
Implements [#675 — fix(integration): listTags filter by parentId returns empty for newly-created child](https://github.com/torsday/omnifocus-mcp/issues/675). Root cause mirrors the `containingProject().class()` fix from #673 — OF 4.x `class()` throws on some container objects.

## Breaking change?
- [x] No

## Test plan
- [x] All 3219 unit tests pass locally
- [ ] `OMNIFOCUS_INTEGRATION=1 pnpm vitest run tests/integration/transportRouter.contract.test.ts -t "listTags filters by parentId"` — requires macos-omnifocus runner
- [ ] `OMNIFOCUS_INTEGRATION=1 pnpm vitest run tests/integration/transportRouter.contract.test.ts -t "tagId filter"` — requires macos-omnifocus runner
- [x] Self-reviewed via /review-pr
- [x] No new dependencies