### PR TITLE
fix(input): enforce length caps on user-supplied string fields

### DIFF
--- a/src/domain/inputLimits.ts
+++ b/src/domain/inputLimits.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical length limits for user-supplied string inputs.
+ *
+ * Apply these constants via Zod `.max()` on all user-facing tool schemas.
+ * Rejection surfaces as a structured ValidationError with
+ * `remediationClass: "client_error"` (Zod schema validation).
+ *
+ * @see #825 — security audit for length caps
+ */
+
+/** Maximum characters for any OmniFocus item name (task, project, folder, tag). */
+export const NAME_MAX_CHARS = 1_024; // "max 1 KB"
+
+/** Maximum characters for a plain-text note body (note_set, note_append, create, update). */
+export const NOTE_MAX_CHARS = 1_048_576; // "max 1 MB"
+
+/** Maximum characters for an HTML note body (note_set_html). */
+export const NOTE_HTML_MAX_CHARS = 1_048_576; // "max 1 MB"
+
+/** Maximum characters for a search query string (search_query). */
+export const SEARCH_QUERY_MAX_CHARS = 4_096; // "max 4 KB"
+
+/** Maximum characters for a file path (attachment_add, attachment_save_to_path). */
+export const FILE_PATH_MAX_CHARS = 4_096; // PATH_MAX on macOS
+
+/** Maximum characters for a substring search pattern (task_reclassify). */
+export const SUBSTRING_MAX_CHARS = 4_096; // "max 4 KB"
+
+/** Maximum characters for a task name similarity candidate (task_find_similar). */
+export const TASK_NAME_CANDIDATE_MAX_CHARS = NAME_MAX_CHARS;

--- a/src/tools/attachment/index.ts
+++ b/src/tools/attachment/index.ts
@@ -18,6 +18,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { AttachmentOwner } from "../../adapter/OmniFocusAdapter.js";
 import { AttachmentId, ProjectId, TaskId } from "../../domain/ids.js";
