### PR TITLE
fix(jxa): use tasks() not flattenedTasks() for parentId filter

### DIFF
--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -193,7 +193,10 @@ function run(argv) {
     }
   } else if (args.parentId) {
     try {
-      tasks = ofApp.defaultDocument.flattenedTasks.byId(args.parentId).flattenedTasks();
+      // Use .tasks() (direct children only) not .flattenedTasks() (all descendants).
+      // flattenedTasks() would include grandchildren and deeper, violating the
+      // direct-children contract documented on OmniFocusAdapter.listTasks — see #695.
+      tasks = ofApp.defaultDocument.flattenedTasks.byId(args.parentId).tasks();
     } catch (_e) {
       throw new Error(`Parent task not found: ${args.parentId}`);
     }


### PR DESCRIPTION
## Summary

- `listTasks({ parentId })` was returning grandchildren and deeper descendants because `flattenedTasks()` is recursive
- Changed to `tasks()` (direct children only) in the `parentId` branch of `task_list.js`
- One-character-class fix; no other files touched

## Why

`flattenedTasks()` walks the entire descendant tree. `tasks()` returns only immediate children. The `OmniFocusAdapter.listTasks` contract documents `parentId` as a direct-children filter, not a subtree filter — the two semantics diverged silently.

This also fixes the `duplicateTask — recursive clones full subtree depth-first` integration test which was asserting `["c1", "c2"]` but getting `["c1", "c2", "g1"]` (grandchild leaked through).

## Test plan

- [x] `pnpm test` — 3219 passed, 0 failed
- [x] `pnpm typecheck` — clean

Closes #695