### PR TITLE
test(jxa): recalibrate stryker threshold to 58 (slice 8 of #723)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       #
       # The gate runs once per release tag — between unit tests and publish — and
       # fails the release when the mutation score drops below the calibrated
-      # `thresholds.break` in stryker.conf.json (currently 57.74 = baseline − 5
+      # `thresholds.break` in stryker.conf.json (currently 58 = floor(baseline) − 5
       # per ADR §3). The HTML + JSON reports are uploaded as workflow artifacts
       # for post-mortem on a fail and for traceability on a pass.
       - name: Stryker mutation testing (release gate)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ If it exits 1, re-grant permission in System Settings as above.
 
 ## Mutation testing (release-time hard gate)
 
-Releases are gated on a Stryker mutation-testing run that fails the publish if the score regresses below `thresholds.break = 57.74` (= calibration baseline − 5). Per [ADR-0017](./docs/adr/0017-mutation-testing-release-gate.md). The gate fires once per `v*.*.*` tag push in [`.github/workflows/release.yml`](./.github/workflows/release.yml); reports upload as `mutation-report-<tag>` workflow artifact (90-day retention).
+Releases are gated on a Stryker mutation-testing run that fails the publish if the score regresses below `thresholds.break = 58` (= floor(calibration baseline) − 5). Per [ADR-0017](./docs/adr/0017-mutation-testing-release-gate.md). The gate fires once per `v*.*.*` tag push in [`.github/workflows/release.yml`](./.github/workflows/release.yml); reports upload as `mutation-report-<tag>` workflow artifact (90-day retention).
 
 ### Running locally
 

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -17,6 +17,16 @@
     "inline in tool handlers). Both globs produced warnings and zero matches;",
     "removing them leaves coverage unchanged.",
     "",
+    "Slice 8 (#756): post-#723 recalibration on 2026-05-08. Mutator scope is",
+    "unchanged (TS-only per ADR-0017); the JXA-side test surface added by",
+    "slices 1–7b mutates nothing here, so the score is expected to drift only",
+    "from incidental TS test churn. Run: 2978 mutants instrumented, 9m50s",
+    "wall-clock. Outcome:",
+    "  killed=1230, survived=564, timeout=11, noCoverage=152, compileError=1021.",
+    "  mutationScore = (1230+11)/(1230+564+11+152) = 1241/1957 = 63.41%",
+    "  → drift +0.67pp vs slice-1B baseline (well under the ±5pp meaningful bar).",
+    "  → thresholds.break re-pinned to floor(63.41) − 5 = 58 per ADR-0017 §3.",
+    "",
     "Plugins are listed explicitly because pnpm's strict node_modules layout",
     "breaks Stryker's default `@stryker-mutator/*` plugin discovery glob in",
     "child processes."
@@ -42,6 +52,6 @@
   "thresholds": {
     "high": 80,
     "low": 60,
-    "break": 57.74
+    "break": 58
   }
 }


### PR DESCRIPTION
## Summary
- Re-pin `thresholds.break` from 57.74 → **58** (= `floor(63.41) − 5`) after slices 1–7b of #723 landed sandbox tests for ~100% of the JXA scripts.
- Fresh `pnpm mutation` on slice-7b head: 2978 mutants, 9m50s, score **63.41%** (killed=1230, survived=564, timeout=11, noCoverage=152, compileError=1021).
- Drift vs slice-1B baseline (62.74%) is **+0.67pp** — well under the ±5pp meaningful bar; mutator scope unchanged (TS-only per ADR-0017).
- Updated config comment, `CONTRIBUTING.md` release-gate paragraph, and the inline reference in `.github/workflows/release.yml` to match.

Closes #756.

## Issue
Implements [#756 — recalibrate Stryker mutation threshold (slice 8 of #723)](https://github.com/torsday/omnifocus-mcp/issues/756). Per [ADR-0017 §3](./docs/adr/0017-mutation-testing-release-gate.md).

## Breaking change?
- [x] No — release gate stays in place; threshold is tightened by ~0.26 (from 57.74 to 58.00). The current score (63.41%) clears the new threshold by 5.41pp.

## Test plan
- [x] `pnpm mutation` run locally; final score 63.41% ≥ break threshold 58 → exit 0.
- [x] `pnpm lint` clean (incl. `verify-nl-quality`, `lint-custom`, `docs:check`).
- [x] No new dependencies.
- [ ] Release-gate exercise deferred until the next `v*.*.*` tag (gate runs in `release.yml`, not on PR).