### PR TITLE
test(jxa): mutation harness + folder mutation scripts (slice 3 of #723)

### DIFF
--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -20,6 +20,7 @@
  */
 
 import { ScriptError } from "../../../errors/index.js";
+import { defineWritableNameAccessor } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -265,20 +266,35 @@ export function fakeFolder(
   overrides: FakeFolderOverrides & { id?: () => string; name?: () => string } = {},
 ) {
   const id = overrides.id ?? fn(`folder_${++_folderSeq}`);
-  const name = overrides.name ?? fn(`Folder ${_folderSeq}`);
+  // `folders` is exposed as a callable that doubles as a push-target so
+  // `parentFolder.folders.push(child)` works in mutation scripts. The
+  // underlying array is captured from the override (or an empty list) at
+  // construction time; subsequent push() calls mutate that array, and reads
+  // via `folder.folders()` see the current contents.
+  const childrenArr: unknown[] = overrides.folders ? Array.from(overrides.folders()) : [];
+  const folders = Object.assign(() => childrenArr, {
+    push: (item: unknown) => {
+      childrenArr.push(item);
+    },
+  });
   const now = new Date();
-  return {
+  const folder: Record<string, unknown> = {
     id,
-    name,
     container: overrides.container ?? throwing(),
     parent: overrides.parent ?? throwing(),
-    folders: overrides.folders ?? fn([]),
+    folders,
     projects: overrides.projects ?? fn([]),
     note: overrides.note ?? fn(""),
     status: overrides.status ?? fn("active"),
     creationDate: overrides.creationDate ?? fn(now),
     modificationDate: overrides.modificationDate ?? fn(now),
   };
+  // `name` is a writable accessor so folder_update.js's `target.name = "X"`
+  // updates the value AND `target.name()` continues to return the latest
+  // value via the getter — the JXA semantics build_folder.js relies on.
+  // Default: invoke the supplied function once to seed the initial string.
+  defineWritableNameAccessor(folder, (overrides.name ?? fn(`Folder ${_folderSeq}`))());
+  return folder;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -17,8 +17,11 @@
 import { describe, expect, it } from "vitest";
 import attachmentListScript from "../../../scripts/jxa/attachment_list.js";
 import changesSinceScript from "../../../scripts/jxa/changes_since.js";
+import folderCreateScript from "../../../scripts/jxa/folder_create.js";
+import folderDeleteScript from "../../../scripts/jxa/folder_delete.js";
 import folderGetScript from "../../../scripts/jxa/folder_get.js";
 import folderListScript from "../../../scripts/jxa/folder_list.js";
+import folderUpdateScript from "../../../scripts/jxa/folder_update.js";
 import forecastGetScript from "../../../scripts/jxa/forecast_get.js";
 import perspectiveListScript from "../../../scripts/jxa/perspective_list.js";
 import projectGetScript from "../../../scripts/jxa/project_get.js";
@@ -1154,6 +1157,127 @@ describe("JXA sandbox — task_search", () => {
         { projects: [fakeProject()] },
       ),
     ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_create.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — folder_create", () => {
+  it("creates a top-level folder with the supplied name", () => {
+    const result = runJxaScriptInSandbox<{ folder: { name: string; parentId: null } }>(
+      folderCreateScript,
+      { name: "Areas" },
+      {},
+    );
+    expect(result.folder.name).toBe("Areas");
+    expect(result.folder.parentId).toBeNull();
+  });
+
+  it("creates a sub-folder under an existing parent", () => {
+    const parent = fakeFolder({ id: () => "folder_parent", name: () => "Parent" });
+    const result = runJxaScriptInSandbox<{ folder: { name: string; parentId: string | null } }>(
+      folderCreateScript,
+      { name: "Child", parentId: "folder_parent" },
+      { folders: [parent] },
+    );
+    expect(result.folder.name).toBe("Child");
+    // folder_create supplies a single-entry parentMap so build_folder reports
+    // parentage correctly even with the OF 4.8.8 folder.parent() bug (#515).
+    expect(result.folder.parentId).toBe("folder_parent");
+  });
+
+  it("throws ValidationError when name is empty", () => {
+    expect(() => runJxaScriptInSandbox(folderCreateScript, { name: "" }, {})).toThrow(
+      "ValidationError: name is required",
+    );
+  });
+
+  it("throws when the supplied parentId does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(folderCreateScript, { name: "Orphan", parentId: "missing" }, {}),
+    ).toThrow("Parent folder not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_update.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — folder_update", () => {
+  it("renames the folder and returns the updated shape", () => {
+    const target = fakeFolder({ id: () => "folder_target", name: () => "Old" });
+    const result = runJxaScriptInSandbox<{ folder: { id: string; name: string } }>(
+      folderUpdateScript,
+      { id: "folder_target", name: "New" },
+      { folders: [target] },
+    );
+    expect(result.folder.id).toBe("folder_target");
+    expect(result.folder.name).toBe("New");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        folderUpdateScript,
+        { id: "missing", name: "Anything" },
+        { folders: [fakeFolder()] },
+      ),
+    ).toThrow("Folder not found: missing");
+  });
+
+  it("preserves the parentId via the precomputed parentMap — regression #515", () => {
+    const child = fakeFolder({ id: () => "folder_child", parent: throwing() });
+    const parent = fakeFolder({ id: () => "folder_parent", folders: () => [child] });
+    const result = runJxaScriptInSandbox<{ folder: { parentId: string | null } }>(
+      folderUpdateScript,
+      { id: "folder_child", name: "Renamed" },
+      { folders: [parent, child] },
+    );
+    expect(result.folder.parentId).toBe("folder_parent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// folder_delete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — folder_delete", () => {
+  it("deletes an empty folder and echoes the id", () => {
+    const target = fakeFolder({ id: () => "folder_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      folderDeleteScript,
+      { id: "folder_target" },
+      { folders: [target] },
+    );
+    expect(result.id).toBe("folder_target");
+  });
+
+  it("refuses to delete a folder that contains projects", () => {
+    const target = fakeFolder({
+      id: () => "folder_with_proj",
+      projects: () => [fakeProject()],
+    });
+    expect(() =>
+      runJxaScriptInSandbox(folderDeleteScript, { id: "folder_with_proj" }, { folders: [target] }),
+    ).toThrow(/Folder is not empty.*projects: 1/);
+  });
+
+  it("refuses to delete a folder that contains sub-folders", () => {
+    const target = fakeFolder({
+      id: () => "folder_with_subs",
+      folders: () => [fakeFolder()],
+    });
+    expect(() =>
+      runJxaScriptInSandbox(folderDeleteScript, { id: "folder_with_subs" }, { folders: [target] }),
+    ).toThrow(/Folder is not empty.*subfolders: 1/);
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(folderDeleteScript, { id: "missing" }, { folders: [fakeFolder()] }),
+    ).toThrow("Folder not found: missing");
   });
 });
 

--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -188,11 +188,21 @@ function buildFakeDocument(doc: SandboxDocument) {
     },
   });
 
+  // Top-level folder collection. Mutation scripts push newly-constructed
+  // folders here via `ofApp.defaultDocument.folders.push(newFolder)`. Test
+  // assertions verify the script's return value rather than walking the
+  // fake's collections, so we don't bother syncing flattenedFolders on push.
+  const docFoldersArr: unknown[] = [];
+  const docFolders = Object.assign(() => docFoldersArr, {
+    push: (item: unknown) => docFoldersArr.push(item),
+  });
+
   return {
     flattenedTags: () => tags,
     flattenedTasks,
     flattenedProjects,
     flattenedFolders: () => folders,
+    folders: docFolders,
     // Some scripts access inbox tasks through the document
     inbox: {
       tasks: () => inboxTasks,
@@ -205,6 +215,18 @@ function buildFakeDocument(doc: SandboxDocument) {
 function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: SandboxDocument) {
   const windows = doc.windows ?? [];
   const perspectives = doc.perspectives ?? [];
+  // Track mutation-side effects so tests can assert post-condition without
+  // shimming `delete` to actually mutate the fake document. Scripts only
+  // care that delete() didn't throw.
+  const deleted: unknown[] = [];
+
+  // `ofApp.Folder({ name })` is the JXA constructor folder_create.js uses.
+  // It returns a fresh fake folder; the script then push()es it into the
+  // parent's folders collection. The constructed folder honours the same
+  // contract as `fakeFolder()` (name(), id(), parent(), folders(), …) so
+  // build_folder.js can build a domain Folder from it without surprises.
+  const folderConstructor = (opts: { name?: string } = {}) => makeConstructedFolder(opts);
+
   return (_name: string) => ({
     // Scripts set this; we accept and ignore it.
     includeStandardAdditions: false,
@@ -212,5 +234,60 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
     inbox: document.inbox,
     windows: () => windows,
     perspectives: () => perspectives,
+    Folder: folderConstructor,
+    delete: (target: unknown) => {
+      deleted.push(target);
+    },
+    /** Test-only — surface what `ofApp.delete()` was called with. */
+    _deleted: deleted,
+  });
+}
+
+let _constructedFolderSeq = 0;
+
+/**
+ * Build a fake JXA Folder created via `ofApp.Folder({ name })`. The shape
+ * mirrors `fakeFolder()` but only the fields the JXA scripts read or
+ * mutate are populated. `name` is a writable accessor (Object.defineProperty
+ * getter+setter) so `target.name = "X"` updates the value AND `target.name()`
+ * still returns the latest value via the getter — the JXA semantics
+ * folder_update.js relies on.
+ */
+function makeConstructedFolder(opts: { name?: string }): Record<string, unknown> {
+  const id = `constructed_folder_${++_constructedFolderSeq}`;
+  const childrenArr: unknown[] = [];
+  const folders = Object.assign(() => childrenArr, {
+    push: (item: unknown) => childrenArr.push(item),
+  });
+  const noThrow = () => {
+    throw new ScriptError("Can't get object.", { details: { stderr: "Can't get object." } });
+  };
+  const folder: Record<string, unknown> = {
+    id: () => id,
+    parent: noThrow,
+    folders,
+    projects: () => [],
+    creationDate: () => new Date(),
+    modificationDate: () => new Date(),
+  };
+  defineWritableNameAccessor(folder, opts.name ?? `Folder ${_constructedFolderSeq}`);
+  return folder;
+}
+
+/**
+ * Define a writable `name` field that survives `obj.name = "X"` assignment
+ * AND continues to be invocable as `obj.name()` afterwards. JXA exposes
+ * properties this way — assignment goes through a setter, read returns a
+ * callable getter — and folder_update.js relies on exactly that pattern.
+ */
+export function defineWritableNameAccessor(obj: Record<string, unknown>, initial: string): void {
+  let current = initial;
+  Object.defineProperty(obj, "name", {
+    configurable: true,
+    enumerable: true,
+    get: () => () => current,
+    set: (value: unknown) => {
+      current = typeof value === "function" ? String((value as () => unknown)()) : String(value);
+    },
   });
 }


### PR DESCRIPTION
## Summary

- Extends the sandbox harness so mutation-style JXA scripts can be unit tested without OmniFocus.
- Adds 11 sandbox tests across `folder_create`, `folder_update`, `folder_delete`.
- Brings coverage from 18 of 60+ scripts (~30%) to 21 of 60+ (~35%) on the way to the 80% target tracked by [#723](https://github.com/torsday/omnifocus-mcp/issues/723).
- Unblocks slices 4–7 (tag / project / task / batch mutations) which all reuse the same constructor + push + writable-property pattern this slice introduces.

## Harness extensions

`src/adapter/jxa/sandbox/index.ts`:

- **`ofApp.Folder({ name })` constructor** — returns a fresh fake folder shaped like `fakeFolder()` so `build_folder.js` can build a domain Folder from the result of `folder_create.js` without surprises.
- **`ofApp.defaultDocument.folders`** is now a callable + push-target so `folder_create`'s `defaultDocument.folders.push(newFolder)` works for top-level folder additions.
- **`ofApp.delete(target)`** tracked as a no-op — `folder_delete`'s assertion is on the script's return shape, not on collection state.
- **`defineWritableNameAccessor`** (exported) — installs a getter+setter on a fake's `name` field so `target.name = "X"` updates the value AND `target.name()` continues to return the latest value via the getter. JXA exposes properties this way; `folder_update.js` relies on exactly that pattern.

`src/adapter/jxa/sandbox/fixtures.ts`:

- `fakeFolder.folders` is now a callable that doubles as a push-target so `parentFolder.folders.push(child)` mutates the underlying array (and `folder.folders()` reads see the additions).
- `fakeFolder.name` uses `defineWritableNameAccessor` so `target.name = "X"` works in tests of `folder_update`.

## Design link

Slice 3 of [#723](https://github.com/torsday/omnifocus-mcp/issues/723). Sibling slices 1 (#738), 2a (#740), 2b (#742) all merged. Independent of the upcoming slices 4–7 (which depend on this PR's harness pattern landing first).

Closes #741

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` all green locally (3312 passing, 56 skipped, 198 files).
- [x] Sandbox suite alone: 95 tests pass (84 prior + 11 new).
- [x] Self-reviewed via `/review-pr` — coverage is happy path + the documented refusal paths in `folder_delete` (projects > 0 / subfolders > 0); not full enumeration.

## Coverage detail

| Script | Tests added | Cases |
|---|---|---|
| `folder_create` | 4 | top-level happy path; sub-folder via parentMap (regression #515); empty-name validation; missing parent throws |
| `folder_update` | 3 | rename happy path; missing id throws; parentId preserved via parentMap (regression #515) |
| `folder_delete` | 4 | empty-folder happy path; refuses with projects > 0; refuses with subfolders > 0; missing id throws |

## Conventions checklist

- [x] Conventional Commit
- [x] No new dependencies
- [x] No public surface change — sandbox harness API additions are additive (new constructor, new exported helper, push-capable collections)