### PR TITLE
refactor(jxa): replace dead byId guards with lookupOrThrow helper

### DIFF
--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -20,22 +20,21 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 BUNDLE="dist/index.js"
-# 760 KiB. Bumped 740 → 760 KiB on 2026-04-30 alongside #686
-# (DRY JXA scripts via build-time helper inlining per ADR-0020): the
-# @inline directive expands the canonical buildTask + buildRepetition
-# helper into each of 8 task-side consumer scripts. Net effect on disk
-# is −1482 lines of source, but the bundled string grows because the
-# canonical helper carries a top-of-file docblock (~30 lines) plus the
-# new effectiveAvailability branch — that payload is inlined verbatim
-# into all 8 consumers via scriptInlinerPlugin. Measured 767126 bytes
-# against the 757760 (740 KiB) ceiling. Bumping by 20 KiB to 778240 to
-# absorb the inlined helper docblock and leave ~11 KiB headroom.
-# Previously 740 KiB alongside #689 (ban-empty-catch comment payload);
+# 780 KiB. Bumped 760 → 780 KiB on 2026-04-30 alongside #687
+# (lookupOrThrow shared JXA helper, ADR-0020): the helper is inlined
+# into 16 consumer scripts via the @inline directive. Trimmed the
+# helper file to a 6-line summary comment + 8-line function so the
+# 16-fold inlining stays compact, but the cumulative payload still
+# pushed the bundle to 777929 bytes — 311 bytes under the 760 KiB
+# ceiling, which is too tight for routine work. Bumping by 20 KiB to
+# 798720 to restore ~20 KiB headroom.
+# Previously 760 KiB alongside #686 (DRY JXA scripts, buildTask helper);
+# 740 KiB alongside #689 (ban-empty-catch comment payload);
 # 700 KiB alongside #681; 680 KiB alongside #483 slice 1 (webhooks);
 # 660 KiB alongside #485 slice 1 (decision-journal); 640 KiB alongside
 # #484; 625 KiB alongside #577; 610 KiB alongside #570; 580 KiB alongside
 # #494; 540, 525, originally 500 KiB. Keep in sync with DESIGN §20.
-BUDGET=778240
+BUDGET=798720
 
 if [ ! -f "$BUNDLE" ]; then
   echo "::error::$BUNDLE not found — run 'pnpm build' first." >&2
@@ -43,9 +42,9 @@ if [ ! -f "$BUNDLE" ]; then
 fi
 
 SIZE=$(wc -c < "$BUNDLE" | tr -d ' ')
-echo "$BUNDLE: ${SIZE} bytes (budget: ${BUDGET} bytes / 760 KiB)"
+echo "$BUNDLE: ${SIZE} bytes (budget: ${BUDGET} bytes / 780 KiB)"
 
 if [ "$SIZE" -gt "$BUDGET" ]; then
-  echo "::error::bundle exceeds 760 KiB budget (${SIZE} > ${BUDGET})" >&2
+  echo "::error::bundle exceeds 780 KiB budget (${SIZE} > ${BUDGET})" >&2
   exit 1
 fi

--- a/src/scripts/jxa/_helpers/lookup_or_throw.js
+++ b/src/scripts/jxa/_helpers/lookup_or_throw.js
@@ -1,0 +1,15 @@
+// lookupOrThrow — force a JXA byId(...) lookup and throw a structured
+// "<kindLabel> not found: <idValue>" error if the id doesn't exist.
+// JXA byId is lazy and always truthy; the lookup fires on the next method
+// call as "(-1728)". Calling .id() here forces resolution while kindLabel
+// and idValue are in scope. See #687, #674, ADR-0020.
+// Inlined into consumers via `// @inline _helpers/lookup_or_throw.js`.
+// biome-ignore lint/correctness/noUnusedVariables: inlined via @inline directive (ADR-0020).
+function lookupOrThrow(specifier, kindLabel, idValue) {
+  try {
+    specifier.id();
+  } catch (_e) {
+    throw new Error(`${kindLabel} not found: ${idValue}`);
+  }
+  return specifier;
+}

