### PR TITLE
infra(ci): add package.json/pnpm-lock.yaml to meta-lint path filter

### DIFF
--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -36,6 +36,12 @@ on:
       # meta-lint job, and branch protection blocked the merge. Widen the
       # net to src/** so any production-code diff fires the regression guards.
       - "src/**"
+      # dep-bump PRs (dependabot/renovate) only touch package.json and
+      # pnpm-lock.yaml. Without these entries the workflow never fires,
+      # required checks are never reported, and branch protection blocks
+      # the merge requiring an admin bypass (#736).
+      - "package.json"
+      - "pnpm-lock.yaml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `package.json` and `pnpm-lock.yaml` to the `paths:` filter in `meta-lint.yml`
- dep-bump PRs (dependabot/renovate) that only touch these files now trigger meta-lint, so required checks report and branch protection doesn't block the merge

Closes #736.

## Issue
Implements [#736 — infra(ci): add package.json/lock to meta-lint path filter so dep PRs can merge without admin bypass](https://github.com/torsday/omnifocus-mcp/issues/736).

## Breaking change?
- [x] No

## Test plan
- [x] Self-reviewed via /review-pr — 6-line addition, no logic change
- [x] All 3423 tests pass locally
- [x] No new dependencies