### PR TITLE
test(benchmark): token-cost benchmark suite for canonical LLM workflows

### DIFF
--- a/.github/workflows/token-cost-bench.yml
+++ b/.github/workflows/token-cost-bench.yml
@@ -1,0 +1,41 @@
+name: Token-cost benchmark
+
+# Non-required check (#771). Runs the hermetic in-memory benchmark suite
+# against the checked-in baseline; fails on ≥ 5% drift in any tracked
+# field. Promote to required once the baseline has held for one week of
+# unrelated PR traffic — see tests/benchmark/token-cost/README.md.
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/benchmark/token-cost/**"
+      - ".github/workflows/token-cost-bench.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  push:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: token-cost-bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 10
+    name: token-cost bench
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test:bench:tokens

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "test:integration": "OMNIFOCUS_INTEGRATION=1 vitest run tests/integration",
     "test:perf": "OMNIFOCUS_PERF=1 vitest run tests/perf",
     "test:e2e": "OMNIFOCUS_E2E=1 vitest run tests/e2e",
+    "test:bench:tokens": "OMNIFOCUS_BENCH=1 vitest run tests/benchmark/token-cost",
+    "bench:tokens": "tsx tests/benchmark/token-cost/cli.ts",
     "mutation": "stryker run",
     "prepublishOnly": "pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run build",
     "prepare": "simple-git-hooks"

--- a/tests/benchmark/token-cost/README.md
+++ b/tests/benchmark/token-cost/README.md
@@ -1,0 +1,131 @@
+# Token-cost benchmark suite (#771)
+
+A measurement-only suite that records the bytes (and estimated tokens) an
+LLM agent exchanges with this MCP server when running canonical
+workflows. Every optimization PR under [#770](https://github.com/torsday/omnifocus-mcp/issues/770)
+runs against this suite to prove non-zero improvement on at least one
+workflow without regressing the others.
+
+The suite is hermetic: it drives `InMemoryAdapter` directly, does not
+touch JXA, and does not require OmniFocus to be running.
+
+## What it measures
+
+For each fixture workflow the suite records:
+
+| Field | What it captures |
+| --- | --- |
+| `toolListBytes` | UTF-8 length of the simulated `tools/list` payload (every tool's `{name, description, inputSchema}`). Workflow-independent. |
+| `totalRequestBytes` | Sum of UTF-8 lengths of every JSON-stringified tool input the workflow sends. |
+| `totalResponseBytes` | Sum of UTF-8 lengths of every `toolResponse(envelope)` the workflow receives. Captures both `content[0].text` and `structuredContent` — what the wire delivers. |
+| `totalRoundTripBytes` | `totalRequestBytes + totalResponseBytes`. |
+| `totalTokens` | `(toolListBytes + totalRoundTripBytes) / TOKEN_DIVISOR`, rounded. |
+| `byTool[<name>]` | Per-tool aggregate `{ calls, responseBytes }` — surfaces hotspots so an optimization PR can scope its change. |
+
+### Why measure at the handler boundary, not the JSON-RPC wire?
+
+The full `startServer()` boot installs signal handlers, opens stdio, and
+starts the database watcher — none of which the benchmark needs.
+Refactoring boot into an in-process variant was an explicit non-goal of
+[#771](https://github.com/torsday/omnifocus-mcp/issues/771).
+Measuring at the handler boundary captures everything that varies under
+[#770](https://github.com/torsday/omnifocus-mcp/issues/770) optimizations
+(tool descriptions, input schemas, response payloads). The JSON-RPC
+framing adds a small constant per call (~30 B for
+`{"jsonrpc":"2.0","id":N,"result":...}`); excluding it isolates the
+optimizable surface.
+
+### Token estimate
+
+Tokens are estimated as `bytes / 4` (`TOKEN_DIVISOR` in
+[`tokenizer.ts`](./tokenizer.ts)). For the JSON shapes this suite measures
+— mostly ASCII keys, ULID/short-name IDs, ISO timestamps — Claude
+tokenizers land empirically in the 3.5–4.5 bytes-per-token range, so 4
+is a documented heuristic that puts token deltas in lockstep with byte
+deltas. The absolute number is less important than the stability of the
+conversion: the snapshot's tolerance band catches both metrics.
+
+If a future ticket pulls in a real tokenizer, swap the implementation
+behind `estimateTokens` and re-baseline once.
+
+## Fixture workflows
+
+| Workflow | What it exercises |
+| --- | --- |
+| `inbox-triage` | `tag_create` → `task_batch_create` (20 tasks with multi-KB notes) → `task_list` (inbox) → `task_batch_assign` (flag + tag + defer) → `task_batch_complete` (5) → `task_list` (post-triage). |
+| `weekly-review` | Seeds 5 projects × 3 tasks with `nextReviewDate` in the past, then `review_list_due` → for each project: `task_list` + `project_mark_reviewed`. |
+| `project-planning` | `project_create` → `tag_create` → `task_batch_create` (10 milestone tasks) → `task_batch_assign` (tag + defer) → `project_get` → `task_list` (post-planning). |
+
+Notes are intentionally sized in the multi-KB range so downstream
+truncation work ([#775](https://github.com/torsday/omnifocus-mcp/issues/775))
+shows measurable effect against this baseline.
+
+## Drift policy
+
+The baseline at [`__snapshots__/baseline.json`](./__snapshots__/baseline.json)
+is the contract. Each run rebuilds the counts and compares.
+
+- **Drift `< 5%`** in any tracked field → passes silently. Absorbs
+  fixture noise (cache mode, ID counter shifts under refactor, minor
+  envelope additions).
+- **Drift `≥ 5%`** in either direction → fails the run, prints the diff.
+  Symmetric thresholds catch both regressions and improvements that
+  forgot to re-baseline.
+
+### How optimization PRs use this suite
+
+A PR under #770 should:
+
+1. Implement the optimization.
+2. Run `pnpm bench:tokens` locally to see the diff.
+3. Run `pnpm bench:tokens --update` to rewrite the baseline.
+4. Include the baseline diff in the PR — the JSON change is the
+   documentation that the optimization landed.
+5. Confirm at least one workflow's `totalRoundTripBytes` dropped and no
+   workflow regressed by ≥ 5%.
+
+A PR that should **not** affect token cost (refactor, bug fix, new
+unrelated feature) but trips drift is a real regression and must be
+investigated before merge.
+
+## Running
+
+```bash
+# Pretty-printed local run, compared to baseline (exits non-zero on drift)
+pnpm bench:tokens
+
+# Re-baseline (writes __snapshots__/baseline.json)
+pnpm bench:tokens --update
+
+# CI-style run via vitest (used by the GitHub Actions workflow)
+pnpm test:bench:tokens
+```
+
+The vitest entry is gated on `OMNIFOCUS_BENCH=1` so it stays out of the
+default `pnpm test` matrix.
+
+## CI promotion path
+
+The benchmark currently runs as a **non-required** check in
+[`.github/workflows/token-cost-bench.yml`](../../../.github/workflows/token-cost-bench.yml).
+
+Promote to required once:
+
+1. The baseline has held for one week of unrelated PR traffic without
+   spurious failures.
+2. Re-baselining cadence under #770 stabilizes (a re-baseline per
+   optimization PR is expected — too-frequent re-baselines outside #770
+   suggest fixture flakiness).
+
+Promotion is a one-line edit to the repo's branch protection settings;
+no code change here.
+
+## Adding a new fixture
+
+1. Add `tests/benchmark/token-cost/workflows/<name>.ts` exporting an
+   `async run<Name>(ctx: BenchToolContext): Promise<Bench>` that calls
+   `bench.call(toolName, input, () => handle<Name>(input, derivedCtx))`
+   for each tool invocation.
+2. Wire it into [`run.test.ts`](./run.test.ts) and [`cli.ts`](./cli.ts).
+3. Run `pnpm bench:tokens --update` to extend the baseline.
+4. Document the new workflow in the table above.

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -1,0 +1,89 @@
+{
+  "generatedAt": "2026-05-09",
+  "toolListBytes": 166460,
+  "workflows": {
+    "inbox-triage": {
+      "callCount": 6,
+      "totalRequestBytes": 29554,
+      "totalResponseBytes": 146252,
+      "totalRoundTripBytes": 175806,
+      "totalTokens": 85567,
+      "byTool": {
+        "tag_create": {
+          "calls": 1,
+          "responseBytes": 958
+        },
+        "task_batch_assign": {
+          "calls": 1,
+          "responseBytes": 4426
+        },
+        "task_batch_complete": {
+          "calls": 1,
+          "responseBytes": 1530
+        },
+        "task_batch_create": {
+          "calls": 1,
+          "responseBytes": 4514
+        },
+        "task_list": {
+          "calls": 2,
+          "responseBytes": 134824
+        }
+      }
+    },
+    "project-planning": {
+      "callCount": 6,
+      "totalRequestBytes": 2609,
+      "totalResponseBytes": 37754,
+      "totalRoundTripBytes": 40363,
+      "totalTokens": 51706,
+      "byTool": {
+        "project_create": {
+          "calls": 1,
+          "responseBytes": 1118
+        },
+        "project_get": {
+          "calls": 1,
+          "responseBytes": 16422
+        },
+        "tag_create": {
+          "calls": 1,
+          "responseBytes": 974
+        },
+        "task_batch_assign": {
+          "calls": 1,
+          "responseBytes": 2002
+        },
+        "task_batch_create": {
+          "calls": 1,
+          "responseBytes": 2090
+        },
+        "task_list": {
+          "calls": 1,
+          "responseBytes": 15148
+        }
+      }
+    },
+    "weekly-review": {
+      "callCount": 11,
+      "totalRequestBytes": 292,
+      "totalResponseBytes": 33000,
+      "totalRoundTripBytes": 33292,
+      "totalTokens": 49938,
+      "byTool": {
+        "project_mark_reviewed": {
+          "calls": 5,
+          "responseBytes": 4010
+        },
+        "review_list_due": {
+          "calls": 1,
+          "responseBytes": 6780
+        },
+        "task_list": {
+          "calls": 5,
+          "responseBytes": 22210
+        }
+      }
+    }
+  }
+}

--- a/tests/benchmark/token-cost/byteCounter.ts
+++ b/tests/benchmark/token-cost/byteCounter.ts
@@ -1,0 +1,22 @@
+/**
+ * UTF-8 byte counting for the token-cost benchmark suite (#771).
+ *
+ * `JSON.stringify(value).length` returns *code units*, which over-counts
+ * surrogate pairs and under-counts multi-byte UTF-8 sequences for any
+ * non-ASCII content the LLM round-trips. The suite drives mostly-ASCII
+ * fixtures, but the helper lives here so that any future fixture with
+ * notes containing emoji or non-Latin characters measures correctly.
+ *
+ * `Buffer.byteLength(s, "utf8")` is the canonical Node way to size a
+ * string at the wire — that's what the MCP transport actually writes.
+ */
+
+/** UTF-8 byte length of a JSON-stringifiable value. */
+export function jsonByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value) ?? "", "utf8");
+}
+
+/** UTF-8 byte length of a string. */
+export function stringByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}

