### PR TITLE
fix(omnijs): validate parent match in task_reorder before reorder

### DIFF
--- a/src/scripts/omnijs/task_reorder.js
+++ b/src/scripts/omnijs/task_reorder.js
@@ -55,6 +55,20 @@
         error: { code: "NOT_FOUND", message: `Reference task not found: ${refId}` },
       });
     }
+    // Guard: ref must share the same direct parent as task. In OmniJS the
+    // parent of a task is `task.parent` (the containing task or project).
+    // Compare by primaryKey so we never coerce across specifier types.
+    // Mirrors InMemoryAdapter.resolveReorderDestination — see #676.
+    const taskParentKey = task.parent?.id?.primaryKey ?? null;
+    const refParentKey = ref.parent?.id?.primaryKey ?? null;
+    if (taskParentKey !== refParentKey) {
+      return JSON.stringify({
+        error: {
+          code: "VALIDATION",
+          message: "reorderTask: reference task must share parent with the task being moved",
+        },
+      });
+    }
     location = mode === "before" ? ref.before : ref.after;
   } else if (mode === "start" || mode === "end") {
     let c;


### PR DESCRIPTION
## Summary

- `reorderTask(a, { before: b })` was resolving `undefined` when `b` belonged to a different parent than `a`, instead of rejecting with `ValidationError`
- Added parent-key comparison (`task.parent?.id?.primaryKey`) in `task_reorder.js` after looking up the reference task
- Mirrors the same guard in `InMemoryAdapter.resolveReorderDestination` (lines 695–699) — contract parity

## Why

The adapter contract test (`reorderTask — ValidationError when reference has different parent`) asserts rejection with `ValidationError`. The OmniJS script didn't check parent before calling `moveTasks()`, so the promise resolved `undefined` instead of rejecting.

The `VALIDATION` error code in OmniJS output is already mapped to `ValidationError` by `OmniJsTransport` — no transport changes needed.

## Test plan

- [x] `pnpm test` — 3219 passed, 0 failed
- [x] `pnpm typecheck` — clean
- [x] Pre-push hooks (lint, build, test) — all passed

Closes #676