### PR TITLE
feat(tools): default-truncate task notes in bulk reads (#775)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4298,6 +4298,7 @@ Fetch a single OmniFocus task by persistent ID. Use when you have a known task I
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Persistent ID of the task to fetch. Get from task_list or task_get_many. |
 | `includeSubtasks` | boolean | No | Include direct subtasks in the response. Default true. |
+| `notePreviewChars` | number | No | Maximum characters of the task's note (and each subtask's note) to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
 
 ### Example call
 
@@ -4340,6 +4341,7 @@ Fetch up to 100 tasks by persistent ID in a single OmniFocus round-trip. Use whe
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `ids` | string[] | Yes | Array of task IDs to fetch (0..100). Get IDs from task_list, search_query, or task_find_by_name. Missing IDs are omitted (not errors) and appear in meta.warnings. |
+| `notePreviewChars` | number | No | Maximum characters of each task's note to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
 
 ### Example call
 
@@ -4403,6 +4405,7 @@ List tasks in OmniFocus with optional filters (project, tag, inbox, flagged, com
 | `updatedSince` | string | No | Return only tasks modified strictly after this timestamp. Accepts ISO-8601 with offset (e.g. '2026-04-21T10:00:00-07:00') or a relative shortcut: today, yesterday, this-week, next-week, end-of-week, end-of-month. Use this for incremental sync: call without updatedSince on session start, then pass the previous response timestamp on subsequent calls. Note: deleted tasks cannot be detected — use a snapshot resource for deletion detection. |
 | `inbox` | boolean | No | true = Inbox tasks only (no project assignment). Cannot be combined with projectId or parentId. Use this to surface unprocessed captures without knowing their IDs. |
 | `cursor` | string | No | Opaque cursor from a previous task_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError. |
+| `notePreviewChars` | number | No | Maximum characters of each task's note to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
 
 ### Example call
 

--- a/src/tools/task/get.test.ts
+++ b/src/tools/task/get.test.ts
@@ -116,3 +116,54 @@ describe("task_get — NotFound", () => {
     await expect(handleTaskGet({ id: ghost }, ctx)).rejects.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Note preview (#775)
+// ---------------------------------------------------------------------------
+
+describe("task_get — note preview truncation", () => {
+  it("returns short notes inline (no truncation triplet) by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "n", note: "small note" });
+
+    const envelope = await handleTaskGet({ id }, ctx);
+    const task = envelope.data.task as unknown as Record<string, unknown>;
+    expect(task.note).toBe("small note");
+    expect(task).not.toHaveProperty("notePreview");
+  });
+
+  it("truncates long notes and emits the preview triplet by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "n", note: "x".repeat(500) });
+
+    const envelope = await handleTaskGet({ id }, ctx);
+    const task = envelope.data.task as unknown as Record<string, unknown>;
+    expect(task.note).toBeUndefined();
+    expect(task.notePreview).toBe("x".repeat(200));
+    expect(task.noteTruncated).toBe(true);
+    expect(task.noteLength).toBe(500);
+  });
+
+  it("truncates subtask notes too", async () => {
+    const { ctx, adapter } = makeCtx();
+    const parentId = await adapter.createTask({ name: "P" });
+    await adapter.createTask({ name: "C", parentId, note: "y".repeat(400) });
+
+    const envelope = await handleTaskGet({ id: parentId }, ctx);
+    const subtask = envelope.data.subtasks?.[0] as unknown as Record<string, unknown> | undefined;
+    expect(subtask?.notePreview).toBe("y".repeat(200));
+    expect(subtask?.noteTruncated).toBe(true);
+    expect(subtask?.noteLength).toBe(400);
+  });
+
+  it("returns full note inline when notePreviewChars is -1", async () => {
+    const { ctx, adapter } = makeCtx();
+    const longNote = "z".repeat(500);
+    const id = await adapter.createTask({ name: "n", note: longNote });
+
+    const envelope = await handleTaskGet({ id, notePreviewChars: -1 }, ctx);
+    const task = envelope.data.task as unknown as Record<string, unknown>;
+    expect(task.note).toBe(longNote);
+    expect(task).not.toHaveProperty("notePreview");
+  });
+});

--- a/src/tools/task/get.ts
+++ b/src/tools/task/get.ts
@@ -16,6 +16,7 @@ import { TaskId } from "../../domain/ids.js";
 import { parseWaitingOn } from "../../domain/waitingOn.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TaskGetInput, TaskService } from "../../services/taskService.js";
+import { applyNotePreview, DEFAULT_NOTE_PREVIEW_CHARS } from "./notePreview.js";
 
 export const TASK_GET_DESCRIPTION =
   "Fetch a single OmniFocus task by persistent ID. " +
@@ -33,6 +34,15 @@ export const taskGetInputSchema = z.object({
     .boolean()
     .optional()
     .describe("Include direct subtasks in the response. Default true."),
+  notePreviewChars: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      `Maximum characters of the task's note (and each subtask's note) to return. Default ${DEFAULT_NOTE_PREVIEW_CHARS}. ` +
+        "When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. " +
+        "Pass -1 to disable truncation and return full notes inline.",
+    ),
 });
 
 export type TaskGetToolInput = z.infer<typeof taskGetInputSchema>;
@@ -48,13 +58,18 @@ export interface TaskGetContext {
  * @throws {OmniFocusNotRunning} when OmniFocus is not running
  */
 export async function handleTaskGet(input: TaskGetToolInput, ctx: TaskGetContext) {
-  const result = await ctx.taskService.get(input as TaskGetInput);
+  const { notePreviewChars: rawPreviewChars, ...rest } = input;
+  const result = await ctx.taskService.get(rest as TaskGetInput);
+  // Parse waitingOn / decision against the full note before applying truncation.
   const waitingOn = parseWaitingOn(result.task.note);
   const decision = parseDecision(result.task.note);
+  const previewChars = rawPreviewChars ?? DEFAULT_NOTE_PREVIEW_CHARS;
+  const task = applyNotePreview(result.task, previewChars);
+  const subtasks = result.subtasks?.map((t) => applyNotePreview(t, previewChars));
   return ok(
     {
-      task: result.task,
-      ...(result.subtasks !== undefined && { subtasks: result.subtasks }),
+      task,
+      ...(subtasks !== undefined && { subtasks }),
       ...(waitingOn !== undefined && { waitingOn }),
       ...(decision !== undefined && { decision }),
     },

--- a/src/tools/task/getMany.test.ts
+++ b/src/tools/task/getMany.test.ts
@@ -161,3 +161,37 @@ describe("task_get_many — over-limit guard", () => {
     await expect(handleTaskGetMany({ ids }, ctx)).rejects.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Note preview (#775)
+// ---------------------------------------------------------------------------
+
+describe("task_get_many — note preview truncation", () => {
+  it("truncates each task's long note by default and leaves short notes inline", async () => {
+    const { ctx, adapter } = makeCtx();
+    const longId = await adapter.createTask({ name: "long", note: "a".repeat(500) });
+    const shortId = await adapter.createTask({ name: "short", note: "small" });
+
+    const envelope = await handleTaskGetMany({ ids: [longId, shortId] }, ctx);
+    const [long, short] = envelope.data.tasks as unknown as Record<string, unknown>[];
+
+    expect(long?.note).toBeUndefined();
+    expect(long?.notePreview).toBe("a".repeat(200));
+    expect(long?.noteTruncated).toBe(true);
+    expect(long?.noteLength).toBe(500);
+
+    expect(short?.note).toBe("small");
+    expect(short).not.toHaveProperty("notePreview");
+  });
+
+  it("returns full notes inline when notePreviewChars is -1", async () => {
+    const { ctx, adapter } = makeCtx();
+    const longNote = "z".repeat(500);
+    const id = await adapter.createTask({ name: "n", note: longNote });
+
+    const envelope = await handleTaskGetMany({ ids: [id], notePreviewChars: -1 }, ctx);
+    const task = envelope.data.tasks[0] as unknown as Record<string, unknown>;
+    expect(task.note).toBe(longNote);
+    expect(task).not.toHaveProperty("notePreview");
+  });
+});

--- a/src/tools/task/getMany.ts
+++ b/src/tools/task/getMany.ts
@@ -29,6 +29,7 @@ import { TaskId } from "../../domain/ids.js";
 import { parseWaitingOn, type WaitingOn } from "../../domain/waitingOn.js";
 import { ok, type ResponseMeta, toolResponse, warnIdsNotFound } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
+import { applyNotePreview, DEFAULT_NOTE_PREVIEW_CHARS } from "./notePreview.js";
 
 // ---------------------------------------------------------------------------
 // Tool description
@@ -60,6 +61,15 @@ export const taskGetManyInputSchema = z.object({
     .max(MAX_IDS)
     .describe(
       `Array of task IDs to fetch (0..${MAX_IDS}). Get IDs from task_list, search_query, or task_find_by_name. Missing IDs are omitted (not errors) and appear in meta.warnings.`,
+    ),
+  notePreviewChars: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      `Maximum characters of each task's note to return. Default ${DEFAULT_NOTE_PREVIEW_CHARS}. ` +
+        "When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. " +
+        "Pass -1 to disable truncation and return full notes inline.",
     ),
 });
 
@@ -98,15 +108,15 @@ export async function handleTaskGetMany(input: TaskGetManyInput, ctx: TaskGetMan
 
   const raw = await ctx.adapter.getTasksMany(input.ids);
 
-  const tasks = raw.filter((t): t is NonNullable<typeof t> => t !== null);
+  const fullTasks = raw.filter((t): t is NonNullable<typeof t> => t !== null);
   const missing = input.ids.filter((_id, i) => raw[i] === null);
 
   // Surface parsed waiting-on and decision-journal data as sibling fields
   // keyed by task id so the Task domain object stays the canonical wire shape
-  // (#482, #485).
+  // (#482, #485). Parse against the full note before applying truncation.
   const waitingOn: Record<string, WaitingOn> = {};
   const decisions: Record<string, Decision> = {};
-  for (const t of tasks) {
+  for (const t of fullTasks) {
     const w = parseWaitingOn(t.note);
     if (w !== undefined) waitingOn[t.id] = w;
     const d = parseDecision(t.note);
@@ -114,6 +124,9 @@ export async function handleTaskGetMany(input: TaskGetManyInput, ctx: TaskGetMan
   }
   const hasWaitingOn = Object.keys(waitingOn).length > 0;
   const hasDecisions = Object.keys(decisions).length > 0;
+
+  const previewChars = input.notePreviewChars ?? DEFAULT_NOTE_PREVIEW_CHARS;
+  const tasks = fullTasks.map((t) => applyNotePreview(t, previewChars));
 
   const warnings = missing.length > 0 ? [warnIdsNotFound(missing)] : undefined;
   const meta = ctx.makeMeta({ ...(warnings !== undefined ? { warnings } : {}) });

--- a/src/tools/task/list.test.ts
+++ b/src/tools/task/list.test.ts
@@ -178,3 +178,57 @@ describe("handleTaskList — inbox filter", () => {
     ).rejects.toMatchObject({ code: "OF_VALIDATION" });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Note preview (#775)
+// ---------------------------------------------------------------------------
+
+describe("handleTaskList — note preview truncation", () => {
+  it("returns short notes inline (no truncation triplet) by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "short", note: "small note", flagged: true });
+
+    const result = await handleTaskList({ flagged: true }, ctx);
+    const task = result.data.tasks[0];
+    expect(task).toBeDefined();
+    expect((task as { note?: string }).note).toBe("small note");
+    expect(task).not.toHaveProperty("notePreview");
+    expect(task).not.toHaveProperty("noteTruncated");
+    expect(task).not.toHaveProperty("noteLength");
+  });
+
+  it("truncates long notes and emits the preview triplet by default (200 chars)", async () => {
+    const { ctx, adapter } = makeCtx();
+    const longNote = "x".repeat(500);
+    await adapter.createTask({ name: "long", note: longNote, flagged: true });
+
+    const result = await handleTaskList({ flagged: true }, ctx);
+    const task = result.data.tasks[0] as unknown as Record<string, unknown>;
+    expect(task.note).toBeUndefined();
+    expect(task.notePreview).toBe("x".repeat(200));
+    expect(task.noteTruncated).toBe(true);
+    expect(task.noteLength).toBe(500);
+  });
+
+  it("respects a custom notePreviewChars override", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "n", note: "y".repeat(300), flagged: true });
+
+    const result = await handleTaskList({ flagged: true, notePreviewChars: 50 }, ctx);
+    const task = result.data.tasks[0] as unknown as Record<string, unknown>;
+    expect(task.notePreview).toBe("y".repeat(50));
+    expect(task.noteLength).toBe(300);
+  });
+
+  it("returns the full note inline when notePreviewChars is -1", async () => {
+    const { ctx, adapter } = makeCtx();
+    const longNote = "z".repeat(500);
+    await adapter.createTask({ name: "n", note: longNote, flagged: true });
+
+    const result = await handleTaskList({ flagged: true, notePreviewChars: -1 }, ctx);
+    const task = result.data.tasks[0] as unknown as Record<string, unknown>;
+    expect(task.note).toBe(longNote);
+    expect(task).not.toHaveProperty("notePreview");
+    expect(task).not.toHaveProperty("noteTruncated");
+  });
+});

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -25,6 +25,7 @@ import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
 import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TaskListInput, TaskService } from "../../services/taskService.js";
 import { TaskSortBySchema } from "../../services/taskService.js";
+import { applyNotePreview, DEFAULT_NOTE_PREVIEW_CHARS } from "./notePreview.js";
 
 // ---------------------------------------------------------------------------
 // Tool description (shown to the LLM via tools/list)
@@ -141,6 +142,15 @@ export const taskListInputSchema = z.object({
     .describe(
       "Opaque cursor from a previous task_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError.",
     ),
+  notePreviewChars: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      `Maximum characters of each task's note to return. Default ${DEFAULT_NOTE_PREVIEW_CHARS}. ` +
+        "When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. " +
+        "Pass -1 to disable truncation and return full notes inline.",
+    ),
 });
 
 /** TypeScript input type derived from {@link taskListInputSchema}. */
@@ -162,14 +172,17 @@ export interface ToolContext {
  * can invoke it without constructing an McpServer.
  */
 export async function handleTaskList(input: TaskListToolInput, ctx: ToolContext) {
-  const serviceInput = input as TaskListInput;
+  const { notePreviewChars: rawPreviewChars, ...rest } = input;
+  const serviceInput = rest as TaskListInput;
   const result = await ctx.taskService.list(serviceInput);
   const pagination: Pagination = {
     cursor: result.nextCursor,
     hasMore: result.hasMore,
   };
   const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
-  return ok({ tasks: result.tasks }, meta, pagination);
+  const previewChars = rawPreviewChars ?? DEFAULT_NOTE_PREVIEW_CHARS;
+  const tasks = result.tasks.map((t) => applyNotePreview(t, previewChars));
+  return ok({ tasks }, meta, pagination);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/notePreview.test.ts
+++ b/src/tools/task/notePreview.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the note-preview helper (#775).
+ */
+
+import { describe, expect, test } from "vitest";
+import { applyNotePreview, DEFAULT_NOTE_PREVIEW_CHARS, NO_TRUNCATION } from "./notePreview.js";
+
+describe("applyNotePreview", () => {
+  test("passes through when note is null", () => {
+    const task = { id: "t1", name: "x", note: null };
+    expect(applyNotePreview(task, 50)).toBe(task);
+  });
+
+  test("passes through when note is shorter than the cap", () => {
+    const task = { id: "t1", name: "x", note: "short" };
+    expect(applyNotePreview(task, 50)).toBe(task);
+  });
+
+  test("passes through at exact-equal length boundary", () => {
+    const task = { id: "t1", name: "x", note: "abcde" };
+    expect(applyNotePreview(task, 5)).toBe(task);
+  });
+
+  test("truncates and emits the triplet when note exceeds the cap", () => {
+    const long = "a".repeat(500);
+    const task = { id: "t1", name: "x", note: long, flagged: false };
+    const result = applyNotePreview(task, 200);
+
+    expect(result).not.toBe(task);
+    expect(result).toEqual({
+      id: "t1",
+      name: "x",
+      flagged: false,
+      notePreview: "a".repeat(200),
+      noteTruncated: true,
+      noteLength: 500,
+    });
+    expect(result).not.toHaveProperty("note");
+  });
+
+  test("noteLength reports UTF-8 byte length, not codepoint count", () => {
+    // "🌲" is U+1F332 — 4 UTF-8 bytes, 1 codepoint, 2 UTF-16 code units.
+    const note = "🌲".repeat(50); // 50 codepoints, 200 UTF-8 bytes
+    const task = { id: "t1", note };
+    const result = applyNotePreview(task, 10);
+
+    if (!("noteTruncated" in result)) throw new Error("expected truncation");
+    expect(result.notePreview).toBe("🌲".repeat(10));
+    expect(result.noteLength).toBe(200);
+  });
+
+  test("truncates at codepoint boundary, not UTF-16 code unit", () => {
+    // A run of supplementary-plane codepoints. Naively slicing the JS string
+    // by .length would split a surrogate pair at an odd index; iterating by
+    // codepoint never does.
+    const note = "🌲🌳🌴🌵🌶".repeat(20); // 100 codepoints
+    const task = { id: "t1", note };
+    const result = applyNotePreview(task, 7);
+
+    if (!("noteTruncated" in result)) throw new Error("expected truncation");
+    expect(Array.from(result.notePreview)).toHaveLength(7);
+    expect(result.notePreview).toBe("🌲🌳🌴🌵🌶🌲🌳");
+  });
+
+  test("opts out when notePreviewChars is negative (NO_TRUNCATION)", () => {
+    const long = "a".repeat(5000);
+    const task = { id: "t1", note: long };
+    expect(applyNotePreview(task, NO_TRUNCATION)).toBe(task);
+  });
+
+  test("zero cap yields an empty preview when the note is non-empty", () => {
+    const task = { id: "t1", note: "anything" };
+    const result = applyNotePreview(task, 0);
+
+    if (!("noteTruncated" in result)) throw new Error("expected truncation");
+    expect(result.notePreview).toBe("");
+    expect(result.noteTruncated).toBe(true);
+    expect(result.noteLength).toBe(8);
+  });
+
+  test("DEFAULT_NOTE_PREVIEW_CHARS is 200", () => {
+    expect(DEFAULT_NOTE_PREVIEW_CHARS).toBe(200);
+  });
+});

--- a/src/tools/task/notePreview.ts
+++ b/src/tools/task/notePreview.ts
@@ -1,0 +1,70 @@
+/**
+ * Note-preview contract for task read responses (#775).
+ *
+ * OmniFocus task notes can be multi-KB markdown bodies. Bulk reads return
+ * the full note for every task by default — a real workflow cost when
+ * notes are long but the LLM only needs the metadata. This module
+ * implements the truncation contract: short notes pass through untouched
+ * (backwards compatible), long notes are replaced with a `notePreview` +
+ * `noteTruncated: true` + `noteLength` triplet so the LLM knows the
+ * preview is partial and can fetch the full text via `note_get` when
+ * needed.
+ *
+ * Truncation is at a Unicode codepoint boundary, never a UTF-16 code unit
+ * — so a 4-byte emoji at the boundary won't be split into half a
+ * surrogate pair.
+ *
+ * @see DESIGN.md §26 — read tool pattern
+ * @see src/tools/note/get.ts — `note_get` is the full-text fetcher
+ */
+
+/** Default character cap for the note-preview window. */
+export const DEFAULT_NOTE_PREVIEW_CHARS = 200;
+
+/** Sentinel value: pass `-1` (or any negative number) to opt out of truncation. */
+export const NO_TRUNCATION = -1;
+
+/**
+ * Fields added to a Task's wire shape when its note exceeds the preview cap.
+ * Mutually exclusive with the `note` field — when truncation applies, `note`
+ * is removed and these three appear instead.
+ */
+export interface NotePreviewFields {
+  notePreview: string;
+  noteTruncated: true;
+  noteLength: number;
+}
+
+const utf8Encoder = new TextEncoder();
+
+/**
+ * Apply the note-preview contract to a Task-shaped object.
+ *
+ * - `notePreviewChars < 0`: opt-out, returns the input unchanged.
+ * - `task.note` null or codepoint-length ≤ `notePreviewChars`: returns the
+ *   input unchanged (the common short-note case is wire-compatible with
+ *   pre-#775 callers).
+ * - Otherwise: returns a new object with `note` removed and `notePreview`,
+ *   `noteTruncated`, `noteLength` added. `noteLength` is the UTF-8 byte
+ *   length of the original note — what an HTTP `Content-Length` would
+ *   report — so the LLM can decide whether fetching the full text is
+ *   worth the cost.
+ */
+export function applyNotePreview<T extends { note: string | null }>(
+  task: T,
+  notePreviewChars: number,
+): T | (Omit<T, "note"> & NotePreviewFields) {
+  if (notePreviewChars < 0) return task;
+  if (task.note === null) return task;
+
+  const codepoints = Array.from(task.note);
+  if (codepoints.length <= notePreviewChars) return task;
+
+  const { note, ...rest } = task;
+  return {
+    ...rest,
+    notePreview: codepoints.slice(0, notePreviewChars).join(""),
+    noteTruncated: true,
+    noteLength: utf8Encoder.encode(note).length,
+  };
+}

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -1,13 +1,13 @@
 {
   "generatedAt": "2026-05-09",
-  "toolListBytes": 166460,
+  "toolListBytes": 168032,
   "workflows": {
     "inbox-triage": {
       "callCount": 6,
       "totalRequestBytes": 29554,
-      "totalResponseBytes": 146252,
-      "totalRoundTripBytes": 175806,
-      "totalTokens": 85567,
+      "totalResponseBytes": 72126,
+      "totalRoundTripBytes": 101680,
+      "totalTokens": 67428,
       "byTool": {
         "tag_create": {
           "calls": 1,
@@ -27,7 +27,7 @@
         },
         "task_list": {
           "calls": 2,
-          "responseBytes": 134824
+          "responseBytes": 60698
         }
       }
     },
@@ -36,7 +36,7 @@
       "totalRequestBytes": 2609,
       "totalResponseBytes": 37754,
       "totalRoundTripBytes": 40363,
-      "totalTokens": 51706,
+      "totalTokens": 52099,
       "byTool": {
         "project_create": {
           "calls": 1,
@@ -69,7 +69,7 @@
       "totalRequestBytes": 292,
       "totalResponseBytes": 33000,
       "totalRoundTripBytes": 33292,
-      "totalTokens": 49938,
+      "totalTokens": 50331,
       "byTool": {
         "project_mark_reviewed": {
           "calls": 5,


### PR DESCRIPTION
## Summary

- Add `notePreviewChars` parameter (default 200, `-1` = opt-out) to `task_list`, `task_get`, and `task_get_many`. Notes longer than the cap return as the triplet `notePreview` + `noteTruncated: true` + `noteLength` (full UTF-8 byte length); short notes pass through unchanged so existing callers see no wire-shape change.
- New helper `src/tools/task/notePreview.ts` truncates at a Unicode codepoint boundary so multi-byte characters (emoji, combining marks) never get split. `waitingOn` / `decision` parsing in `task_get` and `task_get_many` runs against the full note before truncation, preserving fenced-metadata semantics.
- Re-baseline the inbox-triage benchmark: **−50.7% on `totalResponseBytes`** (146,252 → 72,126 B). `tools/list` grows ~1.6 KiB to document the new field across the three tools.

## Design link

Implements [#775 — feat(tools): default-truncate task notes in bulk reads + full-text fetcher (#770)](https://github.com/torsday/omnifocus-mcp/issues/775). The existing `note_get` tool serves as the full-text fetcher per the AC ("If a `task_note_get`-equivalent already exists, document and reuse it").

Closes #775

## Breaking change?

- [x] No — short notes (the common case) pass through with the existing wire shape; the new fields only appear when truncation is applied. Callers that need full notes inline can pass `notePreviewChars: -1`.

## Test plan

- [x] Unit tests cover happy + edge + error — 9 helper tests (UTF-8 boundary, codepoint boundary, null note, opt-out, zero, exact-length boundary) + 10 handler tests across the three tools
- [x] `pnpm typecheck && pnpm lint && pnpm test` green (3486 passed locally + pre-push hook)
- [x] Benchmark drift gate green (`pnpm bench:tokens`) after re-baseline; inbox-triage shows −50.7% on `totalResponseBytes`
- [x] Response envelope + typed error preserved
- [x] Tool descriptions extended with the new field; `pnpm docs:check` passes against regenerated `docs/tools.md`

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] No DESIGN.md drift — truncation contract lives in the schema `.describe()` strings (DESIGN §6.8.1)