### PR TITLE
fix: bug-hunt sweep — loop-detector hash, stale budget docs, biome schema pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
 
       - run: pnpm build
 
-      - name: Bundle-size budget (< 500 KB per DESIGN §20)
+      - name: Bundle-size budget (< 800 KiB per DESIGN §20)
         run: bash scripts/check-bundle-size.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
 
           echo "Integration suite passed on $sha (run age: ${age_h}h)."
 
-      - name: Bundle-size budget (< 500 KB per DESIGN §20)
+      - name: Bundle-size budget (< 800 KiB per DESIGN §20)
         run: bash scripts/check-bundle-size.sh
 
       # Extract release notes from CHANGELOG.md before publishing so a

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -2,7 +2,7 @@
 # check-bundle-size.sh
 #
 # Enforce the bundle-size budget for dist/index.js per DESIGN §20:
-#   "Bundle size budget: < 580 KiB (tsup --minify); above that blocks release."
+#   "Bundle size budget: < 800 KiB (tsup --minify); above that blocks release."
 #
 # This script is the single source of truth for the budget value. CI, the
 # release workflow, and the /release skill all call it so the threshold

--- a/src/logging/transportCall.test.ts
+++ b/src/logging/transportCall.test.ts
@@ -60,6 +60,27 @@ describe("hashArgs", () => {
   it("distinguishes different values", () => {
     expect(hashArgs({ a: 1 })).not.toBe(hashArgs({ a: 2 }));
   });
+
+  it("distinguishes args that differ only at a nested level", () => {
+    // Regression: previously the replacer-array form of `JSON.stringify`
+    // dropped nested keys, so two semantically-different calls with the
+    // same top-level shape collapsed into one transport.call argsHash.
+    expect(hashArgs({ id: "X", changes: { name: "P1" } })).not.toBe(
+      hashArgs({ id: "X", changes: { name: "P2" } }),
+    );
+  });
+
+  it("is stable regardless of key order at any nesting level", () => {
+    expect(hashArgs({ id: "X", changes: { name: "n", note: "x" } })).toBe(
+      hashArgs({ changes: { note: "x", name: "n" }, id: "X" }),
+    );
+  });
+
+  it("does not crash on null/undefined args and gives them distinct hashes", () => {
+    expect(() => hashArgs(null)).not.toThrow();
+    expect(() => hashArgs(undefined)).not.toThrow();
+    expect(hashArgs(null)).not.toBe(hashArgs(undefined));
+  });
 });
 
 describe("runJxaScript transport.call event", () => {

--- a/src/logging/transportCall.ts
+++ b/src/logging/transportCall.ts
@@ -29,16 +29,30 @@ import { createHash } from "node:crypto";
 import { getCorrelationId } from "./correlation.js";
 import { logger } from "./logger.js";
 
+/**
+ * Recursively serialize a value with object keys sorted at every depth so
+ * structurally-identical inputs hash identically and structurally-distinct
+ * inputs do not.
+ *
+ * The native `JSON.stringify(value, replacerArray)` form is *not*
+ * sufficient: passing `Object.keys(value).sort()` as the replacer filters
+ * properties to that fixed key list at *every* depth, so nested keys not
+ * present at the top level get dropped — collapsing distinct calls into
+ * the same hash.
+ */
+function stableStringify(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`);
+  return `{${entries.join(",")}}`;
+}
+
 /** Stable sha1-prefix hash of any JSON-serialisable args object. */
 export function hashArgs(args: unknown): string {
-  // Sort top-level keys when args is a plain object so `{a:1,b:2}` and
-  // `{b:2,a:1}` collapse to the same hash. Non-objects (primitives, arrays,
-  // null) serialize as-is.
-  const isPlainObject = typeof args === "object" && args !== null && !Array.isArray(args);
-  const serialized = isPlainObject
-    ? JSON.stringify(args, Object.keys(args as object).sort())
-    : JSON.stringify(args ?? null);
-  return createHash("sha1").update(serialized).digest("hex").slice(0, 16);
+  return createHash("sha1").update(stableStringify(args)).digest("hex").slice(0, 16);
 }
 
 /** Emit a single `transport.call` event at debug level. */

--- a/src/loopDetector/LoopDetector.test.ts
+++ b/src/loopDetector/LoopDetector.test.ts
@@ -138,6 +138,35 @@ describe("buildCallKey", () => {
   it("differs for different tool names with same args", () => {
     expect(buildCallKey("task_list", { id: "x" })).not.toBe(buildCallKey("task_get", { id: "x" }));
   });
+
+  it("distinguishes args that differ only at a nested level", () => {
+    // Regression: previously `JSON.stringify(args, Object.keys(args).sort())`
+    // dropped nested keys, so two semantically-different `task_update` calls
+    // with the same top-level shape collided into the same dedup key and
+    // tripped a false-positive WARN_LOOP_DETECTED → OF_LOOP_DETECTED.
+    const a = { id: "X", changes: { name: "P1" } };
+    const b = { id: "X", changes: { name: "P2" } };
+    expect(buildCallKey("task_update", a)).not.toBe(buildCallKey("task_update", b));
+  });
+
+  it("is stable regardless of key order at any nesting level", () => {
+    const a = { id: "X", changes: { name: "n", note: "x" } };
+    const b = { changes: { note: "x", name: "n" }, id: "X" };
+    expect(buildCallKey("task_update", a)).toBe(buildCallKey("task_update", b));
+  });
+
+  it("does not crash on null/undefined args", () => {
+    // Regression: `Object.keys(null)` / `Object.keys(undefined)` throw,
+    // so the previous implementation crashed in the middleware before
+    // the tool handler ran.
+    expect(() => buildCallKey("task_list", null)).not.toThrow();
+    expect(() => buildCallKey("task_list", undefined)).not.toThrow();
+    expect(buildCallKey("task_list", null)).not.toBe(buildCallKey("task_list", undefined));
+  });
+
+  it("distinguishes arrays with different elements", () => {
+    expect(buildCallKey("t", { ids: ["a", "b"] })).not.toBe(buildCallKey("t", { ids: ["a", "c"] }));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/loopDetector/LoopDetector.ts
+++ b/src/loopDetector/LoopDetector.ts
@@ -47,13 +47,41 @@ const DEFAULT_CONFIG: LoopDetectorConfig = {
 };
 
 /**
+ * Recursively serialize a value so structurally-identical inputs produce
+ * identical strings: object keys are sorted at every nesting level, arrays
+ * preserve order, primitives go through `JSON.stringify`. `undefined` is
+ * encoded explicitly so it survives the hash (plain `JSON.stringify`
+ * returns `undefined`).
+ *
+ * The native `JSON.stringify(value, replacerArray)` form is *not*
+ * sufficient: passing `Object.keys(value).sort()` as the replacer filters
+ * properties to that fixed key list at *every* depth, so nested keys not
+ * present at the top level get dropped. That made
+ * `{id:"X", changes:{name:"P1"}}` and `{id:"X", changes:{name:"P2"}}`
+ * collide, producing false-positive `WARN_LOOP_DETECTED` (and after the
+ * error threshold, hard `OF_LOOP_DETECTED` errors that blocked legitimate
+ * follow-up calls).
+ */
+function stableStringify(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify((value as Record<string, unknown>)[k])}`);
+  return `{${entries.join(",")}}`;
+}
+
+/**
  * Build a stable dedup key from a tool name and its raw arguments object.
  *
- * Uses deterministic JSON serialization (keys sorted) so that
- * `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` hash to the same value.
+ * Uses deterministic recursive JSON serialization (keys sorted at every
+ * level) so that `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` hash to the same
+ * value, while `{ id: "X", changes: { name: "P1" } }` and
+ * `{ id: "X", changes: { name: "P2" } }` do not.
  */
 export function buildCallKey(toolName: string, args: unknown): string {
-  const serialized = JSON.stringify(args, Object.keys(args as object).sort());
+  const serialized = stableStringify(args);
   const hash = createHash("sha1").update(serialized).digest("hex").slice(0, 16);
   return `${toolName}:${hash}`;
 }


### PR DESCRIPTION
Closes #763

## Summary

Three independent bugs found during a sweep of the codebase. Two further findings warranted their own tickets and stay out of this PR (#760, #761) so each ships with its own test plan.

### 1. `fix(observability)`: hash nested args correctly and survive null/undefined — Closes #763

**The bug.** `LoopDetector.buildCallKey` and `transportCall.hashArgs` both used `JSON.stringify(value, Object.keys(value).sort())` to produce a "stable" hash. The replacer-array form filters properties to the listed keys at *every* depth, so any property not present at the top level was dropped from the serialized output. Two semantically-different calls with the same top-level shape collapsed into a single hash:

```js
buildCallKey("task_update", {id:"X", changes:{name:"P1"}})
=== buildCallKey("task_update", {id:"X", changes:{name:"P2"}})  // ← same hash!
```

That made the LoopDetector raise false-positive `WARN_LOOP_DETECTED` and — past the error threshold — throw a hard `OF_LOOP_DETECTED` that **blocked the legitimate follow-up call before the tool handler ran**. The transport.call event suffered the same misclassification (lower impact: debug-level only), making `argsHash` unsafe as a correlation key.

`buildCallKey` also crashed on null/undefined args because `Object.keys(null)` throws `TypeError: Cannot convert undefined or null to object`. The SDK normally validates args to an object before invoking the callback, but the loop detector observed args directly in middleware, so an unschematic tool (or a future SDK behavior change) would have surfaced the crash before any handler ran.

**The fix.** Both call sites now use a recursive `stableStringify` that sorts object keys at every nesting level, preserves array order, encodes `undefined` explicitly, and never throws on null/undefined. New regression tests cover the nested-key, key-reorder, null/undefined, and array-element cases for both `buildCallKey` and `hashArgs` (+7 tests; 3430 total still green).

### 2. `docs(release)`: align stale bundle-size budget mentions with current 800 KiB

Three places still referred to the old budget after the bumps tracked in DESIGN §20 (most recently 780→800 KiB alongside #705):

- `scripts/check-bundle-size.sh:5` — header docstring said "< 580 KiB"
- `.github/workflows/ci.yml:51` — step name said "(< 500 KB per DESIGN §20)"
- `.github/workflows/release.yml:139` — same step name

The actual `BUDGET=819200` (800 KiB) in `check-bundle-size.sh` is correct; only the human-facing labels were stale. CI and release annotations now match the budget the script enforces.

### 3. `chore(lint)`: pin biome `$schema` to installed 2.4.14

`biome.json`'s `$schema` URL pointed at `2.4.13/schema.json` while the installed `@biomejs/biome` is `2.4.14`, surfacing an informational deserialization mismatch on every `pnpm lint` run. Benign but noise.

## Filed as separate tickets (not in this PR)

- #760 — `fix(pagination): hashFilter must sort nested object keys for stable cursor filterHash` — same bug family as #1 above, but in `src/pagination/cursor.ts`. Latent (no current caller passes a nested filter) so kept out of this sweep to keep the diff small.
- #761 — `fix(webhooks): defaultHttpsRequest must register res.on('error') so dispatch never throws upward` — webhook delivery can crash the server on response-stream errors, violating ADR-0016 §4e ("delivery failures NEVER throw upward"). One-line fix, but warrants its own test plan.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (the biome 2.4.13/2.4.14 info is gone)
- [x] `pnpm test` — 3430 passed (was 3423; +7 regression tests, no regressions)
- [ ] CI pipeline green