### PR TITLE
chore(ci): bump actions/upload-artifact v4 → v7 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload mutation report
         if: always() # upload on fail too — the HTML report is how you triage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutation-report-${{ github.ref_name }}
           path: reports/mutation/


### PR DESCRIPTION
## Summary
- Updates `release.yml:81` from `actions/upload-artifact@v4` to `@v7`
- `integration.yml` has run `@v7` cleanly in production; this aligns both workflows
- Default behavior (zipped artifact) unchanged; v7's new `archive: false` option is not used here

Closes #732.

## Issue
Implements [#732 — deps(ci): merge actions/upload-artifact v4 → v7 bump — PR #712](https://github.com/torsday/omnifocus-mcp/issues/732). The original dependabot PR #712 could not merge due to branch protection gates; this PR applies the same change with a proper issue link.

## Breaking change?
- [x] No

## Test plan
- [x] Self-reviewed — 1-line change, v7 already proven in integration.yml
- [x] All tests pass locally (pre-push hook green)
- [x] No new dependencies