### PR TITLE
fix(jxa): route task tag mutations through OmniJS to defeat silent no-op

### DIFF
--- a/src/adapter/jxa/JxaTransport.tasks.integration.test.ts
+++ b/src/adapter/jxa/JxaTransport.tasks.integration.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { ProjectId, TaskId } from "../../domain/ids.js";
+import type { ProjectId, TagId, TaskId } from "../../domain/ids.js";
 import { JxaTransport } from "./JxaTransport.js";
 
 const INTEGRATION = process.env.OMNIFOCUS_INTEGRATION === "1";
@@ -116,5 +116,76 @@ describe.skipIf(!INTEGRATION)("JxaTransport — task integration", () => {
     const tasks = await t.listTasks({});
     const found = tasks.find((task) => task.id === createdTaskId);
     expect(found).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tag-mutation regression — #716
+//
+// OmniFocus 4.x JXA's task.addTag(tag) / task.removeTag(tag) silently no-op
+// on existing tasks resolved by id — the call returns without error but no
+// row is written to the underlying SQLite TaskToTag join table. The fix
+// (#716) routes the tag-set replacement through OmniJS via
+// ofApp.evaluateJavascript inside the JXA script. This suite guards against
+// regression by verifying that updateTask / batchUpdateTasks actually
+// persist tagIds against a real OmniFocus instance.
+//
+// Isolated lifecycle (own task + own tags) so we don't depend on shared
+// state from the suite above.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!INTEGRATION)("JxaTransport — task tag persistence (#716)", () => {
+  const t = new JxaTransport();
+  // Initialised in beforeAll; never undefined in test bodies. Using definite-
+  // assignment-by-cast keeps the inner tests free of `!` non-null assertions.
+  let taskId = "" as TaskId;
+  let tagAId = "" as TagId;
+  let tagBId = "" as TagId;
+
+  beforeAll(async () => {
+    taskId = await t.createTask({ name: "__mcp_test_task_716__" });
+    tagAId = await t.createTag({ name: "__mcp_test_tag_a_716__" });
+    tagBId = await t.createTag({ name: "__mcp_test_tag_b_716__" });
+  });
+
+  afterAll(async () => {
+    if (taskId)
+      await t.deleteTask(taskId).catch(() => {
+        /* best-effort cleanup */
+      });
+    if (tagAId)
+      await t.deleteTag(tagAId).catch(() => {
+        /* best-effort cleanup */
+      });
+    if (tagBId)
+      await t.deleteTag(tagBId).catch(() => {
+        /* best-effort cleanup */
+      });
+  });
+
+  it("updateTask persists tagIds: add to empty task", async () => {
+    await t.updateTask(taskId, { tagIds: [tagAId] });
+    const task = await t.getTask(taskId);
+    expect(task.tagIds).toContain(tagAId);
+  });
+
+  it("updateTask persists tagIds: replacement swaps A for B", async () => {
+    await t.updateTask(taskId, { tagIds: [tagBId] });
+    const task = await t.getTask(taskId);
+    expect(task.tagIds).toContain(tagBId);
+    expect(task.tagIds).not.toContain(tagAId);
+  });
+
+  it("updateTask persists tagIds: empty array clears all tags", async () => {
+    await t.updateTask(taskId, { tagIds: [] });
+    const task = await t.getTask(taskId);
+    expect(task.tagIds).toEqual([]);
+  });
+
+  it("batchUpdateTasks persists tagIds", async () => {
+    await t.batchUpdateTasks([{ id: taskId, patch: { tagIds: [tagAId, tagBId] } }]);
+    const task = await t.getTask(taskId);
+    expect(task.tagIds).toContain(tagAId);
+    expect(task.tagIds).toContain(tagBId);
   });
 });

