### PR TITLE
docs(release): add migrations.md with per-release breaking-change guidance

### DIFF
--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -105,6 +105,32 @@ jobs:
       - name: Verify no tool-count strings in living docs
         run: scripts/verify-no-tool-counts.sh
 
+  migrations-doc:
+    # Regression guard — any PR labelled `breaking-change` must update
+    # docs/migrations.md with what changed, why, and how to migrate.
+    # Surfaces as an ::error:: annotation on the doc itself.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Collect PR labels and changed files
+        id: ctx
+        run: |
+          labels=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | tr '\n' ' ')
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Verify migrations.md updated for breaking-change PRs
+        run: scripts/verify-migrations-doc.sh
+        env:
+          PR_LABELS: ${{ steps.ctx.outputs.labels }}
+          CHANGED_FILES: ${{ steps.ctx.outputs.changed }}
+
   nl-quality:
     # NL-quality lint per `docs/nl-quality-standards.md` — every tool
     # description includes a worked Example, every Zod input schema field

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ These files are marked `linguist-generated` in `.gitattributes` so GitHub collap
 - `SPEC.md` — functional scope and resolved decisions
 - `DESIGN.md` — architecture and options evaluated (28 sections covering envelope, IDs, dates, pagination, concurrency, lifecycle, security, testing, CI, observability, config, distribution, versioning, deps, example tool, i18n, resources)
 - `docs/clients/README.md` — index of the 6 client integration guides (Claude Code, Claude Desktop, Codex, OpenCode, Pi, generic stdio); read this for any client-specific routing question
