### PR TITLE
chore(infra): wire audit-issue creation to project board

### DIFF
--- a/.github/workflows/validate-deps-nightly.yml
+++ b/.github/workflows/validate-deps-nightly.yml
@@ -57,6 +57,10 @@ jobs:
         if: steps.validate.outputs.rc != '0'
         env:
           REPORT: ${{ steps.validate.outputs.report }}
+          # PROJECT_TOKEN is a fine-grained PAT with Projects read/write — same
+          # secret used by board-sync.yml. Falls back to GITHUB_TOKEN (issues
+          # only); project wiring is non-fatal so the fallback is acceptable.
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           TITLE="[audit] Dependency-graph drift"
           BODY=$(cat <<EOF
@@ -84,9 +88,17 @@ jobs:
             gh issue edit "$EXISTING" --body "$BODY"
             echo "Refreshed #$EXISTING"
           else
-            gh issue create \
+            ISSUE_URL=$(gh issue create \
               --title "$TITLE" \
               --body "$BODY" \
               --label "$AUDIT_LABEL" \
-              --label "type: chore"
+              --label "type: chore" \
+              --label "model: sonnet-low" \
+              | tail -n1)
+            echo "Created $ISSUE_URL"
+            # Wire into project #4 so it appears on the board.
+            # Failures here are non-fatal — the issue itself was created.
+            gh project item-add 4 --owner torsday --url "$ISSUE_URL" 2>/dev/null \
+              && echo "Added to project #4" \
+              || echo "Warning: could not add $ISSUE_URL to project #4 (non-fatal)"
           fi


### PR DESCRIPTION
## Summary

- Fixes the only non-canonical issue-creation path found in this repo: `validate-deps-nightly.yml` called `gh issue create` without adding the new issue to project #4 or setting a `model:` label
- Adds `model: sonnet-low` label to auto-created audit issues so the board's tier filter works
- After `gh issue create`, calls `gh project item-add 4` so audit issues are wired atomically (non-fatal fallback if the project write fails)
- Overrides `GH_TOKEN` on that step with `PROJECT_TOKEN` (same PAT used by `board-sync.yml`) to allow project mutations

`scripts/file-issue.sh` already validates the 4-tier `model:` enum (`sonnet-low|opus-med|opus-high|opus-1m-max`) — Gap 1 from the issue body was already fixed before this cycle.

## Test plan

- [ ] Workflow runs end-to-end when `validate-deps.sh` reports findings: new audit issue appears on project board with correct labels
- [ ] Existing refresh path (issue already open) is unchanged
- [ ] `file-issue.sh --model sonnet-low` still works (no changes to the script)

Closes #693