--- a/src/scripts/jxa/task_batch_update.js
+++ b/src/scripts/jxa/task_batch_update.js
@@ -41,22 +41,25 @@ function run(argv) {
       task.containsSingletonActions = patch.completedByChildren;
     }
     if (patch.tagIds) {
-      const existing = task.tags();
-      for (let i = 0; i < existing.length; i++) {
-        try {
-          task.removeTag(existing[i]);
-        } catch (_e) {
-          /* OF 4.x: property access may not exist on all object types — default used */
-        }
-      }
-      for (let i = 0; i < patch.tagIds.length; i++) {
-        try {
-          const tag = doc.flattenedTags.byId(patch.tagIds[i]);
-          if (tag) task.addTag(tag);
-        } catch (_e) {
-          /* OF 4.x: property access may not exist on all object types — default used */
-        }
-      }
+      // OmniFocus 4.x: JXA tag mutation silently no-ops on existing tasks
+      // (#716). Delegate to OmniJS — see task_update.js for the same fix.
+      const omniJsScript =
+        "(() => {" +
+        "  const t = Task.byIdentifier(" +
+        JSON.stringify(task.id()) +
+        ");" +
+        "  if (!t) return;" +
+        "  const desired = " +
+        JSON.stringify(patch.tagIds) +
+        ";" +
+        "  const existing = t.tags.slice();" +
+        "  for (let i = 0; i < existing.length; i++) t.removeTag(existing[i]);" +
+        "  for (let i = 0; i < desired.length; i++) {" +
+        "    const tg = Tag.byIdentifier(desired[i]);" +
+        "    if (tg) t.addTag(tg);" +
+        "  }" +
+        "})()";
+      ofApp.evaluateJavascript(omniJsScript);
     }
   }
 

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -56,22 +56,30 @@ function run(argv) {
   }
 
   if (args.tagIds !== undefined) {
-    try {
-      const currentTags = found.tags();
-      for (let i = 0; i < currentTags.length; i++) {
-        found.removeTag(currentTags[i]);
-      }
-    } catch (_e) {
-      /* OF 4.x: property access may not exist on all object types — default used */
-    }
-    for (let i = 0; i < args.tagIds.length; i++) {
-      try {
-        const tag = ofApp.defaultDocument.flattenedTags.byId(args.tagIds[i]);
-        found.addTag(tag);
-      } catch (_e) {
-        /* OF 4.x: property access may not exist on all object types — default used */
-      }
-    }
+    // OmniFocus 4.x: JXA's task.addTag(tag) / task.removeTag(tag) silently
+    // no-op on existing tasks resolved by id (#716) — the call returns without
+    // error but no row is written to the underlying SQLite TaskToTag table.
+    // OmniJS's Task.addTag / Task.removeTag are reliable, so delegate the
+    // tag-set replacement to OmniJS via evaluateJavascript. Tag IDs missing
+    // from the OmniJS store are silently skipped (matches caller-layer
+    // semantics in src/tools/task/update.ts which validates existence first).
+    const omniJsScript =
+      "(() => {" +
+      "  const t = Task.byIdentifier(" +
+      JSON.stringify(args.id) +
+      ");" +
+      "  if (!t) return;" +
+      "  const desired = " +
+      JSON.stringify(args.tagIds) +
+      ";" +
+      "  const existing = t.tags.slice();" +
+      "  for (let i = 0; i < existing.length; i++) t.removeTag(existing[i]);" +
+      "  for (let i = 0; i < desired.length; i++) {" +
+      "    const tg = Tag.byIdentifier(desired[i]);" +
+      "    if (tg) t.addTag(tg);" +
+      "  }" +
+      "})()";
+    ofApp.evaluateJavascript(omniJsScript);
   }
 
   return JSON.stringify({ task: buildTask(found) });


### PR DESCRIPTION
## Summary

- OmniFocus 4.x JXA's `task.addTag(tag)` / `task.removeTag(tag)` silently no-ops on existing tasks resolved by id — call returns without error, no row written to the underlying SQLite `TaskToTag` join table (verified by the reporter at SQLite + GUI layers).
- Replace the failing JXA addTag/removeTag loop in `task_update.js` and `task_batch_update.js` with a single `ofApp.evaluateJavascript()` call delegating the tag-set replacement to OmniJS (`Task.byIdentifier` + `addTag`/`removeTag`), the proven pattern already used in `src/scripts/omnijs/task_create.js` and `task_duplicate.js`.
- Single fix point covers `task_update`, `task_batch_update`, `task_batch_assign`, and `task_reclassify` — the handler in `src/tools/task/update.ts` already resolves `addTags`/`removeTags` to a final `tagIds` set before adapter call.

## Design link

Closes #716.

Related: #332 (`tag_create` -1728 — same lazy-specifier family, fixed via re-fetch).

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` green locally (3243 unit tests pass)
- [x] New gated integration suite `JxaTransport — task tag persistence (#716)` added to `JxaTransport.tasks.integration.test.ts`. Run with `OMNIFOCUS_INTEGRATION=1 pnpm test:integration` against a live OmniFocus instance — covers add-to-empty / replacement / clear / batch paths.
- [ ] Reporter to confirm `task_update`/`task_batch_assign` calls now persist tagIds end-to-end against their environment (npm 1.2.3+).
- [x] Self-reviewed via /review-pr — diff stays within the cited file paths in the bug report.

## Conventions checklist

- [x] No new deps
- [x] Conventional Commits
- [x] No stdout output during server run