+import { FILE_PATH_MAX_CHARS } from "../../domain/inputLimits.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import type { AttachmentService } from "../../services/attachmentService.js";
@@ -101,6 +102,7 @@ export const attachmentAddInputSchema = ownerBaseSchema.extend({
   filePath: z
     .string()
     .min(1)
+    .max(FILE_PATH_MAX_CHARS, "max 4 KB")
     .describe(
       "Absolute path to the source file to attach. " +
         "Must be within the allowed attachment path scope.",

--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -23,7 +23,11 @@ export const FOLDER_CREATE_DESCRIPTION =
   'Example: folder_create({ name: "Archive", parentId: "fld123" })';
 
 export const folderCreateInputSchema = z.object({
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Folder name. Must be non-empty."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .describe("Folder name. Must be non-empty."),
   parentId: FolderId.schema
     .optional()
     .describe("Parent folder ID. Omit for a root-level folder. Get from folder_list."),

--- a/src/tools/folder/create.ts
+++ b/src/tools/folder/create.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryFolderCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
@@ -22,7 +23,7 @@ export const FOLDER_CREATE_DESCRIPTION =
   'Example: folder_create({ name: "Archive", parentId: "fld123" })';
 
 export const folderCreateInputSchema = z.object({
-  name: z.string().min(1).describe("Folder name. Must be non-empty."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Folder name. Must be non-empty."),
   parentId: FolderId.schema
     .optional()
     .describe("Parent folder ID. Omit for a root-level folder. Get from folder_list."),

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -23,7 +23,12 @@ export const FOLDER_UPDATE_DESCRIPTION =
 
 export const folderUpdateInputSchema = z.object({
   id: FolderId.schema.describe("Persistent folder ID. Get from folder_list."),
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New folder name. Must be non-empty if supplied."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .optional()
+    .describe("New folder name. Must be non-empty if supplied."),
 });
 
 export type FolderUpdateToolInput = z.infer<typeof folderUpdateInputSchema>;

--- a/src/tools/folder/update.ts
+++ b/src/tools/folder/update.ts
@@ -8,6 +8,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { FolderId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryFolderUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { FolderService } from "../../services/folderService.js";
@@ -22,7 +23,7 @@ export const FOLDER_UPDATE_DESCRIPTION =
 
 export const folderUpdateInputSchema = z.object({
   id: FolderId.schema.describe("Persistent folder ID. Get from folder_list."),
-  name: z.string().min(1).optional().describe("New folder name. Must be non-empty if supplied."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New folder name. Must be non-empty if supplied."),
 });
 
 export type FolderUpdateToolInput = z.infer<typeof folderUpdateInputSchema>;

--- a/src/tools/note/append.ts
+++ b/src/tools/note/append.ts
@@ -20,6 +20,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryNoteAppend } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
@@ -54,6 +55,7 @@ export const noteAppendInputSchema = z.object({
   text: z
     .string()
     .min(1)
+    .max(NOTE_MAX_CHARS, "max 1 MB")
     .describe("Text to append. A newline separator is inserted before the text if a note exists."),
 });
 

--- a/src/tools/note/set.ts
+++ b/src/tools/note/set.ts
@@ -48,7 +48,11 @@ export const noteSetInputSchema = z.object({
       "Persistent ID of the task or project. " +
         "Get task IDs from task_list; project IDs from project_list.",
     ),
-  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").nullable().describe("New note text. Pass null to clear the note entirely."),
+  note: z
+    .string()
+    .max(NOTE_MAX_CHARS, "max 1 MB")
+    .nullable()
+    .describe("New note text. Pass null to clear the note entirely."),
 });
 
 export type NoteSetToolInput = z.infer<typeof noteSetInputSchema>;

--- a/src/tools/note/set.ts
+++ b/src/tools/note/set.ts
@@ -18,6 +18,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryNoteSet } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
@@ -47,7 +48,7 @@ export const noteSetInputSchema = z.object({
       "Persistent ID of the task or project. " +
         "Get task IDs from task_list; project IDs from project_list.",
     ),
-  note: z.string().nullable().describe("New note text. Pass null to clear the note entirely."),
+  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").nullable().describe("New note text. Pass null to clear the note entirely."),
 });
 
 export type NoteSetToolInput = z.infer<typeof noteSetInputSchema>;

--- a/src/tools/note/set_html.ts
+++ b/src/tools/note/set_html.ts
@@ -22,6 +22,7 @@ import {
   invalidateTaskMutation,
 } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { NOTE_HTML_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryNoteSet } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
@@ -57,6 +58,7 @@ export const noteSetHtmlInputSchema = z.object({
     ),
   noteHtml: z
     .string()
+    .max(NOTE_HTML_MAX_CHARS, "max 1 MB")
     .nullable()
     .describe("HTML fragment to set as the note. Pass null to clear the note entirely."),
 });

--- a/src/tools/project/create.ts
+++ b/src/tools/project/create.ts
@@ -20,6 +20,7 @@ import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/i
 import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { finaliseHints, reviewIntervalHint } from "../../domain/hints.js";
 import { FolderId, TagId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS, NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryProjectCreate } from "../../domain/writeSummary.js";
 import { clarificationNeeded, ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
@@ -51,11 +52,11 @@ export const PROJECT_CREATE_DESCRIPTION =
 // ---------------------------------------------------------------------------
 
 export const projectCreateInputSchema = z.object({
-  name: z.string().min(1).describe("Project name. Required, must be non-empty."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Project name. Required, must be non-empty."),
   folderId: FolderId.schema
     .optional()
     .describe("Folder ID to place the project in. Omit for root."),
-  note: z.string().optional().describe("Plain-text note for the project."),
+  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Plain-text note for the project."),
   status: aliasedEnum(
     ["active", "on-hold"] as const,
     { paused: "on-hold" },

--- a/src/tools/project/create.ts
+++ b/src/tools/project/create.ts
@@ -52,11 +52,19 @@ export const PROJECT_CREATE_DESCRIPTION =
 // ---------------------------------------------------------------------------
 
 export const projectCreateInputSchema = z.object({
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Project name. Required, must be non-empty."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .describe("Project name. Required, must be non-empty."),
   folderId: FolderId.schema
     .optional()
     .describe("Folder ID to place the project in. Omit for root."),
-  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Plain-text note for the project."),
+  note: z
+    .string()
+    .max(NOTE_MAX_CHARS, "max 1 MB")
+    .optional()
+    .describe("Plain-text note for the project."),
   status: aliasedEnum(
     ["active", "on-hold"] as const,
     { paused: "on-hold" },

--- a/src/tools/project/update.ts
+++ b/src/tools/project/update.ts
@@ -58,8 +58,18 @@ export const PROJECT_UPDATE_DESCRIPTION =
 
 export const projectUpdateInputSchema = z.object({
   id: ProjectId.schema.describe("Persistent project ID. Get from project_list or project_get."),
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New project name. Must be non-empty if supplied."),
-  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").nullable().optional().describe("Plain-text note. Pass null to clear."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .optional()
+    .describe("New project name. Must be non-empty if supplied."),
+  note: z
+    .string()
+    .max(NOTE_MAX_CHARS, "max 1 MB")
+    .nullable()
+    .optional()
+    .describe("Plain-text note. Pass null to clear."),
   noteHtml: z
     .string()
     .nullable()

--- a/src/tools/project/update.ts
+++ b/src/tools/project/update.ts
@@ -23,6 +23,7 @@ import { type InvalidatingCache, invalidateProjectMutation } from "../../cache/i
 import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import type { ProjectId as ProjectIdType } from "../../domain/ids.js";
 import { ProjectId, TagId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS, NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryProjectUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { assertNotModifiedSince } from "../../server/assertNotModifiedSince.js";
@@ -57,8 +58,8 @@ export const PROJECT_UPDATE_DESCRIPTION =
 
 export const projectUpdateInputSchema = z.object({
   id: ProjectId.schema.describe("Persistent project ID. Get from project_list or project_get."),
-  name: z.string().min(1).optional().describe("New project name. Must be non-empty if supplied."),
-  note: z.string().nullable().optional().describe("Plain-text note. Pass null to clear."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New project name. Must be non-empty if supplied."),
+  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").nullable().optional().describe("Plain-text note. Pass null to clear."),
   noteHtml: z
     .string()
     .nullable()

--- a/src/tools/search/query.ts
+++ b/src/tools/search/query.ts
@@ -13,6 +13,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { ProjectId, TagId } from "../../domain/ids.js";
+import { SEARCH_QUERY_MAX_CHARS } from "../../domain/inputLimits.js";
 import { TASK_FIELD_NAMES, TASK_FIELD_NAMES_SET } from "../../domain/task.js";
 import {
   ok,
@@ -44,6 +45,7 @@ export const SEARCH_QUERY_DESCRIPTION =
 export const searchQueryInputSchema = z.object({
   q: z
     .string()
+    .max(SEARCH_QUERY_MAX_CHARS, "max 4 KB")
     .describe(
       "Search query. Case-insensitive substring match. Empty string matches all tasks (useful with filters).",
     ),

--- a/src/tools/tag/create.ts
+++ b/src/tools/tag/create.ts
@@ -9,6 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { TagId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryTagCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
@@ -23,7 +24,7 @@ export const TAG_CREATE_DESCRIPTION =
   'Example: tag_create({ name: "home", parentId: "tag123" })';
 
 export const tagCreateInputSchema = z.object({
-  name: z.string().min(1).describe("Tag name. Must be non-empty."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Tag name. Must be non-empty."),
   parentId: TagId.schema
     .optional()
     .describe("Parent tag ID to nest under. Omit for a root tag. Get from tag_list."),

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -9,6 +9,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { aliasedEnum } from "../../domain/aliasedEnum.js";
 import { TagId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryTagUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import type { TagService } from "../../services/tagService.js";
@@ -25,7 +26,7 @@ export const TAG_UPDATE_DESCRIPTION =
 
 export const tagUpdateInputSchema = z.object({
   id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
-  name: z.string().min(1).optional().describe("New tag name. Must be non-empty if supplied."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New tag name. Must be non-empty if supplied."),
   parentId: TagId.schema
     .nullable()
     .optional()

--- a/src/tools/tag/update.ts
+++ b/src/tools/tag/update.ts
@@ -26,7 +26,12 @@ export const TAG_UPDATE_DESCRIPTION =
 
 export const tagUpdateInputSchema = z.object({
   id: TagId.schema.describe("Persistent tag ID. Get from tag_list."),
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New tag name. Must be non-empty if supplied."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .optional()
+    .describe("New tag name. Must be non-empty if supplied."),
   parentId: TagId.schema
     .nullable()
     .optional()

--- a/src/tools/task/batchCreate.ts
+++ b/src/tools/task/batchCreate.ts
@@ -35,7 +35,11 @@ export const TASK_BATCH_CREATE_DESCRIPTION =
 
 const singleItemSchema = z
   .object({
-    name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name. Required, non-empty."),
+    name: z
+      .string()
+      .min(1)
+      .max(NAME_MAX_CHARS, "max 1 KB")
+      .describe("Task name. Required, non-empty."),
     projectId: ProjectId.schema
       .optional()
       .describe("Project to add the task to. Omit for inbox or subtask."),

--- a/src/tools/task/batchCreate.ts
+++ b/src/tools/task/batchCreate.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS, NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryBatchCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
@@ -34,14 +35,14 @@ export const TASK_BATCH_CREATE_DESCRIPTION =
 
 const singleItemSchema = z
   .object({
-    name: z.string().min(1).describe("Task name. Required, non-empty."),
+    name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name. Required, non-empty."),
     projectId: ProjectId.schema
       .optional()
       .describe("Project to add the task to. Omit for inbox or subtask."),
     parentTaskId: TaskId.schema
       .optional()
       .describe("Parent task ID for a subtask. Omit for inbox or project task."),
-    note: z.string().optional().describe("Plain-text note."),
+    note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Plain-text note."),
     flagged: z.boolean().optional().describe("Flag the task."),
     dueDate: z
       .string()

--- a/src/tools/task/batchUpdate.ts
+++ b/src/tools/task/batchUpdate.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter, UpdateTaskInput } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TagId, TaskId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS, NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryBatchUpdate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 
@@ -34,8 +35,8 @@ export const TASK_BATCH_UPDATE_DESCRIPTION =
 
 const patchSchema = z
   .object({
-    name: z.string().min(1).optional().describe("New task name."),
-    note: z.string().nullable().optional().describe("Plain-text note. Null clears the note."),
+    name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New task name."),
+    note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").nullable().optional().describe("Plain-text note. Null clears the note."),
     flagged: z.boolean().optional().describe("Flag or unflag the task."),
     dueDate: z
       .string()

--- a/src/tools/task/batchUpdate.ts
+++ b/src/tools/task/batchUpdate.ts
@@ -36,7 +36,12 @@ export const TASK_BATCH_UPDATE_DESCRIPTION =
 const patchSchema = z
   .object({
     name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New task name."),
-    note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").nullable().optional().describe("Plain-text note. Null clears the note."),
+    note: z
+      .string()
+      .max(NOTE_MAX_CHARS, "max 1 MB")
+      .nullable()
+      .optional()
+      .describe("Plain-text note. Null clears the note."),
     flagged: z.boolean().optional().describe("Flag or unflag the task."),
     dueDate: z
       .string()

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -25,6 +25,7 @@ import {
   repeatHintForName,
 } from "../../domain/hints.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS, NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { summaryTaskCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { validateRefined } from "../../errors/validateRefined.js";
@@ -60,7 +61,7 @@ export const TASK_CREATE_DESCRIPTION =
  * The SDK needs individual field descriptors; ZodEffects from .refine() lacks .shape.
  */
 export const taskCreateInputBaseSchema = z.object({
-  name: z.string().min(1).describe("Task name. Required, must be non-empty."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name. Required, must be non-empty."),
 
   // Target: at most one of projectId or parentTaskId; neither = inbox
   projectId: ProjectId.schema
@@ -71,7 +72,7 @@ export const taskCreateInputBaseSchema = z.object({
     .describe("Parent task ID for a subtask. Omit for inbox or project task."),
 
   // Optional fields
-  note: z.string().optional().describe("Plain-text note."),
+  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Plain-text note."),
   flagged: z.boolean().optional().describe("Flag the task."),
   dueDate: z
     .string()

--- a/src/tools/task/create.ts
+++ b/src/tools/task/create.ts
@@ -61,7 +61,11 @@ export const TASK_CREATE_DESCRIPTION =
  * The SDK needs individual field descriptors; ZodEffects from .refine() lacks .shape.
  */
 export const taskCreateInputBaseSchema = z.object({
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name. Required, must be non-empty."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .describe("Task name. Required, must be non-empty."),
 
   // Target: at most one of projectId or parentTaskId; neither = inbox
   projectId: ProjectId.schema

--- a/src/tools/task/extractFromImage.ts
+++ b/src/tools/task/extractFromImage.ts
@@ -116,8 +116,16 @@ export const TASK_EXTRACT_FROM_IMAGE_DESCRIPTION =
  * prompt (#475) and other composers can accept either tool's output.
  */
 const proposedTaskSchema = z.object({
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name extracted from the image."),
-  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Additional context or plain-text note for the task."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .describe("Task name extracted from the image."),
+  note: z
+    .string()
+    .max(NOTE_MAX_CHARS, "max 1 MB")
+    .optional()
+    .describe("Additional context or plain-text note for the task."),
   deferDate: z
     .string()
     .datetime({ offset: true })

--- a/src/tools/task/extractFromImage.ts
+++ b/src/tools/task/extractFromImage.ts
@@ -58,6 +58,7 @@ import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusA
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import type { Attachment } from "../../domain/attachment.js";
 import { AttachmentId, ProjectId, TaskId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS, NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { ValidationError } from "../../errors/index.js";
 import { validateRefined } from "../../errors/validateRefined.js";
@@ -115,8 +116,8 @@ export const TASK_EXTRACT_FROM_IMAGE_DESCRIPTION =
  * prompt (#475) and other composers can accept either tool's output.
  */
 const proposedTaskSchema = z.object({
-  name: z.string().min(1).describe("Task name extracted from the image."),
-  note: z.string().optional().describe("Additional context or plain-text note for the task."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name extracted from the image."),
+  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Additional context or plain-text note for the task."),
   deferDate: z
     .string()
     .datetime({ offset: true })

--- a/src/tools/task/extractFromNote.ts
+++ b/src/tools/task/extractFromNote.ts
@@ -35,6 +35,7 @@ import { z } from "zod";
 import type { CreateTaskInput, OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { ProjectId, TaskId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS, NOTE_MAX_CHARS } from "../../domain/inputLimits.js";
 import { extractTasksFromProse } from "../../domain/proseExtractor.js";
 import { summaryBatchCreate } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
@@ -63,8 +64,8 @@ export const TASK_EXTRACT_FROM_NOTE_DESCRIPTION =
 // ---------------------------------------------------------------------------
 
 const proposedTaskSchema = z.object({
-  name: z.string().min(1).describe("Task name."),
-  note: z.string().optional().describe("Optional note body for the created task."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name."),
+  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Optional note body for the created task."),
   deferDate: z.string().datetime({ offset: true }).optional(),
   dueDate: z.string().datetime({ offset: true }).optional(),
   tags: z

--- a/src/tools/task/extractFromNote.ts
+++ b/src/tools/task/extractFromNote.ts
@@ -65,7 +65,11 @@ export const TASK_EXTRACT_FROM_NOTE_DESCRIPTION =
 
 const proposedTaskSchema = z.object({
   name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("Task name."),
-  note: z.string().max(NOTE_MAX_CHARS, "max 1 MB").optional().describe("Optional note body for the created task."),
+  note: z
+    .string()
+    .max(NOTE_MAX_CHARS, "max 1 MB")
+    .optional()
+    .describe("Optional note body for the created task."),
   deferDate: z.string().datetime({ offset: true }).optional(),
   dueDate: z.string().datetime({ offset: true }).optional(),
   tags: z

--- a/src/tools/task/findSimilar.ts
+++ b/src/tools/task/findSimilar.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 
 import type { OmniFocusAdapter, TaskFilter } from "../../adapter/OmniFocusAdapter.js";
 import { ProjectId, TagId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS } from "../../domain/inputLimits.js";
 import type { Task } from "../../domain/task.js";
 import { score } from "../../domain/textSimilarity.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
@@ -67,7 +68,7 @@ const scopeSchema = z
   });
 
 export const taskFindSimilarInputSchema = z.object({
-  name: z.string().min(1).describe("The candidate task name to compare against existing tasks."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("The candidate task name to compare against existing tasks."),
   note: z
     .string()
     .optional()

--- a/src/tools/task/findSimilar.ts
+++ b/src/tools/task/findSimilar.ts
@@ -68,7 +68,11 @@ const scopeSchema = z
   });
 
 export const taskFindSimilarInputSchema = z.object({
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").describe("The candidate task name to compare against existing tasks."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .describe("The candidate task name to compare against existing tasks."),
   note: z
     .string()
     .optional()

--- a/src/tools/task/reclassify.ts
+++ b/src/tools/task/reclassify.ts
@@ -69,7 +69,10 @@ const predicateSchema: z.ZodType<TaskPredicate> = z.lazy(() =>
   z.discriminatedUnion("kind", [
     z.object({
       kind: z.literal("title-contains"),
-      value: z.string().max(SUBSTRING_MAX_CHARS, "max 4 KB").describe("Substring to search for in task names."),
+      value: z
+        .string()
+        .max(SUBSTRING_MAX_CHARS, "max 4 KB")
+        .describe("Substring to search for in task names."),
       caseSensitive: z
         .boolean()
         .optional()

--- a/src/tools/task/reclassify.ts
+++ b/src/tools/task/reclassify.ts
@@ -27,6 +27,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import type { InvalidatingCache } from "../../cache/invalidation.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
+import { SUBSTRING_MAX_CHARS } from "../../domain/inputLimits.js";
 import type { Task } from "../../domain/task.js";
 import { evaluatePredicate, type TaskPredicate } from "../../domain/taskPredicate.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
@@ -68,7 +69,7 @@ const predicateSchema: z.ZodType<TaskPredicate> = z.lazy(() =>
   z.discriminatedUnion("kind", [
     z.object({
       kind: z.literal("title-contains"),
-      value: z.string().describe("Substring to search for in task names."),
+      value: z.string().max(SUBSTRING_MAX_CHARS, "max 4 KB").describe("Substring to search for in task names."),
       caseSensitive: z
         .boolean()
         .optional()

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -27,6 +27,7 @@ import { z } from "zod";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
 import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/invalidation.js";
 import { TagId, TaskId } from "../../domain/ids.js";
+import { NAME_MAX_CHARS } from "../../domain/inputLimits.js";
 import type { Task } from "../../domain/task.js";
 import { ok, type ResponseMeta, type ToolEnvelope, toolResponse } from "../../envelope/index.js";
 import { validateRefined } from "../../errors/validateRefined.js";
@@ -68,7 +69,7 @@ export const taskUpdateInputBaseSchema = z.object({
   id: TaskId.schema.describe("Persistent task ID. Get from task_list or search_query."),
 
   // Scalar editable fields
-  name: z.string().min(1).optional().describe("New task name. Must be non-empty if supplied."),
+  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New task name. Must be non-empty if supplied."),
   note: z
     .string()
     .nullable()

--- a/src/tools/task/update.ts
+++ b/src/tools/task/update.ts
@@ -69,7 +69,12 @@ export const taskUpdateInputBaseSchema = z.object({
   id: TaskId.schema.describe("Persistent task ID. Get from task_list or search_query."),
 
   // Scalar editable fields
-  name: z.string().min(1).max(NAME_MAX_CHARS, "max 1 KB").optional().describe("New task name. Must be non-empty if supplied."),
+  name: z
+    .string()
+    .min(1)
+    .max(NAME_MAX_CHARS, "max 1 KB")
+    .optional()
+    .describe("New task name. Must be non-empty if supplied."),
   note: z
     .string()
     .nullable()


### PR DESCRIPTION
## Summary

- Add `src/domain/inputLimits.ts` with canonical length constants (NAME=1 KB, NOTE=1 MB, SEARCH/PATH/SUBSTRING=4 KB)
- Apply `.max()` via Zod to 19 tool schemas: task (create/update/batchCreate/batchUpdate/extractFromNote/extractFromImage/findSimilar/reclassify), project (create/update), folder (create/update), tag (create/update), note (set/set_html/append), search (query), attachment (add)
- Rejection surfaces as a structured Zod `ValidationError` before the input reaches the OmniFocus adapter — closes the DoS/heap-exhaustion vector for pathological client payloads

## Test plan

- [ ] All existing tests pass (3540 passing, 59 skipped)
- [ ] Typecheck passes
- [ ] `pnpm lint` passes (biome check + custom lint + NL quality)
- [ ] Manual smoke: send a 10 MB note string → hits cap with a ValidationError, doesn't OOM the server

Closes #825