### PR TITLE
infra(lint): token-budget assertion for tool descriptions

### DIFF
--- a/src/tools/descriptions.lint.test.ts
+++ b/src/tools/descriptions.lint.test.ts
@@ -8,17 +8,45 @@
  *   3. What it returns     (Returns …)
  *   4. Side effects        (Side effects: / safe to / no side effects / …)
  *
+ * Also enforces a per-description token budget so the static tools/list
+ * prefix does not drift upward silently (#777). Budget = p95 + headroom;
+ * tools that legitimately exceed it get a named exemption with a reason.
+ *
  * This test fails CI on violations so that the standard is enforced
  * automatically as new tools are added. To fix a violation, update the
  * description in the tool's source file (e.g. src/tools/task/list.ts).
  *
  * @see src/tools/descriptionShape.ts — matcher implementation
  * @see src/tools/allDescriptions.ts — central description registry
+ * @see tests/benchmark/token-cost/tokenizer.ts — shared TOKEN_DIVISOR
  */
 
 import { describe, expect, it } from "vitest";
+import { estimateTokens } from "../../tests/benchmark/token-cost/tokenizer.js";
 import { ALL_TOOL_DESCRIPTIONS } from "./allDescriptions.js";
 import { checkDescriptionShape, formatShapeViolations } from "./descriptionShape.js";
+
+/**
+ * Per-description token ceiling (p95 of current baseline ≈ 303 tokens, plus ~15%
+ * headroom). New descriptions must stay under this limit. Existing tools that
+ * historically exceeded this threshold are listed in TOKEN_BUDGET_EXEMPTIONS below
+ * and should be trimmed in a follow-up pass (#770 optimizations).
+ */
+const TOKEN_BUDGET = 350;
+
+/**
+ * Tools granted a temporary exemption because their description exceeded TOKEN_BUDGET
+ * when the budget was introduced (2026-05-09 baseline). Each entry records the token
+ * count at exemption time; if the description is later trimmed below TOKEN_BUDGET
+ * the exemption should be removed.
+ *
+ * Do NOT add new entries here for convenience — trim the description instead.
+ * The exemption mechanism exists for legacy outliers only.
+ */
+const TOKEN_BUDGET_EXEMPTIONS: ReadonlySet<string> = new Set([
+  // 352 tokens at baseline — complex reclassification logic with many options
+  "task_reclassify",
+]);
 
 describe("tool descriptions — DESIGN §6.8 shape lint", () => {
   it("every tool description satisfies the four-section shape", () => {
@@ -32,5 +60,36 @@ describe("tool descriptions — DESIGN §6.8 shape lint", () => {
 
   it("registry is non-empty (guard against accidental empty import)", () => {
     expect(Object.keys(ALL_TOOL_DESCRIPTIONS).length).toBeGreaterThan(0);
+  });
+
+  it(`every description is ≤ ${TOKEN_BUDGET} tokens (tools/list static cost budget)`, () => {
+    const violations: string[] = [];
+
+    for (const [name, desc] of Object.entries(ALL_TOOL_DESCRIPTIONS)) {
+      const tokens = estimateTokens(Buffer.byteLength(desc, "utf8"));
+      if (tokens > TOKEN_BUDGET && !TOKEN_BUDGET_EXEMPTIONS.has(name)) {
+        violations.push(
+          `  ${name}: ${tokens} tokens (budget: ${TOKEN_BUDGET}, over by ${tokens - TOKEN_BUDGET})`,
+        );
+      }
+    }
+
+    expect(
+      violations.join("\n"),
+      `Descriptions exceeding token budget — trim or add a named exemption:\n${violations.join("\n")}`,
+    ).toBe("");
+  });
+
+  it("reports total tools/list token estimate", () => {
+    const totalTokens = Object.values(ALL_TOOL_DESCRIPTIONS).reduce(
+      (sum, desc) => sum + estimateTokens(Buffer.byteLength(desc, "utf8")),
+      0,
+    );
+    const toolCount = Object.keys(ALL_TOOL_DESCRIPTIONS).length;
+    // biome-ignore lint/suspicious/noConsole: informational summary visible in test output
+    console.log(
+      `tools/list descriptions: ${toolCount} tools, ~${totalTokens} tokens total (budget: ${TOKEN_BUDGET}/tool)`,
+    );
+    expect(toolCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a 350-token per-description ceiling in `descriptions.lint.test.ts` (p95 baseline ≈ 303 + ~15% headroom)
- One named exemption: `task_reclassify` at 352 tokens (marked for future trimming in #770 pass)
- Informational test prints total tools/list token cost each CI run (~23,599 tokens, 142 tools)
- Reuses `estimateTokens` from the benchmark tokenizer (#771) — single source of truth for the `bytes/4` heuristic

Closes #777.

## Issue
Implements [#777 — infra(lint): token-budget assertion for tool descriptions](https://github.com/torsday/omnifocus-mcp/issues/777).

## Breaking change?
- [x] No

## Test plan
- [x] `descriptions.lint.test.ts` — 4 tests pass (shape, registry, budget, total)
- [x] Full unit suite — 3438 tests pass
- [x] Biome lint clean
- [x] Self-reviewed via /review-pr
- [x] No new dependencies