--- a/src/scripts/jxa/_helpers/lookup_or_throw.test.ts
+++ b/src/scripts/jxa/_helpers/lookup_or_throw.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the lookupOrThrow JXA helper (#687).
+ *
+ * The helper is a raw-JS function inlined into JXA consumer scripts via the
+ * scriptInlinerPlugin (ADR-0020). It runs inside `osascript`, not Node — so
+ * we can't import it as a module. Instead we read the source file and eval
+ * it into a closure that exposes the function for direct invocation.
+ *
+ * What we're verifying:
+ *   1. Returns the specifier unchanged when `.id()` succeeds.
+ *   2. Throws `<Kind> not found: <id>` when `.id()` throws.
+ *   3. Preserves the kindLabel and idValue verbatim — important for the
+ *      stderr classifier in `scriptRunner.ts` that maps "<X> not found:"
+ *      to typed `NotFound` errors.
+ *   4. Supports the batch-script kindLabel form (`OF_NOT_FOUND: <kind>`)
+ *      so the existing per-item errorCode regex `^(OF_[A-Z_]+):` still
+ *      extracts `OF_NOT_FOUND`.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const helperSource = readFileSync(resolve(__dirname, "lookup_or_throw.js"), "utf8");
+
+/**
+ * Eval the helper source into a closure and return the function. We can't
+ * use `import` because the file isn't an ES module — it's raw JS spliced
+ * into JXA consumer scripts.
+ */
+function loadHelper(): (specifier: unknown, kindLabel: string, idValue: string) => unknown {
+  // biome-ignore lint/security/noGlobalEval: test-only — exercising the helper string in isolation.
+  return eval(`(function() { ${helperSource}; return lookupOrThrow; })()`);
+}
+
+describe("lookupOrThrow (JXA helper, #687)", () => {
+  const lookupOrThrow = loadHelper();
+
+  it("returns the specifier when .id() succeeds", () => {
+    const specifier = { id: () => "abc-123" };
+    expect(lookupOrThrow(specifier, "Project", "abc-123")).toBe(specifier);
+  });
+
+  it("throws `<Kind> not found: <id>` when .id() throws", () => {
+    const specifier = {
+      id: () => {
+        throw new Error("Can't get object. (-1728)");
+      },
+    };
+    expect(() => lookupOrThrow(specifier, "Project", "missing-xyz")).toThrow(
+      "Project not found: missing-xyz",
+    );
+  });
+
+  it("preserves the exact kindLabel for the stderr classifier", () => {
+    // The classifier regex in scriptRunner.ts is `\bnot found\b` — any of
+    // these labels must produce a message that matches.
+    const specifier = {
+      id: () => {
+        throw new Error("(-1728)");
+      },
+    };
+    for (const label of ["Project", "Task", "Folder", "Tag", "Parent task", "Reference task"]) {
+      expect(() => lookupOrThrow(specifier, label, "id1")).toThrow(`${label} not found: id1`);
+    }
+  });
+
+  it("supports the batch-script `OF_NOT_FOUND:` prefix form", () => {
+    // Batch scripts (task_batch_*) feed the helper a kindLabel that already
+    // contains the OF_NOT_FOUND prefix. The per-item handler in those
+    // scripts extracts errorCode via `^(OF_[A-Z_]+):` — the resulting
+    // message must still match.
+    const specifier = {
+      id: () => {
+        throw new Error("(-1728)");
+      },
+    };
+    let caught: Error | null = null;
+    try {
+      lookupOrThrow(specifier, "OF_NOT_FOUND: task", "missing-task-id");
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.message).toBe("OF_NOT_FOUND: task not found: missing-task-id");
+    // The errorCode-extraction regex used in batch scripts.
+    const m = caught?.message.match(/^(OF_[A-Z_]+):/);
+    expect(m?.[1]).toBe("OF_NOT_FOUND");
+  });
+
+  it("includes the idValue in the message so triage points at the bad input", () => {
+    const specifier = {
+      id: () => {
+        throw new Error("nope");
+      },
+    };
+    expect(() => lookupOrThrow(specifier, "Project", "prj_specific-id_42")).toThrow(
+      /prj_specific-id_42$/,
+    );
+  });
+});

--- a/src/scripts/jxa/project_create.js
+++ b/src/scripts/jxa/project_create.js
@@ -228,10 +228,15 @@ function run(argv) {
   // OmniFocus 4.x rejects `doc.make({ new: "project", withProperties })` with
   // error -10024. The working pattern mirrors the inbox-task fix in #275:
   // construct a specifier via the class name and push it onto the collection.
+  // @inline _helpers/lookup_or_throw.js
+
   let newProj;
   if (args.folderId) {
-    const folder = ofApp.defaultDocument.folders.byId(args.folderId);
-    if (!folder) throw new Error(`Folder not found: ${args.folderId}`);
+    const folder = lookupOrThrow(
+      ofApp.defaultDocument.folders.byId(args.folderId),
+      "Folder",
+      args.folderId,
+    );
     newProj = ofApp.Project(props);
     folder.projects.push(newProj);
   } else {

--- a/src/scripts/jxa/tag_create.js
+++ b/src/scripts/jxa/tag_create.js
@@ -98,10 +98,16 @@ function run(argv) {
   // with error -10024. Use the Tag(props)+push pattern (mirrors task_create
   // fix in #331 and project/folder/tag fix in #319).
   const doc = ofApp.defaultDocument;
+
+  // @inline _helpers/lookup_or_throw.js
+
   let newTag;
   if (args.parentId) {
-    const parentTag = doc.flattenedTags.byId(args.parentId);
-    if (!parentTag) throw new Error(`Parent tag not found: ${args.parentId}`);
+    const parentTag = lookupOrThrow(
+      doc.flattenedTags.byId(args.parentId),
+      "Parent tag",
+      args.parentId,
+    );
     newTag = ofApp.Tag({ name: args.name });
     parentTag.tags.push(newTag);
   } else {

--- a/src/scripts/jxa/task_batch_complete.js
+++ b/src/scripts/jxa/task_batch_complete.js
@@ -17,14 +17,15 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   const succeeded = [];
   const failed = [];
 
   for (let i = 0; i < args.items.length; i++) {
     const it = args.items[i];
     try {
-      const task = doc.flattenedTasks.byId(it.id);
-      if (!task) throw new Error(`OF_NOT_FOUND: task ${it.id}`);
+      const task = lookupOrThrow(doc.flattenedTasks.byId(it.id), "OF_NOT_FOUND: task", it.id);
       const when = it.at ? new Date(it.at) : new Date();
       try {
         task.markComplete({ completionDate: when });

--- a/src/scripts/jxa/task_batch_create.js
+++ b/src/scripts/jxa/task_batch_create.js
@@ -18,6 +18,8 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   const succeeded = [];
   const failed = [];
 
@@ -34,12 +36,18 @@ function run(argv) {
 
       let newTask;
       if (input.parentId) {
-        const parent = doc.flattenedTasks.byId(input.parentId);
-        if (!parent) throw new Error(`OF_NOT_FOUND: parent task ${input.parentId}`);
+        const parent = lookupOrThrow(
+          doc.flattenedTasks.byId(input.parentId),
+          "OF_NOT_FOUND: parent task",
+          input.parentId,
+        );
         newTask = parent.make({ new: "task", withProperties: props });
       } else if (input.projectId) {
-        const proj = doc.flattenedProjects.byId(input.projectId);
-        if (!proj) throw new Error(`OF_NOT_FOUND: project ${input.projectId}`);
+        const proj = lookupOrThrow(
+          doc.flattenedProjects.byId(input.projectId),
+          "OF_NOT_FOUND: project",
+          input.projectId,
+        );
         newTask = proj.make({ new: "task", withProperties: props });
       } else {
         // Inbox creation: `doc.make({ new: "inboxTask" })` fails with -10024

--- a/src/scripts/jxa/task_batch_delete.js
+++ b/src/scripts/jxa/task_batch_delete.js
@@ -18,14 +18,15 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   const succeeded = [];
   const failed = [];
 
   for (let i = 0; i < args.items.length; i++) {
     const it = args.items[i];
     try {
-      const task = doc.flattenedTasks.byId(it.id);
-      if (!task) throw new Error(`OF_NOT_FOUND: task ${it.id}`);
+      const task = lookupOrThrow(doc.flattenedTasks.byId(it.id), "OF_NOT_FOUND: task", it.id);
       task.delete();
       succeeded.push({ index: i, value: it.id });
     } catch (e) {

--- a/src/scripts/jxa/task_batch_drop.js
+++ b/src/scripts/jxa/task_batch_drop.js
@@ -19,14 +19,15 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   const succeeded = [];
   const failed = [];
 
   for (let i = 0; i < args.items.length; i++) {
     const it = args.items[i];
     try {
-      const task = doc.flattenedTasks.byId(it.id);
-      if (!task) throw new Error(`OF_NOT_FOUND: task ${it.id}`);
+      const task = lookupOrThrow(doc.flattenedTasks.byId(it.id), "OF_NOT_FOUND: task", it.id);
       // In OmniFocus 4.x JXA, `task.dropped = true` is rejected with -10003
       // ("Can't set that. Access not allowed."). Use ofApp.markDropped() instead.
       ofApp.markDropped(task);

--- a/src/scripts/jxa/task_batch_undrop.js
+++ b/src/scripts/jxa/task_batch_undrop.js
@@ -19,14 +19,15 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   const succeeded = [];
   const failed = [];
 
   for (let i = 0; i < args.items.length; i++) {
     const it = args.items[i];
     try {
-      const task = doc.flattenedTasks.byId(it.id);
-      if (!task) throw new Error(`OF_NOT_FOUND: task ${it.id}`);
+      const task = lookupOrThrow(doc.flattenedTasks.byId(it.id), "OF_NOT_FOUND: task", it.id);
       // In OmniFocus 4.x JXA, `task.dropped = false` is rejected with -10003
       // ("Can't set that. Access not allowed."). Use ofApp.markIncomplete() instead,
       // which clears the dropped flag and restores the task to active status.

--- a/src/scripts/jxa/task_batch_update.js
+++ b/src/scripts/jxa/task_batch_update.js
@@ -18,6 +18,8 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   const succeeded = [];
   const failed = [];
 
@@ -61,8 +63,7 @@ function run(argv) {
   for (let i = 0; i < args.updates.length; i++) {
     const u = args.updates[i];
     try {
-      const task = doc.flattenedTasks.byId(u.id);
-      if (!task) throw new Error(`OF_NOT_FOUND: task ${u.id}`);
+      const task = lookupOrThrow(doc.flattenedTasks.byId(u.id), "OF_NOT_FOUND: task", u.id);
       applyPatch(task, u.patch || {});
       succeeded.push({ index: i, value: u.id });
     } catch (e) {

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -20,6 +20,7 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_task.js
+  // @inline _helpers/lookup_or_throw.js
 
   if (!args.name || args.name.trim() === "") {
     throw new Error("ValidationError: name is required and cannot be empty");
@@ -41,28 +42,21 @@ function run(argv) {
   // The working pattern mirrors the inbox-task fix in #275 and the
   // project/folder/tag fix in #319: construct a specifier via the class name
   // and push it onto the target collection.
-  // JXA's `byId(...)` returns a lazy specifier that's always truthy; the
-  // actual lookup happens on the first method call (#674). Force it early
-  // by calling `.id()` so a missing target produces a structured
-  // "X not found: <id>" message that the classifier maps to NotFound, not
-  // an opaque "Can't get object. (-1728)" surfaced as ScriptError.
   let newTask;
   if (args.parentId) {
-    const parent = ofApp.defaultDocument.flattenedTasks.byId(args.parentId);
-    try {
-      parent.id();
-    } catch (_e) {
-      throw new Error(`Parent task not found: ${args.parentId}`);
-    }
+    const parent = lookupOrThrow(
+      ofApp.defaultDocument.flattenedTasks.byId(args.parentId),
+      "Parent task",
+      args.parentId,
+    );
     newTask = ofApp.Task(props);
     parent.tasks.push(newTask);
   } else if (args.projectId) {
-    const proj = ofApp.defaultDocument.flattenedProjects.byId(args.projectId);
-    try {
-      proj.id();
-    } catch (_e) {
-      throw new Error(`Project not found: ${args.projectId}`);
-    }
+    const proj = lookupOrThrow(
+      ofApp.defaultDocument.flattenedProjects.byId(args.projectId),
+      "Project",
+      args.projectId,
+    );
     newTask = ofApp.Task(props);
     proj.tasks.push(newTask);
   } else {

--- a/src/scripts/jxa/task_drop.js
+++ b/src/scripts/jxa/task_drop.js
@@ -13,8 +13,9 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const found = ofApp.defaultDocument.flattenedTasks.byId(args.id);
-  if (!found) throw new Error(`Task not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  const found = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
 
   // In OmniFocus 4.x JXA, `task.dropped = true` is rejected with -10003
   // ("Can't set that. Access not allowed."). Use ofApp.markDropped() instead.

--- a/src/scripts/jxa/task_duplicate.js
+++ b/src/scripts/jxa/task_duplicate.js
@@ -19,16 +19,23 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
-  const source = doc.flattenedTasks.byId(args.id);
-  if (!source) throw new Error(`Task not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  const source = lookupOrThrow(doc.flattenedTasks.byId(args.id), "Task", args.id);
 
   let destContainer; // OF object: project | parent task | document (inbox)
   if (args.destination?.projectId) {
-    destContainer = doc.flattenedProjects.byId(args.destination.projectId);
-    if (!destContainer) throw new Error(`Project not found: ${args.destination.projectId}`);
+    destContainer = lookupOrThrow(
+      doc.flattenedProjects.byId(args.destination.projectId),
+      "Project",
+      args.destination.projectId,
+    );
   } else if (args.destination?.parentId) {
-    destContainer = doc.flattenedTasks.byId(args.destination.parentId);
-    if (!destContainer) throw new Error(`Parent task not found: ${args.destination.parentId}`);
+    destContainer = lookupOrThrow(
+      doc.flattenedTasks.byId(args.destination.parentId),
+      "Parent task",
+      args.destination.parentId,
+    );
   } else if (args.destination && args.destination.toInbox === true) {
     destContainer = doc; // inbox = document-level make
   } else {

--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -21,26 +21,29 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_task.js
+  // @inline _helpers/lookup_or_throw.js
 
   let tasks;
   if (args.inbox) {
     // inboxTasks() returns only tasks with no project assignment — exactly the Inbox scope.
     tasks = ofApp.defaultDocument.inboxTasks();
   } else if (args.projectId) {
-    try {
-      tasks = ofApp.defaultDocument.flattenedProjects.byId(args.projectId).flattenedTasks();
-    } catch (_e) {
-      throw new Error(`Project not found: ${args.projectId}`);
-    }
+    const proj = lookupOrThrow(
+      ofApp.defaultDocument.flattenedProjects.byId(args.projectId),
+      "Project",
+      args.projectId,
+    );
+    tasks = proj.flattenedTasks();
   } else if (args.parentId) {
-    try {
-      // Use .tasks() (direct children only) not .flattenedTasks() (all descendants).
-      // flattenedTasks() would include grandchildren and deeper, violating the
-      // direct-children contract documented on OmniFocusAdapter.listTasks — see #695.
-      tasks = ofApp.defaultDocument.flattenedTasks.byId(args.parentId).tasks();
-    } catch (_e) {
-      throw new Error(`Parent task not found: ${args.parentId}`);
-    }
+    const parent = lookupOrThrow(
+      ofApp.defaultDocument.flattenedTasks.byId(args.parentId),
+      "Parent task",
+      args.parentId,
+    );
+    // Use .tasks() (direct children only) not .flattenedTasks() (all descendants).
+    // flattenedTasks() would include grandchildren and deeper, violating the
+    // direct-children contract documented on OmniFocusAdapter.listTasks — see #695.
+    tasks = parent.tasks();
   } else {
     tasks = ofApp.defaultDocument.flattenedTasks();
   }

--- a/src/scripts/jxa/task_move.js
+++ b/src/scripts/jxa/task_move.js
@@ -23,13 +23,21 @@ function run(argv) {
   }
   if (!found) throw new Error(`Task not found: ${args.id}`);
 
+  // @inline _helpers/lookup_or_throw.js
+
   if (args.parentId) {
-    const parent = ofApp.defaultDocument.flattenedTasks.byId(args.parentId);
-    if (!parent) throw new Error(`Parent task not found: ${args.parentId}`);
+    const parent = lookupOrThrow(
+      ofApp.defaultDocument.flattenedTasks.byId(args.parentId),
+      "Parent task",
+      args.parentId,
+    );
     found.move({ to: parent });
   } else if (args.projectId) {
-    const proj = ofApp.defaultDocument.flattenedProjects.byId(args.projectId);
-    if (!proj) throw new Error(`Project not found: ${args.projectId}`);
+    const proj = lookupOrThrow(
+      ofApp.defaultDocument.flattenedProjects.byId(args.projectId),
+      "Project",
+      args.projectId,
+    );
     found.move({ to: proj });
   } else {
     found.move({ to: ofApp.defaultDocument });

--- a/src/scripts/jxa/task_reorder.js
+++ b/src/scripts/jxa/task_reorder.js
@@ -23,26 +23,22 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
-  const task = doc.flattenedTasks.byId(args.id);
-  if (!task) throw new Error(`Task not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  const task = lookupOrThrow(doc.flattenedTasks.byId(args.id), "Task", args.id);
 
   if (args.mode === "before" || args.mode === "after") {
     if (!args.refId) throw new Error(`reorderTask: refId required for mode=${args.mode}`);
-    const ref = doc.flattenedTasks.byId(args.refId);
-    if (!ref) throw new Error(`Reference task not found: ${args.refId}`);
+    const ref = lookupOrThrow(doc.flattenedTasks.byId(args.refId), "Reference task", args.refId);
     // OmniFocus JXA: move <task> to <before|after> <reference>
     task.move({ to: ref, positioned: args.mode });
   } else if (args.mode === "start" || args.mode === "end") {
     const c = args.container || {};
     let container;
     if (c.projectId) {
-      const proj = doc.flattenedProjects.byId(c.projectId);
-      if (!proj) throw new Error(`Project not found: ${c.projectId}`);
-      container = proj;
+      container = lookupOrThrow(doc.flattenedProjects.byId(c.projectId), "Project", c.projectId);
     } else if (c.parentId) {
-      const parent = doc.flattenedTasks.byId(c.parentId);
-      if (!parent) throw new Error(`Parent task not found: ${c.parentId}`);
-      container = parent;
+      container = lookupOrThrow(doc.flattenedTasks.byId(c.parentId), "Parent task", c.parentId);
     } else {
       // Inbox: move into the document's inbox.
       container = doc.inboxTasks;

--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -32,6 +32,7 @@ function run(argv) {
   const dueAfter = args.dueAfter ? new Date(args.dueAfter) : null;
 
   // @inline _helpers/build_task.js
+  // @inline _helpers/lookup_or_throw.js
 
   // ---------------------------------------------------------------------------
   // Collect candidate tasks
@@ -39,11 +40,12 @@ function run(argv) {
 
   let tasks;
   if (args.projectId) {
-    try {
-      tasks = ofApp.defaultDocument.flattenedProjects.byId(args.projectId).flattenedTasks();
-    } catch (_e) {
-      throw new Error(`Project not found: ${args.projectId}`);
-    }
+    const proj = lookupOrThrow(
+      ofApp.defaultDocument.flattenedProjects.byId(args.projectId),
+      "Project",
+      args.projectId,
+    );
+    tasks = proj.flattenedTasks();
   } else {
     tasks = ofApp.defaultDocument.flattenedTasks();
   }

--- a/src/scripts/jxa/task_undrop.js
+++ b/src/scripts/jxa/task_undrop.js
@@ -13,8 +13,9 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const found = ofApp.defaultDocument.flattenedTasks.byId(args.id);
-  if (!found) throw new Error(`Task not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  const found = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
 
   // In OmniFocus 4.x JXA, `task.dropped = false` is rejected with -10003.
   // ofApp.markIncomplete() clears the dropped flag (restores to active status).


### PR DESCRIPTION
## Summary

- Extract a shared `lookupOrThrow(specifier, kindLabel, idValue)` helper under `src/scripts/jxa/_helpers/` and inline it into 16 consumer scripts via the `// @inline` directive (ADR-0020).
- Replaces dead `if (!byId(...)) throw` guards: JXA's `byId` returns a lazy specifier that's always truthy, so the existing branches never fire and operators see generic `(-1728)` rather than the structured `<Kind> not found: <id>` message that points at the bad input.
- Batch scripts (`task_batch_*`) fold the `OF_NOT_FOUND:` prefix into `kindLabel` so the per-item `^(OF_[A-Z_]+):` errorCode regex still extracts `OF_NOT_FOUND` — the contract enforced by `batchAssign.test.ts`.

## Design link

Closes #687 (follow-up to #674 which mapped `(-1728)` → `NotFound` at the boundary as defense-in-depth).

## Breaking change?

- [x] No

## Test plan

- [x] Unit tests cover happy + edge + error (`lookup_or_throw.test.ts`: 5 tests — success path, throws on missing, kindLabel preserved verbatim across 6 labels, `OF_NOT_FOUND:` prefix form, idValue in message)
- [x] `pnpm typecheck && pnpm lint && pnpm test` are green (3237 passed / 52 skipped)
- [x] `pnpm build` clean; bundle 777929 / 798720 bytes (~21 KB headroom)
- [x] No stdout output during server run
- [x] Typed error path preserved — stderr classifier maps the `<Kind> not found:` message to typed `NotFound`

Bundle budget bumped 760 → 780 KiB to absorb the 16-fold inlining; helper trimmed to a 6-line summary comment + 8-line function to minimise per-consumer payload.

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependencies
- [x] No public-surface changes (purely internal JXA helper extraction)