--- a/tests/benchmark/token-cost/cli.ts
+++ b/tests/benchmark/token-cost/cli.ts
@@ -1,0 +1,100 @@
+/**
+ * CLI entry for `pnpm bench:tokens` (#771).
+ *
+ * Runs every fixture workflow, prints a human-readable per-workflow
+ * summary, and either compares against the checked-in baseline (default)
+ * or rewrites it (`--update`). Exits non-zero on drift ≥ 5%.
+ */
+
+import { createBenchContext, measureToolsListOnce, type WorkflowResult } from "./runBench.js";
+import {
+  buildSnapshot,
+  DRIFT_FAIL_PCT,
+  diffSnapshots,
+  formatDrift,
+  readSnapshot,
+  SNAPSHOT_PATH,
+  writeSnapshot,
+} from "./snapshot.js";
+import { estimateTokens } from "./tokenizer.js";
+import { runInboxTriage } from "./workflows/inboxTriage.js";
+import { runProjectPlanning } from "./workflows/projectPlanning.js";
+import { runWeeklyReview } from "./workflows/weeklyReview.js";
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  return `${(n / 1024).toFixed(1)} KiB`;
+}
+
+function pad(label: string, w: number): string {
+  return label.length >= w ? label : `${label}${" ".repeat(w - label.length)}`;
+}
+
+async function main(): Promise<void> {
+  const update = process.argv.includes("--update");
+
+  const toolListBytes = measureToolsListOnce();
+  const results: WorkflowResult[] = [];
+
+  for (const [label, runner] of [
+    ["inbox-triage", runInboxTriage] as const,
+    ["weekly-review", runWeeklyReview] as const,
+    ["project-planning", runProjectPlanning] as const,
+  ]) {
+    const bench = await runner(createBenchContext());
+    const result = bench.result(toolListBytes);
+    results.push(result);
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.log(`\n# ${label}`);
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.log(
+      `  calls: ${result.callCount}  ` +
+        `req: ${fmtBytes(result.totalRequestBytes)}  ` +
+        `res: ${fmtBytes(result.totalResponseBytes)}  ` +
+        `total: ${fmtBytes(result.totalRoundTripBytes)}  ` +
+        `tokens: ${result.totalTokens}`,
+    );
+    for (const tool of Object.keys(result.byTool).sort()) {
+      const slot = result.byTool[tool]!;
+      // biome-ignore lint/suspicious/noConsole: intentional CLI output
+      console.log(`    ${pad(tool, 26)} calls=${slot.calls}  res=${fmtBytes(slot.responseBytes)}`);
+    }
+  }
+
+  // biome-ignore lint/suspicious/noConsole: intentional CLI output
+  console.log(
+    `\ntools/list payload: ${fmtBytes(toolListBytes)} (~${estimateTokens(toolListBytes)} tokens)`,
+  );
+
+  const current = buildSnapshot(results);
+
+  if (update) {
+    writeSnapshot(current);
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.log(`\nbaseline updated: ${SNAPSHOT_PATH}`);
+    return;
+  }
+
+  const baseline = readSnapshot();
+  if (baseline === undefined) {
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.error(
+      `\nno baseline snapshot at ${SNAPSHOT_PATH} — run \`pnpm bench:tokens --update\` to create one`,
+    );
+    process.exit(1);
+  }
+  const drift = diffSnapshots(baseline, current);
+  if (drift.length > 0) {
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.error(`\ndrift ≥ ${DRIFT_FAIL_PCT}%:\n${formatDrift(drift)}`);
+    process.exit(1);
+  }
+  // biome-ignore lint/suspicious/noConsole: intentional CLI output
+  console.log(`\nno drift ≥ ${DRIFT_FAIL_PCT}% — baseline holds`);
+}
+
+main().catch((err) => {
+  // biome-ignore lint/suspicious/noConsole: intentional CLI error
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/benchmark/token-cost/run.test.ts
+++ b/tests/benchmark/token-cost/run.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Vitest entry for the token-cost benchmark suite (#771).
+ *
+ * Gated on `OMNIFOCUS_BENCH=1` so it does not bloat the default test
+ * matrix — the suite is hermetic (in-memory adapter, no external IO),
+ * but it produces console output and is intended to run as a separate
+ * CI job per the suite's README.
+ *
+ * The single `bench` test runs every workflow against a fresh
+ * {@link createBenchContext}, builds the snapshot payload, and
+ * compares against the checked-in baseline. Drift ≥ 5% in any
+ * tracked field fails the test.
+ */
+
+import { describe, expect, test } from "vitest";
+import { createBenchContext, measureToolsListOnce, type WorkflowResult } from "./runBench.js";
+import { buildSnapshot, diffSnapshots, formatDrift, readSnapshot } from "./snapshot.js";
+import { runInboxTriage } from "./workflows/inboxTriage.js";
+import { runProjectPlanning } from "./workflows/projectPlanning.js";
+import { runWeeklyReview } from "./workflows/weeklyReview.js";
+
+const ENABLED = process.env.OMNIFOCUS_BENCH === "1";
+
+if (!ENABLED) {
+  describe("token-cost benchmark", () => {
+    test.skip("skipped — set OMNIFOCUS_BENCH=1 to run", () => {});
+  });
+} else {
+  describe("token-cost benchmark", () => {
+    test("workflows match baseline within 5% tolerance", async () => {
+      const toolListBytes = measureToolsListOnce();
+      const results: WorkflowResult[] = [];
+
+      for (const runner of [runInboxTriage, runWeeklyReview, runProjectPlanning]) {
+        const bench = await runner(createBenchContext());
+        results.push(bench.result(toolListBytes));
+      }
+
+      const current = buildSnapshot(results);
+      const baseline = readSnapshot();
+      if (baseline === undefined) {
+        throw new Error("no baseline snapshot — run `pnpm bench:tokens --update` to generate one");
+      }
+      const drift = diffSnapshots(baseline, current);
+      expect(drift, `drift detected:\n${formatDrift(drift)}`).toEqual([]);
+    });
+  });
+}

--- a/tests/benchmark/token-cost/runBench.ts
+++ b/tests/benchmark/token-cost/runBench.ts
@@ -1,0 +1,216 @@
+/**
+ * Token-cost benchmark harness (#771).
+ *
+ * Drives canonical LLM workflows against the {@link InMemoryAdapter} and
+ * measures the I/O an MCP client would observe per call:
+ *
+ * - `requestBytes`: UTF-8 length of the JSON-stringified tool input
+ * - `responseBytes`: UTF-8 length of the JSON-stringified tool response
+ *   (matches what `toolResponse(...)` emits, including both `content[0].text`
+ *   and `structuredContent`)
+ * - `tokens`: byte estimate via {@link estimateTokens}
+ *
+ * Why measure at the handler boundary rather than the JSON-RPC wire? The
+ * server boots a real `McpServer` only inside `startServer()` (signal
+ * handlers, stdio, watcher), so reusing it for an in-process benchmark
+ * would mean refactoring boot — explicit non-goal of #771. The handler
+ * boundary captures everything that varies under optimization in #770:
+ * tool descriptions (via tools/list), input schemas, response payloads.
+ * The JSON-RPC framing adds a small constant overhead per call (~30 B for
+ * `{"jsonrpc":"2.0","id":N,"result":...}`); measuring without it isolates
+ * the optimizable surface.
+ *
+ * @see tests/benchmark/token-cost/README.md — baseline policy, fixtures
+ * @see #770 — parent epic (per-tool optimizations consume this baseline)
+ */
+
+import { InMemoryAdapter } from "../../../src/adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../../../src/cache/lruCache.js";
+import type { ResponseMeta } from "../../../src/envelope/index.js";
+import { isError, type ToolEnvelope, toolResponse } from "../../../src/envelope/index.js";
+import { generateCorrelationId, getCorrelationId } from "../../../src/logging/correlation.js";
+import { AttachmentService } from "../../../src/services/attachmentService.js";
+import { ExportService } from "../../../src/services/exportService.js";
+import { FolderService } from "../../../src/services/folderService.js";
+import { ForecastService } from "../../../src/services/forecastService.js";
+import { PerspectiveService } from "../../../src/services/perspectiveService.js";
+import { PluginService } from "../../../src/services/pluginService.js";
+import { ProjectService } from "../../../src/services/projectService.js";
+import { ReviewService } from "../../../src/services/reviewService.js";
+import { SearchService } from "../../../src/services/searchService.js";
+import { TagService } from "../../../src/services/tagService.js";
+import { TaskService } from "../../../src/services/taskService.js";
+import { jsonByteLength } from "./byteCounter.js";
+import { estimateTokens } from "./tokenizer.js";
+import { computeToolsListBytes } from "./toolsList.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CallRecord {
+  tool: string;
+  requestBytes: number;
+  responseBytes: number;
+  outcome: "ok" | "error";
+}
+
+export interface WorkflowResult {
+  workflow: string;
+  toolListBytes: number;
+  callCount: number;
+  totalRequestBytes: number;
+  totalResponseBytes: number;
+  totalRoundTripBytes: number;
+  totalTokens: number;
+  /** Per-tool aggregate response bytes — surfaces hotspots. */
+  byTool: Record<string, { calls: number; responseBytes: number }>;
+}
+
+/**
+ * Service+cache+adapter bundle the workflow handlers consume. Tools accept a
+ * superset of these fields via per-tool context shapes (e.g. `{adapter,
+ * makeMeta, cache}` or `{taskService, makeMeta}`); workflows wire the
+ * specific shape each call needs.
+ */
+export interface BenchToolContext {
+  adapter: InMemoryAdapter;
+  cache: OmniFocusLruCache;
+  taskService: TaskService;
+  projectService: ProjectService;
+  tagService: TagService;
+  folderService: FolderService;
+  attachmentService: AttachmentService;
+  exportService: ExportService;
+  forecastService: ForecastService;
+  perspectiveService: PerspectiveService;
+  pluginService: PluginService;
+  reviewService: ReviewService;
+  searchService: SearchService;
+  makeMeta: (partial?: Partial<ResponseMeta>) => ResponseMeta;
+}
+
+/**
+ * Local mirror of `composition.ts` `makeMeta` — duplicated rather than
+ * imported because that module pulls in `JxaTransport`, which static-
+ * imports precompiled JXA `.js` scripts that `tsx` cannot resolve as ESM.
+ * Keeping this small inline copy avoids dragging the live transport chain
+ * into the bench harness.
+ */
+function makeMeta(partial: Partial<ResponseMeta> = {}): ResponseMeta {
+  return {
+    correlationId: getCorrelationId() ?? generateCorrelationId(),
+    durationMs: 0,
+    cacheHit: false,
+    transport: "jxa",
+    ofVersion: "unknown",
+    ...partial,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bench
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fresh `BenchToolContext` backed by an `InMemoryAdapter`. Each
+ * workflow gets its own context so cross-workflow state never leaks.
+ */
+/** Pin the adapter clock to a fixed date so timestamps in responses are stable. */
+const PINNED_NOW = () => new Date("2026-05-01T12:00:00.000Z");
+
+export function createBenchContext(): BenchToolContext {
+  const adapter = new InMemoryAdapter({ now: PINNED_NOW });
+  const cache = new OmniFocusLruCache({ capacity: 256, ttlMs: 60_000 });
+  return {
+    adapter,
+    cache,
+    taskService: new TaskService({ adapter, cache }),
+    projectService: new ProjectService({ adapter, cache }),
+    tagService: new TagService({ adapter, cache }),
+    folderService: new FolderService({ adapter, cache }),
+    attachmentService: new AttachmentService({
+      adapter,
+      allowedPaths: [],
+      maxAttachmentMb: 16,
+    }),
+    exportService: new ExportService({ adapter }),
+    forecastService: new ForecastService({ adapter }),
+    perspectiveService: new PerspectiveService({ adapter }),
+    pluginService: new PluginService({ adapter }),
+    reviewService: new ReviewService({ adapter, cache }),
+    searchService: new SearchService({ adapter }),
+    makeMeta,
+  };
+}
+
+export class Bench {
+  readonly workflow: string;
+  private readonly calls: CallRecord[] = [];
+
+  constructor(workflow: string) {
+    this.workflow = workflow;
+  }
+
+  /**
+   * Invoke a tool handler, record per-call I/O, and return the envelope so
+   * the workflow can chain on it.
+   *
+   * `fn` receives the raw input the workflow already passed and returns the
+   * envelope the handler produced. The harness wraps with `toolResponse(...)`
+   * to match the wire shape an MCP client would observe.
+   */
+  async call<T>(
+    tool: string,
+    input: unknown,
+    fn: () => Promise<ToolEnvelope<T>>,
+  ): Promise<ToolEnvelope<T>> {
+    const requestBytes = jsonByteLength(input);
+    let envelope: ToolEnvelope<T>;
+    let outcome: "ok" | "error" = "ok";
+    try {
+      envelope = await fn();
+    } catch (err) {
+      this.calls.push({ tool, requestBytes, responseBytes: 0, outcome: "error" });
+      throw err;
+    }
+    if (isError(envelope)) outcome = "error";
+    const responseBytes = jsonByteLength(toolResponse(envelope));
+    this.calls.push({ tool, requestBytes, responseBytes, outcome });
+    return envelope;
+  }
+
+  /** Aggregate results into a `WorkflowResult`. */
+  result(toolListBytes: number): WorkflowResult {
+    let totalRequest = 0;
+    let totalResponse = 0;
+    const byTool: Record<string, { calls: number; responseBytes: number }> = {};
+    for (const c of this.calls) {
+      totalRequest += c.requestBytes;
+      totalResponse += c.responseBytes;
+      let slot = byTool[c.tool];
+      if (slot === undefined) {
+        slot = { calls: 0, responseBytes: 0 };
+        byTool[c.tool] = slot;
+      }
+      slot.calls += 1;
+      slot.responseBytes += c.responseBytes;
+    }
+    const totalRoundTrip = totalRequest + totalResponse;
+    return {
+      workflow: this.workflow,
+      toolListBytes,
+      callCount: this.calls.length,
+      totalRequestBytes: totalRequest,
+      totalResponseBytes: totalResponse,
+      totalRoundTripBytes: totalRoundTrip,
+      totalTokens: estimateTokens(toolListBytes + totalRoundTrip),
+      byTool,
+    };
+  }
+}
+
+/** Convenience — share one tools/list measurement across workflows in a run. */
+export function measureToolsListOnce(): number {
+  return computeToolsListBytes();
+}

--- a/tests/benchmark/token-cost/snapshot.ts
+++ b/tests/benchmark/token-cost/snapshot.ts
@@ -1,0 +1,146 @@
+/**
+ * Snapshot read/write/compare for the token-cost benchmark suite (#771).
+ *
+ * Snapshots are checked-in JSON files that capture the byte counts produced
+ * by each fixture workflow on a known-good main. Every CI run rebuilds the
+ * counts and compares against the snapshot:
+ *
+ * - Drift `< {@link DRIFT_FAIL_PCT}` (5%) is treated as fixture noise and
+ *   passes silently.
+ * - Drift `≥ 5%` in either direction fails the run, printing a diff.
+ *
+ * Why two-sided? Optimization PRs in #770 *want* to lower bytes; an
+ * improvement of ≥ 5% should fail until the PR re-baselines so the change
+ * is documented in the diff. Symmetric thresholds also catch regressions
+ * a one-sided gate would miss.
+ *
+ * The snapshot intentionally records only top-level totals + per-tool
+ * aggregates — not the full {@link CallRecord} array. Per-call detail
+ * fluctuates with adapter-internal ID generation order; the totals do not.
+ *
+ * Re-baseline by running `pnpm bench:tokens --update`. The script writes
+ * the current run to `__snapshots__/baseline.json`. The PR diff that
+ * results is the documentation.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { WorkflowResult } from "./runBench.js";
+
+export const DRIFT_FAIL_PCT = 5;
+
+const SNAPSHOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "__snapshots__");
+const BASELINE_PATH = resolve(SNAPSHOT_DIR, "baseline.json");
+
+/** Persisted shape — totals only, sorted by workflow name for stable diffs. */
+export interface SnapshotPayload {
+  /** ISO date the snapshot was last regenerated; advisory. */
+  generatedAt: string;
+  /** Tools/list payload bytes — workflow-independent. */
+  toolListBytes: number;
+  /** Per-workflow totals, keyed by workflow name. */
+  workflows: Record<
+    string,
+    {
+      callCount: number;
+      totalRequestBytes: number;
+      totalResponseBytes: number;
+      totalRoundTripBytes: number;
+      totalTokens: number;
+      byTool: Record<string, { calls: number; responseBytes: number }>;
+    }
+  >;
+}
+
+export function buildSnapshot(results: WorkflowResult[]): SnapshotPayload {
+  const sorted = [...results].sort((a, b) => a.workflow.localeCompare(b.workflow));
+  const toolListBytes = sorted[0]?.toolListBytes ?? 0;
+  const workflows: SnapshotPayload["workflows"] = {};
+  for (const r of sorted) {
+    const sortedByTool: Record<string, { calls: number; responseBytes: number }> = {};
+    for (const k of Object.keys(r.byTool).sort()) {
+      sortedByTool[k] = r.byTool[k]!;
+    }
+    workflows[r.workflow] = {
+      callCount: r.callCount,
+      totalRequestBytes: r.totalRequestBytes,
+      totalResponseBytes: r.totalResponseBytes,
+      totalRoundTripBytes: r.totalRoundTripBytes,
+      totalTokens: r.totalTokens,
+      byTool: sortedByTool,
+    };
+  }
+  return { generatedAt: new Date().toISOString().slice(0, 10), toolListBytes, workflows };
+}
+
+export function readSnapshot(): SnapshotPayload | undefined {
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as SnapshotPayload;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+export function writeSnapshot(payload: SnapshotPayload): void {
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+export interface DriftFinding {
+  path: string;
+  baseline: number;
+  current: number;
+  driftPct: number;
+}
+
+/** Compare two snapshots, reporting any field whose drift exceeds the threshold. */
+export function diffSnapshots(baseline: SnapshotPayload, current: SnapshotPayload): DriftFinding[] {
+  const findings: DriftFinding[] = [];
+  pushIfDrifted(findings, "toolListBytes", baseline.toolListBytes, current.toolListBytes);
+
+  const wfNames = new Set([...Object.keys(baseline.workflows), ...Object.keys(current.workflows)]);
+  for (const wf of [...wfNames].sort()) {
+    const b = baseline.workflows[wf];
+    const c = current.workflows[wf];
+    if (!b) {
+      findings.push({ path: `${wf} (new workflow)`, baseline: 0, current: 1, driftPct: 100 });
+      continue;
+    }
+    if (!c) {
+      findings.push({ path: `${wf} (removed workflow)`, baseline: 1, current: 0, driftPct: 100 });
+      continue;
+    }
+    pushIfDrifted(findings, `${wf}.callCount`, b.callCount, c.callCount);
+    pushIfDrifted(findings, `${wf}.totalRequestBytes`, b.totalRequestBytes, c.totalRequestBytes);
+    pushIfDrifted(findings, `${wf}.totalResponseBytes`, b.totalResponseBytes, c.totalResponseBytes);
+    pushIfDrifted(
+      findings,
+      `${wf}.totalRoundTripBytes`,
+      b.totalRoundTripBytes,
+      c.totalRoundTripBytes,
+    );
+    pushIfDrifted(findings, `${wf}.totalTokens`, b.totalTokens, c.totalTokens);
+  }
+  return findings;
+}
+
+function pushIfDrifted(out: DriftFinding[], path: string, baseline: number, current: number): void {
+  if (baseline === 0 && current === 0) return;
+  const driftPct = baseline === 0 ? 100 : ((current - baseline) / baseline) * 100;
+  if (Math.abs(driftPct) >= DRIFT_FAIL_PCT) {
+    out.push({ path, baseline, current, driftPct });
+  }
+}
+
+export function formatDrift(findings: DriftFinding[]): string {
+  if (findings.length === 0) return "no drift ≥ 5%";
+  return findings
+    .map((f) => {
+      const sign = f.driftPct >= 0 ? "+" : "";
+      return `  ${f.path}: ${f.baseline} → ${f.current} (${sign}${f.driftPct.toFixed(1)}%)`;
+    })
+    .join("\n");
+}
+
+export const SNAPSHOT_PATH = BASELINE_PATH;

--- a/tests/benchmark/token-cost/tokenizer.ts
+++ b/tests/benchmark/token-cost/tokenizer.ts
@@ -1,0 +1,33 @@
+/**
+ * Token-count heuristic for the benchmark suite (#771).
+ *
+ * The suite needs a token estimate alongside byte counts so optimization
+ * PRs in #770 can reason in the same units the LLM bills in. We cannot
+ * pull Anthropic's tokenizer at suite-time (no network in CI; the tokenizer
+ * is also not on npm under a stable, dependency-light handle), and pinning
+ * a heavyweight BPE library here for an estimate is out of proportion to
+ * the signal needed.
+ *
+ * Choice: a documented byte-divisor heuristic, `bytes / TOKEN_DIVISOR`.
+ * For the JSON payloads this suite measures (mostly ASCII keys, IDs,
+ * short names, ISO dates), the empirical bytes-per-token for Claude
+ * tokenizers sits in roughly the 3.5–4.5 range — `4` is the well-known
+ * rule-of-thumb that lands inside that band and matches what tools like
+ * `tiktoken`'s cl100k report on similar JSON shapes.
+ *
+ * The absolute number is less important than the *stability* of the
+ * conversion: every workflow uses the same divisor, so token deltas track
+ * byte deltas linearly and the snapshot's tolerance band catches both.
+ *
+ * If a future ticket pulls in Anthropic's official tokenizer or a small
+ * BPE library, swap the implementation here and re-baseline once. Callers
+ * only see {@link estimateTokens}.
+ */
+
+/** Bytes per token. ASCII-JSON heuristic; see file docblock. */
+export const TOKEN_DIVISOR = 4;
+
+/** Estimated token count for a UTF-8 byte length. Rounds half-up. */
+export function estimateTokens(bytes: number): number {
+  return Math.round(bytes / TOKEN_DIVISOR);
+}

--- a/tests/benchmark/token-cost/toolsList.ts
+++ b/tests/benchmark/token-cost/toolsList.ts
@@ -1,0 +1,50 @@
+/**
+ * Tools-manifest payload measurement (#771).
+ *
+ * The MCP `tools/list` response is the single largest payload an LLM
+ * agent sees per session — every tool's name, description, and JSON
+ * input schema. Optimizations in #770 (description trimming, schema
+ * compaction) target this surface, so the benchmark needs a stable
+ * byte count for it.
+ *
+ * We rebuild the manifest here from {@link ALL_TOOL_DESCRIPTIONS} and
+ * {@link ALL_INPUT_SCHEMAS} rather than booting an `McpServer` and
+ * issuing a JSON-RPC `tools/list` call — that path requires the full
+ * `startServer()` wiring which is out of scope for #771. The shape
+ * matches the SDK's `tools/list` result: `{ tools: [{ name,
+ * description, inputSchema }, ...] }` with `inputSchema` produced via
+ * Zod v4's built-in `toJSONSchema`. That conversion path is what the
+ * MCP SDK uses internally on Zod v4 schemas, so the byte count tracks
+ * the wire payload to within JSON-RPC framing overhead.
+ */
+
+import { z } from "zod";
+import { ALL_TOOL_DESCRIPTIONS } from "../../../src/tools/allDescriptions.js";
+import { ALL_INPUT_SCHEMAS } from "../../../src/tools/allInputSchemas.js";
+import { jsonByteLength } from "./byteCounter.js";
+
+interface ManifestEntry {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** Build the manifest payload (deterministic key order). */
+export function buildToolsListPayload(): { tools: ManifestEntry[] } {
+  const names = Object.keys(ALL_TOOL_DESCRIPTIONS).sort();
+  const tools: ManifestEntry[] = names.map((name) => {
+    const description = ALL_TOOL_DESCRIPTIONS[name] ?? "";
+    const schema = ALL_INPUT_SCHEMAS[name];
+    const inputSchema =
+      schema !== undefined
+        ? (z.toJSONSchema(schema, { io: "input" }) as Record<string, unknown>)
+        : { type: "object", properties: {}, additionalProperties: false };
+    return { name, description, inputSchema };
+  });
+  return { tools };
+}
+
+/** UTF-8 byte length of the serialized tools/list payload. */
+export function computeToolsListBytes(): number {
+  return jsonByteLength(buildToolsListPayload());
+}

--- a/tests/benchmark/token-cost/workflows/inboxTriage.ts
+++ b/tests/benchmark/token-cost/workflows/inboxTriage.ts
@@ -1,0 +1,101 @@
+/**
+ * Fixture workflow — bulk inbox triage (#771).
+ *
+ * Captures the high-frequency "I dumped 20 things into my inbox; help me
+ * sort them" pattern. Exercises the heaviest read+write surface in the
+ * server: bulk creation, list with note bodies, batch updates that flag
+ * + assign tags + set defer dates, and a partial completion sweep.
+ *
+ * Notes are deliberately multi-KB so downstream truncation work (#775)
+ * shows measurable effect against this baseline.
+ */
+
+import { handleTagCreate } from "../../../../src/tools/tag/create.js";
+import { handleTaskBatchAssign } from "../../../../src/tools/task/batchAssign.js";
+import { handleTaskBatchComplete } from "../../../../src/tools/task/batchComplete.js";
+import { handleTaskBatchCreate } from "../../../../src/tools/task/batchCreate.js";
+import { handleTaskList } from "../../../../src/tools/task/list.js";
+import { Bench, type BenchToolContext } from "../runBench.js";
+
+const NOTE_TEMPLATE =
+  "Captured from email thread. Stakeholders: alex@example.com, jamie@example.com. " +
+  "Background: this dropped out of the planning sync on Tuesday and needs a decision before Friday. " +
+  "Open questions: budget envelope, owning team, dependency on the migration epic. " +
+  "Links: https://example.com/wiki/topic, https://example.com/jira/ABC-123. ";
+
+function inboxItems(count: number) {
+  const items: Array<{ name: string; note: string; flagged?: boolean }> = [];
+  for (let i = 0; i < count; i += 1) {
+    items.push({
+      name: `Triage candidate ${String(i + 1).padStart(2, "0")} — capture from inbox`,
+      note: NOTE_TEMPLATE.repeat(3 + (i % 3)),
+      flagged: i % 4 === 0,
+    });
+  }
+  return items;
+}
+
+export async function runInboxTriage(ctx: BenchToolContext): Promise<Bench> {
+  const bench = new Bench("inbox-triage");
+
+  // 1) Create a tag the triager assigns to actionable items.
+  const tagInput = { name: "@actionable" };
+  const tagEnv = await bench.call("tag_create", tagInput, () =>
+    handleTagCreate(tagInput, { tagService: ctx.tagService, makeMeta: ctx.makeMeta }),
+  );
+  if (!("data" in tagEnv)) throw new Error("tag_create did not succeed");
+  const tagId = tagEnv.data.tag.id;
+
+  // 2) Capture 20 inbox items in one batch.
+  const createInput = { items: inboxItems(20) };
+  const createEnv = await bench.call("task_batch_create", createInput, () =>
+    handleTaskBatchCreate(createInput, {
+      adapter: ctx.adapter,
+      makeMeta: ctx.makeMeta,
+      cache: ctx.cache,
+    }),
+  );
+  if (!("data" in createEnv)) throw new Error("task_batch_create did not succeed");
+  const ids = createEnv.data.created.map((c) => c.value.id);
+
+  // 3) Triager pulls the inbox to review what landed.
+  const listInput = { inbox: true, limit: 50 };
+  await bench.call("task_list", listInput, () =>
+    handleTaskList(listInput, { taskService: ctx.taskService, makeMeta: ctx.makeMeta }),
+  );
+
+  // 4) Triage assignments — flag, tag, defer in one round trip.
+  const assignInput = {
+    assignments: ids.map((id, i) => ({
+      taskId: id,
+      flagged: true,
+      addTagIds: [tagId],
+      ...(i % 2 === 0 && { deferDate: "2026-05-02T08:00:00.000Z" }),
+    })),
+  };
+  await bench.call("task_batch_assign", assignInput, () =>
+    handleTaskBatchAssign(assignInput, {
+      adapter: ctx.adapter,
+      makeMeta: ctx.makeMeta,
+      cache: ctx.cache,
+    }),
+  );
+
+  // 5) Complete the first five during the triage pass.
+  const completeInput = { items: ids.slice(0, 5).map((id) => ({ id })) };
+  await bench.call("task_batch_complete", completeInput, () =>
+    handleTaskBatchComplete(completeInput, {
+      adapter: ctx.adapter,
+      makeMeta: ctx.makeMeta,
+      cache: ctx.cache,
+    }),
+  );
+
+  // 6) Final list — confirm what's still on the plate.
+  const finalListInput = { inbox: true, completed: "exclude" as const, limit: 50 };
+  await bench.call("task_list", finalListInput, () =>
+    handleTaskList(finalListInput, { taskService: ctx.taskService, makeMeta: ctx.makeMeta }),
+  );
+
+  return bench;
+}

--- a/tests/benchmark/token-cost/workflows/projectPlanning.ts
+++ b/tests/benchmark/token-cost/workflows/projectPlanning.ts
@@ -1,0 +1,97 @@
+/**
+ * Fixture workflow — project planning sequence (#771).
+ *
+ * Captures the LLM-driven "spin up a new project from scratch" pattern:
+ * create the project, drop ten tasks under it, attach a tag for tracking,
+ * batch-assign the tag and a defer date, then read the project back to
+ * confirm. Mirrors the project_planning prompt template registered with
+ * the server so the benchmark tracks a workflow agents actually use.
+ */
+
+import type { ProjectId } from "../../../../src/domain/ids.js";
+import { handleProjectCreate } from "../../../../src/tools/project/create.js";
+import { handleProjectGet } from "../../../../src/tools/project/get.js";
+import { handleTagCreate } from "../../../../src/tools/tag/create.js";
+import { handleTaskBatchAssign } from "../../../../src/tools/task/batchAssign.js";
+import { handleTaskBatchCreate } from "../../../../src/tools/task/batchCreate.js";
+import { handleTaskList } from "../../../../src/tools/task/list.js";
+import { Bench, type BenchToolContext } from "../runBench.js";
+
+function planTasks(projectId: ProjectId, count: number) {
+  const phases = ["draft", "review", "build", "test", "ship"];
+  return Array.from({ length: count }, (_, i) => ({
+    name: `${phases[i % phases.length]} — milestone ${String(Math.floor(i / phases.length) + 1)}`,
+    projectId,
+    note: `Acceptance criteria for step ${i + 1}: confirm scope, draft handoff, capture decisions in ADR.`,
+  }));
+}
+
+export async function runProjectPlanning(ctx: BenchToolContext): Promise<Bench> {
+  const bench = new Bench("project-planning");
+
+  // 1) Spin up the project.
+  const projectInput = {
+    name: "Q3 launch readiness",
+    note: "Cross-team launch coordination. Owners: PM, EM, design. Deadline target: end of quarter.",
+    completionCriterion: "sequential" as const,
+  };
+  const projEnv = await bench.call("project_create", projectInput, () =>
+    handleProjectCreate(projectInput, {
+      adapter: ctx.adapter,
+      makeMeta: ctx.makeMeta,
+      cache: ctx.cache,
+    }),
+  );
+  if (!("data" in projEnv)) throw new Error("project_create did not succeed");
+  const projectId = projEnv.data.id;
+
+  // 2) Add a tag the planner uses to flag launch-blocking work.
+  const tagInput = { name: "@launch-blocker" };
+  const tagEnv = await bench.call("tag_create", tagInput, () =>
+    handleTagCreate(tagInput, { tagService: ctx.tagService, makeMeta: ctx.makeMeta }),
+  );
+  if (!("data" in tagEnv)) throw new Error("tag_create did not succeed");
+  const tagId = tagEnv.data.tag.id;
+
+  // 3) Drop ten tasks into the project in one round trip.
+  const tasksInput = { items: planTasks(projectId, 10) };
+  const tasksEnv = await bench.call("task_batch_create", tasksInput, () =>
+    handleTaskBatchCreate(tasksInput, {
+      adapter: ctx.adapter,
+      makeMeta: ctx.makeMeta,
+      cache: ctx.cache,
+    }),
+  );
+  if (!("data" in tasksEnv)) throw new Error("task_batch_create did not succeed");
+  const taskIds = tasksEnv.data.created.map((c) => c.value.id);
+
+  // 4) Tag every other task as a launch blocker, set a uniform defer date.
+  const assignInput = {
+    assignments: taskIds.map((id, i) => ({
+      taskId: id,
+      ...(i % 2 === 0 && { addTagIds: [tagId] }),
+      deferDate: "2026-05-15T08:00:00.000Z",
+    })),
+  };
+  await bench.call("task_batch_assign", assignInput, () =>
+    handleTaskBatchAssign(assignInput, {
+      adapter: ctx.adapter,
+      makeMeta: ctx.makeMeta,
+      cache: ctx.cache,
+    }),
+  );
+
+  // 5) Read the project back to confirm structure (project_get).
+  const getInput = { id: projectId };
+  await bench.call("project_get", getInput, () =>
+    handleProjectGet(getInput, { projectService: ctx.projectService, makeMeta: ctx.makeMeta }),
+  );
+
+  // 6) Read the project's task list (post-planning view).
+  const listInput = { projectId, limit: 50 };
+  await bench.call("task_list", listInput, () =>
+    handleTaskList(listInput, { taskService: ctx.taskService, makeMeta: ctx.makeMeta }),
+  );
+
+  return bench;
+}

--- a/tests/benchmark/token-cost/workflows/weeklyReview.ts
+++ b/tests/benchmark/token-cost/workflows/weeklyReview.ts
@@ -1,0 +1,68 @@
+/**
+ * Fixture workflow — weekly review pass over a seeded database (#771).
+ *
+ * Models the Friday-afternoon GTD ritual: list every project due for
+ * review, walk each one (read its tasks), make small triage updates,
+ * mark it reviewed, repeat. The seeded database carries five projects
+ * so the workflow exercises a representative N rather than spending
+ * its byte budget on a single project's iteration.
+ */
+
+import { handleReviewListDue } from "../../../../src/tools/review/listDue.js";
+import { handleProjectMarkReviewed } from "../../../../src/tools/review/projectMarkReviewed.js";
+import { handleTaskList } from "../../../../src/tools/task/list.js";
+import { Bench, type BenchToolContext } from "../runBench.js";
+
+const PROJECT_NOTE =
+  "Owners: alex, jamie. Status: active. Last review surfaced two blocked items and one stale defer date.";
+
+async function seedReviewDatabase(ctx: BenchToolContext): Promise<void> {
+  // Five projects, three tasks each. Set the next-review date in the past
+  // so every project shows up under review_list_due.
+  const past = "2026-04-15T00:00:00.000Z";
+  for (let p = 0; p < 5; p += 1) {
+    const projectId = await ctx.adapter.createProject({
+      name: `Review fixture project ${String(p + 1).padStart(2, "0")}`,
+      note: PROJECT_NOTE,
+    });
+    await ctx.adapter.updateProject(projectId, { reviewIntervalDays: 7 });
+    await ctx.adapter.setProjectNextReviewDate(projectId, past);
+    for (let t = 0; t < 3; t += 1) {
+      await ctx.adapter.createTask({
+        name: `Open thread ${String(t + 1)} on project ${String(p + 1)}`,
+        projectId,
+        note: "Captured during last review; revisit owner & deadline.",
+      });
+    }
+  }
+}
+
+export async function runWeeklyReview(ctx: BenchToolContext): Promise<Bench> {
+  const bench = new Bench("weekly-review");
+
+  await seedReviewDatabase(ctx);
+
+  // 1) List everything due for review.
+  const listEnv = await bench.call("review_list_due", {}, () =>
+    handleReviewListDue({}, { reviewService: ctx.reviewService, makeMeta: ctx.makeMeta }),
+  );
+  if (!("data" in listEnv)) throw new Error("review_list_due did not succeed");
+  const projects = listEnv.data.projects;
+
+  // 2) For each project: read its task list, then mark it reviewed.
+  for (const p of projects) {
+    const tlInput = { projectId: p.id, limit: 50 };
+    await bench.call("task_list", tlInput, () =>
+      handleTaskList(tlInput, { taskService: ctx.taskService, makeMeta: ctx.makeMeta }),
+    );
+    const markInput = { id: p.id };
+    await bench.call("project_mark_reviewed", markInput, () =>
+      handleProjectMarkReviewed(markInput, {
+        reviewService: ctx.reviewService,
+        makeMeta: ctx.makeMeta,
+      }),
+    );
+  }
+
+  return bench;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       "tests/chaos/**/*.test.ts",
       "tests/integration/**/*.test.ts",
       "tests/perf/**/*.perf.test.ts",
+      "tests/benchmark/**/*.test.ts",
       "tests/e2e/**/*.test.ts",
       "tests/scripts/**/*.test.ts",
       "src/**/*.test.ts",


### PR DESCRIPTION
## Summary

- Adds `tests/benchmark/token-cost/` — a hermetic benchmark harness driving three canonical LLM workflows (inbox triage, weekly review, project planning) against `InMemoryAdapter`.
- Records per-workflow `requestBytes`, `responseBytes`, `roundTripBytes`, token estimate, and per-tool aggregates; persists totals in a checked-in snapshot with a ±5% tolerance band.
- Wires `pnpm bench:tokens` (CLI), `pnpm test:bench:tokens` (vitest gate, `OMNIFOCUS_BENCH=1`), plus a non-required GitHub Actions workflow.

## Design link

Closes #771. Part of the #770 epic — every optimization sub-issue (#773, #774, #775, #778) needs a measurement baseline before merge; this lands it.

Why the harness measures at the handler boundary rather than the JSON-RPC wire is documented in `tests/benchmark/token-cost/runBench.ts` and the suite README — the short version is that extracting `startServer()` was an explicit non-goal of #771, and the handler boundary captures everything that varies under #770 (tool descriptions, input schemas, response payloads).

## Breaking change?

- [x] No

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` green locally (3,431 passed)
- [x] `pnpm bench:tokens --update` regenerates the baseline; subsequent `pnpm bench:tokens` confirms 0% drift
- [x] `pnpm test:bench:tokens` (gated on `OMNIFOCUS_BENCH=1`) passes against the checked-in baseline
- [x] Self-reviewed via `/review-pr`
- [x] No new dependencies (uses existing `zod` v4 `toJSONSchema`)

## How #770 PRs consume this

A token-reduction PR runs `pnpm bench:tokens` to see its delta, runs `pnpm bench:tokens --update` to rewrite the baseline, and includes the JSON diff in the PR — that diff is the documentation. Drift `≥ 5%` in either direction fails CI; smaller drift passes silently to absorb fixture noise. README documents the full policy and the path to promoting the CI check from non-required to required.

## Baseline at land

| Workflow | Calls | Round-trip | Tokens (incl. tools/list) |
|---|---|---|---|
| inbox-triage | 6 | 171.7 KiB | 85,567 |
| weekly-review | 11 | 32.5 KiB | 49,938 |
| project-planning | 6 | 39.4 KiB | 51,706 |

`tools/list` payload is 162.6 KiB (~41,615 tokens) — the largest single line item, and the obvious first target for #770.