### PR TITLE
docs(tests): expand tests/README.md to map all 8 sub-dirs with purpose and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,10 @@ See the [troubleshooting guide](./docs/troubleshooting.md) and per-client guides
 
 Full table with override semantics: [`DESIGN.md §22`](./DESIGN.md#22-configuration--environment).
 
+### Running tests
+
+See [`tests/README.md`](./tests/README.md) for the full test-directory map (benchmark, chaos, contract, e2e, fixtures, integration, perf, scripts) and routing guidance on which sub-directory to use for a given type of test.
+
 ### Running integration tests
 
 Integration tests run against a live OmniFocus install:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,72 +1,43 @@
 # tests/
 
-Cross-cutting test suites that don't belong next to a single source file.
+Cross-cutting test suites. Unit tests that target a single module live next to their source (`src/**/*.test.ts`). Everything here is broader: multi-module, live-process, or data-only.
 
-## Layout
+## Sub-directory index
 
-```
-tests/
-├── contract/    # Adapter contract harness — one suite, all implementations
-└── integration/ # Real-OmniFocus integration tests (gated on env var)
-```
+| Dir | Purpose | Runner | Use when… |
+|---|---|---|---|
+| `benchmark/` | Token-cost benchmarks — counts response bytes per tool call | `pnpm bench:token-cost` | Verifying a change doesn't inflate token spend |
+| `chaos/` | Transport fault injection — every DESIGN §19 failure mode via `ScriptSpawner` seam | `pnpm test` (unit tier) | Adding a new transport error path or retry behaviour |
+| `contract/` | Adapter contract harness — one parameterised suite all `OmniFocusAdapter` implementations must pass | `pnpm test` / `pnpm test:integration` | Adding a new adapter or changing adapter semantics |
+| `e2e/` | Full-stack MCP client — spawns the bundled server over stdio, speaks the SDK protocol | `pnpm test:e2e` | Verifying the tool contract end-to-end through the real transport stack |
+| `fixtures/` | Data-only test assets (JSON readability probes, etc.) — no logic | N/A — imported by other suites | Adding stable input/output pairs for snapshot or readability tests |
+| `integration/` | Live-OmniFocus tests — requires `OMNIFOCUS_INTEGRATION=1` and the macOS self-hosted runner | `pnpm test:integration` | Proving a JXA/OmniJS behaviour against real OmniFocus |
+| `perf/` | SPEC §9 p95 latency targets — gated on `OMNIFOCUS_PERF=1` | `pnpm test:integration` with `OMNIFOCUS_PERF=1` | Checking a change doesn't regress p95 response time |
+| `scripts/` | Unit tests for helpers in `scripts/` (NL-quality lint, etc.) | `pnpm test` (unit tier) | Adding or changing a `scripts/*.ts` helper |
 
-Unit tests that target a single module continue to live next to their source
-(e.g. `src/foo/Foo.test.ts`). The layout matches `vitest.config.ts`:
+## Key files
 
-| Glob                       | Tier        | Runs on                                    |
-|----------------------------|-------------|--------------------------------------------|
-| `src/**/*.test.ts`         | unit        | `pnpm test` (always)                       |
-| `tests/unit/**/*.test.ts`  | unit        | `pnpm test` (always)                       |
-| `tests/integration/**`     | integration | `pnpm test:integration` (opt-in, live OF)  |
+- `tests/e2e/E2EServer.ts` — spawns the server, provides `callTool` / `listTools` surface for suites
+- `tests/e2e/smoke.test.ts` — canonical usage example for `E2EServer`
+- `tests/contract/adapter.contract.ts` — exports `runAdapterContract(label, { createAdapter, cleanup })`
+- `tests/contract/inMemory.contract.test.ts` — drives the contract suite against `InMemoryAdapter` (runs in the unit tier)
+- `tests/benchmark/token-cost/README.md` — token-cost benchmark detail
 
-## Contract harness — `tests/contract/`
+## Invariants worth knowing
 
-`adapter.contract.ts` exports `runAdapterContract(label, { createAdapter })`,
-a single parameterized `describe` block every `OmniFocusAdapter` implementation
-must pass. See DESIGN §19.
-
-**Scope** — CRUD, filter semantics, and the typed error taxonomy. It's the
-substitutability guarantee that lets services accept any adapter.
-
-**Out of scope** — deliberately. These surfaces are exercised only in the
-integration tier against real OmniFocus:
-
-- `available` / `blocked` derivation
-- recurring-task cascade on completion
-- perspective evaluation (`evaluatePerspective`)
-- sync mechanics (`syncTrigger`, `getLastSync`)
-- attachments
-- TaskPaper / OPML round-trips
-- plug-in invocation (`pluginInvoke`)
-
-### Drivers
-
-- `tests/contract/inMemory.contract.test.ts` — runs the suite against
-  `InMemoryAdapter` in the unit tier. This is the one that ships green on
-  every `pnpm test`.
-- (Planned) `tests/integration/adapter.jxa.contract.test.ts`,
-  `…omnijs…`, `…router…` — run the same suite against the real transports
-  under `OMNIFOCUS_INTEGRATION=1`. A live OmniFocus is required; the driver
-  creates and tears down scratch fixtures via the `cleanup` hook.
-
-### Writing a new driver
-
-```ts
-import { runAdapterContract } from "../contract/adapter.contract.js";
-import { JxaTransport } from "../../src/adapter/jxa/JxaTransport.js";
-
-runAdapterContract("JxaTransport", {
-  createAdapter: () => new JxaTransport(/* … */),
-  cleanup: async (adapter) => {
-    // Delete scratch folders/projects/tags/tasks the suite created.
-  },
-});
-```
+- **`tests/integration/`** runs against live OmniFocus on the `macos-omnifocus` self-hosted GitHub Actions runner. Failures there mean a real JXA/OmniJS bug shipped — see issue #679 for historical gap analysis.
+- **`tests/e2e/`** spawns the server as an MCP client (per #80 / #256). Slower than unit tests but exercises the full stdio transport stack.
+- **`tests/contract/`** defines the `TransportRouter` substitutability contract shared by JXA and OmniJS adapters.
+- **`tests/fixtures/`** is data-only; files are marked `linguist-generated` in `.gitattributes` — don't edit them by hand.
 
 ## Running
 
 ```bash
-pnpm test                   # unit tier (always)
-pnpm test:integration       # integration tier (requires OMNIFOCUS_INTEGRATION=1)
-pnpm test tests/contract    # contract harness only
+pnpm test                              # unit tier — chaos, contract (in-memory), scripts
+pnpm test:integration                  # integration + perf (requires OMNIFOCUS_INTEGRATION=1)
+pnpm test:e2e                          # e2e suite (spawns server process)
+pnpm bench:token-cost                  # token-cost benchmark
+pnpm test tests/contract               # contract harness only
 ```
+
+See `package.json` for full flag reference.


### PR DESCRIPTION
## Summary

- Rewrites `tests/README.md` to cover all 8 subdirectories (benchmark, chaos, contract, e2e, fixtures, integration, perf, scripts) with a one-line purpose, the runner command, and "use when" guidance
- Adds key-file callouts for `E2EServer.ts`, the contract harness, and the benchmark README
- Notes invariants: integration tests require the macOS self-hosted runner; fixtures are data-only and marked `linguist-generated`
- Adds a "Running tests" paragraph in `README.md` pointing agents and contributors at `tests/README.md`

## Test plan

- [ ] `tests/README.md` is ≤ 60 lines per table rows + prose (check: `wc -l tests/README.md`)
- [ ] All 8 sub-dirs appear in the index table
- [ ] `README.md` links to `tests/README.md`
- [ ] No test regressions (pre-push hook ran clean)

Closes #844