### PR TITLE
perf(cache): wire cache.wrap into tagService.list, folderService.list, forecastService.get

### DIFF
--- a/src/cache/invalidation.test.ts
+++ b/src/cache/invalidation.test.ts
@@ -126,12 +126,7 @@ describe("invalidateFolderMutation", () => {
     invalidateFolderMutation(cache as unknown as InvalidatingCache, {
       folderId: "folder_3" as FolderId,
     });
-    expect(cache.scopes).toEqual([
-      "folder:folder_3",
-      "folder:list",
-      "perspective:*",
-      "search:*",
-    ]);
+    expect(cache.scopes).toEqual(["folder:folder_3", "folder:list", "perspective:*", "search:*"]);
   });
 });
 

--- a/src/cache/invalidation.test.ts
+++ b/src/cache/invalidation.test.ts
@@ -106,7 +106,13 @@ describe("invalidateTagMutation", () => {
   it("emits tag, tag:list, forecast:*, perspective:*, search:*", () => {
     const cache = makeRecorder();
     invalidateTagMutation(cache as unknown as InvalidatingCache, { tagId: "tag_7" as TagId });
-    expect(cache.scopes).toEqual(["tag:tag_7", "tag:list", "forecast:*", "perspective:*", "search:*"]);
+    expect(cache.scopes).toEqual([
+      "tag:tag_7",
+      "tag:list",
+      "forecast:*",
+      "perspective:*",
+      "search:*",
+    ]);
   });
 });
 
@@ -120,7 +126,12 @@ describe("invalidateFolderMutation", () => {
     invalidateFolderMutation(cache as unknown as InvalidatingCache, {
       folderId: "folder_3" as FolderId,
     });
-    expect(cache.scopes).toEqual(["folder:folder_3", "folder:list", "perspective:*", "search:*"]);
+    expect(cache.scopes).toEqual([
+      "folder:folder_3",
+      "folder:list",
+      "perspective:*",
+      "search:*",
+    ]);
   });
 });
 

