### PR TITLE
ci: gate canonical-repo PRs on integration suite via integration-gate (#724)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,8 @@ name: Integration Tests
 # Runs on:
 #   1. Manual dispatch — any branch, any contributor with write access
 #   2. Tag push matching v* — automatically runs before a release
+#   3. Pull requests targeting `main` — gated to canonical-repo branches; fork
+#      PRs short-circuit the heavy job (no self-hosted runner access from forks).
 #
 # Requirements:
 #   A self-hosted runner labeled `macos-omnifocus` with OmniFocus installed
@@ -11,11 +13,12 @@ name: Integration Tests
 #
 #   Runner setup (auto-start, Automation permission, label): docs/runner-setup.md
 #
-# Graceful degradation:
-#   GitHub skips jobs whose runner label has no registered runner in the
-#   Actions runner pool. When no self-hosted runner is available the workflow
-#   appears as "skipped" (yellow) rather than failing the required-check gate.
-#   This is the intended behavior for v1; see DESIGN.md §20.
+# Required-check gate (gap 2 of #679):
+#   The `integration-gate` job runs on ubuntu-latest for every trigger and
+#   reports a single stable check name that branch protection on `main`
+#   requires. On canonical-repo PRs it fails unless the integration job
+#   succeeded; on fork PRs the integration job is intentionally skipped and
+#   the gate accepts the skip so external contributors aren't blocked.
 
 on:
   workflow_dispatch:
@@ -28,6 +31,10 @@ on:
   push:
     tags:
       - "v*"
+
+  pull_request:
+    branches:
+      - main
 
 # Read-only — integration tests run typecheck/build/test against OmniFocus and
 # upload artifacts on failure; nothing writes back to the repo.
@@ -42,6 +49,13 @@ concurrency:
 jobs:
   integration:
     name: Integration tests (OmniFocus ${{ matrix.of-version }})
+    # Skip the heavy job on fork PRs — self-hosted runners are not available
+    # to forked workflows by GitHub's security model. The `integration-gate`
+    # job below tolerates this skip when the PR is from a fork; on canonical-
+    # repo PRs the skip becomes a failure (the runner is expected).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, macos-omnifocus]
 
     strategy:
@@ -118,3 +132,37 @@ jobs:
             test-results/
             *.log
           retention-days: 7
+
+  integration-gate:
+    # Stable required-check name for branch protection on `main`. Always runs
+    # on ubuntu-latest so the gate is reachable even when the self-hosted
+    # `macos-omnifocus` runner is offline — that's exactly the failure mode
+    # this gate is designed to surface (gap 2 of #679).
+    #
+    # Decision matrix (input: integration job result + PR origin):
+    #   success                              → pass
+    #   skipped + fork PR                    → pass  (forks lack runner access by design)
+    #   skipped + canonical PR / push / dispatch → fail (runner expected, didn't run)
+    #   failure / cancelled                  → fail
+    name: integration-gate
+    runs-on: ubuntu-latest  # allow-hosted: gate must be reachable when self-hosted runner is offline (gap 2 of #679)
+    needs: integration
+    if: always()
+    steps:
+      - name: Evaluate integration outcome
+        env:
+          RESULT: ${{ needs.integration.result }}
+          EVENT: ${{ github.event_name }}
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          echo "integration result: $RESULT (event=$EVENT is_fork=$IS_FORK)"
+          if [ "$RESULT" = "success" ]; then
+            echo "ok: integration suite passed"
+            exit 0
+          fi
+          if [ "$RESULT" = "skipped" ] && [ "$IS_FORK" = "true" ]; then
+            echo "ok: fork PR — integration skipped is acceptable (no self-hosted runner access)"
+            exit 0
+          fi
+          echo "::error::Integration suite did not pass (result=$RESULT). On canonical-repo PRs this gate requires the macos-omnifocus runner to be online and the suite green."
+          exit 1

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -820,10 +820,11 @@ Coverage is not enforced because it's gameable. Test *fidelity* is enforced at r
   - No integration / e2e
   - Must all pass to merge; `main` branch protection enforced
 - **Integration workflow (`integration.yml`):**
-  - Manual dispatch (`workflow_dispatch`) or on tag push
+  - Triggers: manual dispatch (`workflow_dispatch`), tag push, or pull_request to `main`
   - Runs on a self-hosted macOS runner with OmniFocus + seeded DB
   - `OMNIFOCUS_INTEGRATION=1 pnpm test:integration`
-  - Self-hosted runner is optional in v1; if not set up, integration tests run locally via `pnpm test:integration`
+  - Fork PRs short-circuit the heavy job (forks lack self-hosted runner access by GitHub's security model); contributors run integration tests locally instead
+  - `integration-gate` job (ubuntu-latest) is the stable required-check name in branch protection — fork skip is acceptable, canonical-repo skip is a failure (gap 2 of [#679](https://github.com/torsday/omnifocus-mcp/issues/679))
 - **Release workflow (`release.yml`):**
   - Trigger: tag push `v*.*.*`
   - Reuses the PR pipeline + builds distribution

--- a/scripts/verify-no-hosted-runners.sh
+++ b/scripts/verify-no-hosted-runners.sh
@@ -3,7 +3,11 @@
 # runner, except for documented allowlist entries below.
 #
 # Policy (see AGENTS.md):
-#   - ci.yml / integration.yml: self-hosted mac — OS parity / OF access required.
+#   - ci.yml: self-hosted mac — OS parity required.
+#   - integration.yml: integration job stays on self-hosted mac (OF access);
+#     `integration-gate` job is intentionally on ubuntu-latest so the required
+#     check is reachable even when the self-hosted runner is offline — that's
+#     the exact failure this gate exists to surface (gap 2 of #679).
 #   - release.yml: ubuntu-latest — npm provenance rejects self-hosted runners.
 #   - Admin workflows (board-sync, meta-lint, pr-link, pr-title, issue-lint,
 #     verify-constants, post-merge-close, release-please): ubuntu-latest — pure
@@ -33,6 +37,12 @@ ALLOWLIST=(
   ".github/workflows/post-merge-close.yml"
 )
 
+# Per-line marker: a `runs-on: ubuntu-latest` line is permitted in any
+# scanned workflow if the line contains `# allow-hosted` and the file is
+# documented in the policy comment above (e.g. integration-gate in
+# integration.yml). This keeps the file-level guard active for the rest of
+# the workflow while letting one job opt out with an audit trail.
+
 # Build a glob of files to scan, skipping the allowlisted ones.
 files=()
 for f in .github/workflows/*.yml; do
@@ -45,8 +55,9 @@ done
 
 # Plain string-grep is sufficient: every regression seen so far has been
 # `runs-on: ubuntu-latest` typed verbatim by dependabot or copy-paste.
+# Lines tagged `# allow-hosted` are treated as audited exceptions.
 hits=$(grep -nE 'runs-on:.*(ubuntu-latest|macos-latest|windows-latest)' \
-  "${files[@]}" || true)
+  "${files[@]}" | grep -v '# allow-hosted' || true)
 
 if [ -z "$hits" ]; then
   echo "ok: no GitHub-hosted runners referenced"


### PR DESCRIPTION
## Summary

- Add `pull_request: branches: [main]` trigger to `integration.yml`.
- Gate the heavy `integration` job to canonical-repo PRs (forks short-circuit — no self-hosted runner access by GitHub's security model).
- Add a new `integration-gate` job (ubuntu-latest, `if: always()`) that becomes the stable required-check name. Decision matrix:
  - `success` → pass
  - `skipped` + fork PR → pass (forks lack runner access by design)
  - `skipped` + canonical PR / push / dispatch → fail (runner expected, didn't run)
  - `failure` / `cancelled` → fail
- Update `scripts/verify-no-hosted-runners.sh` to honor a per-line `# allow-hosted` marker (audit trail) so the `integration-gate` ubuntu-latest line is permitted while the rest of the integration workflow stays guarded.
- Update DESIGN.md §20 to describe the new trigger + gate.

Closes #724.

## Issue

Implements [#724 — ci: make integration workflow a required check on canonical-repo PRs (gap 2 of #679)](https://github.com/torsday/omnifocus-mcp/issues/724). Closes gap 2 of epic [#679](https://github.com/torsday/omnifocus-mcp/issues/679).

## Breaking change?

- [x] No

## Post-merge follow-up (manual, one-time)

Add `integration-gate` to required status checks on `main`:

```bash
gh api repos/torsday/omnifocus-mcp/branches/main/protection/required_status_checks/contexts \
  --method POST -f 'contexts[]=integration-gate'
```

This is intentionally not done in this PR so the merge isn't gated on a check that doesn't yet exist on the base ref.

## Test plan

- [x] Self-reviewed via /review-pr
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3243 passed, 56 skipped
- [x] `bash scripts/verify-no-hosted-runners.sh` — ok with new `# allow-hosted` marker
- [ ] CI: integration job runs on this canonical-repo PR; integration-gate reports the stable check name
- [ ] After merge: add `integration-gate` to branch protection (see above)
- [ ] Future: confirm a fork PR (when one arrives) sees integration job skipped and integration-gate green