### PR TITLE
fix(server): register recursive zod schemas to unblock tools/list

### DIFF
--- a/src/domain/perspectiveRules.ts
+++ b/src/domain/perspectiveRules.ts
@@ -161,6 +161,12 @@ export const PerspectiveRuleInputSchema: z.ZodType<PerspectiveRule> = z.lazy(() 
   ]),
 );
 
+// Recursive schemas must be registered with a stable id so Zod's
+// `toJSONSchema` (used by the MCP SDK for `tools/list`) emits a `$ref`
+// into `$defs` instead of inlining and recursing forever. Without this,
+// `tools/list` overflows the stack the first time a client calls it (#717).
+PerspectiveRuleInputSchema.register(z.globalRegistry, { id: "PerspectiveRuleInput" });
+
 // Re-export the aggregation type so callers writing input payloads do not
 // need to import from both modules.
 export type { PerspectiveAggregation };

--- a/src/server/mcpServer.test.ts
+++ b/src/server/mcpServer.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { registerPerspectiveCreateTool } from "../tools/perspective/create.js";
+import { registerPerspectiveEvaluateDryRunTool } from "../tools/perspective/evaluateDryRun.js";
+import { registerPerspectiveUpdateTool } from "../tools/perspective/update.js";
+import { registerTaskReclassifyTool } from "../tools/task/reclassify.js";
 import { createMcpServer } from "./mcpServer.js";
 
 describe("createMcpServer", () => {
@@ -23,5 +27,67 @@ describe("createMcpServer", () => {
     // public API shape — tools/list will return an empty array when connected.
     expect(server).toBeDefined();
     // Can't call tools/list without a transport; structural check is sufficient.
+  });
+});
+
+// Reach into the McpServer to invoke the SDK-installed `tools/list` request
+// handler directly. The handler runs the same JSON-schema serializer the
+// real stdio transport uses, so this faithfully reproduces the production
+// path without standing up a transport pair.
+async function invokeListTools(server: ReturnType<typeof createMcpServer>) {
+  const inner = server.server as unknown as {
+    _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+  };
+  const handler = inner._requestHandlers.get("tools/list");
+  if (!handler) throw new Error("tools/list handler not registered");
+  return (await handler({ method: "tools/list", params: {} }, {})) as {
+    tools: Array<{ name: string; inputSchema: Record<string, unknown> }>;
+  };
+}
+
+describe("tools/list serialization (regression for #717)", () => {
+  // The four tools whose input shapes hold recursive Zod schemas
+  // (TaskPredicate, PerspectiveRuleInput). Without `register()`-ing those
+  // schemas with a stable id, the SDK's `toJSONSchema` traversal recurses
+  // forever and the handler throws "Maximum call stack size exceeded",
+  // which makes the MCP handshake unusable for every client.
+  it("serializes task_reclassify input schema without overflow", async () => {
+    const server = createMcpServer();
+    const ctx = {
+      adapter: {} as never,
+      makeMeta: () => ({}) as never,
+    };
+    registerTaskReclassifyTool(server, ctx);
+
+    const result = await invokeListTools(server);
+    expect(result.tools).toHaveLength(1);
+    const json = JSON.stringify(result.tools[0]?.inputSchema);
+    expect(json).toContain("$ref");
+    expect(json).toContain("TaskPredicate");
+  });
+
+  it("serializes perspective tools' input schemas without overflow", async () => {
+    const server = createMcpServer();
+    const ctx = {
+      adapter: {} as never,
+      cache: {} as never,
+      perspectiveService: {} as never,
+      makeMeta: () => ({}) as never,
+    };
+    registerPerspectiveCreateTool(server, ctx);
+    registerPerspectiveEvaluateDryRunTool(server, ctx);
+    registerPerspectiveUpdateTool(server, ctx);
+
+    const result = await invokeListTools(server);
+    const names = result.tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "perspective_create",
+      "perspective_evaluate_dry_run",
+      "perspective_update",
+    ]);
+    for (const tool of result.tools) {
+      const json = JSON.stringify(tool.inputSchema);
+      expect(json).toContain("PerspectiveRuleInput");
+    }
   });
 });

--- a/src/tools/task/reclassify.ts
+++ b/src/tools/task/reclassify.ts
@@ -82,20 +82,30 @@ const predicateSchema: z.ZodType<TaskPredicate> = z.lazy(() =>
       kind: z.literal("project"),
       projectId: ProjectId.schema.describe("Match tasks in this project."),
     }),
