### PR TITLE
test(jxa): single-task mutation scripts via sandbox harness (slice 6 of #723)

### DIFF
--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -143,37 +143,67 @@ export function fakeTask(
   overrides: FakeTaskOverrides & { id?: () => string; name?: () => string } = {},
 ) {
   const id = overrides.id ?? fn(`task_${++_taskSeq}`);
-  const name = overrides.name ?? fn(`Task ${_taskSeq}`);
   const now = new Date();
-  return {
+  // Children/subtasks: pushable callable so task_create.js's
+  // `parent.tasks.push(newTask)` works. Honour custom `tags()` overrides
+  // verbatim (slice 1 / 2 tests pass a static array there).
+  const childrenArr: unknown[] = [];
+  const childTasks = Object.assign(() => childrenArr, {
+    push: (item: unknown) => childrenArr.push(item),
+  });
+  const task: Record<string, unknown> = {
     id,
-    name,
     containingProject: overrides.containingProject ?? throwing(),
     parentTask: overrides.parentTask ?? throwing(),
     tags: overrides.tags ?? fn([]),
-    deferDate: overrides.deferDate ?? fn(null),
-    dueDate: overrides.dueDate ?? fn(null),
-    completionDate: overrides.completionDate ?? fn(null),
-    dropped: overrides.dropped ?? fn(false),
-    completed: overrides.completed ?? fn(false),
-    flagged: overrides.flagged ?? fn(false),
-    effectivelyDropped: overrides.effectivelyDropped ?? fn(false),
-    blocked: overrides.blocked ?? fn(false),
-    numberOfTasks: overrides.numberOfTasks ?? fn(0),
-    estimatedMinutes: overrides.estimatedMinutes ?? fn(null),
+    tasks: childTasks,
     repetitionRule: overrides.repetitionRule ?? fn(null),
-    note: overrides.note ?? fn(""),
     creationDate: overrides.creationDate ?? fn(now),
     modificationDate: overrides.modificationDate ?? fn(now),
     inInbox: overrides.inInbox ?? fn(false),
-    sequential: overrides.sequential ?? fn(false),
     completedByChildren: overrides.completedByChildren ?? fn(false),
     availabilityStatus: overrides.availabilityStatus ?? fn("available"),
     deferDateFloating: overrides.deferDateFloating ?? fn(false),
     dueDateFloating: overrides.dueDateFloating ?? fn(false),
     effectivelyAvailable: overrides.effectivelyAvailable ?? fn(true),
     fileAttachments: overrides.fileAttachments ?? fn([]),
+    blocked: overrides.blocked ?? fn(false),
+    effectivelyDropped: overrides.effectivelyDropped ?? fn(false),
+    numberOfTasks: overrides.numberOfTasks ?? fn(0),
+    // task_delete.js calls `found.delete()` (instance method, not
+    // ofApp.delete). task_duplicate copies tags via `to.addTag(tag)`.
+    // task_move / task_reorder call `found.move({ to, positioned })`. All
+    // are no-ops; assertions go via the script's return value.
+    delete: () => {
+      /* no-op for tests */
+    },
+    addTag: (_tag: unknown) => {
+      /* no-op for tests */
+    },
+    move: (_args: unknown) => {
+      /* no-op for tests */
+    },
+    // task_duplicate calls `cloneTask.make({new: "task", withProperties})`
+    // when recursing into subtasks. Returning a fresh fake-task is enough
+    // for the script to keep walking; tests assert the script's return
+    // shape, not the produced subtree.
+    make: (_args: unknown) => fakeTask({}),
   };
+  // Mutation scripts (task_update / task_complete / task_drop) assign these
+  // via JXA's property-setter syntax. Use writable accessors so the read
+  // path through build_task.js sees the latest values.
+  defineWritableAccessor(task, "name", overrides.name ?? fn(`Task ${_taskSeq}`));
+  defineWritableAccessor(task, "note", overrides.note ?? fn(""));
+  defineWritableAccessor(task, "flagged", overrides.flagged ?? fn(false));
+  defineWritableAccessor(task, "deferDate", overrides.deferDate ?? fn(null));
+  defineWritableAccessor(task, "dueDate", overrides.dueDate ?? fn(null));
+  defineWritableAccessor(task, "completionDate", overrides.completionDate ?? fn(null));
+  defineWritableAccessor(task, "dropped", overrides.dropped ?? fn(false));
+  defineWritableAccessor(task, "completed", overrides.completed ?? fn(false));
+  defineWritableAccessor(task, "estimatedMinutes", overrides.estimatedMinutes ?? fn(null));
+  defineWritableAccessor(task, "sequential", overrides.sequential ?? fn(false));
+  defineWritableAccessor(task, "containsSingletonActions", false);
+  return task;
 }
 
 export interface FakeProjectOverrides {
@@ -217,10 +247,20 @@ export function fakeProject(
 ) {
   const id = overrides.id ?? fn(`project_${++_projectSeq}`);
   const now = new Date();
+  // task_create.js pushes new tasks onto `proj.tasks`; task_duplicate.js
+  // calls `proj.make({ new: "task", withProperties })`. Honour custom
+  // overrides verbatim — only the default path gets push/make.
+  const tasksArr: unknown[] = [];
+  const tasks = overrides.tasks
+    ? overrides.tasks
+    : Object.assign(() => tasksArr, {
+        push: (item: unknown) => tasksArr.push(item),
+        end: { __end: true },
+      });
   const project: Record<string, unknown> = {
     id,
     containingFolder: overrides.containingFolder ?? throwing(),
-    tasks: overrides.tasks ?? fn([]),
+    tasks,
     flattenedTasks: overrides.flattenedTasks ?? fn([]),
     numberOfTasks: overrides.numberOfTasks ?? fn(0),
     numberOfAvailableTasks: overrides.numberOfAvailableTasks ?? fn(0),
@@ -241,6 +281,10 @@ export function fakeProject(
     move: (_args: unknown) => {
       /* no-op */
     },
+    // task_duplicate.js calls `proj.make({ new: "task", withProperties })`
+    // when the destination container is a project. Returns a fresh fake
+    // task — the script just needs `.id()` callable for the return shape.
+    make: (_args: unknown) => fakeTask({}),
   };
   // Mutation scripts assign these via JXA's property-setter syntax.
   // Use writable accessors so `target.x = y` updates the value AND

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -45,10 +45,20 @@ import tagGetScript from "../../../scripts/jxa/tag_get.js";
 import tagGetManyScript from "../../../scripts/jxa/tag_get_many.js";
 import tagListScript from "../../../scripts/jxa/tag_list.js";
 import tagUpdateScript from "../../../scripts/jxa/tag_update.js";
+import taskCompleteScript from "../../../scripts/jxa/task_complete.js";
+import taskCreateScript from "../../../scripts/jxa/task_create.js";
+import taskDeleteScript from "../../../scripts/jxa/task_delete.js";
+import taskDropScript from "../../../scripts/jxa/task_drop.js";
+import taskDuplicateScript from "../../../scripts/jxa/task_duplicate.js";
 import taskGetScript from "../../../scripts/jxa/task_get.js";
 import taskGetManyScript from "../../../scripts/jxa/task_get_many.js";
 import taskListScript from "../../../scripts/jxa/task_list.js";
+import taskMoveScript from "../../../scripts/jxa/task_move.js";
+import taskReorderScript from "../../../scripts/jxa/task_reorder.js";
 import taskSearchScript from "../../../scripts/jxa/task_search.js";
+import taskUncompleteScript from "../../../scripts/jxa/task_uncomplete.js";
+import taskUndropScript from "../../../scripts/jxa/task_undrop.js";
+import taskUpdateScript from "../../../scripts/jxa/task_update.js";
 import windowGetStateScript from "../../../scripts/jxa/window_get_state.js";
 import {
   fakeAttachment,
@@ -1749,6 +1759,375 @@ describe("JXA sandbox — project_set_review_interval", () => {
         { projects: [] },
       ),
     ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_create.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_create", () => {
+  it("creates an inbox task when no project/parent supplied", () => {
+    const result = runJxaScriptInSandbox<{ task: { name: string } }>(
+      taskCreateScript,
+      { name: "Buy milk" },
+      {},
+    );
+    expect(result.task.name).toBe("Buy milk");
+  });
+
+  it("creates a task under a project", () => {
+    const project = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ task: { id: string } }>(
+      taskCreateScript,
+      { name: "Subtask", projectId: "project_target" },
+      { projects: [project] },
+    );
+    expect(result.task.id).toBeDefined();
+  });
+
+  it("creates a task under a parent task", () => {
+    const parent = fakeTask({ id: () => "task_parent" });
+    const result = runJxaScriptInSandbox<{ task: { id: string } }>(
+      taskCreateScript,
+      { name: "Child", parentId: "task_parent" },
+      { tasks: [parent] },
+    );
+    expect(result.task.id).toBeDefined();
+  });
+
+  it("throws ValidationError when name is empty", () => {
+    expect(() => runJxaScriptInSandbox(taskCreateScript, { name: "" }, {})).toThrow(
+      "ValidationError: name is required",
+    );
+  });
+
+  it("throws ValidationError when projectId and parentId are both supplied", () => {
+    expect(() =>
+      runJxaScriptInSandbox(taskCreateScript, { name: "X", projectId: "p", parentId: "t" }, {}),
+    ).toThrow("mutually exclusive");
+  });
+
+  it("throws via lookupOrThrow when projectId does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(taskCreateScript, { name: "X", projectId: "missing" }, {}),
+    ).toThrow("Project not found: missing");
+  });
+
+  it("throws via lookupOrThrow when parentId does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(taskCreateScript, { name: "X", parentId: "missing" }, {}),
+    ).toThrow("Parent task not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_update.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_update", () => {
+  it("renames the task and returns the updated shape", () => {
+    const target = fakeTask({ id: () => "task_target", name: () => "Old" });
+    const result = runJxaScriptInSandbox<{ task: { id: string; name: string } }>(
+      taskUpdateScript,
+      { id: "task_target", name: "New" },
+      { tasks: [target] },
+    );
+    expect(result.task.id).toBe("task_target");
+    expect(result.task.name).toBe("New");
+  });
+
+  it("toggles flagged via property assignment", () => {
+    const target = fakeTask({ id: () => "task_target", flagged: () => false });
+    const result = runJxaScriptInSandbox<{ task: { flagged: boolean } }>(
+      taskUpdateScript,
+      { id: "task_target", flagged: true },
+      { tasks: [target] },
+    );
+    expect(result.task.flagged).toBe(true);
+  });
+
+  it("delegates tagIds replacement to OmniJS via evaluateJavascript", () => {
+    // The actual OmniJS execution is mocked as a no-op; the test asserts
+    // the script does not throw and returns a valid envelope.
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ task: { id: string } }>(
+      taskUpdateScript,
+      { id: "task_target", tagIds: ["tag_a", "tag_b"] },
+      { tasks: [target] },
+    );
+    expect(result.task.id).toBe("task_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        taskUpdateScript,
+        { id: "missing", name: "Anything" },
+        { tasks: [fakeTask()] },
+      ),
+    ).toThrow("Task not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_delete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_delete", () => {
+  it("deletes the task and echoes the id", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskDeleteScript,
+      { id: "task_target" },
+      { tasks: [target] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(taskDeleteScript, { id: "missing" }, { tasks: [fakeTask()] }),
+    ).toThrow("Task not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_complete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_complete", () => {
+  it("marks the task complete and echoes the id", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskCompleteScript,
+      { id: "task_target" },
+      { tasks: [target] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("accepts an optional completionDate without throwing", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskCompleteScript,
+      { id: "task_target", completionDate: "2026-05-08T12:00:00Z" },
+      { tasks: [target] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(taskCompleteScript, { id: "missing" }, { tasks: [] }),
+    ).toThrow("Task not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_uncomplete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_uncomplete", () => {
+  it("calls markIncomplete and echoes the id", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskUncompleteScript,
+      { id: "task_target" },
+      { tasks: [target] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("throws when the id does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(taskUncompleteScript, { id: "missing" }, { tasks: [] }),
+    ).toThrow("Task not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_drop.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_drop", () => {
+  it("calls markDropped and echoes the id", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskDropScript,
+      { id: "task_target" },
+      { tasks: [target] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("throws via lookupOrThrow when the id does not exist", () => {
+    expect(() => runJxaScriptInSandbox(taskDropScript, { id: "missing" }, { tasks: [] })).toThrow(
+      "Task not found: missing",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_undrop.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_undrop", () => {
+  it("calls markIncomplete and echoes the id", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskUndropScript,
+      { id: "task_target" },
+      { tasks: [target] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("throws via lookupOrThrow when the id does not exist", () => {
+    expect(() => runJxaScriptInSandbox(taskUndropScript, { id: "missing" }, { tasks: [] })).toThrow(
+      "Task not found: missing",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_move.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_move", () => {
+  it("moves the task to a different parent task", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const newParent = fakeTask({ id: () => "task_new_parent" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskMoveScript,
+      { id: "task_target", parentId: "task_new_parent" },
+      { tasks: [target, newParent] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("moves the task to a project", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const project = fakeProject({ id: () => "project_dest" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskMoveScript,
+      { id: "task_target", projectId: "project_dest" },
+      { tasks: [target], projects: [project] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("moves the task to the inbox when no destination supplied", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskMoveScript,
+      { id: "task_target" },
+      { tasks: [target] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("throws when the supplied projectId does not exist", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    expect(() =>
+      runJxaScriptInSandbox(
+        taskMoveScript,
+        { id: "task_target", projectId: "missing" },
+        { tasks: [target] },
+      ),
+    ).toThrow("Project not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_duplicate.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_duplicate", () => {
+  it("duplicates a task into the inbox by default", () => {
+    const source = fakeTask({ id: () => "task_source", name: () => "Original" });
+    const result = runJxaScriptInSandbox<{ newId: string; descendantCount: number }>(
+      taskDuplicateScript,
+      { id: "task_source", recursive: false, destination: { toInbox: true } },
+      { tasks: [source] },
+    );
+    expect(result.newId).toBeDefined();
+    expect(result.descendantCount).toBe(0);
+  });
+
+  it("duplicates into a target project when destination.projectId is supplied", () => {
+    const source = fakeTask({ id: () => "task_source" });
+    const project = fakeProject({ id: () => "project_dest" });
+    const result = runJxaScriptInSandbox<{ newId: string }>(
+      taskDuplicateScript,
+      {
+        id: "task_source",
+        recursive: false,
+        destination: { projectId: "project_dest" },
+      },
+      { tasks: [source], projects: [project] },
+    );
+    expect(result.newId).toBeDefined();
+  });
+
+  it("throws via lookupOrThrow when the source task does not exist", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        taskDuplicateScript,
+        { id: "missing", recursive: false },
+        { tasks: [] },
+      ),
+    ).toThrow("Task not found: missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_reorder.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_reorder", () => {
+  it("reorders before a reference task", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const b = fakeTask({ id: () => "task_b" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskReorderScript,
+      { id: "task_a", mode: "before", refId: "task_b" },
+      { tasks: [a, b] },
+    );
+    expect(result.id).toBe("task_a");
+  });
+
+  it("reorders to the start of a project's task list", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const project = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      taskReorderScript,
+      { id: "task_target", mode: "start", container: { projectId: "project_target" } },
+      { tasks: [target], projects: [project] },
+    );
+    expect(result.id).toBe("task_target");
+  });
+
+  it("throws when refId is missing for before/after modes", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    expect(() =>
+      runJxaScriptInSandbox(
+        taskReorderScript,
+        { id: "task_target", mode: "before" },
+        { tasks: [target] },
+      ),
+    ).toThrow("refId required");
+  });
+
+  it("throws on unknown mode", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    expect(() =>
+      runJxaScriptInSandbox(
+        taskReorderScript,
+        { id: "task_target", mode: "sideways" },
+        { tasks: [target] },
+      ),
+    ).toThrow("unknown mode");
   });
 });
 

--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -155,14 +155,70 @@ function buildFakeDocument(doc: SandboxDocument) {
   const folders = doc.folders ?? [];
   const inboxTasks = doc.inboxTasks ?? [];
 
-  // `flattenedTasks` is invoked both as `flattenedTasks()` (returns the
-  // array) and as `flattenedTasks.whose(predicate)()` (returns a callable
-  // wrapping the filtered subset). Functions are objects in JS, so we attach
-  // `whose` directly to the function value.
+  // `flattenedTasks` is invoked three ways: `flattenedTasks()` (returns the
+  // array), `flattenedTasks.whose(predicate)()` (returns a callable wrapping
+  // the filtered subset), and `flattenedTasks.byId(id)` (returns a lazy
+  // specifier whose `.id()` throws when missing — lookupOrThrow relies on
+  // that contract for `task_create` / `task_drop` / `task_undrop` /
+  // `task_duplicate` / `task_reorder` / `task_move`). Functions are objects
+  // in JS, so we attach all three to the function value.
+  //
+  // byId walks the full task tree — top-level tasks plus every reachable
+  // subtask via `.tasks()`, plus every project's `.tasks()` — so a task
+  // pushed onto `parent.tasks` or `proj.tasks` after construction is
+  // findable via `doc.flattenedTasks.byId(id)`. That mirrors how OF
+  // flattens and matches the contract task_create.js relies on for its
+  // post-push re-fetch.
+  type SubtaskNode = { id?: () => string; tasks?: () => unknown[] };
+  function walkSubtasks(roots: unknown[]): unknown[] {
+    const out: unknown[] = [];
+    const stack = [...roots];
+    while (stack.length) {
+      const t = stack.pop() as SubtaskNode;
+      if (!t) continue;
+      out.push(t);
+      if (typeof t.tasks === "function") {
+        try {
+          const children = t.tasks();
+          if (Array.isArray(children)) stack.push(...children);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    return out;
+  }
+  const projectsRef: unknown[] = projects;
+  function allTasks(): unknown[] {
+    const fromProjects: unknown[] = [];
+    for (const p of projectsRef as Array<{ tasks?: () => unknown[] }>) {
+      if (typeof p.tasks === "function") {
+        try {
+          const ts = p.tasks();
+          if (Array.isArray(ts)) fromProjects.push(...walkSubtasks(ts));
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    return [...walkSubtasks(tasks), ...fromProjects];
+  }
   const flattenedTasks = Object.assign(() => tasks, {
     whose: (predicate: Record<string, unknown>) => {
       const filtered = (tasks as TaskRecord[]).filter((t) => matchesPredicate(t, predicate));
       return () => filtered;
+    },
+    byId: (id: string) => {
+      const hit = (allTasks() as Array<{ id?: () => string }>).find(
+        (t) => typeof t.id === "function" && t.id() === id,
+      );
+      if (hit) return hit;
+      const msg = "Can't get object. (-1728)";
+      return {
+        id: () => {
+          throw new ScriptError(msg, { details: { stderr: msg } });
+        },
+      };
     },
   });
 
@@ -266,6 +322,15 @@ function buildFakeDocument(doc: SandboxDocument) {
     },
   });
 
+  // Inbox-task collection. task_create.js (when no project/parent),
+  // task_duplicate.js (toInbox: true), and task_reorder.js (inbox container)
+  // all push to or move into `doc.inboxTasks`. Make it a callable + push
+  // target so `inboxTasks()` returns the current contents and push appends.
+  const inboxArr: unknown[] = [...inboxTasks];
+  const docInboxTasks = Object.assign(() => inboxArr, {
+    push: (item: unknown) => inboxArr.push(item),
+  });
+
   return {
     flattenedTags,
     tags: docTags,
@@ -274,10 +339,15 @@ function buildFakeDocument(doc: SandboxDocument) {
     projects: docProjects,
     flattenedFolders: () => folders,
     folders: docFolders,
-    // Some scripts access inbox tasks through the document
+    inboxTasks: docInboxTasks,
+    // Some scripts access inbox tasks through `doc.inbox.tasks()` instead
+    // of `doc.inboxTasks` — keep both shapes pointing at the same array.
     inbox: {
-      tasks: () => inboxTasks,
+      tasks: () => inboxArr,
     },
+    // Document itself is a valid `make()` target for inbox creation
+    // (task_duplicate's makeInto-the-doc branch).
+    make: (_args: unknown) => makeConstructedTask({}),
     // Pass-through for scripts that check class() on the document itself
     class: () => "document",
   };
@@ -310,14 +380,21 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
   // the build_project.js read surface and exposes writable accessors on
   // every field project_update.js can reassign.
   const projectConstructor = (props: ProjectConstructorOpts = {}) => makeConstructedProject(props);
+  // `ofApp.Task(props)` and `ofApp.InboxTask(props)` are the JXA
+  // constructors task_create.js / task_duplicate.js use. Both produce the
+  // same fake-task shape; the inbox/non-inbox distinction lives in which
+  // collection the caller pushes into.
+  const taskConstructor = (props: TaskConstructorOpts = {}) => makeConstructedTask(props);
 
-  // `markComplete` / `markDropped` / `markReviewed` are app-level verbs the
-  // JXA scripts call instead of property assignment. Track invocations so
-  // tests can assert the script took the right path; the call itself does
-  // nothing else (project state is asserted via the script's return value).
+  // `markComplete` / `markDropped` / `markReviewed` / `markIncomplete` are
+  // app-level verbs the JXA scripts call instead of property assignment.
+  // Track invocations so tests can assert the script took the right path;
+  // the call itself does nothing else (state is asserted via the script's
+  // return value).
   const markedComplete: unknown[] = [];
   const markedDropped: unknown[] = [];
   const markedReviewed: unknown[] = [];
+  const markedIncomplete: unknown[] = [];
 
   return (_name: string) => ({
     // Scripts set this; we accept and ignore it.
@@ -329,6 +406,13 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
     Folder: folderConstructor,
     Tag: tagConstructor,
     Project: projectConstructor,
+    Task: taskConstructor,
+    InboxTask: taskConstructor,
+    // task_update.js delegates tag-set replacement to OmniJS via
+    // `ofApp.evaluateJavascript(omniJsScript)` because JXA's addTag/removeTag
+    // silently no-op on existing tasks (#716). We don't model the OmniJS
+    // semantics — the call just must not throw.
+    evaluateJavascript: (_script: unknown) => undefined,
     delete: (target: unknown) => {
       deleted.push(target);
     },
@@ -341,10 +425,14 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
     markReviewed: (target: unknown) => {
       markedReviewed.push(target);
     },
+    markIncomplete: (target: unknown) => {
+      markedIncomplete.push(target);
+    },
     /** Test-only — surface what `ofApp.delete()` was called with. */
     _deleted: deleted,
     _markedComplete: markedComplete,
     _markedDropped: markedDropped,
+    _markedIncomplete: markedIncomplete,
     _markedReviewed: markedReviewed,
   });
 }
@@ -462,6 +550,9 @@ function makeConstructedProject(opts: ProjectConstructorOpts): Record<string, un
     move: (_args: unknown) => {
       /* no-op for tests; assertions go via the script's return value */
     },
+    // task_duplicate's container.make({new: "task", withProperties})
+    // path when the destination is a project.
+    make: (_args: unknown) => makeConstructedTask({}),
   };
   defineWritableAccessor(project, "name", opts.name ?? `Project ${_constructedProjectSeq}`);
   defineWritableAccessor(project, "note", opts.note ?? "");
@@ -475,6 +566,84 @@ function makeConstructedProject(opts: ProjectConstructorOpts): Record<string, un
   defineWritableAccessor(project, "lastReviewDate", null);
   defineWritableAccessor(project, "reviewIntervalDays", null);
   return project;
+}
+
+/**
+ * Per-property opts accepted by `ofApp.Task({...})` and `ofApp.InboxTask({...})`.
+ * task_create.js and task_duplicate.js forward the union of these fields.
+ */
+export interface TaskConstructorOpts {
+  name?: string;
+  note?: string;
+  flagged?: boolean;
+  deferDate?: Date;
+  dueDate?: Date;
+  estimatedMinutes?: number;
+  sequential?: boolean;
+}
+
+let _constructedTaskSeq = 0;
+
+/**
+ * Build a fake JXA Task created via `ofApp.Task({ ... })` or
+ * `ofApp.InboxTask({ ... })`. Mirrors the read surface of `fakeTask()` so
+ * `build_task.js` can build a domain Task from it; installs writable
+ * accessors on every field a task mutation script may assign. `tasks`
+ * (subtask collection) is push-capable for `task_create`'s parent-task
+ * branch and `task_duplicate`'s subtree clone.
+ */
+function makeConstructedTask(opts: TaskConstructorOpts): Record<string, unknown> {
+  const id = `constructed_task_${++_constructedTaskSeq}`;
+  const childrenArr: unknown[] = [];
+  const tasks = Object.assign(() => childrenArr, {
+    push: (item: unknown) => childrenArr.push(item),
+  });
+  const noThrow = () => {
+    throw new ScriptError("Can't get object.", { details: { stderr: "Can't get object." } });
+  };
+  const task: Record<string, unknown> = {
+    id: () => id,
+    containingProject: noThrow,
+    parentTask: noThrow,
+    tasks,
+    creationDate: () => new Date(),
+    modificationDate: () => new Date(),
+    completionDate: () => null,
+    inInbox: () => false,
+    blocked: () => false,
+    effectivelyDropped: () => false,
+    completed: () => false,
+    dropped: () => false,
+    completedByChildren: () => false,
+    availabilityStatus: () => "available",
+    deferDateFloating: () => false,
+    dueDateFloating: () => false,
+    repetitionRule: () => null,
+    numberOfTasks: () => 0,
+    move: (_args: unknown) => {
+      /* no-op for tests */
+    },
+    delete: () => {
+      /* no-op for tests */
+    },
+    addTag: (_tag: unknown) => {
+      /* no-op for tests */
+    },
+    // task_duplicate's `container.make({ new: "task", withProperties })`
+    // path. We don't recursively build a tree here — return a fresh fake
+    // so the duplicate test can read .id() back.
+    make: (_args: unknown) => makeConstructedTask({}),
+    tags: () => [],
+  };
+  defineWritableAccessor(task, "name", opts.name ?? `Task ${_constructedTaskSeq}`);
+  defineWritableAccessor(task, "note", opts.note ?? "");
+  defineWritableAccessor(task, "flagged", opts.flagged ?? false);
+  defineWritableAccessor(task, "deferDate", opts.deferDate ?? null);
+  defineWritableAccessor(task, "dueDate", opts.dueDate ?? null);
+  defineWritableAccessor(task, "estimatedMinutes", opts.estimatedMinutes ?? null);
+  defineWritableAccessor(task, "sequential", opts.sequential ?? false);
+  defineWritableAccessor(task, "containsSingletonActions", false);
+  return task;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds 33 sandbox tests across all 10 single-task mutation scripts: `task_create`, `task_update`, `task_delete`, `task_complete`, `task_uncomplete`, `task_drop`, `task_undrop`, `task_move`, `task_duplicate`, `task_reorder`.
- Brings coverage from 35 of 60+ scripts (~58%) to 45 of 60+ (~75%) — only the batch + remaining slice (#749) is left to cross 80%.
- Harness extensions: `Task` / `InboxTask` constructors, `markIncomplete`, `evaluateJavascript` no-op, recursive `flattenedTasks.byId`, push-target `doc.inboxTasks`, `doc.make()` for inbox creation, and `make()` on `fakeProject` / `fakeTask` for `task_duplicate`'s subtree clone.

## Harness extensions

`src/adapter/jxa/sandbox/index.ts`:

- **`ofApp.Task(props)` / `ofApp.InboxTask(props)`** — both produce the same fake-task shape; the inbox/non-inbox distinction is which collection the caller pushes into.
- **`ofApp.markIncomplete(target)`** — no-op tracker. `task_uncomplete` and `task_undrop` both call this.
- **`ofApp.evaluateJavascript(script)`** — no-op. `task_update` delegates tag-set replacement to OmniJS via this because JXA's `addTag`/`removeTag` silently no-op on existing tasks (#716); we don't model OmniJS, the call just must not throw.
- **`doc.flattenedTasks.byId(id)`** walks the full task tree (top-level tasks + subtasks recursively + project tasks) so a task pushed onto `parent.tasks` or `proj.tasks` after construction is findable. Mirrors how OF flattens and matches the contract `task_create`'s post-push re-fetch relies on.
- **`doc.inboxTasks`** is a callable + push-target (used by `task_create`'s inbox branch, `task_duplicate`'s `toInbox` path, `task_reorder`'s inbox container).
- **`doc.make()`** returns a fresh fake task (`task_duplicate`'s makeInto-the-doc branch).

`src/adapter/jxa/sandbox/fixtures.ts`:

- `fakeTask` gains writable accessors on every mutation field (`name` / `note` / `flagged` / `deferDate` / `dueDate` / `completionDate` / `dropped` / `completed` / `estimatedMinutes` / `sequential` / `containsSingletonActions`); push-capable `.tasks` (subtask collection); no-op `.delete()` / `.addTag()` / `.move()` / `.make()`.
- `fakeProject.tasks` gains push + `.end` on the default path; `.make()` returns a fresh fake task for `task_duplicate`'s project-destination branch.

## Design link

Slice 6 of [#723](https://github.com/torsday/omnifocus-mcp/issues/723). Builds on slices 3–5. Independent of slice 7 ([#749](https://github.com/torsday/omnifocus-mcp/issues/749)) which reuses the same generalized harness pattern this PR extends.

Closes #748

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` all green locally (3384 passing, 56 skipped, 198 files).
- [x] Sandbox suite alone: 167 tests pass (134 prior + 33 new).
- [x] Self-reviewed via `/review-pr` — coverage focused on each script's documented contract: lookupOrThrow paths, mutation persistence through `build_task.js`, mutex-arg validation, mode validation for `task_reorder`.

## Coverage detail

| Script | Tests added | Cases |
|---|---|---|
| `task_create` | 7 | inbox happy; project happy; parent happy; empty-name validation; projectId+parentId mutex; missing project; missing parent |
| `task_update` | 4 | rename happy; flagged toggle; tagIds → OmniJS delegation no-op; missing id |
| `task_delete` | 2 | happy (instance `.delete()`); missing id |
| `task_complete` | 3 | happy; with completionDate; missing id |
| `task_uncomplete` | 2 | happy; missing id |
| `task_drop` | 2 | happy; missing id via lookupOrThrow |
| `task_undrop` | 2 | happy; missing id via lookupOrThrow |
| `task_move` | 4 | parent dest; project dest; inbox default; missing project |
| `task_duplicate` | 3 | inbox default; project destination; missing source via lookupOrThrow |
| `task_reorder` | 4 | before refId; start of project; missing refId; unknown mode |

## Conventions checklist

- [x] Conventional Commit
- [x] No new dependencies
- [x] No public surface change — sandbox harness API additions are additive