### PR TITLE
fix(integration): unbreak six contract tests on macos-omnifocus runner (closes #768)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "format": "biome format --write .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "OMNIFOCUS_INTEGRATION=1 vitest run tests/integration",
+    "test:integration": "OMNIFOCUS_INTEGRATION=1 vitest run tests/integration --testTimeout=90000",
     "test:perf": "OMNIFOCUS_PERF=1 vitest run tests/perf",
     "test:e2e": "OMNIFOCUS_E2E=1 vitest run tests/e2e",
     "mutation": "stryker run",

--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -49,7 +49,21 @@ function throwing(msg = "Can't get object."): () => never {
 export interface FakeTagOverrides {
   id?: () => string;
   name?: () => string;
+  /**
+   * `tag.parent()` is unusable in OF 4.x (throws "Can't convert types"); the
+   * canonical accessor is `tag.container()`. `parent` is kept here only for
+   * back-compat with mutation scripts that still reference it; build_tag.js
+   * no longer calls it. Override `container` to test build_tag behavior.
+   */
   parent?: () => unknown;
+  /**
+   * `tag.container()` returns either the parent tag or the document.
+   * build_tag.js distinguishes the two by comparing `container.id()` to the
+   * document's `id()`. Default returns a document-shaped stub whose id
+   * matches `buildFakeDocument`'s `_doc_` so the default tag is treated as
+   * top-level (parentId === null).
+   */
+  container?: () => unknown;
   status?: () => string;
   location?: () => unknown;
   creationDate?: () => Date;
@@ -85,6 +99,7 @@ export function fakeTag(
   const tag: Record<string, unknown> = {
     id,
     parent: overrides.parent ?? throwing(),
+    container: overrides.container ?? fn({ id: () => "_doc_" }),
     location: overrides.location ?? fn(null),
     creationDate: overrides.creationDate ?? fn(now),
     modificationDate: overrides.modificationDate ?? fn(now),

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -132,8 +132,8 @@ describe("JXA sandbox — tag_list", () => {
     expect(modifiedAt).toBeGreaterThanOrEqual(before);
   });
 
-  it("parentId is null when parent() throws", () => {
-    const t = fakeTag({ parent: throwing() });
+  it("parentId is null when container() throws", () => {
+    const t = fakeTag({ container: throwing() });
     const result = runJxaScriptInSandbox<{ tags: { parentId: null }[] }>(
       tagListScript,
       {},
@@ -144,10 +144,11 @@ describe("JXA sandbox — tag_list", () => {
 
   it("filters by parentId when provided — regression #515", () => {
     const t1 = fakeTag({ id: () => "tag_a" });
-    // t2WithParent has parentId === "tag_a"; only it should survive the filter
+    // t2WithParent has container().id() === "tag_a" (not the doc id), so its
+    // parentId is "tag_a" and it survives the parentId="tag_a" filter
     const t2WithParent = fakeTag({
       id: () => "tag_b",
-      parent: () => ({ class: () => "tag", id: () => "tag_a" }),
+      container: () => ({ id: () => "tag_a" }),
     });
     const result = runJxaScriptInSandbox<{ tags: { id: string }[] }>(
       tagListScript,
@@ -534,15 +535,15 @@ describe("JXA sandbox — tag_get", () => {
     expect(new Date(result.tag.createdAt).getTime()).toBeGreaterThanOrEqual(before);
   });
 
-  it("treats parent.class() throw as 'real tag' so parentId is the parent.id — regression #673", () => {
-    // OF 4.x: p.class() throws "Can't convert types" on real Tag specifiers,
-    // and only the document responds. The script must keep parentId set to
-    // the parent's id() rather than skipping to null.
-    const parentTag = {
-      class: throwing("Can't convert types."),
-      id: () => "tag_parent",
-    };
-    const t = fakeTag({ id: () => "tag_child", parent: () => parentTag });
+  it("derives parentId from container().id() when it isn't the document — regression #673/#766", () => {
+    // OF 4.x: tag.parent() throws "Can't convert types" on real Tag specifiers,
+    // so build_tag.js uses tag.container() instead and distinguishes "container
+    // is the document" (parentId=null) from "container is the parent tag"
+    // (parentId=container.id) by comparing container.id() to doc.id().
+    const t = fakeTag({
+      id: () => "tag_child",
+      container: () => ({ id: () => "tag_parent" }),
+    });
     const result = runJxaScriptInSandbox<{ tag: { parentId: string | null } }>(
       tagGetScript,
       { id: "tag_child" },

--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -402,6 +402,10 @@ function buildFakeDocument(doc: SandboxDocument) {
     synchronize: () => undefined,
     // Pass-through for scripts that check class() on the document itself
     class: () => "document",
+    // build_tag.js distinguishes "container is the document" (top-level tag)
+    // from "container is the parent tag" by comparing container.id() to
+    // doc.id(). The default fakeTag's container resolves to this same id.
+    id: () => "_doc_",
   };
 }
 

--- a/src/scripts/jxa/_helpers/build_tag.js
+++ b/src/scripts/jxa/_helpers/build_tag.js
@@ -27,29 +27,25 @@
  * @returns {object} canonical Tag shape per `src/domain/tag.ts`
  */
 // biome-ignore lint/correctness/noUnusedVariables: inlined into JXA consumers via @inline directive (ADR-0020).
-function buildTag(tag) {
+function buildTag(tag, docId) {
+  // OF 4.x: tag.parent() and tag.containingTag() both throw "Can't convert
+  // types." on real Tag specifiers — neither is usable. tag.container() works
+  // and returns either the parent tag or the document. Distinguish by
+  // comparing container.id() to the document's id (passed in as docId because
+  // resolving it per-call would round-trip through osascript on every tag).
   let parentId = null;
   try {
-    const p = tag.parent();
-    if (p) {
-      // OF 4.x: p.class() throws on real Tag specifiers — only the document
-      // responds. Treat throw as "real tag", successful "document" as skip.
-      let isDocument = false;
+    const c = tag.container();
+    if (c) {
       try {
-        isDocument = p.class() === "document";
-      } catch (_classErr) {
-        /* OF 4.x: .class() throws on real project/tag specifiers — treat as non-document */
-      }
-      if (!isDocument) {
-        try {
-          parentId = p.id();
-        } catch (_idErr) {
-          /* OF 4.x: pathological tag specifier — leave parentId = null */
-        }
+        const cid = c.id();
+        if (cid !== docId) parentId = cid;
+      } catch (_idErr) {
+        /* OF 4.x: pathological container specifier — leave parentId = null */
       }
     }
   } catch (_e) {
-    /* OF 4.x: property access may not exist on all object types — default used */
+    /* OF 4.x: container() may also throw on certain specifier shapes */
   }
 
   let location = null;

--- a/src/scripts/jxa/tag_create.js
+++ b/src/scripts/jxa/tag_create.js
@@ -46,6 +46,7 @@ function run(argv) {
   // pushed specifier throw -1728 until the JXA bridge flushes deferred events.
   // .id() is safe immediately; all other properties require re-fetch.
   const tagId = newTag.id();
+  const docId = doc.id();
   const fetchedTag = doc.flattenedTags.byId(tagId);
-  return JSON.stringify({ tag: buildTag(fetchedTag) });
+  return JSON.stringify({ tag: buildTag(fetchedTag, docId) });
 }

--- a/src/scripts/jxa/tag_get.js
+++ b/src/scripts/jxa/tag_get.js
@@ -16,10 +16,12 @@ function run(argv) {
 
   // @inline _helpers/build_tag.js
 
-  const allTags = ofApp.defaultDocument.flattenedTags();
+  const doc = ofApp.defaultDocument;
+  const docId = doc.id();
+  const allTags = doc.flattenedTags();
   for (let i = 0; i < allTags.length; i++) {
     if (allTags[i].id() === args.id) {
-      return JSON.stringify({ tag: buildTag(allTags[i]) });
+      return JSON.stringify({ tag: buildTag(allTags[i], docId) });
     }
   }
 

--- a/src/scripts/jxa/tag_get_many.js
+++ b/src/scripts/jxa/tag_get_many.js
@@ -21,11 +21,13 @@ function run(argv) {
     idSet[args.ids[i]] = null;
   }
 
-  const allTags = ofApp.defaultDocument.flattenedTags();
+  const doc = ofApp.defaultDocument;
+  const docId = doc.id();
+  const allTags = doc.flattenedTags();
   for (let i = 0; i < allTags.length; i++) {
     const tid = allTags[i].id();
     if (Object.hasOwn(idSet, tid)) {
-      idSet[tid] = buildTag(allTags[i]);
+      idSet[tid] = buildTag(allTags[i], docId);
     }
   }
 

--- a/src/scripts/jxa/tag_list.js
+++ b/src/scripts/jxa/tag_list.js
@@ -16,12 +16,14 @@ function run(argv) {
 
   // @inline _helpers/build_tag.js
 
-  const allTags = ofApp.defaultDocument.flattenedTags();
+  const doc = ofApp.defaultDocument;
+  const docId = doc.id();
+  const allTags = doc.flattenedTags();
   const result = [];
 
   for (let i = 0; i < allTags.length; i++) {
     const tag = allTags[i];
-    const built = buildTag(tag);
+    const built = buildTag(tag, docId);
 
     // JxaTransport sends `parentId: null` / `status: null` for "no filter"
     // (rather than omitting). Treat null and undefined identically here so

--- a/src/scripts/jxa/tag_update.js
+++ b/src/scripts/jxa/tag_update.js
@@ -16,7 +16,9 @@ function run(argv) {
 
   // @inline _helpers/build_tag.js
 
-  const allTags = ofApp.defaultDocument.flattenedTags();
+  const doc = ofApp.defaultDocument;
+  const docId = doc.id();
+  const allTags = doc.flattenedTags();
   let target = null;
   for (let i = 0; i < allTags.length; i++) {
     if (allTags[i].id() === args.id) {
@@ -34,5 +36,5 @@ function run(argv) {
   }
   if (args.allowsNextAction !== undefined) target.allowsNextAction = args.allowsNextAction;
 
-  return JSON.stringify({ tag: buildTag(target) });
+  return JSON.stringify({ tag: buildTag(target, docId) });
 }

--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -44,6 +44,18 @@ function run(argv) {
     // flattenedTasks() would include grandchildren and deeper, violating the
     // direct-children contract documented on OmniFocusAdapter.listTasks — see #695.
     tasks = parent.tasks();
+  } else if (args.tagId) {
+    // Scoping the source to the tag's own tasks is asymptotically required:
+    // scanning flattenedTasks() over a real user DB (10k+ tasks) and calling
+    // buildTask on each can exceed the 30s scriptRunner timeout. The tag-rooted
+    // collection is bounded by the tag's actual usage. The post-loop tagId
+    // filter is then a no-op for this branch but kept as a safety net.
+    const tag = lookupOrThrow(
+      ofApp.defaultDocument.flattenedTags.byId(args.tagId),
+      "Tag",
+      args.tagId,
+    );
+    tasks = tag.tasks();
   } else {
     tasks = ofApp.defaultDocument.flattenedTasks();
   }

--- a/tests/contract/adapter.contract.ts
+++ b/tests/contract/adapter.contract.ts
@@ -40,10 +40,17 @@ import { NotFound, ValidationError } from "../../src/errors/index.js";
  *
  * `cleanup` is optional and is called after each test to tear down any
  * fixtures the driver created (e.g. delete test projects from a real OF).
+ *
+ * `hookTimeoutMs` overrides vitest's 10s default for `beforeEach`/`afterEach`.
+ * Live-OF cleanup deletes entities one round-trip at a time and frequently
+ * needs >10s. The per-test `testTimeout` is set via the `--testTimeout` CLI
+ * flag in `package.json` `test:integration` script (vitest doesn't accept a
+ * per-driver test timeout from inside the harness).
  */
 export interface AdapterContractOptions {
   createAdapter: () => OmniFocusAdapter | Promise<OmniFocusAdapter>;
   cleanup?: (adapter: OmniFocusAdapter) => void | Promise<void>;
+  hookTimeoutMs?: number;
 }
 
 /**
@@ -58,16 +65,18 @@ export interface AdapterContractOptions {
  * ```
  */
 export function runAdapterContract(label: string, options: AdapterContractOptions): void {
+  const hookTimeout = options.hookTimeoutMs;
+
   describe(`adapter contract — ${label}`, () => {
     let adapter: OmniFocusAdapter;
 
     beforeEach(async () => {
       adapter = await options.createAdapter();
-    });
+    }, hookTimeout);
 
     afterEach(async () => {
       if (options.cleanup) await options.cleanup(adapter);
-    });
+    }, hookTimeout);
 
     // ---------------------------------------------------------------------
     // Tasks — CRUD
@@ -351,9 +360,18 @@ export function runAdapterContract(label: string, options: AdapterContractOption
       });
 
       test("listProjects filters by status", async () => {
-        const onHold = await adapter.createProject({ name: "p1", status: "on-hold" });
-        await adapter.createProject({ name: "p2", status: "active" });
-        const result = await adapter.listProjects({ status: "on-hold" });
+        // Scope to a test folder so the filter only sees this test's projects.
+        // Live OF DBs typically have other on-hold projects from real use; an
+        // unscoped status filter would race against them. Mirrors how the
+        // other filter tests (flagged, completed, dueBefore) scope to a project.
+        const folderId = await adapter.createFolder({ name: "status-filter-test" });
+        const onHold = await adapter.createProject({
+          name: "p1",
+          status: "on-hold",
+          folderId,
+        });
+        await adapter.createProject({ name: "p2", status: "active", folderId });
+        const result = await adapter.listProjects({ status: "on-hold", folderId });
         expect(result.map((p) => p.id)).toEqual([onHold]);
       });
 

--- a/tests/integration/transportRouter.contract.test.ts
+++ b/tests/integration/transportRouter.contract.test.ts
@@ -114,6 +114,19 @@ if (!INTEGRATION) {
             return id;
           };
         }
+        // duplicateTask creates a new task (and optionally a clone subtree).
+        // Track the returned newId so cleanup deletes the clone — without
+        // this, recursive duplicates accumulate as detritus across runs.
+        // Descendants cascade-delete when newId is removed.
+        if (prop === "duplicateTask") {
+          return async (
+            ...args: Parameters<OmniFocusAdapter["duplicateTask"]>
+          ): Promise<{ newId: TaskId; descendantCount: number }> => {
+            const result = await target.duplicateTask(...args);
+            state.taskIds.push(result.newId);
+            return result;
+          };
+        }
 
         // Delegate everything else.
         const val = Reflect.get(target, prop, target);
@@ -155,8 +168,13 @@ if (!INTEGRATION) {
   }
 
   // Mount the shared contract suite against the live TransportRouter.
+  // Cleanup deletes entities through osascript one round-trip at a time and
+  // frequently needs more than vitest's 10s default; bump only the hook
+  // timeout here. The per-test timeout is bumped at the script level — see
+  // `pnpm test:integration` in package.json.
   runAdapterContract("TransportRouter (live OmniFocus)", {
     createAdapter: makeTrackingAdapter,
     cleanup: cleanupAdapter,
+    hookTimeoutMs: 90_000,
   });
 }


### PR DESCRIPTION
## Summary

Fixes the six contract-test failures that have been red on the `macos-omnifocus` self-hosted runner since before [#735](https://github.com/torsday/omnifocus-mcp/pull/735) made the integration suite a required check. With these fixes, [#735](https://github.com/torsday/omnifocus-mcp/pull/735)'s `integration-gate` job goes green and that PR can merge cleanly without admin override.

## The fixes

1. **`tag.parent()` → `tag.container()` in OF 4.x** (`build_tag.js` + 5 callers). The previous workaround relied on catching `parent.class()`'s throw vs. `"document"` return, but in OF 4.x `parent()` *itself* throws `"Can't convert types"`. The outer catch swallowed it and `parentId` stayed `null` for every tag. `container()` works, returns the parent tag (or document for top-level tags), and `container.id() === doc.id()` cleanly distinguishes the two. `docId` is computed once per script invocation and threaded into `buildTag`.

2. **Tag-rooted source for `tagId` filter** (`task_list.js`). Scanning `flattenedTasks()` over a real DB and calling `buildTask` per task blew the 30s scriptRunner timeout. When `tagId` is given (and no other source-narrowing filter), source from `tag.tasks()` instead — bounded by the tag's actual usage.

3. **Folder-scope the `listProjects` status filter test** (`adapter.contract.ts`). Other filter tests scope to a project to dodge the maintainer's actual data; this one didn't and was racing real on-hold projects.

4. **Live-OF hook + test timeouts** (`adapter.contract.ts` + `transportRouter.contract.test.ts` + `package.json`). vitest's 5s/10s defaults are too tight for live OF (each `osascript` round-trip is hundreds of ms; tests creating 4+ entities plus cleanup needs 20–60s). Adds optional `hookTimeoutMs` to `AdapterContractOptions`; the live-OF driver passes 90s. Per-test timeout is bumped to 90s via `--testTimeout=90000` on the `test:integration` script. InMemory tier ignores both.

5. **Track `duplicateTask` newId for cleanup** (`transportRouter.contract.test.ts`). The proxy intercepted only the four `create*` methods, so recursive duplicate clones accumulated as detritus. Adding the interception lets cleanup cascade-delete the clone subtree via the root.

#### Note on the "intermittent NotFound" failure

The cross-project reorder failure observed in [#735](https://github.com/torsday/omnifocus-mcp/pull/735)'s CI (`NotFound: Can't get object. (-1728)`) reproduces against the older PR base but passes consistently on current `main`. No code change here addresses it directly — it appears to have been state-dependent on whatever was different about the PR base.

## Test plan

- [x] All 6 originally-failing tests pass locally (`OMNIFOCUS_INTEGRATION=1 pnpm test:integration -t '<filter>'`):
  - `listTags filters by parentId` ✓
  - `tagId filter returns tasks carrying that tag` ✓
  - `listProjects filters by status` ✓
  - `duplicateTask — recursive clones full subtree depth-first` ✓
  - `reorderTask — at:end moves task to end of container` ✓
  - `reorderTask — { at, in } to a different project reparents` ✓
- [ ] Full `pnpm test:integration` suite green
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm test` (unit) green
- [ ] `bash scripts/check-bundle-size.sh` passes (810391 bytes / 819200 budget after build)

## Closes

Closes #768.

## Follow-up

After this merges, [#735](https://github.com/torsday/omnifocus-mcp/pull/735) should be re-run; the `integration-gate` check should go green and that PR can merge without admin override.
