### PR TITLE
fix(webhooks): register res.on('error') so dispatch never throws upward

### DIFF
--- a/src/webhooks/httpsDispatcher.test.ts
+++ b/src/webhooks/httpsDispatcher.test.ts
@@ -8,9 +8,16 @@
  */
 
 import { createHmac } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type * as https from "node:https";
+import { describe, expect, it, vi } from "vitest";
 import type { WebhookEvent } from "./events.js";
-import { HttpsDispatcher, type HttpsRequestFn, SIGNATURE_HEADER } from "./httpsDispatcher.js";
+import {
+  buildHttpsRequest,
+  HttpsDispatcher,
+  type HttpsRequestFn,
+  SIGNATURE_HEADER,
+} from "./httpsDispatcher.js";
 import type { Webhook } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -329,5 +336,65 @@ describe("HttpsDispatcher — failure-mode discipline", () => {
     await h.dispatcher.deliver(sampleEvent(), () => undefined);
     expect(h.requests).toHaveLength(0);
     expect(h.writes.join("\n")).toContain("not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultHttpsRequest — response-stream error wiring (#761)
+// ---------------------------------------------------------------------------
+
+describe("defaultHttpsRequest — response-stream error handling", () => {
+  /**
+   * Build a fake `https.request` whose response stream emits `error` after
+   * the request callback fires — the exact failure mode #761 closes.
+   * Without `res.on("error", reject)`, this would escape as
+   * `uncaughtException` rather than rejecting the dispatch promise.
+   */
+  function fakeHttpsRequestEmittingResError(err: Error): typeof https.request {
+    return ((_opts: unknown, cb?: unknown) => {
+      const fakeRes = Object.assign(new EventEmitter(), { statusCode: 200 });
+      const fakeReq = Object.assign(new EventEmitter(), {
+        destroy: vi.fn(),
+        write: vi.fn(),
+        end: vi.fn(),
+      });
+      if (typeof cb === "function") {
+        queueMicrotask(() => {
+          (cb as (res: unknown) => void)(fakeRes);
+          // Emit one tick later so `res.on("error", reject)` is in place.
+          queueMicrotask(() => fakeRes.emit("error", err));
+        });
+      }
+      return fakeReq as unknown as ReturnType<typeof https.request>;
+    }) as unknown as typeof https.request;
+  }
+
+  it("rejects when the response stream emits 'error' after the request callback fires", async () => {
+    const httpsRequest = fakeHttpsRequestEmittingResError(new Error("ECONNRESET mid-body"));
+    const request = buildHttpsRequest(httpsRequest);
+    await expect(
+      request({ url: "https://example.com/hook", body: "{}", headers: {}, timeoutMs: 1000 }),
+    ).rejects.toThrow(/ECONNRESET mid-body/);
+  });
+
+  it("flows response-stream errors through HttpsDispatcher's retry path (no uncaughtException)", async () => {
+    // Verify the fix composes with the retry loop: a response-stream error
+    // increments consecutiveFailures exactly like a request-stream error
+    // would, instead of bypassing circuit-breaker accounting.
+    const httpsRequest = fakeHttpsRequestEmittingResError(new Error("peer reset"));
+    const writes: string[] = [];
+    const dispatcher = new HttpsDispatcher({
+      request: buildHttpsRequest(httpsRequest),
+      now: () => 0,
+      sleep: async () => {},
+      write: (line) => writes.push(line),
+    });
+
+    await expect(
+      dispatcher.deliver(sampleEvent(), () => WEBHOOK_NO_SECRET),
+    ).resolves.toBeUndefined();
+
+    const circuit = dispatcher.inspectCircuit(WEBHOOK_NO_SECRET.name);
+    expect(circuit?.consecutiveFailures).toBe(1);
   });
 });

--- a/src/webhooks/httpsDispatcher.ts
+++ b/src/webhooks/httpsDispatcher.ts
@@ -63,33 +63,54 @@ export type HttpsRequestFn = (args: {
   timeoutMs: number;
 }) => Promise<HttpsRequestResult>;
 
-/** Default implementation using `node:https`. */
-export const defaultHttpsRequest: HttpsRequestFn = ({ url, body, headers, timeoutMs }) =>
-  new Promise<HttpsRequestResult>((resolve, reject) => {
-    const parsed = new URL(url);
-    const req = https.request(
-      {
-        method: "POST",
-        host: parsed.host,
-        path: `${parsed.pathname}${parsed.search}`,
-        headers: { "Content-Length": Buffer.byteLength(body), ...headers },
-        timeout: timeoutMs,
-      },
-      (res) => {
-        // Drain — Node won't release the socket otherwise.
-        res.on("data", () => {});
-        res.on("end", () => {
-          resolve({ statusCode: res.statusCode ?? 0 });
-        });
-      },
-    );
-    req.on("error", reject);
-    req.on("timeout", () => {
-      req.destroy(new Error(`request timeout after ${timeoutMs}ms`));
+/**
+ * Build an `HttpsRequestFn` against an injected `https.request` factory.
+ *
+ * Exported so unit tests can substitute a fake transport (ESM forbids
+ * `vi.spyOn` on module namespace exports like `https.request`). Production
+ * callers use {@link defaultHttpsRequest}, which closes over the real
+ * `https.request`.
+ */
+export function buildHttpsRequest(httpsRequest: typeof https.request): HttpsRequestFn {
+  return ({ url, body, headers, timeoutMs }) =>
+    new Promise<HttpsRequestResult>((resolve, reject) => {
+      const parsed = new URL(url);
+      const req = httpsRequest(
+        {
+          method: "POST",
+          host: parsed.host,
+          path: `${parsed.pathname}${parsed.search}`,
+          headers: { "Content-Length": Buffer.byteLength(body), ...headers },
+          timeout: timeoutMs,
+        },
+        (res) => {
+          // Wire response-stream errors into the same rejection path as
+          // request-stream errors. Without this listener, an `error` emitted
+          // by `res` after the request callback fires (premature socket
+          // close, malformed transfer-encoding, peer reset mid-body, TLS
+          // error during streaming) escapes as `uncaughtException`,
+          // bypassing the retry loop and circuit breaker. ADR-0016 §4e:
+          // "delivery failures NEVER throw upward." Attaches before `data`
+          // so the listener is in place by the time bytes arrive.
+          res.on("error", reject);
+          // Drain — Node won't release the socket otherwise.
+          res.on("data", () => {});
+          res.on("end", () => {
+            resolve({ statusCode: res.statusCode ?? 0 });
+          });
+        },
+      );
+      req.on("error", reject);
+      req.on("timeout", () => {
+        req.destroy(new Error(`request timeout after ${timeoutMs}ms`));
+      });
+      req.write(body);
+      req.end();
     });
-    req.write(body);
-    req.end();
-  });
+}
+
+/** Default implementation closing over the real `node:https` request. */
+export const defaultHttpsRequest: HttpsRequestFn = buildHttpsRequest(https.request);
 
 // ---------------------------------------------------------------------------
 // Circuit breaker — per-webhook


### PR DESCRIPTION
## Summary

- `defaultHttpsRequest` only listened for `'error'` on the request stream; errors emitted by the **response** stream after the request callback fired (premature socket close, malformed transfer-encoding, peer reset mid-body, TLS error during streaming) escaped as `uncaughtException`, bypassing the retry loop and circuit breaker.
- Adds `res.on('error', reject)` inside the `https.request` callback so a response-stream error rejects the dispatch promise, flows through the existing retry loop, and increments `consecutiveFailures` exactly like a request-stream error.
- Refactors `defaultHttpsRequest` to a thin invocation of an exported `buildHttpsRequest(httpsRequest)` factory so unit tests can inject a fake `https.request` (ESM forbids `vi.spyOn` on namespace exports).

## Design link

Closes #761. The fix restores the contract in [ADR-0016 §4e](docs/adr/0016-webhook-orchestrator.md): *delivery failures NEVER throw upward*.

## Breaking change?

- [x] No — internal-only refactor; `defaultHttpsRequest`'s wire shape is unchanged.

## Test plan

- [x] New unit test: response-stream error rejects the promise (would hang and time out without the fix — promise never resolves because no `data`/`end` ever fires)
- [x] New integration-style test: response-stream error flows through `HttpsDispatcher.deliver`, increments `consecutiveFailures` exactly once, and never throws upward
- [x] All 21 dispatcher tests pass
- [x] `pnpm typecheck && pnpm lint && pnpm test` green locally (3,433 passed)