### PR TITLE
fix(watcher): detect sandboxed omnifocus database path

### DIFF
--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -32,6 +32,10 @@ on:
       # regression guards run on script-only PRs too — they're cheap on
       # unchanged inputs, and #703 hit this exact gap.
       - "src/scripts/**"
+      # Same gap re-surfaced on #709 — a watcher-only diff didn't fire any
+      # meta-lint job, and branch protection blocked the merge. Widen the
+      # net to src/** so any production-code diff fires the regression guards.
+      - "src/**"
 
 permissions:
   contents: read

--- a/src/watcher/DatabaseWatcher.test.ts
+++ b/src/watcher/DatabaseWatcher.test.ts
@@ -13,9 +13,11 @@
 
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DatabaseWatcher } from "./DatabaseWatcher.js";
+import { DatabaseWatcher, resolveDefaultDbPath } from "./DatabaseWatcher.js";
 import type { ChangeContext } from "./types.js";
 
 vi.mock("../logging/logger.js", () => ({
@@ -409,5 +411,87 @@ describe("DatabaseWatcher — Swift fast path", () => {
     vi.advanceTimersByTime(200);
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — resolveDefaultDbPath()
+// ---------------------------------------------------------------------------
+
+describe("resolveDefaultDbPath", () => {
+  const originalEnv = process.env.OF_DB_PATH;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalEnv === undefined) delete process.env.OF_DB_PATH;
+    else process.env.OF_DB_PATH = originalEnv;
+  });
+
+  const home = os.homedir();
+  const sandboxOf4 = path.join(
+    home,
+    "Library",
+    "Containers",
+    "com.omnigroup.OmniFocus4",
+    "Data",
+    "Library",
+    "Application Support",
+    "OmniFocus",
+    "OmniFocus.ofocus",
+  );
+  const sandboxOf3 = path.join(
+    home,
+    "Library",
+    "Containers",
+    "com.omnigroup.OmniFocus3",
+    "Data",
+    "Library",
+    "Application Support",
+    "OmniFocus",
+    "OmniFocus.ofocus",
+  );
+  const nonSandbox = path.join(
+    home,
+    "Library",
+    "Application Support",
+    "OmniFocus",
+    "OmniFocus.ofocus",
+  );
+
+  it("honors OF_DB_PATH env override above all probing", () => {
+    process.env.OF_DB_PATH = "/custom/loc/My.ofocus";
+    const existsSpy = vi.spyOn(fs, "existsSync");
+    expect(resolveDefaultDbPath()).toBe("/custom/loc/My.ofocus");
+    expect(existsSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores empty OF_DB_PATH and falls through to probing", () => {
+    process.env.OF_DB_PATH = "";
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => p === sandboxOf4);
+    expect(resolveDefaultDbPath()).toBe(sandboxOf4);
+  });
+
+  it("prefers OmniFocus 4 sandbox container when present", () => {
+    delete process.env.OF_DB_PATH;
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    expect(resolveDefaultDbPath()).toBe(sandboxOf4);
+  });
+
+  it("falls back to OmniFocus 3 sandbox when only OF3 exists", () => {
+    delete process.env.OF_DB_PATH;
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => p === sandboxOf3);
+    expect(resolveDefaultDbPath()).toBe(sandboxOf3);
+  });
+
+  it("falls back to non-sandbox path when only it exists", () => {
+    delete process.env.OF_DB_PATH;
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => p === nonSandbox);
+    expect(resolveDefaultDbPath()).toBe(nonSandbox);
+  });
+
+  it("returns the non-sandbox path as a final fallback when nothing exists", () => {
+    delete process.env.OF_DB_PATH;
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(resolveDefaultDbPath()).toBe(nonSandbox);
   });
 });

