### PR TITLE
test(jxa): cover read scripts that need fixture extensions (slice 2b of #723)

### DIFF
--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -122,6 +122,12 @@ export interface FakeTaskOverrides {
   availabilityStatus?: () => string;
   deferDateFloating?: () => boolean;
   dueDateFloating?: () => boolean;
+  // build_task.js with `effectiveAvailability: true` calls this; the
+  // forecast and search scripts both pass that option.
+  effectivelyAvailable?: () => boolean;
+  // attachment_list reads this on tasks; default empty array, override
+  // with [fakeAttachment(...)] in tests that exercise attachments.
+  fileAttachments?: () => unknown[];
 }
 
 let _taskSeq = 0;
@@ -159,6 +165,8 @@ export function fakeTask(
     availabilityStatus: overrides.availabilityStatus ?? fn("available"),
     deferDateFloating: overrides.deferDateFloating ?? fn(false),
     dueDateFloating: overrides.dueDateFloating ?? fn(false),
+    effectivelyAvailable: overrides.effectivelyAvailable ?? fn(true),
+    fileAttachments: overrides.fileAttachments ?? fn([]),
   };
 }
 
@@ -191,6 +199,8 @@ export interface FakeProjectOverrides {
   lastReviewDate?: () => Date | null;
   deferDateFloating?: () => boolean;
   dueDateFloating?: () => boolean;
+  // attachment_list reads this on projects; default empty array.
+  fileAttachments?: () => unknown[];
 }
 
 let _projectSeq = 0;
@@ -228,6 +238,7 @@ export function fakeProject(
     lastReviewDate: overrides.lastReviewDate ?? fn(null),
     deferDateFloating: overrides.deferDateFloating ?? fn(false),
     dueDateFloating: overrides.dueDateFloating ?? fn(false),
+    fileAttachments: overrides.fileAttachments ?? fn([]),
   };
 }
 
