### PR TITLE
test(jxa): batch + remaining mutation scripts via sandbox harness (slice 7 of #723)

### DIFF
--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -151,6 +151,7 @@ export function fakeTask(
   const childTasks = Object.assign(() => childrenArr, {
     push: (item: unknown) => childrenArr.push(item),
   });
+  const attachmentsArr: unknown[] = [];
   const task: Record<string, unknown> = {
     id,
     containingProject: overrides.containingProject ?? throwing(),
@@ -166,10 +167,17 @@ export function fakeTask(
     deferDateFloating: overrides.deferDateFloating ?? fn(false),
     dueDateFloating: overrides.dueDateFloating ?? fn(false),
     effectivelyAvailable: overrides.effectivelyAvailable ?? fn(true),
-    fileAttachments: overrides.fileAttachments ?? fn([]),
     blocked: overrides.blocked ?? fn(false),
     effectivelyDropped: overrides.effectivelyDropped ?? fn(false),
     numberOfTasks: overrides.numberOfTasks ?? fn(0),
+    // attachment_add.js pushes new attachments onto `task.fileAttachments`.
+    // Honour custom callable overrides verbatim — only the default path
+    // gets push, which is enough for the slice-7 tests.
+    fileAttachments: overrides.fileAttachments
+      ? overrides.fileAttachments
+      : Object.assign(() => attachmentsArr, {
+          push: (item: unknown) => attachmentsArr.push(item),
+        }),
     // task_delete.js calls `found.delete()` (instance method, not
     // ofApp.delete). task_duplicate copies tags via `to.addTag(tag)`.
     // task_move / task_reorder call `found.move({ to, positioned })`. All
@@ -181,6 +189,11 @@ export function fakeTask(
       /* no-op for tests */
     },
     move: (_args: unknown) => {
+      /* no-op for tests */
+    },
+    // task_batch_complete.js calls `task.markComplete({completionDate})`
+    // as a per-task instance method (distinct from the app-level verb).
+    markComplete: (_args: unknown) => {
       /* no-op for tests */
     },
     // task_duplicate calls `cloneTask.make({new: "task", withProperties})`
@@ -251,6 +264,7 @@ export function fakeProject(
   // calls `proj.make({ new: "task", withProperties })`. Honour custom
   // overrides verbatim — only the default path gets push/make.
   const tasksArr: unknown[] = [];
+  const projectAttachmentsArr: unknown[] = [];
   const tasks = overrides.tasks
     ? overrides.tasks
     : Object.assign(() => tasksArr, {
@@ -274,7 +288,11 @@ export function fakeProject(
     lastReviewDate: overrides.lastReviewDate ?? fn(null),
     deferDateFloating: overrides.deferDateFloating ?? fn(false),
     dueDateFloating: overrides.dueDateFloating ?? fn(false),
-    fileAttachments: overrides.fileAttachments ?? fn([]),
+    fileAttachments: overrides.fileAttachments
+      ? overrides.fileAttachments
+      : Object.assign(() => projectAttachmentsArr, {
+          push: (item: unknown) => projectAttachmentsArr.push(item),
+        }),
     // project_update / project_move call `target.move({to: ...})`. The
     // assertion is on the script's return value, not on the fake's
     // post-state, so move() is intentionally a no-op.
@@ -415,10 +433,17 @@ export interface FakeWindowOverrides {
 
 /** Build a fake JXA Window object as used by `window_get_state.js`. */
 export function fakeWindow(overrides: FakeWindowOverrides = {}) {
-  return {
-    perspectiveName: overrides.perspectiveName ?? fn("Forecast"),
-    focus: overrides.focus ?? fn([]),
-  };
+  const win: Record<string, unknown> = {};
+  // perspectiveName is read-only on Window in JXA (window_get_state reads
+  // it; window_set_perspective writes the separate `perspective` field).
+  // Keep the function override for the read path.
+  win.perspectiveName = overrides.perspectiveName ?? fn("Forecast");
+  // window_set_focus.js assigns `w.focus = [target]`; build_..._for read
+  // via `w.focus()`. window_set_perspective.js assigns `w.perspective = X`
+  // (write-only). Use writable accessors for both.
+  defineWritableAccessor(win, "focus", overrides.focus ?? fn([]));
+  defineWritableAccessor(win, "perspective", null);
+  return win;
 }
 
 export interface FakePerspectiveOverrides {

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -15,7 +15,9 @@
  */
 
 import { describe, expect, it } from "vitest";
+import attachmentAddScript from "../../../scripts/jxa/attachment_add.js";
 import attachmentListScript from "../../../scripts/jxa/attachment_list.js";
+import attachmentRemoveScript from "../../../scripts/jxa/attachment_remove.js";
 import changesSinceScript from "../../../scripts/jxa/changes_since.js";
 import folderCreateScript from "../../../scripts/jxa/folder_create.js";
 import folderDeleteScript from "../../../scripts/jxa/folder_delete.js";
@@ -39,12 +41,20 @@ import projectSetNextReviewDateScript from "../../../scripts/jxa/project_set_nex
 import projectSetReviewIntervalScript from "../../../scripts/jxa/project_set_review_interval.js";
 import projectUpdateScript from "../../../scripts/jxa/project_update.js";
 import reviewListDueScript from "../../../scripts/jxa/review_list_due.js";
+import syncTriggerScript from "../../../scripts/jxa/sync_trigger.js";
 import tagCreateScript from "../../../scripts/jxa/tag_create.js";
 import tagDeleteScript from "../../../scripts/jxa/tag_delete.js";
 import tagGetScript from "../../../scripts/jxa/tag_get.js";
 import tagGetManyScript from "../../../scripts/jxa/tag_get_many.js";
 import tagListScript from "../../../scripts/jxa/tag_list.js";
 import tagUpdateScript from "../../../scripts/jxa/tag_update.js";
+import taskBatchCompleteScript from "../../../scripts/jxa/task_batch_complete.js";
+import taskBatchCreateScript from "../../../scripts/jxa/task_batch_create.js";
+import taskBatchDeleteScript from "../../../scripts/jxa/task_batch_delete.js";
+import taskBatchDropScript from "../../../scripts/jxa/task_batch_drop.js";
+import taskBatchUncompleteScript from "../../../scripts/jxa/task_batch_uncomplete.js";
+import taskBatchUndropScript from "../../../scripts/jxa/task_batch_undrop.js";
+import taskBatchUpdateScript from "../../../scripts/jxa/task_batch_update.js";
 import taskCompleteScript from "../../../scripts/jxa/task_complete.js";
 import taskCreateScript from "../../../scripts/jxa/task_create.js";
 import taskDeleteScript from "../../../scripts/jxa/task_delete.js";
@@ -60,6 +70,8 @@ import taskUncompleteScript from "../../../scripts/jxa/task_uncomplete.js";
 import taskUndropScript from "../../../scripts/jxa/task_undrop.js";
 import taskUpdateScript from "../../../scripts/jxa/task_update.js";
 import windowGetStateScript from "../../../scripts/jxa/window_get_state.js";
+import windowSetFocusScript from "../../../scripts/jxa/window_set_focus.js";
+import windowSetPerspectiveScript from "../../../scripts/jxa/window_set_perspective.js";
 import {
   fakeAttachment,
   fakeFolder,
@@ -2128,6 +2140,380 @@ describe("JXA sandbox — task_reorder", () => {
         { tasks: [target] },
       ),
     ).toThrow("unknown mode");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_batch_complete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_batch_complete", () => {
+  it("succeeds for found ids; fails OF_NOT_FOUND for missing", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const b = fakeTask({ id: () => "task_b" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string; index: number }[];
+    }>(
+      taskBatchCompleteScript,
+      { items: [{ id: "task_a" }, { id: "task_missing" }, { id: "task_b" }] },
+      { tasks: [a, b] },
+    );
+    expect(result.succeeded.map((s) => s.value)).toEqual(["task_a", "task_b"]);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+    expect(result.failed[0]?.index).toBe(1);
+  });
+
+  it("returns empty arrays when items is empty", () => {
+    const result = runJxaScriptInSandbox<{ succeeded: unknown[]; failed: unknown[] }>(
+      taskBatchCompleteScript,
+      { items: [] },
+      {},
+    );
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_batch_create.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_batch_create", () => {
+  it("creates a mix of inbox + project + parent tasks per item", () => {
+    const project = fakeProject({ id: () => "project_target" });
+    const parent = fakeTask({ id: () => "task_parent" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string }[];
+    }>(
+      taskBatchCreateScript,
+      {
+        inputs: [
+          { name: "Inbox 1" },
+          { name: "Under project", projectId: "project_target" },
+          { name: "Subtask", parentId: "task_parent" },
+        ],
+      },
+      { projects: [project], tasks: [parent] },
+    );
+    expect(result.succeeded).toHaveLength(3);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it("captures per-item OF_NOT_FOUND when a parent or project is missing", () => {
+    const result = runJxaScriptInSandbox<{
+      succeeded: unknown[];
+      failed: { index: number; errorCode: string }[];
+    }>(
+      taskBatchCreateScript,
+      {
+        inputs: [
+          { name: "Inbox" },
+          { name: "Bad parent", parentId: "missing" },
+          { name: "Bad project", projectId: "missing" },
+        ],
+      },
+      {},
+    );
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.failed.map((f) => f.errorCode)).toEqual(["OF_NOT_FOUND", "OF_NOT_FOUND"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_batch_delete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_batch_delete", () => {
+  it("succeeds for found ids; fails OF_NOT_FOUND for missing", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string }[];
+    }>(taskBatchDeleteScript, { items: [{ id: "task_a" }, { id: "missing" }] }, { tasks: [a] });
+    expect(result.succeeded.map((s) => s.value)).toEqual(["task_a"]);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_batch_drop.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_batch_drop", () => {
+  it("succeeds for found ids; fails OF_NOT_FOUND for missing", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string }[];
+    }>(taskBatchDropScript, { items: [{ id: "task_a" }, { id: "missing" }] }, { tasks: [a] });
+    expect(result.succeeded.map((s) => s.value)).toEqual(["task_a"]);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_batch_uncomplete.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_batch_uncomplete", () => {
+  it("succeeds for found ids via flattenedTasks scan", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const b = fakeTask({ id: () => "task_b" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string }[];
+    }>(
+      taskBatchUncompleteScript,
+      { items: [{ id: "task_a" }, { id: "task_b" }] },
+      { tasks: [a, b] },
+    );
+    expect(result.succeeded.map((s) => s.value).sort()).toEqual(["task_a", "task_b"]);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it("fails with OF_NOT_FOUND for missing ids", () => {
+    const result = runJxaScriptInSandbox<{
+      succeeded: unknown[];
+      failed: { errorCode: string }[];
+    }>(taskBatchUncompleteScript, { items: [{ id: "missing" }] }, { tasks: [] });
+    expect(result.succeeded).toHaveLength(0);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_batch_undrop.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_batch_undrop", () => {
+  it("succeeds for found ids; fails OF_NOT_FOUND for missing", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string }[];
+    }>(taskBatchUndropScript, { items: [{ id: "task_a" }, { id: "missing" }] }, { tasks: [a] });
+    expect(result.succeeded.map((s) => s.value)).toEqual(["task_a"]);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task_batch_update.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — task_batch_update", () => {
+  it("applies patches per item; OF_NOT_FOUND for missing", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const result = runJxaScriptInSandbox<{
+      succeeded: { value: string }[];
+      failed: { errorCode: string }[];
+    }>(
+      taskBatchUpdateScript,
+      {
+        updates: [
+          { id: "task_a", patch: { name: "renamed", flagged: true } },
+          { id: "missing", patch: { name: "x" } },
+        ],
+      },
+      { tasks: [a] },
+    );
+    expect(result.succeeded.map((s) => s.value)).toEqual(["task_a"]);
+    expect(result.failed[0]?.errorCode).toBe("OF_NOT_FOUND");
+  });
+
+  it("delegates tagIds replacement to OmniJS via evaluateJavascript", () => {
+    const a = fakeTask({ id: () => "task_a" });
+    const result = runJxaScriptInSandbox<{ succeeded: { value: string }[] }>(
+      taskBatchUpdateScript,
+      { updates: [{ id: "task_a", patch: { tagIds: ["tag_x"] } }] },
+      { tasks: [a] },
+    );
+    expect(result.succeeded.map((s) => s.value)).toEqual(["task_a"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachment_add.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — attachment_add", () => {
+  it("adds an attachment to a task and returns the new id", () => {
+    const target = fakeTask({ id: () => "task_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      attachmentAddScript,
+      { taskId: "task_target", filePath: "/tmp/file.pdf" },
+      { tasks: [target] },
+    );
+    expect(result.id).toMatch(/^constructed_attachment_/);
+  });
+
+  it("adds an attachment to a project", () => {
+    const project = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ id: string }>(
+      attachmentAddScript,
+      { projectId: "project_target", filePath: "/tmp/file.pdf" },
+      { projects: [project] },
+    );
+    expect(result.id).toBeDefined();
+  });
+
+  it("throws when the taskId is missing", () => {
+    expect(() =>
+      runJxaScriptInSandbox(
+        attachmentAddScript,
+        { taskId: "missing", filePath: "/tmp/x" },
+        { tasks: [] },
+      ),
+    ).toThrow("Task not found: missing");
+  });
+
+  it("throws when neither taskId nor projectId is supplied", () => {
+    expect(() => runJxaScriptInSandbox(attachmentAddScript, { filePath: "/tmp/x" }, {})).toThrow(
+      "One of taskId or projectId is required",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachment_remove.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — attachment_remove", () => {
+  it("removes an attachment by id from a task", () => {
+    const att = fakeAttachment({ id: () => "att_target" });
+    const target = fakeTask({ id: () => "task_target", fileAttachments: () => [att] });
+    const result = runJxaScriptInSandbox<Record<string, never>>(
+      attachmentRemoveScript,
+      { taskId: "task_target", attachmentId: "att_target" },
+      { tasks: [target] },
+    );
+    expect(result).toEqual({});
+  });
+
+  it("throws when the attachment id does not exist on the task", () => {
+    const target = fakeTask({
+      id: () => "task_target",
+      fileAttachments: () => [fakeAttachment({ id: () => "att_other" })],
+    });
+    expect(() =>
+      runJxaScriptInSandbox(
+        attachmentRemoveScript,
+        { taskId: "task_target", attachmentId: "att_missing" },
+        { tasks: [target] },
+      ),
+    ).toThrow("Attachment not found: att_missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// window_set_focus.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — window_set_focus", () => {
+  it("returns NO_FRONT_WINDOW when there are no windows", () => {
+    const result = runJxaScriptInSandbox<{ error: { code: string } }>(
+      windowSetFocusScript,
+      { containerId: "anything" },
+      { windows: [] },
+    );
+    expect(result.error.code).toBe("NO_FRONT_WINDOW");
+  });
+
+  it("clears focus when containerId is null", () => {
+    const w = fakeWindow();
+    const result = runJxaScriptInSandbox<{ focusContainerIds: string[] }>(
+      windowSetFocusScript,
+      { containerId: null },
+      { windows: [w] },
+    );
+    expect(result.focusContainerIds).toEqual([]);
+  });
+
+  it("focuses on a project when found", () => {
+    const w = fakeWindow();
+    const project = fakeProject({ id: () => "project_target" });
+    const result = runJxaScriptInSandbox<{ focusContainerIds: string[] }>(
+      windowSetFocusScript,
+      { containerId: "project_target" },
+      { windows: [w], projects: [project] },
+    );
+    expect(result.focusContainerIds).toEqual(["project_target"]);
+  });
+
+  it("falls back to folder lookup when no project matches", () => {
+    const w = fakeWindow();
+    const folder = fakeFolder({ id: () => "folder_target" });
+    const result = runJxaScriptInSandbox<{ focusContainerIds: string[] }>(
+      windowSetFocusScript,
+      { containerId: "folder_target" },
+      { windows: [w], folders: [folder] },
+    );
+    expect(result.focusContainerIds).toEqual(["folder_target"]);
+  });
+
+  it("returns NOT_FOUND when neither projects nor folders match", () => {
+    const w = fakeWindow();
+    const result = runJxaScriptInSandbox<{ error: { code: string } }>(
+      windowSetFocusScript,
+      { containerId: "missing" },
+      { windows: [w] },
+    );
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// window_set_perspective.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — window_set_perspective", () => {
+  it("returns NO_FRONT_WINDOW when there are no windows", () => {
+    const result = runJxaScriptInSandbox<{ error: { code: string } }>(
+      windowSetPerspectiveScript,
+      { perspectiveName: "Forecast" },
+      { windows: [] },
+    );
+    expect(result.error.code).toBe("NO_FRONT_WINDOW");
+  });
+
+  it("switches to the named perspective when found", () => {
+    const w = fakeWindow();
+    const persp = fakePerspective({ name: () => "Weekly" });
+    const result = runJxaScriptInSandbox<{ perspectiveName: string }>(
+      windowSetPerspectiveScript,
+      { perspectiveName: "Weekly" },
+      { windows: [w], perspectives: [persp] },
+    );
+    expect(result.perspectiveName).toBe("Weekly");
+  });
+
+  it("returns NOT_FOUND when no perspective matches the name", () => {
+    const w = fakeWindow();
+    const result = runJxaScriptInSandbox<{ error: { code: string } }>(
+      windowSetPerspectiveScript,
+      { perspectiveName: "NoSuch" },
+      { windows: [w], perspectives: [] },
+    );
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sync_trigger.js
+// ---------------------------------------------------------------------------
+
+describe("JXA sandbox — sync_trigger", () => {
+  it("returns lastSyncAt as an ISO string and inFlight: false", () => {
+    const before = Date.now();
+    const result = runJxaScriptInSandbox<{ lastSyncAt: string; inFlight: boolean }>(
+      syncTriggerScript,
+      {},
+      {},
+    );
+    expect(result.inFlight).toBe(false);
+    expect(new Date(result.lastSyncAt).getTime()).toBeGreaterThanOrEqual(before);
   });
 });
 

--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -131,14 +131,19 @@ export function runJxaScriptInSandbox<T = unknown>(
 ): T {
   const document = buildFakeDocument(doc);
   const fakeApp = buildFakeApp(document, doc);
+  // `Path(filePath)` is a JXA global. attachment_add.js wraps a string
+  // filePath into one before passing it to `ofApp.FileAttachment({file})`.
+  // The fake passes the path through unchanged — the FileAttachment ctor
+  // ignores the file argument anyway.
+  const fakePath = (p: string) => ({ __path: p });
 
-  // Wrap the script in an IIFE that receives `Application` as a parameter,
-  // then call `run(argv)` with the serialized args — matching how osascript
-  // invokes the function with `argv` as a string array.
-  const wrapper = `(function(Application) { ${scriptSource}; return run; })`;
+  // Wrap the script in an IIFE that receives `Application` and `Path` as
+  // parameters, then call `run(argv)` with the serialized args — matching
+  // how osascript invokes the function with `argv` as a string array.
+  const wrapper = `(function(Application, Path) { ${scriptSource}; return run; })`;
 
   // biome-ignore lint/security/noGlobalEval: intentional — this module IS the sandbox; eval is the mechanism that injects a synthetic Application global into the script's scope without spawning osascript.
-  const runFn = eval(wrapper)(fakeApp) as (argv: string[]) => string;
+  const runFn = eval(wrapper)(fakeApp, fakePath) as (argv: string[]) => string;
 
   const raw = runFn([JSON.stringify(args)]);
   return JSON.parse(raw) as T;
@@ -348,6 +353,8 @@ function buildFakeDocument(doc: SandboxDocument) {
     // Document itself is a valid `make()` target for inbox creation
     // (task_duplicate's makeInto-the-doc branch).
     make: (_args: unknown) => makeConstructedTask({}),
+    // sync_trigger.js calls `doc.synchronize()` fire-and-forget.
+    synchronize: () => undefined,
     // Pass-through for scripts that check class() on the document itself
     class: () => "document",
   };
@@ -428,6 +435,10 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
     markIncomplete: (target: unknown) => {
       markedIncomplete.push(target);
     },
+    // attachment_add.js: `ofApp.FileAttachment({ file: pathObj })` returns
+    // a freshly-constructed fake attachment. The id() method is the only
+    // accessor the script reads back via `attsArr[attsArr.length-1].id()`.
+    FileAttachment: (_args: unknown) => makeConstructedAttachment(),
     /** Test-only — surface what `ofApp.delete()` was called with. */
     _deleted: deleted,
     _markedComplete: markedComplete,
@@ -435,6 +446,18 @@ function buildFakeApp(document: ReturnType<typeof buildFakeDocument>, doc: Sandb
     _markedIncomplete: markedIncomplete,
     _markedReviewed: markedReviewed,
   });
+}
+
+let _constructedAttachmentSeq = 0;
+function makeConstructedAttachment(): Record<string, unknown> {
+  const id = `constructed_attachment_${++_constructedAttachmentSeq}`;
+  return {
+    id: () => id,
+    name: () => "constructed.dat",
+    fileType: () => null,
+    fileSize: () => null,
+    creationDate: () => new Date(),
+  };
 }
 
 let _constructedFolderSeq = 0;


### PR DESCRIPTION
## Summary

- Adds 26 sandbox tests across 12 scripts: 7 task batch (`create/update/delete/complete/uncomplete/drop/undrop`), 2 attachment mutation (`add/remove`), 2 window mutation (`set_focus/set_perspective`), and `sync_trigger`.
- Brings coverage from 45 of 60+ scripts (~75%) to **57 of 60+ (~95%)** — past the **80% AC threshold tracked by [#723](https://github.com/torsday/omnifocus-mcp/issues/723)**.
- Three scripts (`app_launch`, `attachment_save_to_path`, `perspective_evaluate`) need heavier harness work; tracked in slice 7b: [#753](https://github.com/torsday/omnifocus-mcp/issues/753).

## Harness extensions

`src/adapter/jxa/sandbox/index.ts`:

- **`ofApp.FileAttachment({ file })`** — constructor for `attachment_add`'s push-onto-fileAttachments path; returned fake exposes `id()`.
- **`doc.synchronize()`** — no-op for `sync_trigger`.
- **`Path(filePath)` global** — passed into the script wrapper alongside `Application`. `attachment_add` wraps the filePath in a `Path()` before handing it to `FileAttachment`.

`src/adapter/jxa/sandbox/fixtures.ts`:

- **`fakeTask.markComplete({completionDate})`** — instance method no-op (`task_batch_complete` prefers this over the app-level verb).
- **`fakeTask.fileAttachments` / `fakeProject.fileAttachments`** are now push-capable callables on the default path; custom callable overrides are honoured verbatim.
- **`fakeWindow.focus` / `fakeWindow.perspective`** use `defineWritableAccessor` so `window_set_focus` / `window_set_perspective`'s property assignments persist.

## Design link

Slice 7 of [#723](https://github.com/torsday/omnifocus-mcp/issues/723). Builds on slices 3–6. After this lands, the AC's ≥80% coverage target is met and slice 8 (Stryker threshold recalibration) becomes ready.

Closes #749

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` all green locally (3410 passing, 56 skipped, 198 files).
- [x] Sandbox suite alone: 193 tests pass (167 prior + 26 new).
- [x] Self-reviewed via `/review-pr` — coverage focused on the batch envelope shape, the per-item `OF_NOT_FOUND` paths, the window error codes (`NO_FRONT_WINDOW` / `NOT_FOUND`), and the script-level `One of taskId or projectId is required` validation.

## Coverage detail

| Script | Tests added | Cases |
|---|---|---|
| `task_batch_create` | 2 | mixed inbox/project/parent; per-item OF_NOT_FOUND |
| `task_batch_update` | 2 | patch + missing id; tagIds delegates to evaluateJavascript |
| `task_batch_delete` | 1 | mixed found/missing → OF_NOT_FOUND |
| `task_batch_complete` | 2 | mixed found/missing; empty input |
| `task_batch_uncomplete` | 2 | flattenedTasks scan; missing id |
| `task_batch_drop` | 1 | mixed found/missing |
| `task_batch_undrop` | 1 | mixed found/missing |
| `attachment_add` | 4 | task happy; project happy; missing task; mutex args |
| `attachment_remove` | 2 | happy; missing attachment id |
| `window_set_focus` | 5 | NO_FRONT_WINDOW; clear via null; project; folder fallback; NOT_FOUND |
| `window_set_perspective` | 3 | NO_FRONT_WINDOW; happy; NOT_FOUND |
| `sync_trigger` | 1 | ISO lastSyncAt + inFlight: false |

## Conventions checklist

- [x] Conventional Commit
- [x] No new dependencies
- [x] No public surface change — sandbox harness API additions are additive