### PR TITLE
fix: bug-hunt sweep — guard inmemory re-complete count drift

### DIFF
--- a/src/adapter/inMemory/InMemoryAdapter.test.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.test.ts
@@ -102,6 +102,16 @@ describe("InMemoryAdapter — Tasks", () => {
     await expect(a.uncompleteTask(id)).resolves.toBeUndefined();
   });
 
+  it("re-completing an already-completed task does not double-count completedTaskCount", async () => {
+    const a = makeAdapter();
+    const projectId = await a.createProject({ name: "p" });
+    const id = await a.createTask({ name: "t", projectId });
+    await a.completeTask(id);
+    await a.completeTask(id);
+    const project = await a.getProject(projectId);
+    expect(project.completedTaskCount).toBe(1);
+  });
+
   it("dropTask + undropTask round-trip", async () => {
     const a = makeAdapter();
     const id = await a.createTask({ name: "t" });

--- a/src/adapter/inMemory/InMemoryAdapter.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.ts
@@ -327,7 +327,9 @@ export class InMemoryAdapter implements OmniFocusAdapter {
       completedAt: stamp,
       modifiedAt: (stamp ?? isoOf(this.now())) as unknown as Task["modifiedAt"],
     });
-    this.bumpProjectCompletedCount(task.projectId, completed ? +1 : -1);
+    if (completed !== task.completed) {
+      this.bumpProjectCompletedCount(task.projectId, completed ? +1 : -1);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Sweep PR from \`/hunt-bugs\` on 2026-05-08. Single inline fix that passed the rubric; companion ticket filed for the second finding.

## Commits

- **fix(in-memory): skip project completedTaskCount bump when task state unchanged** — [src/adapter/inMemory/InMemoryAdapter.ts:330](src/adapter/inMemory/InMemoryAdapter.ts#L330). \`applyTaskCompletion\` re-stamps \`completedAt\` on re-complete (intentional per the \`task_batch_complete\` contract), but was also calling \`bumpProjectCompletedCount(+1)\` on every call — drifting the test fake's \`completedTaskCount\` upward by one per redundant complete. Guarded the bump on \`completed !== task.completed\` so it only moves on a true state transition; the mirror uncomplete-of-incomplete case was already handled by the early return.

## Triage report

- Inline fixes: **1** (this PR)
- Tickets filed: **1** — Closes #764
- Skipped (dedup): **2** — already-filed #760 (hashFilter nested-key sort), #761 (defaultHttpsRequest res.on('error'))

## Tests

- [x] Local test suite green after the commit (3431 passed / 56 skipped)
- [x] New regression test: \`re-completing an already-completed task does not double-count completedTaskCount\` ([src/adapter/inMemory/InMemoryAdapter.test.ts:105](src/adapter/inMemory/InMemoryAdapter.test.ts#L105))
- [ ] CI green on the sweep PR

## Linked

- Tickets filed: #764 — \`fix(shutdown): validate env-var grace periods to reject NaN/empty/non-positive values\`
- Companion previous sweep: previous \`/hunt-bugs\` cycle merged \`fix(observability): hash nested args correctly and survive null/undefined\` (\`dcec35c\`) and the bundled bug-hunt sweep prior

> Surfaced and shipped via \`/hunt-bugs\` sweep on 2026-05-08.