--- a/src/cache/invalidation.test.ts
+++ b/src/cache/invalidation.test.ts
@@ -103,10 +103,10 @@ describe("invalidateProjectMutation", () => {
 // ---------------------------------------------------------------------------
 
 describe("invalidateTagMutation", () => {
-  it("emits tag, forecast:*, perspective:*, search:*", () => {
+  it("emits tag, tag:list, forecast:*, perspective:*, search:*", () => {
     const cache = makeRecorder();
     invalidateTagMutation(cache as unknown as InvalidatingCache, { tagId: "tag_7" as TagId });
-    expect(cache.scopes).toEqual(["tag:tag_7", "forecast:*", "perspective:*", "search:*"]);
+    expect(cache.scopes).toEqual(["tag:tag_7", "tag:list", "forecast:*", "perspective:*", "search:*"]);
   });
 });
 
@@ -115,12 +115,12 @@ describe("invalidateTagMutation", () => {
 // ---------------------------------------------------------------------------
 
 describe("invalidateFolderMutation", () => {
-  it("emits folder, perspective:*, search:* (forecast intentionally skipped)", () => {
+  it("emits folder, folder:list, perspective:*, search:* (forecast intentionally skipped)", () => {
     const cache = makeRecorder();
     invalidateFolderMutation(cache as unknown as InvalidatingCache, {
       folderId: "folder_3" as FolderId,
     });
-    expect(cache.scopes).toEqual(["folder:folder_3", "perspective:*", "search:*"]);
+    expect(cache.scopes).toEqual(["folder:folder_3", "folder:list", "perspective:*", "search:*"]);
   });
 });
 

--- a/src/cache/invalidation.ts
+++ b/src/cache/invalidation.ts
@@ -98,6 +98,7 @@ export function invalidateProjectMutation(
  */
 export function invalidateTagMutation(cache: InvalidatingCache, opts: { tagId: TagId }): void {
   cache.invalidate(`tag:${opts.tagId}`);
+  cache.invalidate("tag:list");
   cache.invalidate("forecast:*");
   cache.invalidate("perspective:*");
   cache.invalidate("search:*");
@@ -115,6 +116,7 @@ export function invalidateFolderMutation(
   opts: { folderId: FolderId },
 ): void {
   cache.invalidate(`folder:${opts.folderId}`);
+  cache.invalidate("folder:list");
   cache.invalidate("perspective:*");
   cache.invalidate("search:*");
 }

--- a/src/server/composition.ts
+++ b/src/server/composition.ts
@@ -130,7 +130,7 @@ export function composeServices(adapter: OmniFocusAdapter, config: Config): Serv
       maxAttachmentMb: config.OMNIFOCUS_MAX_ATTACHMENT_MB,
     }),
     exportService: new ExportService({ adapter }),
-    forecastService: new ForecastService({ adapter }),
+    forecastService: new ForecastService({ adapter, cache }),
     perspectiveService: new PerspectiveService({ adapter }),
     pluginService: new PluginService({ adapter }),
     reviewService: new ReviewService({ adapter, cache }),

--- a/src/services/folderService.ts
+++ b/src/services/folderService.ts
@@ -14,9 +14,9 @@
  * - `move` is a thin wrapper over `updateFolder(id, { parentId })`.
  * - Cache invalidation: when the optional `cache` dep is supplied, every
  *   write method flushes the folder-mutation scope set (see
- *   docs/cache-invalidation.md) via `invalidateFolderMutation`. Reads
- *   still go straight to the adapter until the service-layer read cache
- *   lands with #36.
+ *   docs/cache-invalidation.md) via `invalidateFolderMutation`. `list`
+ *   reads through the cache using `folder:list:${hash}` keys cleared by
+ *   folder mutations.
  *
  * @see DESIGN.md §26 — reference implementation
  * @see docs/domain-reference.md — Folder schema
@@ -30,9 +30,16 @@ import type {
 import { type InvalidatingCache, invalidateFolderMutation } from "../cache/invalidation.js";
 import type { Folder } from "../domain/folder.js";
 import type { FolderId } from "../domain/ids.js";
+import { hashFilter } from "../pagination/cursor.js";
+
+/** Cache surface for FolderService: invalidation (for writes) + read-through (for list). */
+export interface FolderServiceCache extends InvalidatingCache {
+  wrap<T>(key: string, factory: () => Promise<T>): Promise<T>;
+  has(key: string): boolean;
+}
 
 /** Helper — emit the folder-mutation scope set if a cache is wired. */
-function flushFolder(cache: InvalidatingCache | undefined, folderId: FolderId): void {
+function flushFolder(cache: FolderServiceCache | undefined, folderId: FolderId): void {
   if (cache !== undefined) invalidateFolderMutation(cache, { folderId });
 }
 
@@ -71,10 +78,10 @@ export interface FolderCreateResult {
 export interface FolderServiceDeps {
   adapter: OmniFocusAdapter;
   /**
-   * Optional cache; when supplied, every write method flushes the
-   * folder-mutation scope set (docs/cache-invalidation.md).
+   * Optional cache; when supplied, `list` reads through it and every write
+   * method flushes the folder-mutation scope set (docs/cache-invalidation.md).
    */
-  cache?: InvalidatingCache;
+  cache?: FolderServiceCache;
 }
 
 /**
@@ -85,7 +92,7 @@ export interface FolderServiceDeps {
  */
 export class FolderService {
   private readonly adapter: OmniFocusAdapter;
-  private readonly cache: InvalidatingCache | undefined;
+  private readonly cache: FolderServiceCache | undefined;
 
   constructor({ adapter, cache }: FolderServiceDeps) {
     this.adapter = adapter;
@@ -103,9 +110,14 @@ export class FolderService {
    * @returns Matching folders in adapter-natural order.
    */
   async list(input: FolderListInput = {}): Promise<FolderListResult> {
-    const folders = await this.adapter.listFolders(
-      input.parentId !== undefined ? { parentId: input.parentId } : {},
-    );
+    const adapterInput = input.parentId !== undefined ? { parentId: input.parentId } : {};
+    if (this.cache !== undefined) {
+      const cacheKey = `folder:list:${hashFilter(input as Record<string, unknown>)}`;
+      const cacheHit = this.cache.has(cacheKey);
+      const folders = await this.cache.wrap(cacheKey, () => this.adapter.listFolders(adapterInput));
+      return { folders, cacheHit };
+    }
+    const folders = await this.adapter.listFolders(adapterInput);
     return { folders, cacheHit: false };
   }
 

--- a/src/services/forecastService.test.ts
+++ b/src/services/forecastService.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import { InMemoryAdapter } from "../adapter/inMemory/InMemoryAdapter.js";
+import { OmniFocusLruCache } from "../cache/lruCache.js";
 import { ForecastService } from "./forecastService.js";
 
 const FROM = "2026-04-23T00:00:00.000Z";
@@ -102,9 +103,26 @@ describe("ForecastService.get", () => {
     expect(result.flagged).toHaveLength(0);
   });
 
-  it("reports cacheHit false", async () => {
+  it("reports cacheHit false on first call", async () => {
     const { service } = makeService();
     const result = await service.get({ from: FROM, to: TO });
     expect(result.cacheHit).toBe(false);
+  });
+
+  it("reports cacheHit true on second call with same input when cache is wired", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date("2026-04-23T12:00:00.000Z") });
+    const cache = new OmniFocusLruCache();
+    const service = new ForecastService({ adapter, cache });
+    await service.get({ from: FROM, to: TO });
+    const second = await service.get({ from: FROM, to: TO });
+    expect(second.cacheHit).toBe(true);
+  });
+
+  it("reports cacheHit false without a cache dep", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date("2026-04-23T12:00:00.000Z") });
+    const service = new ForecastService({ adapter });
+    await service.get({ from: FROM, to: TO });
+    const second = await service.get({ from: FROM, to: TO });
+    expect(second.cacheHit).toBe(false);
   });
 });

--- a/src/services/forecastService.ts
+++ b/src/services/forecastService.ts
@@ -13,6 +13,13 @@
 import type { ForecastInput, OmniFocusAdapter } from "../adapter/OmniFocusAdapter.js";
 import type { TagId } from "../domain/ids.js";
 import type { Task } from "../domain/task.js";
+import { hashFilter } from "../pagination/cursor.js";
+
+/** Minimal read-through cache surface needed by ForecastService. */
+interface ReadCache {
+  wrap<T>(key: string, factory: () => Promise<T>): Promise<T>;
+  has(key: string): boolean;
+}
 
 export interface ForecastGetResult {
   overdue: Task[];
@@ -24,9 +31,11 @@ export interface ForecastGetResult {
 
 export class ForecastService {
   private readonly adapter: OmniFocusAdapter;
+  private readonly cache: ReadCache | undefined;
 
-  constructor(deps: { adapter: OmniFocusAdapter }) {
+  constructor(deps: { adapter: OmniFocusAdapter; cache?: ReadCache }) {
     this.adapter = deps.adapter;
+    this.cache = deps.cache;
   }
 
   /**
@@ -36,6 +45,12 @@ export class ForecastService {
    * don't need rather than opting in.
    */
   async get(input: ForecastInput): Promise<ForecastGetResult> {
+    if (this.cache !== undefined) {
+      const cacheKey = `forecast:${hashFilter(input as unknown as Record<string, unknown>)}`;
+      const cacheHit = this.cache.has(cacheKey);
+      const result = await this.cache.wrap(cacheKey, () => this.adapter.getForecast(input));
+      return { ...result, cacheHit };
+    }
     const result = await this.adapter.getForecast(input);
     return { ...result, cacheHit: false };
   }

--- a/src/services/tagService.ts
+++ b/src/services/tagService.ts
@@ -14,9 +14,8 @@
  *   operations (DESIGN agent_systems §atomic).
  * - Cache invalidation: when the optional `cache` dep is supplied, every
  *   write method flushes the tag-mutation scope set (see
- *   docs/cache-invalidation.md) via `invalidateTagMutation`. Reads still
- *   go straight to the adapter until the service-layer read cache lands
- *   with #36.
+ *   docs/cache-invalidation.md) via `invalidateTagMutation`. `list` reads
+ *   through the cache using `tag:list:${hash}` keys cleared by tag mutations.
  *
  * @see DESIGN.md §26 — reference implementation
  * @see docs/domain-reference.md — Tag schema
@@ -31,9 +30,16 @@ import type {
 import { type InvalidatingCache, invalidateTagMutation } from "../cache/invalidation.js";
 import type { TagId } from "../domain/ids.js";
 import type { Tag, TagLocation } from "../domain/tag.js";
+import { hashFilter } from "../pagination/cursor.js";
+
+/** Cache surface for TagService: invalidation (for writes) + read-through (for list). */
+export interface TagServiceCache extends InvalidatingCache {
+  wrap<T>(key: string, factory: () => Promise<T>): Promise<T>;
+  has(key: string): boolean;
+}
 
 /** Helper — emit the tag-mutation scope set if a cache is wired. */
-function flushTag(cache: InvalidatingCache | undefined, tagId: TagId): void {
+function flushTag(cache: TagServiceCache | undefined, tagId: TagId): void {
   if (cache !== undefined) invalidateTagMutation(cache, { tagId });
 }
 
@@ -74,10 +80,10 @@ export interface TagCreateResult {
 export interface TagServiceDeps {
   adapter: OmniFocusAdapter;
   /**
-   * Optional cache; when supplied, every write method flushes the
-   * tag-mutation scope set (docs/cache-invalidation.md).
+   * Optional cache; when supplied, `list` reads through it and every write
+   * method flushes the tag-mutation scope set (docs/cache-invalidation.md).
    */
-  cache?: InvalidatingCache;
+  cache?: TagServiceCache;
 }
 
 /**
@@ -89,7 +95,7 @@ export interface TagServiceDeps {
  */
 export class TagService {
   private readonly adapter: OmniFocusAdapter;
-  private readonly cache: InvalidatingCache | undefined;
+  private readonly cache: TagServiceCache | undefined;
 
   constructor({ adapter, cache }: TagServiceDeps) {
     this.adapter = adapter;
@@ -107,10 +113,17 @@ export class TagService {
    * @returns All matching tags in adapter-natural order.
    */
   async list(input: TagListInput = {}): Promise<TagListResult> {
-    const tags = await this.adapter.listTags({
+    const adapterInput = {
       ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
       ...(input.status !== undefined ? { status: input.status } : {}),
-    });
+    };
+    if (this.cache !== undefined) {
+      const cacheKey = `tag:list:${hashFilter(input as Record<string, unknown>)}`;
+      const cacheHit = this.cache.has(cacheKey);
+      const tags = await this.cache.wrap(cacheKey, () => this.adapter.listTags(adapterInput));
+      return { tags, cacheHit };
+    }
+    const tags = await this.adapter.listTags(adapterInput);
     return { tags, cacheHit: false };
   }
 

--- a/src/tools/folder/folder.test.ts
+++ b/src/tools/folder/folder.test.ts
@@ -293,21 +293,57 @@ describe("FolderService — cache invalidation", () => {
     const folderService = new FolderService({ adapter, cache });
 
     const { id } = await folderService.create({ name: "Area" });
-    expect(scopes.slice(-3)).toEqual([`folder:${id}`, "perspective:*", "search:*"]);
+    expect(scopes.slice(-4)).toEqual([`folder:${id}`, "folder:list", "perspective:*", "search:*"]);
 
     const before = scopes.length;
     await folderService.update(id, { name: "Area!" });
     await folderService.move(id, null);
     await folderService.delete(id);
 
-    // Three mutations × three scopes each = nine new emissions.
-    expect(scopes.length - before).toBe(9);
+    // Three mutations × four scopes each = twelve new emissions.
+    expect(scopes.length - before).toBe(12);
     for (let i = 0; i < 3; i++) {
-      expect(scopes.slice(before + i * 3, before + i * 3 + 3)).toEqual([
+      expect(scopes.slice(before + i * 4, before + i * 4 + 4)).toEqual([
         `folder:${id}`,
+        "folder:list",
         "perspective:*",
         "search:*",
       ]);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FolderService.list — cache read-through
+// ---------------------------------------------------------------------------
+
+describe("FolderService.list — cache hit", () => {
+  it("reports cacheHit true on second call with same input", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date(0) });
+    const cache = new OmniFocusLruCache();
+    const folderService = new FolderService({ adapter, cache });
+    await adapter.createFolder({ name: "Area" });
+    await folderService.list();
+    const second = await folderService.list();
+    expect(second.cacheHit).toBe(true);
+  });
+
+  it("reports cacheHit false when no cache is wired", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date(0) });
+    const folderService = new FolderService({ adapter });
+    await adapter.createFolder({ name: "Area" });
+    await folderService.list();
+    const second = await folderService.list();
+    expect(second.cacheHit).toBe(false);
+  });
+
+  it("cache is cleared after a mutation", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date(0) });
+    const cache = new OmniFocusLruCache();
+    const folderService = new FolderService({ adapter, cache });
+    await folderService.list();
+    await folderService.create({ name: "Area" });
+    const afterMutation = await folderService.list();
+    expect(afterMutation.cacheHit).toBe(false);
   });
 });

--- a/src/tools/tag/mutations.test.ts
+++ b/src/tools/tag/mutations.test.ts
@@ -296,7 +296,7 @@ describe("TagService — cache invalidation", () => {
 
     const { id } = await tagService.create({ name: "Work" });
 
-    expect(scopes).toEqual([`tag:${id}`, "forecast:*", "perspective:*", "search:*"]);
+    expect(scopes).toEqual([`tag:${id}`, "tag:list", "forecast:*", "perspective:*", "search:*"]);
   });
 
   it("update / delete / move / setStatus / setAllowsNextAction all flush the tag scope set", async () => {
@@ -315,15 +315,51 @@ describe("TagService — cache invalidation", () => {
     await tagService.setAllowsNextAction(id, false);
     await tagService.delete(id);
 
-    // Five mutations × four scopes each = 20 emissions, all with the same shape.
-    expect(scopes).toHaveLength(20);
+    // Five mutations × five scopes each = 25 emissions, all with the same shape.
+    expect(scopes).toHaveLength(25);
     for (let i = 0; i < 5; i++) {
-      expect(scopes.slice(i * 4, i * 4 + 4)).toEqual([
+      expect(scopes.slice(i * 5, i * 5 + 5)).toEqual([
         `tag:${id}`,
+        "tag:list",
         "forecast:*",
         "perspective:*",
         "search:*",
       ]);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TagService.list — cache read-through
+// ---------------------------------------------------------------------------
+
+describe("TagService.list — cache hit", () => {
+  it("reports cacheHit true on second call with same input", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date(0) });
+    const cache = new OmniFocusLruCache();
+    const tagService = new TagService({ adapter, cache });
+    await adapter.createTag({ name: "Work" });
+    await tagService.list();
+    const second = await tagService.list();
+    expect(second.cacheHit).toBe(true);
+  });
+
+  it("reports cacheHit false when no cache is wired", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date(0) });
+    const tagService = new TagService({ adapter });
+    await adapter.createTag({ name: "Work" });
+    await tagService.list();
+    const second = await tagService.list();
+    expect(second.cacheHit).toBe(false);
+  });
+
+  it("cache is cleared after a mutation", async () => {
+    const adapter = new InMemoryAdapter({ now: () => new Date(0) });
+    const cache = new OmniFocusLruCache();
+    const tagService = new TagService({ adapter, cache });
+    await tagService.list();
+    await tagService.create({ name: "Work" });
+    const afterMutation = await tagService.list();
+    expect(afterMutation.cacheHit).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Define `TagServiceCache` / `FolderServiceCache` interfaces (extend `InvalidatingCache` with `wrap` + `has`) so services can both read through and write-invalidate via the same dep
- Wrap `TagService.list` with `tag:list:${hash}` keys; `FolderService.list` with `folder:list:${hash}` keys; `ForecastService.get` with `forecast:${hash}` keys (already covered by the existing `forecast:*` invalidation scope)
- `invalidateTagMutation` now flushes `tag:list` scope in addition to the per-ID scope; `invalidateFolderMutation` flushes `folder:list` scope
- Wire `cache` into `ForecastService` in `composition.ts`
- Update all affected test assertions (scope counts); add cache-hit and post-mutation invalidation tests (8 new tests across tag, folder, forecast service files)

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 3532 tests pass (8 new)
- [x] Local pre-push hook (typecheck + lint + docs) — passes

Closes #790