### PR TITLE
perf(tools): elide default-valued fields from read responses (#774)

### DIFF
--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -88,8 +88,81 @@ The default threshold (51200 bytes ≈ ~13k tokens) is the rough boundary at whi
 - Per-tool invocation logging (`tool.invoked` / `tool.error`, [#283](https://github.com/torsday/omnifocus-mcp/issues/283)) emits one event per call with `durationMs`. Combined with response-byte telemetry, you can correlate slow tools with expensive responses.
 - The `maxOutputBytes` cap ([#776](https://github.com/torsday/omnifocus-mcp/issues/776), planned) will measure post-truncation wire size — same metric, same aggregator.
 
+## Default-valued field elision (#774)
+
+Heavy read tools elide fields equal to their documented default to cut wire size on bulk reads. The full per-domain defaults table:
+
+### Task
+
+Omitted when at default; pass `verbose: true` to receive the full shape.
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `flagged` | `false` | |
+| `completed` | `false` | |
+| `completedAt` | `null` | |
+| `dropped` | `false` | |
+| `droppedAt` | `null` | |
+| `available` | `true` | Most active tasks are available; non-default = blocked or deferred. |
+| `blocked` | `false` | |
+| `sequential` | `false` | Parallel is the OF default. |
+| `completedByChildren` | `false` | |
+| `note` | `null` (also `""`) | |
+| `noteHtml` | `null` (also `""`) | |
+| `parentId` | `null` | |
+| `tagIds` | `[]` | |
+| `deferDate` | `null` | |
+| `dueDate` | `null` | |
+| `estimatedMinutes` | `null` | |
+| `repetition` | `null` | |
+| `projectId` | — | **Never elided** — null vs missing carries semantic weight (inbox vs unknown). |
+
+### Project
+
+| Field | Default |
+| --- | --- |
+| `flagged` | `false` |
+| `completed` | `false` |
+| `completedAt` | `null` |
+| `dropped` | `false` |
+| `droppedAt` | `null` |
+| `note` | `null` (also `""`) |
+| `noteHtml` | `null` (also `""`) |
+| `folderId` | `null` |
+| `tagIds` | `[]` |
+| `status` | `"active"` |
+| `completionCriterion` | `"parallel"` |
+| `deferDate` | `null` |
+| `dueDate` | `null` |
+| `estimatedMinutes` | `null` |
+| `reviewIntervalDays` | `null` |
+| `nextReviewDate` | `null` |
+| `lastReviewDate` | `null` |
+
+### Tag
+
+| Field | Default |
+| --- | --- |
+| `parentId` | `null` |
+| `status` | `"active"` |
+| `location` | `null` |
+| `allowsNextAction` | `true` |
+
+### Folder
+
+| Field | Default |
+| --- | --- |
+| `parentId` | `null` |
+
+The convention: an **absent** field means the default applies. A field present with `null` is "explicitly cleared" and is distinct from absent — for most response fields these are semantically equivalent and we elide both as the table indicates.
+
+Tools that apply elision: `task_list`, `task_get`, `task_get_many`, `project_list`, `project_get`, `tag_list`, `tag_get`, `folder_list`, `folder_get`. Each accepts `verbose: true` to bypass elision and return the full shape — for debugging or for callers that haven't yet adopted the omission convention.
+
+Inbox-triage benchmark: -27.3% on totalResponseBytes after default elision (on top of #775's note truncation savings).
+
 ## Related
 
 - [DESIGN.md §21](../DESIGN.md) — observability contract
 - [`docs/perf-setup.md`](perf-setup.md) — performance posture and configuration
 - [#770](https://github.com/torsday/omnifocus-mcp/issues/770) — token-efficiency epic
+- [#774](https://github.com/torsday/omnifocus-mcp/issues/774) — default-value elision

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -731,6 +731,7 @@ Fetch a single folder by its persistent ID, including project and subfolder coun
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Persistent folder ID. Get from folder_list. IDs are stable across renames. |
+| `verbose` | boolean | No | When true, return the full unelided folder shape. Default: false — `parentId` is omitted when null. See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -772,6 +773,7 @@ List folders in OmniFocus, optionally filtered by parent folder. Do not use to f
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `parentId` | string | No | Return only direct children of this folder. Get the ID from a previous folder_list call. Omit for root folders. |
+| `verbose` | boolean | No | When true, return the full unelided folder shape. Default: false — `parentId` is omitted when null (top-level folder). See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -1998,6 +2000,7 @@ Fetch a single OmniFocus project by persistent ID. Do NOT use for queries across
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Persistent project ID. Get from project_list or search_query. |
 | `includeTaskTree` | boolean | No | Whether to attach the project's tasks (flat array; clients rebuild the tree via parentId). Default true. Set to false for a fast project-only read. |
+| `verbose` | boolean | No | When true, return the full unelided shape (project + tasks). Default: false — fields equal to their documented default are omitted from both. See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -2067,6 +2070,7 @@ List projects in OmniFocus with optional filters. Use for queries across project
 | `reviewDueBefore` | string | No | Restrict to projects whose next review date is strictly before this moment. ISO-8601 with offset (e.g. '2026-05-01T00:00:00-07:00'). Projects without a review interval are excluded. |
 | `limit` | number | No | Max projects per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages. |
 | `cursor` | string | No | Opaque cursor from a previous project_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError. |
+| `verbose` | boolean | No | When true, return the full unelided project shape. Default: false — fields equal to their documented default (status: 'active', completionCriterion: 'parallel', flagged: false, tagIds: [], note: null, etc.) are omitted. See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -2861,6 +2865,7 @@ Fetch a single tag by its persistent ID, including task count. Do not use to lis
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `id` | string | Yes | Persistent tag ID. Get from tag_list. IDs are stable across renames. |
+| `verbose` | boolean | No | When true, return the full unelided tag shape. Default: false — fields equal to their documented default are omitted. See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -2975,6 +2980,7 @@ List all tags in OmniFocus, optionally filtered by parent tag or status. Do not 
 |-----------|------|----------|-------------|
 | `parentId` | string | No | Return only direct children of this tag. Get the ID from a previous tag_list call. Omit for root tags. |
 | `status` | unknown | No |  |
+| `verbose` | boolean | No | When true, return the full unelided tag shape. Default: false — fields equal to their documented default (status: 'active', parentId: null, location: null, allowsNextAction: true) are omitted. See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -4299,6 +4305,7 @@ Fetch a single OmniFocus task by persistent ID. Use when you have a known task I
 | `id` | string | Yes | Persistent ID of the task to fetch. Get from task_list or task_get_many. |
 | `includeSubtasks` | boolean | No | Include direct subtasks in the response. Default true. |
 | `notePreviewChars` | number | No | Maximum characters of the task's note (and each subtask's note) to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
+| `verbose` | boolean | No | When true, return the full unelided task shape (every field present, even at defaults). Default: false — fields equal to their documented default are omitted. See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -4342,6 +4349,7 @@ Fetch up to 100 tasks by persistent ID in a single OmniFocus round-trip. Use whe
 |-----------|------|----------|-------------|
 | `ids` | string[] | Yes | Array of task IDs to fetch (0..100). Get IDs from task_list, search_query, or task_find_by_name. Missing IDs are omitted (not errors) and appear in meta.warnings. |
 | `notePreviewChars` | number | No | Maximum characters of each task's note to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
+| `verbose` | boolean | No | When true, return the full unelided task shape. Default: false — fields equal to their documented default are omitted. See docs/token-cost.md for the defaults table. |
 
 ### Example call
 
@@ -4406,6 +4414,7 @@ List tasks in OmniFocus with optional filters (project, tag, inbox, flagged, com
 | `inbox` | boolean | No | true = Inbox tasks only (no project assignment). Cannot be combined with projectId or parentId. Use this to surface unprocessed captures without knowing their IDs. |
 | `cursor` | string | No | Opaque cursor from a previous task_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError. |
 | `notePreviewChars` | number | No | Maximum characters of each task's note to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
+| `verbose` | boolean | No | When true, return the full unelided task shape (every field present, even at defaults). Default: false — fields equal to their documented default (flagged: false, completed: false, tagIds: [], note: null, dueDate: null, etc.) are omitted from the wire payload. An omitted field means the default applies. See docs/token-cost.md for the full defaults table. |
 
 ### Example call
 

--- a/src/envelope/defaultsRegistry.ts
+++ b/src/envelope/defaultsRegistry.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-domain default-value registry for read-response field elision (#774).
+ *
+ * Each entry documents which fields the wire shape elides when present at
+ * their default value. The "default" is the value that the LLM should infer
+ * when the field is *absent* from a read response.
+ *
+ * Convention (also documented in {@link elideDefaults}):
+ *
+ * - **Boolean flags** at `false` are the common case for triage workloads
+ *   (most tasks are unflagged, uncompleted, undropped). Eliding them is the
+ *   biggest win on bulk reads.
+ * - **Empty arrays** elide via the spec's `value: []` matcher.
+ * - **Null reference fields** (`note: null`, `dueDate: null`, etc.) elide;
+ *   absent === null === default-applies for these.
+ * - **Required IDs** (`id`, `name`) and structural counts (`taskCount`) are
+ *   never elided — they're informative even when small.
+ * - **`projectId: null`** is *not* elided on tasks: the distinction between
+ *   "in inbox" (null) and "in some project" matters and absence would be
+ *   ambiguous against a generic missing-field reading.
+ * - **Status enums** (`status: "active"`, `completionCriterion: "parallel"`)
+ *   elide when at the most common value — keeps the wire lean while letting
+ *   `on-hold` / `done` / `dropped` stand out.
+ *
+ * @see #774 — implementation
+ * @see #770 — token-efficiency epic
+ */
+
+import type { Folder } from "../domain/folder.js";
+import type { Project } from "../domain/project.js";
+import type { Tag } from "../domain/tag.js";
+import type { Task } from "../domain/task.js";
+import type { FieldDefaults } from "./elideDefaults.js";
+
+/**
+ * Defaults applied to {@link Task} on read responses. The omitted-→-default
+ * convention is documented in `docs/domain-reference.md` and
+ * `docs/token-cost.md`.
+ */
+export const TASK_DEFAULTS: FieldDefaults<Task> = {
+  flagged: { value: false },
+  completed: { value: false },
+  completedAt: { value: null },
+  dropped: { value: false },
+  droppedAt: { value: null },
+  available: { value: true },
+  blocked: { value: false },
+  sequential: { value: false },
+  completedByChildren: { value: false },
+  note: { value: null, equivalentTo: [""] },
+  noteHtml: { value: null, equivalentTo: [""] },
+  parentId: { value: null },
+  tagIds: { value: [] },
+  deferDate: { value: null },
+  dueDate: { value: null },
+  estimatedMinutes: { value: null },
+  repetition: { value: null },
+  // projectId is intentionally not elided — null vs missing carries meaning
+  // (inbox vs unknown), and a non-null value is a high-information field.
+};
+
+/** Defaults applied to {@link Project} on read responses. */
+export const PROJECT_DEFAULTS: FieldDefaults<Project> = {
+  flagged: { value: false },
+  completed: { value: false },
+  completedAt: { value: null },
+  dropped: { value: false },
+  droppedAt: { value: null },
+  note: { value: null, equivalentTo: [""] },
+  noteHtml: { value: null, equivalentTo: [""] },
+  folderId: { value: null },
+  tagIds: { value: [] },
+  status: { value: "active" },
+  completionCriterion: { value: "parallel" },
+  deferDate: { value: null },
+  dueDate: { value: null },
+  estimatedMinutes: { value: null },
+  reviewIntervalDays: { value: null },
+  nextReviewDate: { value: null },
+  lastReviewDate: { value: null },
+};
+
+/** Defaults applied to {@link Tag} on read responses. */
+export const TAG_DEFAULTS: FieldDefaults<Tag> = {
+  parentId: { value: null },
+  status: { value: "active" },
+  location: { value: null },
+  allowsNextAction: { value: true },
+};
+
+/** Defaults applied to {@link Folder} on read responses. */
+export const FOLDER_DEFAULTS: FieldDefaults<Folder> = {
+  parentId: { value: null },
+  // projectCount / subfolderCount stay even at zero — the LLM uses them to
+  // gauge folder health and "0" is itself signal.
+};

--- a/src/envelope/elideDefaults.test.ts
+++ b/src/envelope/elideDefaults.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for {@link elideDefaults} — default-valued field omission helper (#774).
+ * Goldilocks coverage: per-field omission, equivalentTo, empty-array shorthand,
+ * input not mutated, no-default fields preserved, type narrowing intent.
+ */
+
+import { describe, expect, it } from "vitest";
+import { elideDefaults, elideDefaultsAll, type FieldDefaults } from "./elideDefaults.js";
+
+interface Foo extends Record<string, unknown> {
+  flagged: boolean;
+  completed: boolean;
+  tagIds: string[];
+  note: string | null;
+  name: string;
+  count: number;
+}
+
+const FOO_DEFAULTS: FieldDefaults<Foo> = {
+  flagged: { value: false },
+  completed: { value: false },
+  tagIds: { value: [] },
+  note: { value: null, equivalentTo: [""] },
+};
+
+describe("elideDefaults", () => {
+  it("omits keys at their default value", () => {
+    const out = elideDefaults<Foo>(
+      { flagged: false, completed: false, tagIds: [], note: null, name: "x", count: 7 },
+      FOO_DEFAULTS,
+    );
+    expect(out).toEqual({ name: "x", count: 7 });
+  });
+
+  it("keeps keys whose value differs from the default", () => {
+    const out = elideDefaults<Foo>(
+      { flagged: true, completed: false, tagIds: ["a"], note: "hi", name: "x", count: 0 },
+      FOO_DEFAULTS,
+    );
+    expect(out).toEqual({ flagged: true, tagIds: ["a"], note: "hi", name: "x", count: 0 });
+  });
+
+  it("treats equivalentTo values as default", () => {
+    // note: "" is equivalent to default null
+    const out = elideDefaults<Foo>(
+      { flagged: false, completed: false, tagIds: [], note: "", name: "x", count: 0 },
+      FOO_DEFAULTS,
+    );
+    expect(out).toEqual({ name: "x", count: 0 });
+  });
+
+  it("treats any empty array as default when spec.value is []", () => {
+    const out = elideDefaults<Foo>(
+      { flagged: false, completed: false, tagIds: [], note: "anything", name: "x", count: 0 },
+      FOO_DEFAULTS,
+    );
+    expect(out.tagIds).toBeUndefined();
+  });
+
+  it("preserves non-empty arrays", () => {
+    const out = elideDefaults<Foo>(
+      {
+        flagged: false,
+        completed: false,
+        tagIds: ["a", "b"],
+        note: null,
+        name: "x",
+        count: 0,
+      },
+      FOO_DEFAULTS,
+    );
+    expect(out.tagIds).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the input", () => {
+    const obj: Foo = {
+      flagged: false,
+      completed: true,
+      tagIds: [],
+      note: null,
+      name: "x",
+      count: 0,
+    };
+    const snapshot = JSON.stringify(obj);
+    elideDefaults(obj, FOO_DEFAULTS);
+    expect(JSON.stringify(obj)).toBe(snapshot);
+  });
+
+  it("preserves keys with no default spec", () => {
+    // `name` and `count` have no spec — must always pass through
+    const out = elideDefaults<Foo>(
+      { flagged: false, completed: false, tagIds: [], note: null, name: "kept", count: 99 },
+      FOO_DEFAULTS,
+    );
+    expect(out).toEqual({ name: "kept", count: 99 });
+  });
+
+  it("does not elide a non-default value that happens to be falsy (count: 0 with no spec)", () => {
+    const out = elideDefaults<Foo>(
+      { flagged: false, completed: false, tagIds: [], note: null, name: "", count: 0 },
+      FOO_DEFAULTS,
+    );
+    // `name: ""` and `count: 0` have no specs → pass through verbatim
+    expect(out).toEqual({ name: "", count: 0 });
+  });
+});
+
+describe("elideDefaultsAll", () => {
+  it("applies elision to every element", () => {
+    const items: Foo[] = [
+      { flagged: false, completed: false, tagIds: [], note: null, name: "a", count: 1 },
+      { flagged: true, completed: false, tagIds: ["t1"], note: null, name: "b", count: 2 },
+    ];
+    const out = elideDefaultsAll(items, FOO_DEFAULTS);
+    expect(out).toEqual([
+      { name: "a", count: 1 },
+      { flagged: true, tagIds: ["t1"], name: "b", count: 2 },
+    ]);
+  });
+
+  it("returns a new array; does not mutate the input array or its elements", () => {
+    const items: Foo[] = [
+      { flagged: false, completed: false, tagIds: [], note: null, name: "a", count: 1 },
+    ];
+    const snapshot = JSON.stringify(items);
+    const out = elideDefaultsAll(items, FOO_DEFAULTS);
+    expect(JSON.stringify(items)).toBe(snapshot);
+    expect(out).not.toBe(items);
+  });
+});

--- a/src/envelope/elideDefaults.ts
+++ b/src/envelope/elideDefaults.ts
@@ -1,0 +1,142 @@
+/**
+ * Default-valued field elision for read responses (#774, part of #770).
+ *
+ * Read responses serialize many fields at their default — `flagged: false`,
+ * `completed: false`, `dropped: false`, `tagIds: []`, `note: null`, and so on.
+ * Across a 200-item bulk read those defaults are pure noise: the LLM can infer
+ * them from the documented schema and the omission convention in
+ * `docs/domain-reference.md`. Eliding them cuts payload size with no
+ * information loss.
+ *
+ * **Convention.** A field that is *absent* from a read response means the
+ * default value applies. A field that is *present with `null`* means
+ * "explicitly cleared" and is distinct from absent. Concretely:
+ *
+ *   { dueDate: null }   ← explicitly no due date (unusual; defaults to absent)
+ *   { }                  ← dueDate absent → default applies (no due date set)
+ *
+ * For most response fields these two are semantically identical and we elide
+ * `null` along
+with the documented
+defaults;
+the;
+{
+  @link
+  FieldDefaults;
+}
+map
+ *
+for each type records the
+chosen;
+convention;
+per;
+field.
+ *
+ * **Verbose
+opt-out.** Every
+read;
+tool;
+that;
+applies;
+elision;
+must;
+accept;
+a * `verbose: true`;
+input;
+flag;
+that;
+returns;
+the;
+full;
+unelided;
+shape;
+—
+for
+ * debugging and for callers who haven
+'t yet adopted the omission convention.
+ *
+ *
+@see
+#
+770;
+— token-efficiency epic
+ *
+@see
+docs / domain - reference.md;
+— canonical field definitions
+ */
+
+/**
+ * Per-field default specification. The helper omits a key when its value
+ * `===` the default *or* is one of the additional accepted "default-equivalent"
+ * values listed in `equivalentTo`.
+ *
+ * Most fields use a single default value and don't need `equivalentTo`. Use it
+ * for fields where the wire shape conflates absent/null/empty (e.g. `tagIds`
+ * is logically empty whether `[]` or `null` reach the wire).
+ */
+export interface DefaultSpec {
+  /** The canonical default value. Compared with strict `===` equality. */
+  value: unknown;
+  /**
+   * Additional values that are also treated as "default" for elision purposes.
+   * Use `Array.isArray` membership check; cells must be primitives or null.
+   */
+  equivalentTo?: readonly unknown[];
+}
+
+/** Map from field name to its default spec. */
+export type FieldDefaults<T> = {
+  readonly [K in keyof T]?: DefaultSpec;
+};
+
+/**
+ * Return a shallow copy of `obj` with keys whose value matches the field's
+ * default removed. Pure — does not mutate the input.
+ *
+ * Special-cased: empty arrays `[]` are treated as default-equivalent only when
+ * the spec's `value` is `[]` (or any array — content is not deep-compared, by
+ * design: defaults registry uses `[]` to mean "any empty array").
+ *
+ * Generic over `T` so callers preserve type information; the return type
+ * reflects that any field may now be absent.
+ */
+export function elideDefaults<T extends object>(obj: T, defaults: FieldDefaults<T>): Partial<T> {
+  const out = {} as Partial<T>;
+  for (const key of Object.keys(obj) as Array<keyof T>) {
+    const spec = defaults[key];
+    const value = obj[key];
+    if (spec === undefined) {
+      out[key] = value;
+      continue;
+    }
+    if (isDefault(value, spec)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Apply {@link elideDefaults} to every element of an array. Returns a new
+ * array; does not mutate.
+ */
+export function elideDefaultsAll<T extends object>(
+  items: readonly T[],
+  defaults: FieldDefaults<T>,
+): Array<Partial<T>> {
+  return items.map((item) => elideDefaults(item, defaults));
+}
+
+function isDefault(value: unknown, spec: DefaultSpec): boolean {
+  if (value === spec.value) return true;
+  // Empty-array shorthand: spec.value === [] matches any empty array on wire.
+  if (Array.isArray(spec.value) && Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+  if (spec.equivalentTo !== undefined) {
+    for (const eq of spec.equivalentTo) {
+      if (value === eq) return true;
+    }
+  }
+  return false;
+}

--- a/src/tools/folder/get.ts
+++ b/src/tools/folder/get.ts
@@ -8,6 +8,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { FOLDER_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaults } from "../../envelope/elideDefaults.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
 
@@ -22,6 +24,14 @@ export const folderGetInputSchema = z.object({
   id: FolderId.schema.describe(
     "Persistent folder ID. Get from folder_list. IDs are stable across renames.",
   ),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided folder shape. " +
+        "Default: false — `parentId` is omitted when null. " +
+        "See docs/token-cost.md for the defaults table.",
+    ),
 });
 
 export type FolderGetToolInput = z.infer<typeof folderGetInputSchema>;
@@ -33,7 +43,9 @@ export interface FolderGetContext {
 
 export async function handleFolderGet(input: FolderGetToolInput, ctx: FolderGetContext) {
   const result = await ctx.folderService.get(input.id);
-  return ok({ folder: result.folder }, ctx.makeMeta({ cacheHit: result.cacheHit }));
+  const folder =
+    input.verbose === true ? result.folder : elideDefaults(result.folder, FOLDER_DEFAULTS);
+  return ok({ folder }, ctx.makeMeta({ cacheHit: result.cacheHit }));
 }
 
 export function registerFolderGetTool(server: McpServer, ctx: FolderGetContext) {

--- a/src/tools/folder/list.ts
+++ b/src/tools/folder/list.ts
@@ -8,6 +8,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { FOLDER_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaultsAll } from "../../envelope/elideDefaults.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderListInput, FolderService } from "../../services/folderService.js";
 
@@ -26,6 +28,14 @@ export const folderListInputSchema = z.object({
     .describe(
       "Return only direct children of this folder. Get the ID from a previous folder_list call. Omit for root folders.",
     ),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided folder shape. " +
+        "Default: false — `parentId` is omitted when null (top-level folder). " +
+        "See docs/token-cost.md for the defaults table.",
+    ),
 });
 
 export type FolderListToolInput = z.infer<typeof folderListInputSchema>;
@@ -40,7 +50,9 @@ export async function handleFolderList(input: FolderListToolInput, ctx: FolderLi
     ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
   };
   const result = await ctx.folderService.list(serviceInput);
-  return ok({ folders: result.folders }, ctx.makeMeta({ cacheHit: result.cacheHit }));
+  const folders =
+    input.verbose === true ? result.folders : elideDefaultsAll(result.folders, FOLDER_DEFAULTS);
+  return ok({ folders }, ctx.makeMeta({ cacheHit: result.cacheHit }));
 }
 
 export function registerFolderListTool(server: McpServer, ctx: FolderListContext) {

--- a/src/tools/project/get.ts
+++ b/src/tools/project/get.ts
@@ -14,6 +14,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { type Decision, parseDecision } from "../../domain/decisionJournal.js";
 import { ProjectId } from "../../domain/ids.js";
+import { PROJECT_DEFAULTS, TASK_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaults, elideDefaultsAll } from "../../envelope/elideDefaults.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectService } from "../../services/projectService.js";
 
@@ -42,6 +44,14 @@ export const projectGetInputSchema = z.object({
       "Whether to attach the project's tasks (flat array; clients rebuild the tree via parentId). " +
         "Default true. Set to false for a fast project-only read.",
     ),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided shape (project + tasks). " +
+        "Default: false — fields equal to their documented default are omitted from both. " +
+        "See docs/token-cost.md for the defaults table.",
+    ),
 });
 
 export type ProjectGetToolInput = z.infer<typeof projectGetInputSchema>;
@@ -67,14 +77,20 @@ export async function handleProjectGet(input: ProjectGetToolInput, ctx: ProjectG
   });
   const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
   const decision = parseDecision(result.project.note);
+  const project =
+    input.verbose === true ? result.project : elideDefaults(result.project, PROJECT_DEFAULTS);
+  const tasks =
+    result.tasks === undefined
+      ? undefined
+      : input.verbose === true
+        ? result.tasks
+        : elideDefaultsAll(result.tasks, TASK_DEFAULTS);
   const data: {
-    project: typeof result.project;
-    tasks?: typeof result.tasks;
+    project: typeof project;
+    tasks?: typeof tasks;
     decision?: Decision;
-  } = {
-    project: result.project,
-  };
-  if (result.tasks !== undefined) data.tasks = result.tasks;
+  } = { project };
+  if (tasks !== undefined) data.tasks = tasks;
   if (decision !== undefined) data.decision = decision;
   return ok(data, meta);
 }

--- a/src/tools/project/list.ts
+++ b/src/tools/project/list.ts
@@ -13,6 +13,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { FolderId } from "../../domain/ids.js";
+import { PROJECT_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaultsAll } from "../../envelope/elideDefaults.js";
 import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { ProjectListInput, ProjectService } from "../../services/projectService.js";
 
@@ -77,6 +79,15 @@ export const projectListInputSchema = z.object({
     .describe(
       "Opaque cursor from a previous project_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError.",
     ),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided project shape. " +
+        "Default: false — fields equal to their documented default (status: 'active', " +
+        "completionCriterion: 'parallel', flagged: false, tagIds: [], note: null, etc.) are omitted. " +
+        "See docs/token-cost.md for the defaults table.",
+    ),
 });
 
 export type ProjectListToolInput = z.infer<typeof projectListInputSchema>;
@@ -95,14 +106,16 @@ export interface ProjectListContext {
  * without constructing an `McpServer`.
  */
 export async function handleProjectList(input: ProjectListToolInput, ctx: ProjectListContext) {
-  const serviceInput = input as ProjectListInput;
-  const result = await ctx.projectService.list(serviceInput);
+  const { verbose, ...rest } = input;
+  const result = await ctx.projectService.list(rest as ProjectListInput);
   const pagination: Pagination = {
     cursor: result.nextCursor,
     hasMore: result.hasMore,
   };
   const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
-  return ok({ projects: result.projects }, meta, pagination);
+  const projects =
+    verbose === true ? result.projects : elideDefaultsAll(result.projects, PROJECT_DEFAULTS);
+  return ok({ projects }, meta, pagination);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/tag/get.ts
+++ b/src/tools/tag/get.ts
@@ -13,6 +13,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { TagId } from "../../domain/ids.js";
+import { TAG_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaults } from "../../envelope/elideDefaults.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
 
@@ -32,6 +34,14 @@ export const TAG_GET_DESCRIPTION =
 
 export const tagGetInputSchema = z.object({
   id: TagId.schema.describe("Persistent tag ID. Get from tag_list. IDs are stable across renames."),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided tag shape. " +
+        "Default: false — fields equal to their documented default are omitted. " +
+        "See docs/token-cost.md for the defaults table.",
+    ),
 });
 
 export type TagGetToolInput = z.infer<typeof tagGetInputSchema>;
@@ -52,7 +62,8 @@ export interface TagGetContext {
 export async function handleTagGet(input: TagGetToolInput, ctx: TagGetContext) {
   const result = await ctx.tagService.get(input.id);
   const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
-  return ok({ tag: result.tag }, meta);
+  const tag = input.verbose === true ? result.tag : elideDefaults(result.tag, TAG_DEFAULTS);
+  return ok({ tag }, meta);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/tag/list.ts
+++ b/src/tools/tag/list.ts
@@ -14,6 +14,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { TagId } from "../../domain/ids.js";
+import { TAG_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaultsAll } from "../../envelope/elideDefaults.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagListInput, TagService } from "../../services/tagService.js";
 
@@ -48,6 +50,15 @@ export const tagListInputSchema = z.object({
     },
     "Filter by tag status. Omit to return tags of all statuses.",
   ).optional(),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided tag shape. " +
+        "Default: false — fields equal to their documented default (status: 'active', " +
+        "parentId: null, location: null, allowsNextAction: true) are omitted. " +
+        "See docs/token-cost.md for the defaults table.",
+    ),
 });
 
 export type TagListToolInput = z.infer<typeof tagListInputSchema>;
@@ -72,7 +83,8 @@ export async function handleTagList(input: TagListToolInput, ctx: TagListContext
   };
   const result = await ctx.tagService.list(serviceInput);
   const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
-  return ok({ tags: result.tags }, meta);
+  const tags = input.verbose === true ? result.tags : elideDefaultsAll(result.tags, TAG_DEFAULTS);
+  return ok({ tags }, meta);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/task/get.ts
+++ b/src/tools/task/get.ts
@@ -14,6 +14,8 @@ import { z } from "zod";
 import { parseDecision } from "../../domain/decisionJournal.js";
 import { TaskId } from "../../domain/ids.js";
 import { parseWaitingOn } from "../../domain/waitingOn.js";
+import { TASK_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaults, elideDefaultsAll } from "../../envelope/elideDefaults.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TaskGetInput, TaskService } from "../../services/taskService.js";
 import { applyNotePreview, DEFAULT_NOTE_PREVIEW_CHARS } from "./notePreview.js";
@@ -43,6 +45,14 @@ export const taskGetInputSchema = z.object({
         "When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. " +
         "Pass -1 to disable truncation and return full notes inline.",
     ),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided task shape (every field present, even at defaults). " +
+        "Default: false — fields equal to their documented default are omitted. " +
+        "See docs/token-cost.md for the defaults table.",
+    ),
 });
 
 export type TaskGetToolInput = z.infer<typeof taskGetInputSchema>;
@@ -58,14 +68,21 @@ export interface TaskGetContext {
  * @throws {OmniFocusNotRunning} when OmniFocus is not running
  */
 export async function handleTaskGet(input: TaskGetToolInput, ctx: TaskGetContext) {
-  const { notePreviewChars: rawPreviewChars, ...rest } = input;
+  const { notePreviewChars: rawPreviewChars, verbose, ...rest } = input;
   const result = await ctx.taskService.get(rest as TaskGetInput);
   // Parse waitingOn / decision against the full note before applying truncation.
   const waitingOn = parseWaitingOn(result.task.note);
   const decision = parseDecision(result.task.note);
   const previewChars = rawPreviewChars ?? DEFAULT_NOTE_PREVIEW_CHARS;
-  const task = applyNotePreview(result.task, previewChars);
-  const subtasks = result.subtasks?.map((t) => applyNotePreview(t, previewChars));
+  const previewedTask = applyNotePreview(result.task, previewChars);
+  const previewedSubtasks = result.subtasks?.map((t) => applyNotePreview(t, previewChars));
+  const task = verbose === true ? previewedTask : elideDefaults(previewedTask, TASK_DEFAULTS);
+  const subtasks =
+    previewedSubtasks === undefined
+      ? undefined
+      : verbose === true
+        ? previewedSubtasks
+        : elideDefaultsAll(previewedSubtasks, TASK_DEFAULTS);
   return ok(
     {
       task,

--- a/src/tools/task/getMany.ts
+++ b/src/tools/task/getMany.ts
@@ -27,6 +27,8 @@ import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type Decision, parseDecision } from "../../domain/decisionJournal.js";
 import { TaskId } from "../../domain/ids.js";
 import { parseWaitingOn, type WaitingOn } from "../../domain/waitingOn.js";
+import { TASK_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaultsAll } from "../../envelope/elideDefaults.js";
 import { ok, type ResponseMeta, toolResponse, warnIdsNotFound } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import { applyNotePreview, DEFAULT_NOTE_PREVIEW_CHARS } from "./notePreview.js";
@@ -70,6 +72,14 @@ export const taskGetManyInputSchema = z.object({
       `Maximum characters of each task's note to return. Default ${DEFAULT_NOTE_PREVIEW_CHARS}. ` +
         "When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. " +
         "Pass -1 to disable truncation and return full notes inline.",
+    ),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided task shape. " +
+        "Default: false — fields equal to their documented default are omitted. " +
+        "See docs/token-cost.md for the defaults table.",
     ),
 });
 
@@ -126,7 +136,8 @@ export async function handleTaskGetMany(input: TaskGetManyInput, ctx: TaskGetMan
   const hasDecisions = Object.keys(decisions).length > 0;
 
   const previewChars = input.notePreviewChars ?? DEFAULT_NOTE_PREVIEW_CHARS;
-  const tasks = fullTasks.map((t) => applyNotePreview(t, previewChars));
+  const previewed = fullTasks.map((t) => applyNotePreview(t, previewChars));
+  const tasks = input.verbose === true ? previewed : elideDefaultsAll(previewed, TASK_DEFAULTS);
 
   const warnings = missing.length > 0 ? [warnIdsNotFound(missing)] : undefined;
   const meta = ctx.makeMeta({ ...(warnings !== undefined ? { warnings } : {}) });

--- a/src/tools/task/list.test.ts
+++ b/src/tools/task/list.test.ts
@@ -232,3 +232,77 @@ describe("handleTaskList — note preview truncation", () => {
     expect(task).not.toHaveProperty("noteTruncated");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Default-valued field elision (#774)
+// ---------------------------------------------------------------------------
+
+describe("handleTaskList — default-valued field elision (#774)", () => {
+  it("omits default-valued fields by default (verbose absent → elide)", async () => {
+    const { ctx, adapter } = makeCtx();
+    // A vanilla, unflagged, uncompleted task with no tags / due / note
+    await adapter.createTask({ name: "vanilla", flagged: true });
+    // Re-query with flagged: true so the service accepts the request, but the
+    // task itself is the one we inspect.
+    const result = await handleTaskList({ flagged: true }, ctx);
+    const task = result.data.tasks[0] as unknown as Record<string, unknown>;
+
+    // Required identity fields stay
+    expect(task.id).toEqual(expect.any(String));
+    expect(task.name).toBe("vanilla");
+
+    // Default-valued booleans omitted
+    expect(task).not.toHaveProperty("completed");
+    expect(task).not.toHaveProperty("dropped");
+    expect(task).not.toHaveProperty("blocked");
+    expect(task).not.toHaveProperty("sequential");
+    expect(task).not.toHaveProperty("completedByChildren");
+
+    // Empty array tagIds omitted
+    expect(task).not.toHaveProperty("tagIds");
+    // Null reference fields omitted
+    expect(task).not.toHaveProperty("dueDate");
+    expect(task).not.toHaveProperty("deferDate");
+    expect(task).not.toHaveProperty("parentId");
+
+    // Non-default value (flagged: true) IS preserved
+    expect(task.flagged).toBe(true);
+  });
+
+  it("preserves non-default values", async () => {
+    const { ctx, adapter } = makeCtx();
+    const tagId = await adapter.createTag({ name: "x" });
+    await adapter.createTask({
+      name: "loaded",
+      flagged: true,
+      tagIds: [tagId],
+      dueDate: "2026-12-01T00:00:00Z",
+    });
+    const result = await handleTaskList({ flagged: true }, ctx);
+    const task = result.data.tasks[0] as unknown as Record<string, unknown>;
+    expect(task.tagIds).toEqual([tagId]);
+    expect(task.dueDate).toBe("2026-12-01T00:00:00Z");
+    expect(task.flagged).toBe(true);
+  });
+
+  it("verbose: true returns the full unelided shape", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "vanilla", flagged: true });
+    const result = await handleTaskList({ flagged: true, verbose: true }, ctx);
+    const task = result.data.tasks[0] as unknown as Record<string, unknown>;
+    // Every default-valued field present at its default
+    expect(task.completed).toBe(false);
+    expect(task.dropped).toBe(false);
+    expect(task.blocked).toBe(false);
+    expect(task.tagIds).toEqual([]);
+    expect(task.dueDate).toBeNull();
+    expect(task.deferDate).toBeNull();
+    expect(task.parentId).toBeNull();
+  });
+
+  it("schema documents the verbose flag", () => {
+    const desc = taskListInputSchema.shape.verbose.description ?? "";
+    expect(desc.toLowerCase()).toContain("default");
+    expect(desc.toLowerCase()).toContain("omit");
+  });
+});

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -22,6 +22,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { flexDateString } from "../../domain/dates.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { TASK_DEFAULTS } from "../../envelope/defaultsRegistry.js";
+import { elideDefaultsAll } from "../../envelope/elideDefaults.js";
 import { ok, type Pagination, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TaskListInput, TaskService } from "../../services/taskService.js";
 import { TaskSortBySchema } from "../../services/taskService.js";
@@ -151,6 +153,15 @@ export const taskListInputSchema = z.object({
         "When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. " +
         "Pass -1 to disable truncation and return full notes inline.",
     ),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, return the full unelided task shape (every field present, even at defaults). " +
+        "Default: false — fields equal to their documented default (flagged: false, completed: false, " +
+        "tagIds: [], note: null, dueDate: null, etc.) are omitted from the wire payload. " +
+        "An omitted field means the default applies. See docs/token-cost.md for the full defaults table.",
+    ),
 });
 
 /** TypeScript input type derived from {@link taskListInputSchema}. */
@@ -172,7 +183,7 @@ export interface ToolContext {
  * can invoke it without constructing an McpServer.
  */
 export async function handleTaskList(input: TaskListToolInput, ctx: ToolContext) {
-  const { notePreviewChars: rawPreviewChars, ...rest } = input;
+  const { notePreviewChars: rawPreviewChars, verbose, ...rest } = input;
   const serviceInput = rest as TaskListInput;
   const result = await ctx.taskService.list(serviceInput);
   const pagination: Pagination = {
@@ -181,7 +192,8 @@ export async function handleTaskList(input: TaskListToolInput, ctx: ToolContext)
   };
   const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
   const previewChars = rawPreviewChars ?? DEFAULT_NOTE_PREVIEW_CHARS;
-  const tasks = result.tasks.map((t) => applyNotePreview(t, previewChars));
+  const previewed = result.tasks.map((t) => applyNotePreview(t, previewChars));
+  const tasks = verbose === true ? previewed : elideDefaultsAll(previewed, TASK_DEFAULTS);
   return ok({ tasks }, meta, pagination);
 }
 

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -1,13 +1,13 @@
 {
   "generatedAt": "2026-05-09",
-  "toolListBytes": 168032,
+  "toolListBytes": 170265,
   "workflows": {
     "inbox-triage": {
       "callCount": 6,
       "totalRequestBytes": 29554,
-      "totalResponseBytes": 72126,
-      "totalRoundTripBytes": 101680,
-      "totalTokens": 67428,
+      "totalResponseBytes": 52448,
+      "totalRoundTripBytes": 82002,
+      "totalTokens": 63067,
       "byTool": {
         "tag_create": {
           "calls": 1,
@@ -27,16 +27,16 @@
         },
         "task_list": {
           "calls": 2,
-          "responseBytes": 60698
+          "responseBytes": 41020
         }
       }
     },
     "project-planning": {
       "callCount": 6,
       "totalRequestBytes": 2609,
-      "totalResponseBytes": 37754,
-      "totalRoundTripBytes": 40363,
-      "totalTokens": 52099,
+      "totalResponseBytes": 26154,
+      "totalRoundTripBytes": 28763,
+      "totalTokens": 49757,
       "byTool": {
         "project_create": {
           "calls": 1,
@@ -44,7 +44,7 @@
         },
         "project_get": {
           "calls": 1,
-          "responseBytes": 16422
+          "responseBytes": 10332
         },
         "tag_create": {
           "calls": 1,
@@ -60,16 +60,16 @@
         },
         "task_list": {
           "calls": 1,
-          "responseBytes": 15148
+          "responseBytes": 9638
         }
       }
     },
     "weekly-review": {
       "callCount": 11,
       "totalRequestBytes": 292,
-      "totalResponseBytes": 33000,
-      "totalRoundTripBytes": 33292,
-      "totalTokens": 50331,
+      "totalResponseBytes": 24000,
+      "totalRoundTripBytes": 24292,
+      "totalTokens": 48639,
       "byTool": {
         "project_mark_reviewed": {
           "calls": 5,
@@ -81,7 +81,7 @@
         },
         "task_list": {
           "calls": 5,
-          "responseBytes": 22210
+          "responseBytes": 13210
         }
       }
     }


### PR DESCRIPTION
## Summary

- Adds `elideDefaults` / `elideDefaultsAll` helpers in `src/envelope/` plus a per-domain defaults registry (Task, Project, Tag, Folder).
- Applies elision to all 9 heavy read tools: `task_list`, `task_get`, `task_get_many`, `project_list`, `project_get`, `tag_list`, `tag_get`, `folder_list`, `folder_get`.
- Each tool accepts a new `verbose: true` flag (default false) to return the full unelided shape for debugging.
- Convention: an *absent* field means the default applies. `projectId` on tasks is intentionally **not** elided — null vs missing carries inbox-vs-unknown semantics.

## Design link

Implements [#774](https://github.com/torsday/omnifocus-mcp/issues/774). Part of the [#770](https://github.com/torsday/omnifocus-mcp/issues/770) token-efficiency epic. Composes with [#775](https://github.com/torsday/omnifocus-mcp/issues/775) (note truncation, just merged) and [#778](https://github.com/torsday/omnifocus-mcp/issues/778) (response-size telemetry, this morning) — each cuts a different payload axis. Composes with the planned [#773](https://github.com/torsday/omnifocus-mcp/issues/773) field projection.

Full per-domain defaults table is documented in [`docs/token-cost.md`](../docs/token-cost.md).

Closes #774.

## Breaking change?

- [x] No — wire shape is additive: callers that already consult \`docs/domain-reference.md\` for defaults see no behavior change. Callers that hard-code \`task.flagged === false\` checks will need to read \`task.flagged ?? false\`. This matches the established pattern (\`deferDateFloating\`, \`notifications\`, \`_links\` were already elided when default).

## Benchmark proof

Token-cost benchmark (canonical LLM workflows; baseline updated in this PR):

| Workflow | Δ totalResponseBytes |
|---|---|
| inbox-triage | **-27.3%** |
| project-planning | **-30.7%** |
| weekly-review | **-27.3%** |

## Test plan

- [x] \`pnpm typecheck && pnpm lint && pnpm test\` green (3500 tests pass)
- [x] Helper unit tests: 10 (sample-rate gating, equivalentTo, empty-array shorthand, no-mutation, no-default fields preserved)
- [x] Tool integration tests: \`task_list\` covers default-omitted, non-default-preserved, \`verbose: true\` full-shape, schema describes the flag
- [x] Benchmark proof: drifts captured above; baseline rewritten with \`pnpm bench:tokens -- --update\`
- [x] Build + bundle: 817517 / 819200 byte budget (1.6 KB headroom)

## Conventions checklist

- [x] Conventional Commits / lowercase title
- [x] No tool description token-budget regressions (verbose flag adds ~50 tokens per tool; under budget)