--- a/src/watcher/DatabaseWatcher.ts
+++ b/src/watcher/DatabaseWatcher.ts
@@ -57,9 +57,9 @@ export interface DatabaseWatcherOptions {
    */
   debounceMs?: number;
   /**
-   * Override the database path. Default:
-   * `~/Library/Application Support/OmniFocus/OmniFocus.ofocus`.
-   * Primarily for testing.
+   * Override the database path. When omitted, the watcher resolves a default
+   * via {@link resolveDefaultDbPath} (env var → sandbox containers →
+   * non-sandbox). Primarily for testing.
    */
   dbPath?: string;
   /**
@@ -74,13 +74,65 @@ export interface DatabaseWatcherOptions {
 // Defaults
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_DB_PATH = path.join(
-  os.homedir(),
-  "Library",
-  "Application Support",
-  "OmniFocus",
-  "OmniFocus.ofocus",
-);
+/**
+ * Candidate database locations, in preference order:
+ *   1. `OF_DB_PATH` env var override (non-standard installs, CI, tests)
+ *   2. OmniFocus 4 sandbox container
+ *   3. OmniFocus 3 sandbox container
+ *   4. Non-sandbox `~/Library/Application Support/OmniFocus`
+ *
+ * App Store / sandboxed builds keep the database under
+ * `~/Library/Containers/<bundle-id>/Data/…`; direct-download builds use
+ * the non-sandbox path. Probing sandbox first means a machine that has
+ * both (e.g. leftover container from a prior install) prefers the live
+ * sandboxed location.
+ *
+ * Returns the first candidate whose `OmniFocus.ofocus` exists, or the
+ * non-sandbox path as a final fallback so the "path not found" warning
+ * surfaces a recognizable location.
+ */
+export function resolveDefaultDbPath(): string {
+  const fromEnv = process.env.OF_DB_PATH;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+
+  const home = os.homedir();
+  const nonSandbox = path.join(
+    home,
+    "Library",
+    "Application Support",
+    "OmniFocus",
+    "OmniFocus.ofocus",
+  );
+  const sandbox = (bundleId: string) =>
+    path.join(
+      home,
+      "Library",
+      "Containers",
+      bundleId,
+      "Data",
+      "Library",
+      "Application Support",
+      "OmniFocus",
+      "OmniFocus.ofocus",
+    );
+
+  const candidates = [
+    sandbox("com.omnigroup.OmniFocus4"),
+    sandbox("com.omnigroup.OmniFocus3"),
+    nonSandbox,
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return nonSandbox;
+}
+
+/**
+ * Default DB path resolved once at module load via {@link resolveDefaultDbPath}.
+ * Exported for tests and diagnostics; production code paths through
+ * {@link DatabaseWatcher} which calls the resolver per-construction.
+ */
+export const DEFAULT_DB_PATH = resolveDefaultDbPath();
 
 /**
  * Resolve the default binary path relative to this file's location so it
@@ -118,7 +170,7 @@ export class DatabaseWatcher {
   constructor(onChange: (ctx: ChangeContext) => void, options: DatabaseWatcherOptions = {}) {
     this.onChange = onChange;
     this.debounceMs = options.debounceMs ?? 500;
-    this.dbPath = options.dbPath ?? DEFAULT_DB_PATH;
+    this.dbPath = options.dbPath ?? resolveDefaultDbPath();
     this.binaryPath = options.binaryPath !== undefined ? options.binaryPath : defaultBinaryPath();
   }
 


### PR DESCRIPTION
## Summary
- Replaces the watcher's hard-coded `~/Library/Application Support/OmniFocus/` default with `resolveDefaultDbPath()`, which probes (in order) `OF_DB_PATH` env override → `com.omnigroup.OmniFocus4` container → `com.omnigroup.OmniFocus3` container → non-sandbox path, and returns the first existing `OmniFocus.ofocus` (final fallback: non-sandbox so the "path not found" warning surfaces a recognizable location).
- Reported from Homebrew tap install testing where the installed binary used the non-sandbox path and silently failed on a machine running a sandboxed OmniFocus.

Closes #709.

## Issue
Implements [#709 — detect omnifocus database path for both sandboxed and non-sandboxed installs](https://github.com/torsday/omnifocus-mcp/issues/709).

## Breaking change?
- [x] No

## Test plan
- [x] Unit tests cover env override, OF4 sandbox preferred, OF3 fallback, non-sandbox fallback, and final-fallback when nothing exists (6 new cases).
- [x] Full suite green locally: 3243 passed / 52 skipped.
- [x] Typecheck + biome + custom lints clean.
- [x] No new dependencies.