+- `docs/migrations.md` — per-release breaking-change log with migration guidance; **must be updated on any `breaking-change` PR**
 - `docs/domain-reference.md` — canonical OmniFocus schemas and glossary
 - `docs/project-views.md` — recommended GitHub Project board views
 - `CONTRIBUTING.md` — patterns, conventions, PR template

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,108 @@
+# Migration and Compatibility Matrix
+
+This document records breaking changes per release, with migration guidance for downstream consumers.
+It is complementary to `CHANGELOG.md` (release-please-managed): the changelog records *what* changed;
+this document records *how to migrate* and which client versions are affected.
+
+**Maintenance rule:** any PR labelled `breaking-change` **must** update this document as part of the
+same commit. CI enforces this via `scripts/verify-migrations-doc.sh`.
+
+---
+
+## Upcoming (unreleased — target v1.4.0)
+
+The following breaking changes are implemented or planned for the next minor release as part of the
+token-efficiency epic (#770). All changes reduce default response payload size; callers who need the
+old shape can opt back in via new flags.
+
+### noteHtml removed from default task/project responses (#791)
+
+| | |
+|---|---|
+| **What changed** | `noteHtml` no longer appears in default `task_list`, `task_get`, `task_get_many`, `project_list`, `project_get`, `project_get_many`, `task_search`, `forecast_get`, `perspective_evaluate` responses. |
+| **Why** | HTML is 3–10× the plaintext byte size. A dedicated `note_get_html` tool already exists. |
+| **Migration** | Call `note_get_html({ targetKind: "task", id })` when you need the HTML. Or pass `includeNoteHtml: true` to the listing tool (opt-in flag added alongside this change). |
+| **Deprecation** | `noteHtml` is removed from the default shape. `includeNoteHtml: true` opt-in is supported indefinitely. |
+
+### `_links` opt-in via `includeLinks` flag (#792)
+
+| | |
+|---|---|
+| **What changed** | `_links` HATEOAS blocks are no longer included by default in task/project responses. |
+| **Why** | `_links` re-encodes `id`/`projectId`/`tagIds` as `omnifocus://` URIs — ~78–100 bytes of pure duplication per task. LLM agents don't follow URLs. |
+| **Migration** | Pass `includeLinks: true` to any listing/get tool to restore the previous behaviour. |
+| **Deprecation** | `_links` remains available indefinitely via the opt-in flag. |
+
+### `forecast_get` `byDate` returns `taskIds` not full task objects (#794)
+
+| | |
+|---|---|
+| **What changed** | `byDate[]` now has shape `{ date: string, taskIds: TaskId[] }` instead of `{ date: string, tasks: Task[] }`. |
+| **Why** | The same Task objects already appear in `dueToday`/`overdue`/`flagged` arrays — `byDate` was pure duplication. |
+| **Migration** | Build a map of `id → task` from the top-level arrays, then dereference `byDate[i].taskIds`. Example: `const byId = Object.fromEntries([...dueToday, ...overdue].map(t => [t.id, t])); byDate.forEach(b => b.taskIds.map(id => byId[id]))` |
+| **Deprecation** | `byDate[].tasks` shape is removed; `byDate[].taskIds` is the stable form going forward. |
+
+### `task_get` defaults `includeSubtasks` to `false` (#796)
+
+| | |
+|---|---|
+| **What changed** | `task_get` now returns `subtaskIds: TaskId[]` and `subtaskCount: number` by default instead of full subtask bodies. |
+| **Why** | A parent task with 30 subtasks was returning ~16 KB of bodies the agent rarely needed. |
+| **Migration** | Pass `includeSubtasks: true` to restore the old shape, or follow up with `task_get_many({ ids: task.subtaskIds })` to fetch only the subtasks you need. |
+| **Deprecation** | `includeSubtasks: true` is supported indefinitely. |
+
+### Default page size lowered to 50 for `task_list`, `project_list`, `search_query` (#797)
+
+| | |
+|---|---|
+| **What changed** | The default `limit` for these tools dropped from 200 (or 100 for `search_query`) to **50**. |
+| **Why** | 200-task pages at current response shape exceed the response stats threshold and put unnecessary token pressure on every list turn. |
+| **Migration** | Pass `limit: 200` (max 1000) to restore the previous default page size. Cursor pagination is unchanged — existing cursor tokens remain valid. |
+| **Deprecation** | The `limit` parameter has no deprecation; pass it explicitly for predictable page sizes. |
+
+### Cursor blob format change — truncated filterHash and unix-millis timestamps (#802)
+
+| | |
+|---|---|
+| **What changed** | Pagination cursor tokens are re-encoded: `filterHash` truncated to ≤16 chars, `lastSortValue` for date fields is now unix-millis (number) instead of an ISO-8601 string. |
+| **Why** | Reduces cursor size by ~130 bytes per response. |
+| **Migration** | Cursors are opaque — callers must not parse or persist them across server versions. Any in-flight cursor from a previous server version returns a `ValidationError`; simply retry the page without the cursor. |
+| **Deprecation** | Old-format cursors are not supported after this release. Never parse cursor tokens. |
+
+### `changes_since` returns field-level deltas instead of full records (#819)
+
+| | |
+|---|---|
+| **What changed** | Response shape: `{ added: Task[], modified: TaskDelta[], removed: TaskId[] }` where `TaskDelta = { id: TaskId, changes: Partial<Task> }`. Previously, `modified` contained full Task records. |
+| **Why** | Sync-style consumers only need changed fields — full records were 5–10× wasteful. |
+| **Migration** | Merge `delta.changes` into your local cache entry: `cache[delta.id] = { ...cache[delta.id], ...delta.changes }`. Callers that need a full record after a delta can call `task_get({ id: delta.id })`. |
+| **Deprecation** | The full-record shape for `modified` is removed; the delta shape is the stable form. |
+
+---
+
+## Compatibility Matrix
+
+| Change | v1.3 | v1.4 (planned) |
+|---|---|---|
+| `noteHtml` in default response | ✅ included | ❌ removed (opt-in via `includeNoteHtml: true`) |
+| `_links` in default response | ✅ included | ❌ removed (opt-in via `includeLinks: true`) |
+| `forecast_get` `byDate[].tasks` | ✅ full objects | ❌ changed to `taskIds: TaskId[]` |
+| `task_get` default `includeSubtasks` | ✅ `true` | ❌ `false` (override with `includeSubtasks: true`) |
+| Default list page size | ✅ 200 / 100 | ❌ 50 for all (override with `limit: N`) |
+| Cursor token format | v1 (SHA-256 + ISO dates) | v2 (truncated hash + unix-millis) |
+| `changes_since` modified shape | full `Task` records | `TaskDelta` (field-level diff) |
+| Length caps on user input (#825) | none | enforced (name ≤ 1 KB, note ≤ 1 MB, etc.) |
+
+**Key:** ✅ unchanged / supported · ❌ breaking change with migration path
+
+---
+
+## Versioning policy
+
+omnifocus-mcp follows [semver](https://semver.org):
+
+- **Patch** (`1.x.y → 1.x.z`): bug fixes, no behaviour change.
+- **Minor** (`1.x → 1.y`): new tools/fields, behavioural changes with opt-in migration window, default changes.
+- **Major** (`1 → 2`): removals with no opt-in escape hatch.
+
+All changes in the v1.4 table above are **minor** (defaults change; old behaviour accessible via flags or workarounds) except cursor format (opaque token — always minor because callers must not parse cursors).

--- a/scripts/verify-migrations-doc.sh
+++ b/scripts/verify-migrations-doc.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# verify-migrations-doc.sh — enforce that PRs labelled `breaking-change`
+# update docs/migrations.md.
+#
+# Usage (CI — runs only when PR_LABELS is set):
+#   PR_LABELS="breaking-change,type: perf" \
+#   CHANGED_FILES="src/tools/task/list.ts docs/migrations.md" \
+#     bash scripts/verify-migrations-doc.sh
+#
+# Usage (local — checks the working tree diff against main):
+#   bash scripts/verify-migrations-doc.sh
+#
+# Exit codes:
+#   0 — OK (not a breaking-change PR, or migrations.md was updated)
+#   1 — PR is labelled breaking-change but docs/migrations.md was not touched
+
+set -euo pipefail
+
+MIGRATIONS_DOC="docs/migrations.md"
+
+# ---------------------------------------------------------------------------
+# 1. Detect whether this is a breaking-change PR
+# ---------------------------------------------------------------------------
+
+is_breaking=0
+
+if [ -n "${PR_LABELS:-}" ]; then
+  # CI path: PR_LABELS is a comma-separated list supplied by the workflow.
+  if echo "$PR_LABELS" | grep -q "breaking-change"; then
+    is_breaking=1
+  fi
+else
+  # Local path: inspect the GITHUB_EVENT_PATH payload if present, otherwise
+  # fall back to checking whether the current branch has any commit message
+  # or PR label indication.  When run locally without GH context we skip.
+  if [ -n "${GITHUB_EVENT_PATH:-}" ] && command -v jq >/dev/null 2>&1; then
+    if jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH" 2>/dev/null \
+        | grep -q "breaking-change"; then
+      is_breaking=1
+    fi
+  fi
+fi
+
+if [ "$is_breaking" -eq 0 ]; then
+  echo "verify-migrations-doc: not a breaking-change PR — skipping."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Check whether docs/migrations.md was modified
+# ---------------------------------------------------------------------------
+
+migrations_touched=0
+
+if [ -n "${CHANGED_FILES:-}" ]; then
+  # CI path: CHANGED_FILES is a space-separated list.
+  if echo "$CHANGED_FILES" | tr ' ' '\n' | grep -q "^${MIGRATIONS_DOC}$"; then
+    migrations_touched=1
+  fi
+else
+  # Local path: compare against the merge-base with main.
+  base=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || echo "")
+  if [ -n "$base" ]; then
+    if git diff --name-only "$base" HEAD | grep -q "^${MIGRATIONS_DOC}$"; then
+      migrations_touched=1
+    fi
+  fi
+fi
+
+if [ "$migrations_touched" -eq 0 ]; then
+  echo "::error file=${MIGRATIONS_DOC}::This PR is labelled 'breaking-change' but docs/migrations.md was not updated." >&2
+  echo "Every breaking change must document what changed, why, and how to migrate." >&2
+  echo "Add a section to docs/migrations.md before merging." >&2
+  exit 1
+fi
+
+echo "verify-migrations-doc: docs/migrations.md updated — OK."


### PR DESCRIPTION
## Summary

- **`docs/migrations.md`** — per-release breaking-change log with migration steps for all upcoming v1.4 changes: #791 (noteHtml), #792 (_links), #794 (byDate), #796 (includeSubtasks default), #797 (list page sizes), #802 (cursor format), #819 (changes_since deltas), #825 (input length caps)
- **`scripts/verify-migrations-doc.sh`** — CI lint: any PR with the `breaking-change` label must update `docs/migrations.md`; exits non-zero with an `::error::` annotation otherwise
- **`meta-lint.yml`** — new `migrations-doc` job wiring the script into CI
- **`AGENTS.md`** — added `docs/migrations.md` to the reference docs section

## Test plan

- [ ] `scripts/verify-migrations-doc.sh` with `PR_LABELS=breaking-change CHANGED_FILES="docs/migrations.md"` → exits 0
- [ ] `scripts/verify-migrations-doc.sh` with `PR_LABELS=breaking-change CHANGED_FILES="src/tools/task/list.ts"` → exits 1
- [ ] `scripts/verify-migrations-doc.sh` with `PR_LABELS="type: perf"` → exits 0 (not a breaking-change PR)
- [ ] `actionlint` on `meta-lint.yml` — passes (new job uses same pattern as others)
- [ ] `shellcheck` on `verify-migrations-doc.sh` — passes

Closes #841