### PR TITLE
ci(build): cap build job at timeout-minutes: 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     # Maintainers re-trigger via push to a same-repo branch after review if needed.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, macos]
+    # Self-hosted runners can lag status replication by 20+ min (#720); cap at 15 min
+    # so a true stall surfaces as a clean failure rather than an indefinite pending check.
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [24]


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 15` to the `build` job in `.github/workflows/ci.yml`
- Prevents self-hosted runner status-replication lag from being indistinguishable from a real hang

Closes #720.

## Issue
Implements [#720 — ci(build): cap build job at timeout-minutes: 15](https://github.com/torsday/omnifocus-mcp/issues/720).

## Breaking change?
- [x] No

## Test plan
- [x] No code changes — CI config only
- [x] Self-reviewed via /review-pr
- [x] No new dependencies