@@ -268,6 +279,70 @@ export function fakeFolder(
     creationDate: overrides.creationDate ?? fn(now),
     modificationDate: overrides.modificationDate ?? fn(now),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Attachment / window / perspective fakes (slice 2b)
+// ---------------------------------------------------------------------------
+
+export interface FakeAttachmentOverrides {
+  id?: () => string;
+  name?: () => string;
+  fileType?: () => string | null;
+  fileSize?: () => number | null;
+  creationDate?: () => Date;
+  /**
+   * `attachment_list.js` calls `att.linked?.()` — pass `undefined` (the
+   * default) to omit the method entirely (script reads `kind: "embedded"`),
+   * or supply `() => true` for the alias path.
+   */
+  linked?: (() => boolean) | undefined;
+}
+
+let _attachmentSeq = 0;
+
+/** Build a fake JXA Attachment object as used by `attachment_list.js`. */
+export function fakeAttachment(overrides: FakeAttachmentOverrides = {}) {
+  const id = overrides.id ?? fn(`att_${++_attachmentSeq}`);
+  const name = overrides.name ?? fn(`Attachment ${_attachmentSeq}`);
+  const now = new Date();
+  const base: Record<string, unknown> = {
+    id,
+    name,
+    fileType: overrides.fileType ?? fn(null),
+    fileSize: overrides.fileSize ?? fn(null),
+    creationDate: overrides.creationDate ?? fn(now),
+  };
+  if (overrides.linked !== undefined) base.linked = overrides.linked;
+  return base;
+}
+
+export interface FakeWindowOverrides {
+  perspectiveName?: () => string;
+  /** Array of focus containers; each must expose `.id()`. */
+  focus?: () => Array<{ id: () => string }>;
+}
+
+/** Build a fake JXA Window object as used by `window_get_state.js`. */
+export function fakeWindow(overrides: FakeWindowOverrides = {}) {
+  return {
+    perspectiveName: overrides.perspectiveName ?? fn("Forecast"),
+    focus: overrides.focus ?? fn([]),
+  };
+}
+
+export interface FakePerspectiveOverrides {
+  id?: () => string;
+  name?: () => string;
+}
+
+let _perspectiveSeq = 0;
+
+/** Build a fake JXA Perspective object as used by `perspective_list.js`. */
+export function fakePerspective(overrides: FakePerspectiveOverrides = {}) {
+  const id = overrides.id ?? fn(`perspective_${++_perspectiveSeq}`);
+  const name = overrides.name ?? fn(`Perspective ${_perspectiveSeq}`);
+  return { id, name };
 }
 
 /** Expose the throwing() helper so test authors can inject faults. */

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -15,9 +15,12 @@
  */
 
 import { describe, expect, it } from "vitest";
+import attachmentListScript from "../../../scripts/jxa/attachment_list.js";
 import changesSinceScript from "../../../scripts/jxa/changes_since.js";
 import folderGetScript from "../../../scripts/jxa/folder_get.js";
 import folderListScript from "../../../scripts/jxa/folder_list.js";
+import forecastGetScript from "../../../scripts/jxa/forecast_get.js";
+import perspectiveListScript from "../../../scripts/jxa/perspective_list.js";
 import projectGetScript from "../../../scripts/jxa/project_get.js";
 import projectGetManyScript from "../../../scripts/jxa/project_get_many.js";
 import projectListScript from "../../../scripts/jxa/project_list.js";
@@ -28,7 +31,18 @@ import tagListScript from "../../../scripts/jxa/tag_list.js";
 import taskGetScript from "../../../scripts/jxa/task_get.js";
 import taskGetManyScript from "../../../scripts/jxa/task_get_many.js";
 import taskListScript from "../../../scripts/jxa/task_list.js";
-import { fakeFolder, fakeProject, fakeTag, fakeTask, throwing } from "./fixtures.js";
+import taskSearchScript from "../../../scripts/jxa/task_search.js";
+import windowGetStateScript from "../../../scripts/jxa/window_get_state.js";
+import {
+  fakeAttachment,
+  fakeFolder,
+  fakePerspective,
+  fakeProject,
+  fakeTag,
+  fakeTask,
+  fakeWindow,
+  throwing,
+} from "./fixtures.js";
 import { runJxaScriptInSandbox } from "./index.js";
 
 // ---------------------------------------------------------------------------
@@ -803,6 +817,343 @@ describe("JXA sandbox — review_list_due", () => {
       projects: { reviewIntervalDays: number | null }[];
     }>(reviewListDueScript, {}, { projects: [p] });
     expect(result.projects[0]?.reviewIntervalDays).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forecast_get.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — forecast_get", () => {
+  // forecast_get queries via flattenedTasks.whose(predicate)() — the harness
+  // implements only the operators the script actually uses (equality plus
+  // _lessThan / _greaterThanEquals / _lessThanEquals on Date properties).
+  const FROM = new Date("2026-05-08T00:00:00Z");
+  const TO = new Date("2026-05-08T23:59:59Z");
+
+  it("buckets overdue, dueToday, deferredToday, and flagged correctly", () => {
+    const overdue = fakeTask({
+      id: () => "task_overdue",
+      dueDate: () => new Date("2026-05-01T00:00:00Z"),
+    });
+    const dueToday = fakeTask({
+      id: () => "task_today",
+      dueDate: () => new Date("2026-05-08T12:00:00Z"),
+    });
+    const deferredToday = fakeTask({
+      id: () => "task_deferred",
+      deferDate: () => new Date("2026-05-08T09:00:00Z"),
+    });
+    const flag = fakeTask({ id: () => "task_flagged", flagged: () => true });
+    const result = runJxaScriptInSandbox<{
+      overdue: { id: string }[];
+      dueToday: { id: string }[];
+      deferredToday: { id: string }[];
+      flagged: { id: string }[];
+    }>(
+      forecastGetScript,
+      { from: FROM.toISOString(), to: TO.toISOString() },
+      { tasks: [overdue, dueToday, deferredToday, flag] },
+    );
+    expect(result.overdue.map((t) => t.id)).toEqual(["task_overdue"]);
+    expect(result.dueToday.map((t) => t.id)).toEqual(["task_today"]);
+    expect(result.deferredToday.map((t) => t.id)).toEqual(["task_deferred"]);
+    expect(result.flagged.map((t) => t.id)).toEqual(["task_flagged"]);
+  });
+
+  it("excludes completed and dropped tasks from every bucket", () => {
+    const completed = fakeTask({
+      id: () => "task_completed",
+      completed: () => true,
+      dueDate: () => new Date("2026-05-08T09:00:00Z"),
+    });
+    const dropped = fakeTask({
+      id: () => "task_dropped",
+      dropped: () => true,
+      flagged: () => true,
+    });
+    const result = runJxaScriptInSandbox<{
+      overdue: unknown[];
+      dueToday: unknown[];
+      flagged: unknown[];
+    }>(
+      forecastGetScript,
+      { from: FROM.toISOString(), to: TO.toISOString() },
+      { tasks: [completed, dropped] },
+    );
+    expect(result.dueToday).toHaveLength(0);
+    expect(result.flagged).toHaveLength(0);
+  });
+
+  it("respects include* flags by skipping their queries", () => {
+    const flag = fakeTask({ flagged: () => true });
+    const result = runJxaScriptInSandbox<{ flagged: unknown[] }>(
+      forecastGetScript,
+      {
+        from: FROM.toISOString(),
+        to: TO.toISOString(),
+        includeFlagged: false,
+      },
+      { tasks: [flag] },
+    );
+    expect(result.flagged).toHaveLength(0);
+  });
+
+  it("dedups a task that matches multiple buckets via the builtById cache", () => {
+    // A task that is both overdue and flagged should appear in both buckets,
+    // but be built only once (the builtById cache keys on the task id).
+    const t = fakeTask({
+      id: () => "task_dual",
+      dueDate: () => new Date("2026-05-01T00:00:00Z"),
+      flagged: () => true,
+    });
+    const result = runJxaScriptInSandbox<{
+      overdue: { id: string }[];
+      flagged: { id: string }[];
+    }>(forecastGetScript, { from: FROM.toISOString(), to: TO.toISOString() }, { tasks: [t] });
+    expect(result.overdue.map((x) => x.id)).toEqual(["task_dual"]);
+    expect(result.flagged.map((x) => x.id)).toEqual(["task_dual"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// window_get_state.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — window_get_state", () => {
+  it("returns perspectiveName + empty focus by default — regression #466", () => {
+    const w = fakeWindow({ perspectiveName: () => "Forecast" });
+    const result = runJxaScriptInSandbox<{
+      perspectiveName: string;
+      focusContainerIds: string[];
+    }>(windowGetStateScript, {}, { windows: [w] });
+    expect(result.perspectiveName).toBe("Forecast");
+    expect(result.focusContainerIds).toEqual([]);
+  });
+
+  it("returns NO_FRONT_WINDOW error when there are no windows", () => {
+    const result = runJxaScriptInSandbox<{ error: { code: string } }>(
+      windowGetStateScript,
+      {},
+      { windows: [] },
+    );
+    expect(result.error.code).toBe("NO_FRONT_WINDOW");
+  });
+
+  it("collects focus container ids in input order", () => {
+    const w = fakeWindow({
+      focus: () => [{ id: () => "container_a" }, { id: () => "container_b" }],
+    });
+    const result = runJxaScriptInSandbox<{ focusContainerIds: string[] }>(
+      windowGetStateScript,
+      {},
+      { windows: [w] },
+    );
+    expect(result.focusContainerIds).toEqual(["container_a", "container_b"]);
+  });
+
+  it("returns null perspectiveName when the getter throws", () => {
+    const w = fakeWindow({ perspectiveName: throwing() });
+    const result = runJxaScriptInSandbox<{ perspectiveName: string | null }>(
+      windowGetStateScript,
+      {},
+      { windows: [w] },
+    );
+    expect(result.perspectiveName).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// perspective_list.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — perspective_list", () => {
+  it("always returns the seven built-in perspectives", () => {
+    const result = runJxaScriptInSandbox<{
+      perspectives: { id: string; kind: string; requiresPro: boolean }[];
+    }>(perspectiveListScript, {}, {});
+    const builtinIds = result.perspectives.filter((p) => p.kind === "builtin").map((p) => p.id);
+    expect(builtinIds).toEqual([
+      "inbox",
+      "projects",
+      "tags",
+      "forecast",
+      "flagged",
+      "nearby",
+      "review",
+    ]);
+    expect(result.perspectives.every((p) => !p.requiresPro || p.kind === "custom")).toBe(true);
+  });
+
+  it("appends custom perspectives with requiresPro: true", () => {
+    const custom = fakePerspective({ id: () => "perspective_x", name: () => "Weekly Review" });
+    const result = runJxaScriptInSandbox<{
+      perspectives: { id: string; name: string; kind: string; requiresPro: boolean }[];
+    }>(perspectiveListScript, {}, { perspectives: [custom] });
+    const customs = result.perspectives.filter((p) => p.kind === "custom");
+    expect(customs).toHaveLength(1);
+    expect(customs[0]).toMatchObject({
+      id: "perspective_x",
+      name: "Weekly Review",
+      kind: "custom",
+      requiresPro: true,
+    });
+  });
+
+  it("dedups built-in names that the OS reports as custom perspectives", () => {
+    // OF reports built-ins under different ids in some versions; the script
+    // skips any custom whose name matches a built-in.
+    const dup = fakePerspective({ id: () => "weird-id", name: () => "Forecast" });
+    const result = runJxaScriptInSandbox<{ perspectives: { name: string; kind: string }[] }>(
+      perspectiveListScript,
+      {},
+      { perspectives: [dup] },
+    );
+    const customs = result.perspectives.filter((p) => p.kind === "custom");
+    expect(customs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachment_list.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — attachment_list", () => {
+  it("returns attachments for the requested taskId", () => {
+    const att = fakeAttachment({
+      id: () => "att_1",
+      name: () => "design.pdf",
+      fileType: () => "application/pdf",
+      fileSize: () => 12345,
+    });
+    const owner = fakeTask({ id: () => "task_owner", fileAttachments: () => [att] });
+    const result = runJxaScriptInSandbox<{
+      attachments: {
+        id: string;
+        name: string;
+        mimeType: string;
+        sizeBytes: number;
+        kind: string;
+      }[];
+    }>(attachmentListScript, { taskId: "task_owner" }, { tasks: [owner] });
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0]).toMatchObject({
+      id: "att_1",
+      name: "design.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 12345,
+      kind: "embedded",
+    });
+  });
+
+  it("returns 'alias' kind when the attachment is linked", () => {
+    const att = fakeAttachment({ linked: () => true });
+    const owner = fakeProject({ id: () => "project_owner", fileAttachments: () => [att] });
+    const result = runJxaScriptInSandbox<{ attachments: { kind: string }[] }>(
+      attachmentListScript,
+      { projectId: "project_owner" },
+      { projects: [owner] },
+    );
+    expect(result.attachments[0]?.kind).toBe("alias");
+  });
+
+  it("throws when the requested taskId does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(attachmentListScript, { taskId: "missing" }, { tasks: [fakeTask()] }),
+    ).toThrow("Task not found: missing");
+  });
+
+  it("throws when neither taskId nor projectId is supplied", () => {
+    expect(() => runJxaScriptInSandbox(attachmentListScript, {}, {})).toThrow(
+      "One of taskId or projectId is required",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_search.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_search", () => {
+  it("filters by keyword in name (default scope: all)", () => {
+    const a = fakeTask({ name: () => "Buy milk" });
+    const b = fakeTask({ name: () => "Pay rent" });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskSearchScript,
+      { q: "milk" },
+      { tasks: [a, b] },
+    );
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.name).toBe("Buy milk");
+  });
+
+  it("scope: 'note' searches only notes", () => {
+    const a = fakeTask({ name: () => "milk", note: () => "" });
+    const b = fakeTask({ name: () => "task", note: () => "remember the milk" });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskSearchScript,
+      { q: "milk", scope: "note" },
+      { tasks: [a, b] },
+    );
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.name).toBe("task");
+  });
+
+  it("excludes completed by default but 'only' returns just completed", () => {
+    const open = fakeTask({ id: () => "task_open" });
+    const done = fakeTask({ id: () => "task_done", completed: () => true });
+    const exclude = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      {},
+      { tasks: [open, done] },
+    );
+    expect(exclude.tasks.map((t) => t.id)).toEqual(["task_open"]);
+    const only = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      { completed: "only" },
+      { tasks: [open, done] },
+    );
+    expect(only.tasks.map((t) => t.id)).toEqual(["task_done"]);
+  });
+
+  it("requires ALL listed tagIds when filtering by tagIds", () => {
+    const tagA = fakeTag({ id: () => "tag_a" });
+    const tagB = fakeTag({ id: () => "tag_b" });
+    const both = fakeTask({ id: () => "task_both", tags: () => [tagA, tagB] });
+    const onlyA = fakeTask({ id: () => "task_a_only", tags: () => [tagA] });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      { tagIds: ["tag_a", "tag_b"] },
+      { tasks: [both, onlyA] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_both"]);
+  });
+
+  it("scopes to a project's flattenedTasks via byId — happy path", () => {
+    const projectTasks = [fakeTask({ id: () => "task_inside" })];
+    const project = fakeProject({
+      id: () => "project_target",
+      flattenedTasks: () => projectTasks,
+    });
+    // outsider should not appear because the script reads tasks from the
+    // project, not from the document's flattenedTasks.
+    const outsider = fakeTask({ id: () => "task_outside" });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      { projectId: "project_target" },
+      { projects: [project], tasks: [outsider] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_inside"]);
+  });
+
+  it("throws via lookupOrThrow when projectId does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        taskSearchScript,
+        { projectId: "missing" },
+        { projects: [fakeProject()] },
+      ),
+    ).toThrow("Project not found: missing");
   });
 });
 

--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -1,3 +1,5 @@
+import { ScriptError } from "../../../errors/index.js";
+
 /**
  * JXA sandbox runner — evaluates a JXA script body in a controlled Node.js
  * context so unit tests can assert control-flow and output shape without
@@ -38,6 +40,72 @@ export interface SandboxDocument {
   projects?: unknown[];
   /** Fake folders for `ofApp.defaultDocument.flattenedFolders()`. */
   folders?: unknown[];
+  /** Fake windows for `ofApp.windows()`. */
+  windows?: unknown[];
+  /** Fake custom perspectives for `ofApp.perspectives()`. */
+  perspectives?: unknown[];
+}
+
+// ---------------------------------------------------------------------------
+// Predicate evaluator for `flattenedTasks.whose(...)`
+// ---------------------------------------------------------------------------
+
+type TaskRecord = Record<string, unknown> & { id?: () => string };
+
+/**
+ * Evaluate a single OmniFocus `whose()`-style predicate against one task.
+ *
+ * Supports the subset of operators the JXA scripts in this repo actually
+ * use: equality on primitive properties, and `_lessThan` / `_lessThanEquals`
+ * / `_greaterThan` / `_greaterThanEquals` on date-valued properties. This is
+ * not a full reimplementation of OmniFocus's query DSL — anything else
+ * silently fails open (the predicate matches), which surfaces as a test
+ * failure rather than a silent miss.
+ */
+function matchesPredicate(task: TaskRecord, predicate: Record<string, unknown>): boolean {
+  for (const [key, expected] of Object.entries(predicate)) {
+    const getter = task[key];
+    if (typeof getter !== "function") return false;
+    const actual = (getter as () => unknown)();
+
+    if (
+      expected !== null &&
+      typeof expected === "object" &&
+      !(expected instanceof Date) &&
+      !Array.isArray(expected)
+    ) {
+      const ops = expected as Record<string, unknown>;
+      // OmniFocus's whose() never matches null or missing values against a
+      // date-comparison operator — a task with no dueDate is not "less than"
+      // any date. Mirror that: if actual isn't a Date the predicate fails.
+      if (!(actual instanceof Date)) return false;
+      const actualTime = actual.getTime();
+      if ("_lessThan" in ops) {
+        const bound = ops._lessThan;
+        if (!(bound instanceof Date)) return false;
+        if (!(actualTime < bound.getTime())) return false;
+      }
+      if ("_lessThanEquals" in ops) {
+        const bound = ops._lessThanEquals;
+        if (!(bound instanceof Date)) return false;
+        if (!(actualTime <= bound.getTime())) return false;
+      }
+      if ("_greaterThan" in ops) {
+        const bound = ops._greaterThan;
+        if (!(bound instanceof Date)) return false;
+        if (!(actualTime > bound.getTime())) return false;
+      }
+      if ("_greaterThanEquals" in ops) {
+        const bound = ops._greaterThanEquals;
+        if (!(bound instanceof Date)) return false;
+        if (!(actualTime >= bound.getTime())) return false;
+      }
+      continue;
+    }
+
+    if (actual !== expected) return false;
+  }
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -62,7 +130,7 @@ export function runJxaScriptInSandbox<T = unknown>(
   doc: SandboxDocument = {},
 ): T {
   const document = buildFakeDocument(doc);
-  const fakeApp = buildFakeApp(document);
+  const fakeApp = buildFakeApp(document, doc);
 
   // Wrap the script in an IIFE that receives `Application` as a parameter,
   // then call `run(argv)` with the serialized args — matching how osascript
@@ -87,10 +155,43 @@ function buildFakeDocument(doc: SandboxDocument) {
   const folders = doc.folders ?? [];
   const inboxTasks = doc.inboxTasks ?? [];
 
+  // `flattenedTasks` is invoked both as `flattenedTasks()` (returns the
+  // array) and as `flattenedTasks.whose(predicate)()` (returns a callable
+  // wrapping the filtered subset). Functions are objects in JS, so we attach
+  // `whose` directly to the function value.
+  const flattenedTasks = Object.assign(() => tasks, {
+    whose: (predicate: Record<string, unknown>) => {
+      const filtered = (tasks as TaskRecord[]).filter((t) => matchesPredicate(t, predicate));
+      return () => filtered;
+    },
+  });
+
+  // `flattenedProjects` is invoked both as `flattenedProjects()` (returns the
+  // array) and as `flattenedProjects.byId(id)` (returns a lazy specifier
+  // whose `.id()` throws when the id is missing — `lookupOrThrow` relies on
+  // exactly that "throw on .id()" contract to map the miss to a typed
+  // NotFound error).
+  const flattenedProjects = Object.assign(() => projects, {
+    byId: (id: string) => {
+      const hit = (projects as Array<{ id?: () => string }>).find(
+        (p) => typeof p.id === "function" && p.id() === id,
+      );
+      if (hit) return hit;
+      // Mirror OF's "errAENoSuchObject (-1728)" — lookupOrThrow catches the
+      // throw and rethrows the typed `<Kind> not found: <id>` message.
+      const msg = "Can't get object. (-1728)";
+      return {
+        id: () => {
+          throw new ScriptError(msg, { details: { stderr: msg } });
+        },
+      };
+    },
+  });
+
   return {
     flattenedTags: () => tags,
-    flattenedTasks: () => tasks,
-    flattenedProjects: () => projects,
+    flattenedTasks,
+    flattenedProjects,
     flattenedFolders: () => folders,
     // Some scripts access inbox tasks through the document
     inbox: {
@@ -101,11 +202,15 @@ function buildFakeDocument(doc: SandboxDocument) {
   };
 }
 
-function buildFakeApp(document: ReturnType<typeof buildFakeDocument>) {
+function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: SandboxDocument) {
+  const windows = doc.windows ?? [];
+  const perspectives = doc.perspectives ?? [];
   return (_name: string) => ({
     // Scripts set this; we accept and ignore it.
     includeStandardAdditions: false,
     defaultDocument: document,
     inbox: document.inbox,
+    windows: () => windows,
+    perspectives: () => perspectives,
   });
 }


### PR DESCRIPTION
## Summary

- Adds 21 sandbox tests across five read-style JXA scripts: `forecast_get`, `window_get_state`, `perspective_list`, `attachment_list`, `task_search`.
- Brings sandbox coverage from 13 of 60+ scripts (~22%) to 18 of 60+ (~30%) on the way to the 80% target tracked by [#723](https://github.com/torsday/omnifocus-mcp/issues/723).
- Extends the sandbox harness with the four app/document-level APIs these scripts touch beyond the slice-1/2a baseline.

## Harness extensions

`src/adapter/jxa/sandbox/index.ts`:
- `flattenedTasks` gains a `.whose(predicate)` filter modelling only the operators `forecast_get` uses: equality on primitives plus `_lessThan` / `_lessThanEquals` / `_greaterThan` / `_greaterThanEquals` on `Date` properties. Null/missing values never match a date operator (mirrors OF semantics — a task with no dueDate is not "less than" any date).
- `flattenedProjects` gains a `.byId(id)` lazy specifier. Missing ids return an object whose `.id()` throws `ScriptError` with the (-1728) signature so the inlined `lookup_or_throw` helper rethrows the typed `"Project not found: <id>"` message — the contract the production transport relies on.
- `buildFakeApp` accepts `windows` + `perspectives` via the `SandboxDocument` shape and exposes `ofApp.windows()` / `ofApp.perspectives()`.

`src/adapter/jxa/sandbox/fixtures.ts`:
- New `fakeAttachment`, `fakeWindow`, `fakePerspective` builders.
- `fakeTask` gains `effectivelyAvailable` (default `() => true`) — required by `build_task` with `effectiveAvailability: true`, used by both `forecast_get` and `task_search`.
- `fakeTask` and `fakeProject` gain `fileAttachments` (default `() => []`).
- `fakeAttachment.linked` is intentionally optional: by default the script reads `kind: "embedded"` (the production default); setting `linked: () => true` exercises the alias path.

## Design link

Slice 2b of [#723](https://github.com/torsday/omnifocus-mcp/issues/723). Sibling: [#740](https://github.com/torsday/omnifocus-mcp/issues/740) (slice 2a — read scripts that needed no harness changes; merged). Independent of [#741](https://github.com/torsday/omnifocus-mcp/issues/741) (slice 3 — mutation harness).

Closes #742

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` all green locally (3301 passing, 56 skipped, 198 files).
- [x] Sandbox suite alone: 84 tests pass (63 prior + 21 new).
- [x] Self-reviewed via `/review-pr` — coverage focused on the regression classes and contract edges per the AC; no over-enumeration.

## Coverage detail

| Script | Tests added | Cases |
|---|---|---|
| `forecast_get` | 4 | bucket distribution; completed/dropped exclusion; `includeFlagged: false`; dual-bucket dedup via builtById |
| `window_get_state` | 4 | happy path; `NO_FRONT_WINDOW` error; focus container ids in input order; `perspectiveName()` throws |
| `perspective_list` | 3 | seven built-ins always returned; custom perspectives appended with `requiresPro: true`; built-in name dedup |
| `attachment_list` | 4 | embedded happy path; `linked()` → `kind: "alias"`; task-not-found throw; missing id args throw |
| `task_search` | 6 | name keyword scope; `note` scope; completed `exclude`/`only`; tagIds AND filter; project scoping via `byId`; project-not-found throw via `lookupOrThrow` |

## Conventions checklist

- [x] Conventional Commit
- [x] No new dependencies
- [x] No public surface change — fixture API additions are additive