### PR TITLE
infra(test): quiet dot reporter in non-interactive shells; add test:quiet / test:loud

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "lint:nl-quality": "tsx scripts/verify-nl-quality.ts",
     "format": "biome format --write .",
     "test": "vitest run",
+    "test:quiet": "VITEST_REPORTER=dot vitest run",
+    "test:loud": "VITEST_REPORTER=verbose vitest run",
     "test:watch": "vitest",
     "test:integration": "OMNIFOCUS_INTEGRATION=1 vitest run tests/integration --testTimeout=90000",
     "test:perf": "OMNIFOCUS_PERF=1 vitest run tests/perf",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,24 @@ const PERF = process.env.OMNIFOCUS_PERF === "1";
 const TEST_TIMEOUT = PERF ? 120_000 : INTEGRATION ? 30_000 : 5_000;
 const HOOK_TIMEOUT = PERF ? 120_000 : INTEGRATION ? 30_000 : 5_000;
 
+// Auto-detect non-interactive environments (agent shells, CI, pipes) and
+// switch to a compact reporter. Full verbose output is only useful when a
+// human is watching — for agents and CI the summary line per file is enough,
+// and failures always show the full stack trace regardless of reporter.
+//
+// Override with VITEST_REPORTER env var, or use pnpm test:loud / pnpm test:quiet.
+//
+// Reporter selection:
+//   VITEST_REPORTER=verbose  → explicit verbose (override)
+//   VITEST_REPORTER=dot      → explicit dot (override)
+//   no TTY and no env var    → "dot" (compact)
+//   TTY                      → "default" (verbose with watch support)
+function resolveReporter(): string {
+  if (process.env.VITEST_REPORTER) return process.env.VITEST_REPORTER;
+  const isInteractive = process.stdout.isTTY === true && !process.env.CI;
+  return isInteractive ? "default" : "dot";
+}
+
 export default defineConfig({
   // Vite plugin — inlines `src/scripts/**\/*.js` as default string exports,
   // matching the production build (tsup + scriptInlinerPlugin). Without this,
@@ -36,7 +54,7 @@ export default defineConfig({
     exclude: ["node_modules", "dist"],
     environment: "node",
     globals: false,
-    reporters: ["default"],
+    reporters: [resolveReporter()],
     testTimeout: TEST_TIMEOUT,
     hookTimeout: HOOK_TIMEOUT,
     clearMocks: true,


### PR DESCRIPTION
## Summary

- `vitest.config.ts` auto-detects non-TTY / `CI=true` and switches to the `dot` reporter (one character per test, summary at end) instead of the verbose default
- `VITEST_REPORTER` env var overrides; `pnpm test:quiet` (always dot) and `pnpm test:loud` (always verbose) added as convenience aliases
- Failure output is unaffected — full stack trace + expected/received always prints regardless of reporter
- Pre-push hook and CI (`pnpm test`) automatically get the quiet reporter since neither has a TTY

## Token reduction

Green run on this branch with `pnpm test:quiet`:
```
 Test Files  203 passed | 12 skipped (215)
      Tests  3540 passed | 59 skipped (3599)
   Duration  6.88s
```
vs the verbose default which prints a per-test-file table (~500 lines). The dot output is ~10 lines total.

## Test plan

- [ ] `pnpm test:quiet` produces dot output on a green run
- [ ] `pnpm test:loud` produces verbose table output
- [ ] `pnpm test` in non-TTY (e.g. `pnpm test | cat`) produces dot output
- [ ] A failing test still shows full stack trace and expected/received diff
- [ ] `pnpm test:mutation` (if available) still works — Stryker parses pass/fail, not output format

Closes #806