### PR TITLE
docs(clients): add docs/clients/README.md indexing the 6 client integration guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ These files are marked `linguist-generated` in `.gitattributes` so GitHub collap
 - `README.md` — project overview with architecture at a glance
 - `SPEC.md` — functional scope and resolved decisions
 - `DESIGN.md` — architecture and options evaluated (28 sections covering envelope, IDs, dates, pagination, concurrency, lifecycle, security, testing, CI, observability, config, distribution, versioning, deps, example tool, i18n, resources)
+- `docs/clients/README.md` — index of the 6 client integration guides (Claude Code, Claude Desktop, Codex, OpenCode, Pi, generic stdio); read this for any client-specific routing question
 - `docs/domain-reference.md` — canonical OmniFocus schemas and glossary
 - `docs/project-views.md` — recommended GitHub Project board views
 - `CONTRIBUTING.md` — patterns, conventions, PR template

--- a/README.md
+++ b/README.md
@@ -911,6 +911,8 @@ Writes are saved locally and show up immediately in subsequent tool calls. Chang
 
 ## Client setup guides
 
+See [`docs/clients/README.md`](./docs/clients/README.md) for the full index with transport details and notable differences between clients.
+
 | Client | Guide |
 |---|---|
 | Claude Code (CLI) | [`docs/clients/claude-code.md`](./docs/clients/claude-code.md) |

--- a/docs/clients/README.md
+++ b/docs/clients/README.md
@@ -1,0 +1,17 @@
+# docs/clients/
+
+Client integration guides for omnifocus-mcp. All clients use the **stdio transport** — omnifocus-mcp is a local process, not a hosted server.
+
+Listed by adoption, with Claude Code first. Alphabetical within tiers.
+
+| Client | Guide | Transport | Notable |
+|---|---|---|---|
+| Claude Code | [claude-code.md](./claude-code.md) | stdio | Project-local config in `.claude/`; supports per-repo MCP server lists |
+| Claude Desktop | [claude-desktop.md](./claude-desktop.md) | stdio | Global config in `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Codex CLI | [codex.md](./codex.md) | stdio | OpenAI Codex CLI; YAML-based `~/.codex/config.yaml` |
+| OpenCode | [opencode.md](./opencode.md) | stdio | Open-source terminal agent by SST; `opencode.json` or `~/.config/opencode/config.json` |
+| Pi | [pi.md](./pi.md) | — | MCP not supported as of mid-2025; page explains why |
+
+If your client isn't listed, see [generic-stdio.md](./generic-stdio.md) — it documents the underlying stdio contract any MCP-compatible client can use.
+
+**Claude Code vs Claude Desktop:** both run the same server over stdio. The difference is config location: Claude Code is project-local (`.claude/`), Claude Desktop is global (`claude_desktop_config.json`). Prefer Claude Code for per-repo server isolation.


### PR DESCRIPTION
## Summary

- Adds `docs/clients/README.md` — table of all 6 guides with transport and one-line notable per client
- Includes "if your client isn't listed → generic-stdio.md" pointer
- Notes the key Claude Code vs Claude Desktop difference (project-local vs global config)
- Links from `README.md` "Client setup guides" section and `AGENTS.md` reference docs

## Test plan

- [ ] `docs/clients/README.md` ≤ 40 lines (`wc -l docs/clients/README.md`)
- [ ] All 6 clients appear in the table
- [ ] `README.md` and `AGENTS.md` both link to the new index
- [ ] Pre-push hook ran clean

Closes #845