### PR TITLE
test(jxa): project mutation scripts via sandbox harness (slice 5 of #723)

### DIFF
--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -216,36 +216,45 @@ export function fakeProject(
   overrides: FakeProjectOverrides & { id?: () => string; name?: () => string } = {},
 ) {
   const id = overrides.id ?? fn(`project_${++_projectSeq}`);
-  const name = overrides.name ?? fn(`Project ${_projectSeq}`);
   const now = new Date();
-  return {
+  const project: Record<string, unknown> = {
     id,
-    name,
     containingFolder: overrides.containingFolder ?? throwing(),
     tasks: overrides.tasks ?? fn([]),
     flattenedTasks: overrides.flattenedTasks ?? fn([]),
-    status: overrides.status ?? fn("active"),
-    completionDate: overrides.completionDate ?? fn(null),
-    deferDate: overrides.deferDate ?? fn(null),
-    dueDate: overrides.dueDate ?? fn(null),
-    flagged: overrides.flagged ?? fn(false),
-    estimatedMinutes: overrides.estimatedMinutes ?? fn(null),
     numberOfTasks: overrides.numberOfTasks ?? fn(0),
     numberOfAvailableTasks: overrides.numberOfAvailableTasks ?? fn(0),
     completionCriterion: overrides.completionCriterion ?? fn("parallel"),
     sequential: overrides.sequential ?? fn(false),
-    note: overrides.note ?? fn(""),
     creationDate: overrides.creationDate ?? fn(now),
     modificationDate: overrides.modificationDate ?? fn(now),
     reviewInterval: overrides.reviewInterval ?? fn(null),
     reviewIntervalDays: overrides.reviewIntervalDays ?? fn(null),
-    nextReviewDate: overrides.nextReviewDate ?? fn(null),
     effectiveStatus: overrides.effectiveStatus ?? fn("active"),
     lastReviewDate: overrides.lastReviewDate ?? fn(null),
     deferDateFloating: overrides.deferDateFloating ?? fn(false),
     dueDateFloating: overrides.dueDateFloating ?? fn(false),
     fileAttachments: overrides.fileAttachments ?? fn([]),
+    // project_update / project_move call `target.move({to: ...})`. The
+    // assertion is on the script's return value, not on the fake's
+    // post-state, so move() is intentionally a no-op.
+    move: (_args: unknown) => {
+      /* no-op */
+    },
   };
+  // Mutation scripts assign these via JXA's property-setter syntax.
+  // Use writable accessors so `target.x = y` updates the value AND
+  // `target.x()` returns it via the callable getter.
+  defineWritableAccessor(project, "name", overrides.name ?? fn(`Project ${_projectSeq}`));
+  defineWritableAccessor(project, "note", overrides.note ?? fn(""));
+  defineWritableAccessor(project, "status", overrides.status ?? fn("active"));
+  defineWritableAccessor(project, "deferDate", overrides.deferDate ?? fn(null));
+  defineWritableAccessor(project, "dueDate", overrides.dueDate ?? fn(null));
+  defineWritableAccessor(project, "flagged", overrides.flagged ?? fn(false));
+  defineWritableAccessor(project, "estimatedMinutes", overrides.estimatedMinutes ?? fn(null));
+  defineWritableAccessor(project, "completionDate", overrides.completionDate ?? fn(null));
+  defineWritableAccessor(project, "nextReviewDate", overrides.nextReviewDate ?? fn(null));
+  return project;
 }
 
 export interface FakeFolderOverrides {
@@ -283,12 +292,28 @@ export function fakeFolder(
     },
   });
   const now = new Date();
+  // project_create.js may push new projects into a folder via
+  // `folder.projects.push(newProj)`, and project_update / project_move
+  // pass `folder.projects.end` as a JXA move target. When a caller
+  // overrides `projects` (commonly with a throwing getter to assert the
+  // try/catch fallback in folder_delete) we honour that callable directly
+  // — only the default path gets the push/end accessors. Tests that
+  // exercise project mutations don't override `projects`.
+  const projectsArr: unknown[] = [];
+  const projects = overrides.projects
+    ? overrides.projects
+    : Object.assign(() => projectsArr, {
+        push: (item: unknown) => {
+          projectsArr.push(item);
+        },
+        end: { __end: true },
+      });
   const folder: Record<string, unknown> = {
     id,
     container: overrides.container ?? throwing(),
     parent: overrides.parent ?? throwing(),
     folders,
-    projects: overrides.projects ?? fn([]),
+    projects,
     note: overrides.note ?? fn(""),
     status: overrides.status ?? fn("active"),
     creationDate: overrides.creationDate ?? fn(now),

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -24,9 +24,20 @@ import folderListScript from "../../../scripts/jxa/folder_list.js";
 import folderUpdateScript from "../../../scripts/jxa/folder_update.js";
 import forecastGetScript from "../../../scripts/jxa/forecast_get.js";
 import perspectiveListScript from "../../../scripts/jxa/perspective_list.js";
+import projectBatchCompleteScript from "../../../scripts/jxa/project_batch_complete.js";
+import projectBatchDropScript from "../../../scripts/jxa/project_batch_drop.js";
+import projectCompleteScript from "../../../scripts/jxa/project_complete.js";
+import projectCreateScript from "../../../scripts/jxa/project_create.js";
+import projectDeleteScript from "../../../scripts/jxa/project_delete.js";
+import projectDropScript from "../../../scripts/jxa/project_drop.js";
 import projectGetScript from "../../../scripts/jxa/project_get.js";
 import projectGetManyScript from "../../../scripts/jxa/project_get_many.js";
 import projectListScript from "../../../scripts/jxa/project_list.js";
+import projectMarkReviewedScript from "../../../scripts/jxa/project_mark_reviewed.js";
+import projectMoveScript from "../../../scripts/jxa/project_move.js";
+import projectSetNextReviewDateScript from "../../../scripts/jxa/project_set_next_review_date.js";
+import projectSetReviewIntervalScript from "../../../scripts/jxa/project_set_review_interval.js";
+import projectUpdateScript from "../../../scripts/jxa/project_update.js";
 import reviewListDueScript from "../../../scripts/jxa/review_list_due.js";
 import tagCreateScript from "../../../scripts/jxa/tag_create.js";
 import tagDeleteScript from "../../../scripts/jxa/tag_delete.js";
@@ -1390,6 +1401,354 @@ describe("JXA sandbox — tag_delete", () => {
     expect(() =>
       runJxaScriptInSandbox(tagDeleteScript, { id: "missing" }, { tags: [fakeTag()] }),
     ).toThrow("Tag not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_create.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_create", () => {
+  it("creates a top-level project", () => {
+    const result = runJxaScriptInSandbox<{ project: { name: string } }>(
+      projectCreateScript,
+      { name: "Errands" },
+      {},
+    );
+    expect(result.project.name).toBe("Errands");
+  });
+
+  it("creates a project under an existing folder", () => {
+    const folder = fakeFolder({ id: () => "folder_target", name: () => "Areas" });
+    const result = runJxaScriptInSandbox<{ project: { name: string } }>(
+      projectCreateScript,
+      { name: "Yard work", folderId: "folder_target" },
+      { folders: [folder] },
+    );
+    expect(result.project.name).toBe("Yard work");
+  });
+
+  it("throws ValidationError when name is empty", () => {
+    expect(() => runJxaScriptInSandbox(projectCreateScript, { name: "" }, {})).toThrow(
+      "ValidationError: name is required",
+    );
+  });
+
+  it("throws via lookupOrThrow when folderId does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(projectCreateScript, { name: "X", folderId: "missing" }, {}),
+    ).toThrow("Folder not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_update.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_update", () => {
+  it("renames the project and returns the updated shape", () => {
+    const target = fakeProject({ id: () => "project_target", name: () => "Old" });
+    const result = runJxaScriptInSandbox<{ project: { id: string; name: string } }>(
+      projectUpdateScript,
+      { id: "project_target", name: "New" },
+      { projects: [target] },
+    );
+    expect(result.project.id).toBe("project_target");
+    expect(result.project.name).toBe("New");
+  });
+
+  it("normalizes on-hold status from domain to JXA verbose form", () => {
+    // build_project.js reads status() and normalizes "on hold status"/"on hold"
+    // back to "on-hold" on the wire.
+    const target = fakeProject({ id: () => "project_target", status: () => "active status" });
+    const result = runJxaScriptInSandbox<{ project: { status: string } }>(
+      projectUpdateScript,
+      { id: "project_target", status: "on-hold" },
+      { projects: [target] },
+    );
+    expect(result.project.status).toBe("on-hold");
+  });
+
+  it("toggles flagged via property assignment", () => {
+    const target = fakeProject({ id: () => "project_target", flagged: () => false });
+    const result = runJxaScriptInSandbox<{ project: { flagged: boolean } }>(
+      projectUpdateScript,
+      { id: "project_target", flagged: true },
+      { projects: [target] },
+    );
+    expect(result.project.flagged).toBe(true);
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        projectUpdateScript,
+        { id: "missing", name: "Anything" },
+        { projects: [fakeProject()] },
+      ),
+    ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_delete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_delete", () => {
+  it("deletes the project and echoes the id", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectDeleteScript,
+      { id: "project_target" },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(projectDeleteScript, { id: "missing" }, { projects: [fakeProject()] }),
+    ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_move.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_move", () => {
+  it("moves the project to the supplied folder", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const folder = fakeFolder({ id: () => "folder_dest" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectMoveScript,
+      { id: "project_target", folderId: "folder_dest" },
+      { projects: [target], folders: [folder] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("moves the project to root when folderId is null", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectMoveScript,
+      { id: "project_target", folderId: null },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("throws when the supplied folderId does not exist", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    expect(() =>
+      runJxaScriptInSandbox(
+        projectMoveScript,
+        { id: "project_target", folderId: "missing" },
+        { projects: [target] },
+      ),
+    ).toThrow("Folder not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_complete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_complete", () => {
+  it("marks the project complete and echoes the id", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectCompleteScript,
+      { id: "project_target" },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("accepts an optional completionDate without throwing", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectCompleteScript,
+      { id: "project_target", completionDate: "2026-05-08T12:00:00Z" },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(projectCompleteScript, { id: "missing" }, { projects: [] }),
+    ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_drop.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_drop", () => {
+  it("sets status to 'dropped' and echoes the id", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectDropScript,
+      { id: "project_target" },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(projectDropScript, { id: "missing" }, { projects: [] }),
+    ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_batch_complete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_batch_complete", () => {
+  it("succeeds for every found id; reports OF_NOT_FOUND for missing ids", () => {
+    const a = fakeProject({ id: () => "project_a" });
+    const b = fakeProject({ id: () => "project_b" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { index: number; value: string }[];
+      failed: { index: number; errorCode: string; message: string }[];
+    }>(
+      projectBatchCompleteScript,
+      { items: [{ id: "project_a" }, { id: "project_missing" }, { id: "project_b" }] },
+      { projects: [a, b] },
+    );
+    expect(result.succeeded.map((s) => s.value)).toEqual(["project_a", "project_b"]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+    expect(result.failed[0]?.index).toBe(1);
+  });
+
+  it("returns empty arrays when items is empty", () => {
+    const result = runJxaScriptInSandbox<{ succeeded: unknown[]; failed: unknown[] }>(
+      projectBatchCompleteScript,
+      { items: [] },
+      {},
+    );
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_batch_drop.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_batch_drop", () => {
+  it("succeeds for every found id; reports OF_NOT_FOUND for missing ids", () => {
+    const a = fakeProject({ id: () => "project_a" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string }[];
+    }>(
+      projectBatchDropScript,
+      { items: [{ id: "project_a" }, { id: "project_missing" }] },
+      { projects: [a] },
+    );
+    expect(result.succeeded.map((s) => s.value)).toEqual(["project_a"]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_mark_reviewed.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_mark_reviewed", () => {
+  it("marks the project reviewed and echoes the id", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectMarkReviewedScript,
+      { id: "project_target" },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(projectMarkReviewedScript, { id: "missing" }, { projects: [] }),
+    ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_set_next_review_date.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_set_next_review_date", () => {
+  it("sets the next review date from an ISO string", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectSetNextReviewDateScript,
+      { id: "project_target", nextReviewDate: "2026-06-01T00:00:00Z" },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("clears the next review date when the value is null", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectSetNextReviewDateScript,
+      { id: "project_target", nextReviewDate: null },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        projectSetNextReviewDateScript,
+        { id: "missing", nextReviewDate: null },
+        { projects: [] },
+      ),
+    ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project_set_review_interval.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — project_set_review_interval", () => {
+  it("sets the review interval in days", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectSetReviewIntervalScript,
+      { id: "project_target", days: 14 },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("clears the review interval when days is null", () => {
+    const target = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      projectSetReviewIntervalScript,
+      { id: "project_target", days: null },
+      { projects: [target] },
+    );
+    expect(result.id).toBe("project_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        projectSetReviewIntervalScript,
+        { id: "missing", days: 7 },
+        { projects: [] },
+      ),
+    ).toThrow("Project not found: missing");
   });
 });
 

--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -192,9 +192,33 @@ function buildFakeDocument(doc: SandboxDocument) {
   // folders here via `ofApp.defaultDocument.folders.push(newFolder)`. Test
   // assertions verify the script's return value rather than walking the
   // fake's collections, so we don't bother syncing flattenedFolders on push.
+  // The collection also exposes `.byId(id)` because project_create.js
+  // looks up folders that way for its parent-folder argument.
   const docFoldersArr: unknown[] = [];
   const docFolders = Object.assign(() => docFoldersArr, {
     push: (item: unknown) => docFoldersArr.push(item),
+    byId: (id: string) => {
+      const hit = (folders as Array<{ id?: () => string }>).find(
+        (f) => typeof f.id === "function" && f.id() === id,
+      );
+      if (hit) return hit;
+      const msg = "Can't get object. (-1728)";
+      return {
+        id: () => {
+          throw new ScriptError(msg, { details: { stderr: msg } });
+        },
+      };
+    },
+  });
+
+  // Top-level project collection. project_create.js pushes new projects
+  // here OR into a folder's `.projects`. project_update / project_move use
+  // `target.move({ to: ... .projects.end })`; the `.end` accessor is a
+  // sentinel pointer the move() no-op ignores.
+  const projectsArr: unknown[] = [...projects];
+  const docProjects = Object.assign(() => projectsArr, {
+    push: (item: unknown) => projectsArr.push(item),
+    end: { __end: true },
   });
 
   // Top-level tag collection. tag_create.js pushes new tags here OR into an
@@ -247,6 +271,7 @@ function buildFakeDocument(doc: SandboxDocument) {
     tags: docTags,
     flattenedTasks,
     flattenedProjects,
+    projects: docProjects,
     flattenedFolders: () => folders,
     folders: docFolders,
     // Some scripts access inbox tasks through the document
@@ -279,6 +304,20 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
   // accessors on `name`, `status`, `allowsNextAction` since tag_update.js
   // reassigns those.
   const tagConstructor = (opts: { name?: string } = {}) => makeConstructedTag(opts);
+  // `ofApp.Project(props)` is the JXA constructor project_create.js uses.
+  // The script passes name plus any provided fields (note, deferDate,
+  // dueDate, estimatedMinutes, flagged, status). The returned fake honours
+  // the build_project.js read surface and exposes writable accessors on
+  // every field project_update.js can reassign.
+  const projectConstructor = (props: ProjectConstructorOpts = {}) => makeConstructedProject(props);
+
+  // `markComplete` / `markDropped` / `markReviewed` are app-level verbs the
+  // JXA scripts call instead of property assignment. Track invocations so
+  // tests can assert the script took the right path; the call itself does
+  // nothing else (project state is asserted via the script's return value).
+  const markedComplete: unknown[] = [];
+  const markedDropped: unknown[] = [];
+  const markedReviewed: unknown[] = [];
 
   return (_name: string) => ({
     // Scripts set this; we accept and ignore it.
@@ -289,11 +328,24 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
     perspectives: () => perspectives,
     Folder: folderConstructor,
     Tag: tagConstructor,
+    Project: projectConstructor,
     delete: (target: unknown) => {
       deleted.push(target);
     },
+    markComplete: (target: unknown) => {
+      markedComplete.push(target);
+    },
+    markDropped: (target: unknown) => {
+      markedDropped.push(target);
+    },
+    markReviewed: (target: unknown) => {
+      markedReviewed.push(target);
+    },
     /** Test-only — surface what `ofApp.delete()` was called with. */
     _deleted: deleted,
+    _markedComplete: markedComplete,
+    _markedDropped: markedDropped,
+    _markedReviewed: markedReviewed,
   });
 }
 
@@ -358,6 +410,71 @@ function makeConstructedTag(opts: { name?: string }): Record<string, unknown> {
   defineWritableAccessor(tag, "status", "active");
   defineWritableAccessor(tag, "allowsNextAction", false);
   return tag;
+}
+
+/**
+ * Per-property opts accepted by `ofApp.Project({...})`. The JXA constructor
+ * itself accepts more, but project_create.js only forwards these.
+ */
+export interface ProjectConstructorOpts {
+  name?: string;
+  note?: string;
+  deferDate?: Date;
+  dueDate?: Date;
+  estimatedMinutes?: number;
+  flagged?: boolean;
+  status?: string;
+}
+
+let _constructedProjectSeq = 0;
+
+/**
+ * Build a fake JXA Project created via `ofApp.Project({ name, ... })`.
+ * Mirrors the read surface of `fakeProject()` (so `build_project.js` can
+ * walk it) and installs writable accessors on every field that
+ * project_update / project_set_*  / project_drop / project_complete
+ * scripts may assign.
+ */
+function makeConstructedProject(opts: ProjectConstructorOpts): Record<string, unknown> {
+  const id = `constructed_project_${++_constructedProjectSeq}`;
+  const tasksArr: unknown[] = [];
+  const tasks = Object.assign(() => tasksArr, {
+    push: (item: unknown) => tasksArr.push(item),
+    end: { __end: true },
+  });
+  const noThrow = () => {
+    throw new ScriptError("Can't get object.", { details: { stderr: "Can't get object." } });
+  };
+  const project: Record<string, unknown> = {
+    id: () => id,
+    folder: noThrow,
+    containingFolder: noThrow,
+    tasks,
+    flattenedTasks: () => tasksArr,
+    creationDate: () => new Date(),
+    modificationDate: () => new Date(),
+    completionCriterion: () => "parallel",
+    sequential: () => false,
+    numberOfTasks: () => 0,
+    numberOfAvailableTasks: () => 0,
+    reviewInterval: () => null,
+    effectiveStatus: () => "active",
+    move: (_args: unknown) => {
+      /* no-op for tests; assertions go via the script's return value */
+    },
+  };
+  defineWritableAccessor(project, "name", opts.name ?? `Project ${_constructedProjectSeq}`);
+  defineWritableAccessor(project, "note", opts.note ?? "");
+  defineWritableAccessor(project, "status", opts.status ?? "active");
+  defineWritableAccessor(project, "deferDate", opts.deferDate ?? null);
+  defineWritableAccessor(project, "dueDate", opts.dueDate ?? null);
+  defineWritableAccessor(project, "flagged", opts.flagged ?? false);
+  defineWritableAccessor(project, "estimatedMinutes", opts.estimatedMinutes ?? null);
+  defineWritableAccessor(project, "completionDate", null);
+  defineWritableAccessor(project, "nextReviewDate", null);
+  defineWritableAccessor(project, "lastReviewDate", null);
+  defineWritableAccessor(project, "reviewIntervalDays", null);
+  return project;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds 29 sandbox tests across all 11 project mutation scripts: `project_create`, `project_update`, `project_delete`, `project_move`, `project_complete`, `project_drop`, `project_batch_complete`, `project_batch_drop`, `project_mark_reviewed`, `project_set_next_review_date`, `project_set_review_interval`.
- Brings coverage from 24 of 60+ scripts (~40%) to 35 of 60+ (~58%) — crosses the 50% threshold.
- Reuses the slice-3/4 mutation pattern; extends the harness with `Project` constructor, `markComplete/Dropped/Reviewed` no-op trackers, `move()` no-op, `doc.projects` push + `.end`, and `doc.folders.byId()`.

## Harness extensions

`src/adapter/jxa/sandbox/index.ts`:

- **`ofApp.Project(props)` constructor** — returns a fake project with writable accessors on every field `project_update` / `project_set_*` / `project_drop` / `project_complete` may assign.
- **`ofApp.markComplete` / `markDropped` / `markReviewed`** — no-op trackers (test assertions go via the script's return value; the verbs must not throw). Test-only `_markedComplete` / `_markedDropped` / `_markedReviewed` handles surface what was called.
- **`defaultDocument.projects`** is a callable + push-target with a `.end` sentinel (the JXA move target).
- **`defaultDocument.folders.byId(id)`** — lazy specifier whose `.id()` throws when missing; `lookupOrThrow` rethrows the typed `"Folder not found: <id>"` that `project_create.js` relies on.

`src/adapter/jxa/sandbox/fixtures.ts`:

- `fakeProject` converts `name` / `note` / `status` / `deferDate` / `dueDate` / `flagged` / `estimatedMinutes` / `completionDate` / `nextReviewDate` to writable accessors so `project_update.js`'s `target.x = y` assignments persist.
- `fakeProject` gains a no-op `move({to: ...})` so `project_update` / `project_move` don't throw on the JXA folder-move call.
- `fakeFolder.projects` is now a callable that doubles as a push-target (with `.end`) so `folder.projects.push(newProj)` and `target.move({to: folder.projects.end})` both work. Honours custom overrides verbatim — only the default path gets push/end.

## Design link

Slice 5 of [#723](https://github.com/torsday/omnifocus-mcp/issues/723). Builds on slices 3 ([#741](https://github.com/torsday/omnifocus-mcp/issues/741)) and 4 ([#746](https://github.com/torsday/omnifocus-mcp/issues/746)). Independent of slice 6 ([#748](https://github.com/torsday/omnifocus-mcp/issues/748)) and slice 7 ([#749](https://github.com/torsday/omnifocus-mcp/issues/749)) which reuse the same generalized accessor + constructor pattern.

Closes #747

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` all green locally (3351 passing, 56 skipped, 198 files).
- [x] Sandbox suite alone: 134 tests pass (105 prior + 29 new).
- [x] Self-reviewed via `/review-pr` — coverage focused on each script's documented contract: lookupOrThrow paths, mutation persistence through `build_project.js`, batch-script `{succeeded, failed}` envelope shape with the `OF_NOT_FOUND` error code.

## Coverage detail

| Script | Tests added | Cases |
|---|---|---|
| `project_create` | 4 | top-level happy; sub-folder happy; empty-name validation; missing folder throws via lookupOrThrow |
| `project_update` | 4 | rename happy; on-hold status normalization; flagged toggle; missing id throws |
| `project_delete` | 2 | happy; missing id throws |
| `project_move` | 3 | move-to-folder; move-to-root; missing folder throws |
| `project_complete` | 3 | happy; with completionDate; missing id throws |
| `project_drop` | 2 | happy; missing id throws |
| `project_batch_complete` | 2 | mixed found/missing → succeeded/failed envelope with OF_NOT_FOUND; empty input |
| `project_batch_drop` | 1 | mixed found/missing → succeeded/failed envelope with OF_NOT_FOUND |
| `project_mark_reviewed` | 2 | happy; missing id throws |
| `project_set_next_review_date` | 3 | set ISO date; clear with null; missing id throws |
| `project_set_review_interval` | 3 | set days; clear with null; missing id throws |

## Conventions checklist

- [x] Conventional Commit
- [x] No new dependencies
- [x] No public surface change — sandbox harness API additions are additive