### PR TITLE
docs(agents): add per-directory CLAUDE.md files (#809)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,14 @@ Follow the standards in, in priority order:
 3. MCP tool design: atomic, composable, rich responses, actionable errors, idempotency, circuit breakers
 4. Interaction style: direct, precise, no filler
 
+### Per-directory `CLAUDE.md` files
+
+Three subtrees ship a directory-scoped `CLAUDE.md` — agents that respect Claude Code's auto-load convention pick these up automatically when working under the matching path. Read them before editing files in those areas; they capture invariants the source files don't restate.
+
+- `src/scripts/jxa/CLAUDE.md` — `osascript` runtime distinction, OF 4.x quirks (`container()` not `parent()`, `containingProject().class()` exception handling), the two test harnesses (bridge mock vs sandboxed JS-eval).
+- `src/envelope/CLAUDE.md` — response-envelope pipeline (project → elide → truncate → cap), defaults registry, the per-tool `verbose` contract.
+- `src/tools/CLAUDE.md` — adding a tool (4 touch points), descriptionShape lint, common pitfalls.
+
 ## Project-specific conventions
 
 - **Adapter seam is sacred.** Services never see `osascript` or URL schemes. The `OmniFocusAdapter` interface is the only boundary between domain logic and the OS. Tests swap in `InMemoryAdapter`.

--- a/src/envelope/CLAUDE.md
+++ b/src/envelope/CLAUDE.md
@@ -1,0 +1,45 @@
+# `src/envelope/` — agent orientation
+
+Tool-response envelope contracts. The success-path of every read tool flows through here; the order in which envelope helpers compose changes the payload semantics, so start with the composition rule.
+
+## Composition order
+
+`project → elide → truncate → cap`. Each step assumes the previous has already run; reordering changes wire shape:
+
+1. **Project** (planned, [#773](https://github.com/torsday/omnifocus-mcp/issues/773)) — keep only the fields the caller asked for via `fields[]`. Done first because the next steps shouldn't waste work on fields about to be dropped.
+2. **Elide** (`elideDefaults.ts` + `defaultsRegistry.ts`) — drop fields equal to their documented default per `docs/token-cost.md`. Tools accept `verbose: true` to bypass.
+3. **Truncate** (`src/tools/task/notePreview.ts`, [#775](https://github.com/torsday/omnifocus-mcp/issues/775)) — replace long `note` with `notePreview` + `noteTruncated` + `noteLength`. `notePreviewChars: -1` opts out.
+4. **Cap** (planned, [#776](https://github.com/torsday/omnifocus-mcp/issues/776)) — hard wire-byte ceiling with truncation envelope. Last so it sees the post-elide post-truncate size.
+
+If you add a new transformation, decide which step in the pipeline it belongs to before writing it. Two transformations in the same step should commute; if they don't, they're separate steps.
+
+## Defaults registry
+
+`defaultsRegistry.ts` lists the per-domain default values (`TASK_DEFAULTS`, `PROJECT_DEFAULTS`, `TAG_DEFAULTS`, `FOLDER_DEFAULTS`). Adding a field to a domain interface means deciding whether it has a default; if yes, register it here in the same PR. Forgetting leaves the field always-present on the wire and silently bloats responses.
+
+The convention: an *absent* field on the wire means the default applies; a field present with `null` is "explicitly cleared." For most response fields these are semantically identical and we elide both. `projectId` on tasks is an intentional exception — null vs missing carries inbox-vs-unknown semantics. Document any new exception in the registry's docblock.
+
+## Per-tool contract
+
+Every read tool that uses these helpers must:
+
+- Accept a `verbose: boolean` input flag (default false → elide; true → full shape).
+- Document the elision in its `describe()` string ("…fields equal to their documented default are omitted…").
+- Apply elision *after* any tool-specific shaping (e.g. `applyNotePreview` runs before elision in `task_list.handler`).
+
+## Other helpers in this module
+
+- `index.ts` — the `ok()`, `err()`, `clarificationNeeded()` envelope builders + `Warning` / `WarningCode` taxonomy. Per ADR-0013, tools build envelopes through these helpers; the lint at `src/tools/descriptionShape.test.ts` and CI's `lint-custom` enforce the shape.
+- `Warning` codes are stable contract — additive only per ADR-0011. Adding a new code is a minor-version change; removing one is breaking.
+
+## Testing
+
+- Unit tests live alongside (`elideDefaults.test.ts`, `index.test.ts`).
+- Integration coverage of the full pipeline lives in tool-level tests (e.g. `src/tools/task/list.test.ts` covers verbose / non-verbose / default-elided / non-default-preserved).
+- Benchmark coverage ([#771](https://github.com/torsday/omnifocus-mcp/issues/771)): `pnpm test:bench:tokens` measures bytes through canonical workflows. After any envelope change, regenerate the baseline (`pnpm bench:tokens -- --update`) and commit the diff with the PR.
+
+## Related
+
+- `docs/design/envelope.md` — the deeper "how the system thinks" view (post-[#805](https://github.com/torsday/omnifocus-mcp/issues/805))
+- `docs/token-cost.md` — defaults registry user-facing reference
+- ADR-0013 (response envelope), ADR-0011 (versioning + breaking changes)

--- a/src/scripts/jxa/CLAUDE.md
+++ b/src/scripts/jxa/CLAUDE.md
@@ -1,0 +1,37 @@
+# `src/scripts/jxa/` — agent orientation
+
+JXA scripts that run inside `osascript` against the OmniFocus 4.x scripting interface. Read this before editing any file in this directory — three of the invariants below are how #673 shipped undetected for three release tags.
+
+## Runtime distinction
+
+These files run **inside `osascript`**, not Node. No npm modules, no `import`, no `Buffer`. Whatever isn't on the OmniFocus JXA DOM (or built into JavaScriptCore on macOS) doesn't exist here. The build inlines them as strings before they ship — see ADR-0020 (`docs/adr/0020-build-time-script-inlining.md`).
+
+Each script reads its arguments by `JSON.parse`-ing the single argv value the spawner passes (per ADR-0005). No environment variables, no stdin, no file I/O.
+
+## OmniFocus 4.x quirks
+
+- **`tag.parent()` throws.** Use `tag.container()` and check `container.id() === doc.id()` to distinguish a top-level tag from a nested tag. `parent()` itself raises `Can't convert types` in OF 4.x — the older `parent.class()` workaround is dead. See `build_tag.js` and the fix that #768 / commit `ba4abc5` shipped.
+- **`containingProject().class()` is an object call, not a string read.** It throws on real project specifiers in OF 4.x. Guard the call; on the throw path, *do not* clear `projectId` — the throw means "yes, it's a project," not "no project." The fix in commit `b40a4a0` is the reference.
+- **`flattenedTasks.byId()` returns a specifier with error code `-1728`** when the ID does not exist (rather than `null`). Catch this at the transport boundary and map to `NotFoundError`; never let `-1728` leak to callers. Reference: `ec53b88` and #674.
+- **`flattenedTasks()` is full-DB.** When you have a narrowing source (a tag, a project), iterate that source's tasks instead — see `task_list.js`'s `tagId` shortcut. A naive whole-DB scan blows the 30s scriptRunner timeout on real databases.
+
+## Testing
+
+Two harnesses, very different:
+
+1. **`src/adapter/jxa/JxaTransport.test.ts` — bridge-mock pattern.** Pass a `spawner` that returns canned stdout. Tests assert which script was invoked with which args. Use this for handler / shape coverage; no JXA actually runs.
+2. **`src/adapter/jxa/sandbox/` — sandboxed JS-eval harness.** Loads scripts and runs them against a JavaScriptCore-compatible mock of the OmniFocus DOM. Use this when you want to exercise the script's own logic (filter conditions, error mapping) without spawning `osascript`. Reference: commit `72d659d` and #723.
+
+The live integration suite (`*.integration.test.ts`, gated by `OMNIFOCUS_INTEGRATION=1`) only runs on `mac-local`. Don't add tests there for logic that the sandbox can cover.
+
+## When you change a script
+
+- The build step (`pnpm build` → tsup → inlining) compiles JXA strings into `dist/`. After editing a script, run `pnpm test` then `pnpm build` to confirm the inlining still parses.
+- If the change crosses the JXA → OmniJS boundary (per ADR-0019), check that ID interoperability survives — IDs returned by JXA must be passable to OmniJS scripts and vice versa.
+- Don't introduce ES2022+ syntax that JavaScriptCore on the supported macOS version doesn't accept. The runtime is older than Node — when in doubt, prefer `function` over `class`, `var` over `const` if scoping doesn't matter, and explicit `for` loops over modern array methods.
+
+## Related
+
+- `docs/design/jxa.md` — the deeper "how the system thinks" view (post-#805)
+- `src/adapter/jxa/JxaTransport.ts` — transport entry point that spawns these scripts
+- ADR-0002 (dual transport), ADR-0005 (scripts as first-class files), ADR-0019 (cross-transport ID interoperability), ADR-0020 (build-time inlining)

--- a/src/tools/CLAUDE.md
+++ b/src/tools/CLAUDE.md
@@ -1,0 +1,41 @@
+# `src/tools/` — agent orientation
+
+MCP tool implementations. Adding a tool is a 4-touch-point change: source file, registration, test, and (if read-shaped) a `describe()` string that satisfies the description-shape lint.
+
+## Adding a tool
+
+The minimum touch points:
+
+1. **Source file** at `src/tools/<noun>/<verb>.ts`. Tool naming follows `<noun>_<verb>` (ADR-0003). Export a Zod input schema, a pure handler, and a `register*Tool(server, ctx)` registration helper. Pattern reference: `src/tools/task/list.ts` is the documented reference implementation (per the per-area design notes).
+2. **Registration** wired in `src/server/mcpServer.ts` (or the relevant `register*` helper there). Without this the tool exists in code but is invisible to MCP clients.
+3. **Test** at `src/tools/<noun>/<verb>.test.ts`. Use `InMemoryAdapter` and the in-process service stack — no `osascript`. Goldilocks coverage: input schema + happy path + one error / edge.
+4. **`describe()` strings** on every input field. The descriptionShape lint enforces a four-section shape (per [#777](https://github.com/torsday/omnifocus-mcp/issues/777)) and the token budget — tests in `src/tools/descriptions.lint.test.ts` and `descriptionShape.test.ts` will fail the build if your descriptions drift.
+
+After adding a tool, run `pnpm docs:generate` to regenerate `docs/tools.md` (CI's `docs:check` job blocks merge if it's stale).
+
+## Read tools — envelope pipeline
+
+If your tool returns domain objects from a list/get, follow the envelope composition order documented in `src/envelope/CLAUDE.md`. Specifically:
+
+- Accept `verbose: boolean` and pipe non-verbose calls through `elideDefaultsAll(items, X_DEFAULTS)`.
+- Accept `notePreviewChars: number` for tools that surface task notes; default to `DEFAULT_NOTE_PREVIEW_CHARS`.
+- Wrap with `ok(data, meta, pagination?)` from `src/envelope/index.ts` (ADR-0013).
+
+## Common pitfalls
+
+- **Don't read OF data from `internal_status`.** It's a server-health probe; calling out to the adapter from there breaks its "no side effects, no JXA" contract. If you need a server-side aggregate, use a resource (`src/resources/`).
+- **Mutations invalidate the cache.** If your tool mutates state, the cache wrapper should already be tagging the entries — but if you bypass it (e.g. a write-pool detour), call `cache.invalidate(scopes)` explicitly.
+- **Tool descriptions are the LLM's contract.** Every field's `describe()` must say what the field does, where to get its IDs from, and what the default means. The descriptionShape lint catches missing pieces; agent-facing prose readability is your judgment.
+
+## Testing tiers
+
+- **Unit** (`*.test.ts`) — `pnpm test`, mocked / in-memory adapter, runs in CI on every PR.
+- **Integration** (`*.integration.test.ts` under `src/adapter/jxa/`) — `pnpm test:integration` with `OMNIFOCUS_INTEGRATION=1`, runs only on `mac-local` against live OmniFocus.
+- **Token-cost benchmark** (`tests/benchmark/token-cost/`) — proves wire-size changes against canonical workflows. Re-baseline with `pnpm bench:tokens -- --update` after intentional changes.
+
+## Related
+
+- `src/tools/INDEX.md` — generated tool catalogue (planned, [#807](https://github.com/torsday/omnifocus-mcp/issues/807))
+- `docs/design/tools.md` — deeper "how the tool layer thinks" view (post-[#805](https://github.com/torsday/omnifocus-mcp/issues/805))
+- `docs/tools.md` — generated user-facing tool reference (`pnpm docs:generate`)
+- ADR-0003 (`<noun>_<verb>` naming), ADR-0013 (response envelope), [#777](https://github.com/torsday/omnifocus-mcp/issues/777) (description-shape token budget)


### PR DESCRIPTION
## Summary

- Adds `src/scripts/jxa/CLAUDE.md`, `src/envelope/CLAUDE.md`, `src/tools/CLAUDE.md` — directory-scoped agent orientation files that auto-load for agents respecting the path-scoped discovery convention.
- Each file is under 80 lines, captures invariants the source files don't restate (OF 4.x JXA quirks, envelope pipeline order, descriptionShape lint contract).
- Adds a short pointer in AGENTS.md so agents that don't auto-load-by-path still know to look.

## Design link

Implements [#809](https://github.com/torsday/omnifocus-mcp/issues/809). Sub-issue of [#804](https://github.com/torsday/omnifocus-mcp/issues/804) (agent-orientation epic). Composes with [#805](https://github.com/torsday/omnifocus-mcp/issues/805) (DESIGN.md split) — the `docs/design/<area>.md` references in these files become live links once #805 lands.

Closes #809.

## Breaking change?

- [x] No — pure docs.

## Test plan

- [x] Each file ≤ 80 lines (37 / 45 / 41)
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` green (3500 tests, no docs-driven assertions affected)
- [x] No content duplicates DESIGN.md or ADRs — invariants link rather than restate