+    // and: all children must match. or: any child suffices. not: inverts.
+    // Description text lives in the field-level descriptions on the leaf
+    // properties — wrapping the recursive reference itself with `.describe()`
+    // produces a wrapper schema that breaks the registered-id lookup below.
     z.object({
       kind: z.literal("and"),
-      predicates: z.array(predicateSchema).describe("All children must match."),
+      predicates: z.array(predicateSchema),
     }),
     z.object({
       kind: z.literal("or"),
-      predicates: z.array(predicateSchema).describe("Any child match suffices."),
+      predicates: z.array(predicateSchema),
     }),
     z.object({
       kind: z.literal("not"),
-      predicate: predicateSchema.describe("Inverts the inner predicate's result."),
+      predicate: predicateSchema,
     }),
   ]),
 );
+
+// Recursive schemas must be registered with a stable id so Zod's
+// `toJSONSchema` (used by the MCP SDK for `tools/list`) emits a `$ref`
+// into `$defs` instead of inlining and recursing forever. Without this,
+// `tools/list` overflows the stack the first time a client calls it (#717).
+predicateSchema.register(z.globalRegistry, { id: "TaskPredicate" });
 
 // ---------------------------------------------------------------------------
 // Changes schema


### PR DESCRIPTION
## Summary

- Register the recursive `TaskPredicate` and `PerspectiveRuleInput` Zod schemas with stable ids so the SDK's `tools/list` JSON Schema serializer emits `$ref` into `$defs` instead of inlining and recursing forever.
- Drop `.describe()` wrappers on recursive references inside the `predicateSchema` lazy body — those wrappers shadow the registered id and re-trigger the cycle.
- Add a regression test that drives the SDK-installed `tools/list` handler end-to-end for the four affected tools (`task_reclassify`, `perspective_create`, `perspective_evaluate_dry_run`, `perspective_update`).

Without this fix, `tools/list` crashes with `Maximum call stack size exceeded` on the first MCP-client request, and every client (Claude Code, Cursor, opencode, …) sees zero tools after the handshake — fully blocking Homebrew installs of v1.2.2.

## Design link

Closes #717

## Breaking change?

- [x] No

## Test plan

- [x] New regression test in `src/server/mcpServer.test.ts` exercises the SDK's `tools/list` handler for both recursive-schema tools and asserts `$ref`-based output.
- [x] `pnpm typecheck && pnpm lint && pnpm test` — all green (3245 passing, 56 skipped, 198 files).
- [x] Existing `task_reclassify` and `perspective_*` unit tests still pass — runtime parsing of the recursive predicates is unchanged.
- [x] `notifications/initialized` AC was already satisfied by the SDK's built-in handler at `node_modules/@modelcontextprotocol/sdk/dist/cjs/server/index.js:56` (the v1.2.2 dependency was old enough to lack this).

## Root cause

`task_reclassify` (added in #545) and the perspective tools (`perspective_create` / `update` / `evaluate_dry_run`) declare recursive Zod schemas via `z.lazy(() => …)` and use them as MCP tool input shapes. The MCP SDK's `tools/list` handler converts each input schema to JSON Schema via `zod/v4-mini`'s `toJSONSchema`, whose `isTransforming` walker has no cycle-detection — every traversal of the lazy schema re-runs the getter and constructs a fresh tree, so the recursion never terminates.

`initialize` and `tools/call` were unaffected because neither serializes the schema; the bug only fires on the discovery RPC. The existing snapshot/lint tests on tool descriptions also did not catch it because they validate the description strings, not the schema serialization.

## Why `register()` (and *also* dropping `.describe()` on the recursive refs)

`schema.register(z.globalRegistry, { id })` makes the JSON-schema generator emit `{ "$ref": "#/$defs/<id>" }` whenever it encounters that exact schema instance, breaking the recursion.

But `someLazySchema.describe(text)` returns a *new wrapper schema* that is not the registered instance, so the inner recursive references like `predicates: z.array(predicateSchema).describe(...)` re-introduce the cycle. We move those descriptions to a single comment in the lazy body — the field-level docs on the leaf properties still describe the predicate semantics fully.

## Conventions checklist

- [x] Conventional Commit
- [x] No new dependencies
- [x] No public surface change (the `taskReclassifyInputBaseSchema` shape is identical at runtime; only the JSON-schema serialization moves the recursive piece into `$defs`)