### PR TITLE
test(jxa): tag mutation scripts via sandbox harness (slice 4 of #723)

### DIFF
--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -20,7 +20,7 @@
  */
 
 import { ScriptError } from "../../../errors/index.js";
-import { defineWritableNameAccessor } from "./index.js";
+import { defineWritableAccessor, defineWritableNameAccessor } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -56,18 +56,10 @@ export interface FakeTagOverrides {
   modificationDate?: () => Date;
   allowsNextAction?: () => boolean;
   tasks?: () => unknown[];
-}
-
-export interface FakeTag {
-  id: () => string;
-  name: () => string;
-  parent: () => unknown;
-  status: () => string;
-  location: () => unknown;
-  creationDate: () => Date;
-  modificationDate: () => Date;
-  allowsNextAction: () => boolean;
-  tasks: () => unknown[];
+  // Child tags (nested tag tree). tag_create.js calls
+  // `parentTag.tags.push(newTag)`; expose this as a callable that doubles
+  // as a push-target so the mutation propagates to subsequent reads.
+  tags?: () => unknown[];
 }
 
 let _tagSeq = 0;
@@ -80,21 +72,34 @@ let _tagSeq = 0;
  */
 export function fakeTag(
   overrides: FakeTagOverrides & { id?: () => string; name?: () => string } = {},
-): FakeTag {
+) {
   const id = overrides.id ?? fn(`tag_${++_tagSeq}`);
-  const name = overrides.name ?? fn(`Tag ${_tagSeq}`);
   const now = new Date();
-  return {
+  // Child-tag collection: pushable callable. Captures the override array
+  // (if any) at construction; subsequent push() mutates it in place so
+  // post-mutation reads via `tag.tags()` see the additions.
+  const childrenArr: unknown[] = overrides.tags ? Array.from(overrides.tags()) : [];
+  const tags = Object.assign(() => childrenArr, {
+    push: (item: unknown) => childrenArr.push(item),
+  });
+  const tag: Record<string, unknown> = {
     id,
-    name,
     parent: overrides.parent ?? throwing(),
-    status: overrides.status ?? fn("active"),
     location: overrides.location ?? fn(null),
     creationDate: overrides.creationDate ?? fn(now),
     modificationDate: overrides.modificationDate ?? fn(now),
-    allowsNextAction: overrides.allowsNextAction ?? fn(false),
     tasks: overrides.tasks ?? fn([]),
+    tags,
   };
+  // tag_update.js reassigns name / status / allowsNextAction via JXA's
+  // property-setter syntax. Use writable accessors so `target.x = y`
+  // updates the value AND `target.x()` returns it via the callable getter.
+  // Pass the override function (or default static getter) through directly
+  // so throwing-getter overrides keep throwing until the script reassigns.
+  defineWritableAccessor(tag, "name", overrides.name ?? fn(`Tag ${_tagSeq}`));
+  defineWritableAccessor(tag, "status", overrides.status ?? fn("active"));
+  defineWritableAccessor(tag, "allowsNextAction", overrides.allowsNextAction ?? fn(false));
+  return tag;
 }
 
 export interface FakeTaskOverrides {

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -28,9 +28,12 @@ import projectGetScript from "../../../scripts/jxa/project_get.js";
 import projectGetManyScript from "../../../scripts/jxa/project_get_many.js";
 import projectListScript from "../../../scripts/jxa/project_list.js";
 import reviewListDueScript from "../../../scripts/jxa/review_list_due.js";
+import tagCreateScript from "../../../scripts/jxa/tag_create.js";
+import tagDeleteScript from "../../../scripts/jxa/tag_delete.js";
 import tagGetScript from "../../../scripts/jxa/tag_get.js";
 import tagGetManyScript from "../../../scripts/jxa/tag_get_many.js";
 import tagListScript from "../../../scripts/jxa/tag_list.js";
+import tagUpdateScript from "../../../scripts/jxa/tag_update.js";
 import taskGetScript from "../../../scripts/jxa/task_get.js";
 import taskGetManyScript from "../../../scripts/jxa/task_get_many.js";
 import taskListScript from "../../../scripts/jxa/task_list.js";
@@ -1278,6 +1281,115 @@ describe("JXA sandbox — folder_delete", () => {
     expect(() =>
       runJxaScriptInSandbox(folderDeleteScript, { id: "missing" }, { folders: [fakeFolder()] }),
     ).toThrow("Folder not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_create.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — tag_create", () => {
+  it("creates a top-level tag with the supplied name", () => {
+    const result = runJxaScriptInSandbox<{ tag: { name: string; parentId: string | null } }>(
+      tagCreateScript,
+      { name: "Work" },
+      {},
+    );
+    expect(result.tag.name).toBe("Work");
+    expect(result.tag.parentId).toBeNull();
+  });
+
+  it("creates a nested tag under an existing parent via byId lookup + push", () => {
+    const parent = fakeTag({ id: () => "tag_parent", name: () => "Errands" });
+    const result = runJxaScriptInSandbox<{ tag: { name: string } }>(
+      tagCreateScript,
+      { name: "Buy milk", parentId: "tag_parent" },
+      { tags: [parent] },
+    );
+    expect(result.tag.name).toBe("Buy milk");
+  });
+
+  it("throws ValidationError when name is empty or whitespace", () => {
+    expect(() => runJxaScriptInSandbox(tagCreateScript, { name: "  " }, {})).toThrow(
+      "ValidationError: name is required",
+    );
+  });
+
+  it("throws via lookupOrThrow when parentId does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(tagCreateScript, { name: "Orphan", parentId: "missing" }, {}),
+    ).toThrow("Parent tag not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_update.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — tag_update", () => {
+  it("renames the tag and returns the updated shape", () => {
+    const target = fakeTag({ id: () => "tag_target", name: () => "Old" });
+    const result = runJxaScriptInSandbox<{ tag: { id: string; name: string } }>(
+      tagUpdateScript,
+      { id: "tag_target", name: "New" },
+      { tags: [target] },
+    );
+    expect(result.tag.id).toBe("tag_target");
+    expect(result.tag.name).toBe("New");
+  });
+
+  it("normalizes the on-hold status from domain to JXA format", () => {
+    // Script writes `target.status = args.status === "on-hold" ? "on hold" : args.status`.
+    // build_tag.js reads target.status() and normalizes back to "on-hold".
+    const target = fakeTag({ id: () => "tag_target", status: () => "active" });
+    const result = runJxaScriptInSandbox<{ tag: { status: string } }>(
+      tagUpdateScript,
+      { id: "tag_target", status: "on-hold" },
+      { tags: [target] },
+    );
+    expect(result.tag.status).toBe("on-hold");
+  });
+
+  it("updates allowsNextAction via property assignment", () => {
+    const target = fakeTag({ id: () => "tag_target", allowsNextAction: () => false });
+    const result = runJxaScriptInSandbox<{ tag: { allowsNextAction: boolean } }>(
+      tagUpdateScript,
+      { id: "tag_target", allowsNextAction: true },
+      { tags: [target] },
+    );
+    expect(result.tag.allowsNextAction).toBe(true);
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        tagUpdateScript,
+        { id: "missing", name: "Anything" },
+        { tags: [fakeTag()] },
+      ),
+    ).toThrow("Tag not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tag_delete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — tag_delete", () => {
+  it("deletes a tag and echoes the id", () => {
+    const target = fakeTag({ id: () => "tag_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      tagDeleteScript,
+      { id: "tag_target" },
+      { tags: [target] },
+    );
+    expect(result.id).toBe("tag_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(tagDeleteScript, { id: "missing" }, { tags: [fakeTag()] }),
+    ).toThrow("Tag not found: missing");
   });
 });
 

--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -197,8 +197,54 @@ function buildFakeDocument(doc: SandboxDocument) {
     push: (item: unknown) => docFoldersArr.push(item),
   });
 
+  // Top-level tag collection. tag_create.js pushes new tags here OR into an
+  // existing parent tag's `.tags` collection. After push it re-fetches via
+  // `flattenedTags.byId(id)`, so we need a flat-walk lookup that descends
+  // into every tag's children — that way a tag pushed onto a parent's
+  // children is still findable from the document.
+  const topLevelTags: unknown[] = [...tags];
+  const docTags = Object.assign(() => topLevelTags, {
+    push: (item: unknown) => topLevelTags.push(item),
+  });
+
+  type TagNode = { id?: () => string; tags?: () => unknown[] };
+  function walkTags(roots: unknown[]): unknown[] {
+    const out: unknown[] = [];
+    const stack = [...roots];
+    while (stack.length) {
+      const t = stack.pop() as TagNode;
+      if (!t) continue;
+      out.push(t);
+      if (typeof t.tags === "function") {
+        try {
+          const children = t.tags();
+          if (Array.isArray(children)) stack.push(...children);
+        } catch {
+          /* ignore — fakes that throw on .tags() shouldn't crash the walk */
+        }
+      }
+    }
+    return out;
+  }
+
+  const flattenedTags = Object.assign(() => walkTags(topLevelTags), {
+    byId: (id: string) => {
+      const hit = (walkTags(topLevelTags) as Array<{ id?: () => string }>).find(
+        (t) => typeof t.id === "function" && t.id() === id,
+      );
+      if (hit) return hit;
+      const msg = "Can't get object. (-1728)";
+      return {
+        id: () => {
+          throw new ScriptError(msg, { details: { stderr: msg } });
+        },
+      };
+    },
+  });
+
   return {
-    flattenedTags: () => tags,
+    flattenedTags,
+    tags: docTags,
     flattenedTasks,
     flattenedProjects,
     flattenedFolders: () => folders,
@@ -226,6 +272,13 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
   // contract as `fakeFolder()` (name(), id(), parent(), folders(), …) so
   // build_folder.js can build a domain Folder from it without surprises.
   const folderConstructor = (opts: { name?: string } = {}) => makeConstructedFolder(opts);
+  // `ofApp.Tag({ name })` is the JXA constructor tag_create.js uses. Same
+  // contract as fakeTag(): build_tag.js reads name(), id(), parent(),
+  // status(), creationDate(), modificationDate(), allowsNextAction(),
+  // tasks().length, location(). The constructed tag installs writable
+  // accessors on `name`, `status`, `allowsNextAction` since tag_update.js
+  // reassigns those.
+  const tagConstructor = (opts: { name?: string } = {}) => makeConstructedTag(opts);
 
   return (_name: string) => ({
     // Scripts set this; we accept and ignore it.
@@ -235,6 +288,7 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
     windows: () => windows,
     perspectives: () => perspectives,
     Folder: folderConstructor,
+    Tag: tagConstructor,
     delete: (target: unknown) => {
       deleted.push(target);
     },
@@ -274,20 +328,73 @@ function makeConstructedFolder(opts: { name?: string }): Record<string, unknown>
   return folder;
 }
 
+let _constructedTagSeq = 0;
+
 /**
- * Define a writable `name` field that survives `obj.name = "X"` assignment
- * AND continues to be invocable as `obj.name()` afterwards. JXA exposes
- * properties this way — assignment goes through a setter, read returns a
- * callable getter — and folder_update.js relies on exactly that pattern.
+ * Build a fake JXA Tag created via `ofApp.Tag({ name })`. The shape mirrors
+ * `fakeTag()` but only the fields tag scripts read or mutate are populated.
+ * `name`, `status`, and `allowsNextAction` are writable accessors so
+ * tag_update.js's `target.<key> = X` assignments persist.
  */
-export function defineWritableNameAccessor(obj: Record<string, unknown>, initial: string): void {
-  let current = initial;
-  Object.defineProperty(obj, "name", {
+function makeConstructedTag(opts: { name?: string }): Record<string, unknown> {
+  const id = `constructed_tag_${++_constructedTagSeq}`;
+  const childrenArr: unknown[] = [];
+  const childTags = Object.assign(() => childrenArr, {
+    push: (item: unknown) => childrenArr.push(item),
+  });
+  const noThrow = () => {
+    throw new ScriptError("Can't get object.", { details: { stderr: "Can't get object." } });
+  };
+  const tag: Record<string, unknown> = {
+    id: () => id,
+    parent: noThrow,
+    tags: childTags,
+    location: () => null,
+    creationDate: () => new Date(),
+    modificationDate: () => new Date(),
+    tasks: () => [],
+  };
+  defineWritableAccessor(tag, "name", opts.name ?? `Tag ${_constructedTagSeq}`);
+  defineWritableAccessor(tag, "status", "active");
+  defineWritableAccessor(tag, "allowsNextAction", false);
+  return tag;
+}
+
+/**
+ * Define a writable JXA-style accessor: `obj[key] = X` updates the value
+ * and `obj[key]()` reads the latest value via a callable getter. Used by
+ * mutation scripts that assign to properties (`target.name = "X"`,
+ * `target.status = "on hold"`, …) and then read them back through
+ * `build_*.js` helpers via zero-arg method calls.
+ *
+ * The initial value can be a static value or a getter function. Passing a
+ * function preserves its behavior — including throwing — until the script
+ * reassigns the property. That matches existing fixture overrides like
+ * `fakeTag({ allowsNextAction: throwing() })` which must still throw on
+ * read until tag_update.js's `target.allowsNextAction = true` rebinds it.
+ */
+export function defineWritableAccessor(
+  obj: Record<string, unknown>,
+  key: string,
+  initial: unknown,
+): void {
+  let getter: () => unknown =
+    typeof initial === "function" ? (initial as () => unknown) : () => initial;
+  Object.defineProperty(obj, key, {
     configurable: true,
     enumerable: true,
-    get: () => () => current,
+    get: () => getter,
     set: (value: unknown) => {
-      current = typeof value === "function" ? String((value as () => unknown)()) : String(value);
+      getter = typeof value === "function" ? (value as () => unknown) : () => value;
     },
   });
+}
+
+/**
+ * Back-compat shim: slice 3 introduced a name-only accessor. Keep the same
+ * surface so the folder fixture's import doesn't churn while the generic
+ * helper above replaces it under the hood.
+ */
+export function defineWritableNameAccessor(obj: Record<string, unknown>, initial: string): void {
+  defineWritableAccessor(obj, "name", initial);
 }


### PR DESCRIPTION
## Summary

- Adds 10 sandbox tests across `tag_create`, `tag_update`, `tag_delete` plus the harness extensions to support them.
- Brings coverage from 21 of 60+ scripts (~35%) to 24 of 60+ (~40%) on the way to the 80% target tracked by [#723](https://github.com/torsday/omnifocus-mcp/issues/723).
- Generalizes the slice-3 writable-name accessor into `defineWritableAccessor` (initial value can be a getter function, preserving throwing-getter semantics until the script reassigns) — reusable across slices 5–7.

## Harness extensions

`src/adapter/jxa/sandbox/index.ts`:

- **`ofApp.Tag({ name })` constructor** — matches the slice-3 Folder pattern; `build_tag.js` can build a domain Tag from the result without any `fakeTag`-specific shape massaging.
- **`defaultDocument.tags`** is a callable + push-target; `tag_create.js`'s `doc.tags.push(newTag)` works for top-level tag additions.
- **`flattenedTags.byId(id)`** walks the tag tree (tags + their children recursively) so `tag_create` can re-fetch a freshly-pushed nested tag via `doc.flattenedTags.byId(tagId)` after the parent's `push()`.
- **`defineWritableAccessor`** (generalized) — initial value can be a static value OR a getter function. Passing a function preserves its behavior — including throwing — until the script reassigns the property. Required by tag_update tests that pass `allowsNextAction: throwing()` overrides.

`src/adapter/jxa/sandbox/fixtures.ts`:

- `fakeTag.name` / `.status` / `.allowsNextAction` are now writable accessors so `tag_update.js`'s `target.x = y` assignments persist through to subsequent `build_tag.js` reads.
- `fakeTag.tags` is a callable that doubles as a push-target so `parentTag.tags.push(child)` mutates the underlying array.

## Design link

Slice 4 of [#723](https://github.com/torsday/omnifocus-mcp/issues/723). Builds on slice 3 ([#741](https://github.com/torsday/omnifocus-mcp/issues/741) / PR #745). Independent of slices 5–7 — those reuse the same generalized accessor + constructor pattern this PR introduces.

Closes #746

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` all green locally (3322 passing, 56 skipped, 198 files).
- [x] Sandbox suite alone: 105 tests pass (95 prior + 10 new).
- [x] Self-reviewed via `/review-pr` — coverage focused on the script's documented contracts (constructor + push round-trip; property-setter persistence; on-hold status normalization; lookupOrThrow paths).

## Coverage detail

| Script | Tests added | Cases |
|---|---|---|
| `tag_create` | 4 | top-level happy path; nested via byId+push; empty-name validation; missing parent throws via `lookupOrThrow` |
| `tag_update` | 4 | rename happy path; on-hold status normalization (domain ↔ JXA); `allowsNextAction` toggle; missing id throws |
| `tag_delete` | 2 | happy path (echoes id); missing id throws |

## Conventions checklist

- [x] Conventional Commit
- [x] No new dependencies
- [x] No public surface change — sandbox harness API additions are additive