### PR TITLE
perf(tools): lower default page size to 50 for task_list, project_list, search_query

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2070,7 +2070,7 @@ List projects in OmniFocus with optional filters. Use for queries across project
 | `status` | unknown | No |  |
 | `flagged` | boolean | No | true = flagged only; false = unflagged only; omit = both. |
 | `reviewDueBefore` | string | No | Restrict to projects whose next review date is strictly before this moment. ISO-8601 with offset (e.g. '2026-05-01T00:00:00-07:00'). Projects without a review interval are excluded. |
-| `limit` | number | No | Max projects per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages. |
+| `limit` | number | No | Max projects per page (1..1000). Default 50. Use `cursor` to fetch subsequent pages. |
 | `cursor` | string | No | Opaque cursor from a previous project_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError. |
 | `verbose` | boolean | No | When true, return the full unelided project shape. Default: false — fields equal to their documented default (status: 'active', completionCriterion: 'parallel', flagged: false, tagIds: [], note: null, etc.) are omitted. See docs/token-cost.md for the defaults table. |
 | `fields` | string[] | No | Restrict each returned project to this list of top-level fields (id is always returned). Omit for the full project shape. Empty array returns just id. Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS. |
@@ -2611,7 +2611,7 @@ Full-text search across OmniFocus task names and/or notes. Use for finding tasks
 | `tagIds` | string[] | No | Restrict to tasks carrying ALL of these tags. Get IDs from tag_list. |
 | `flagged` | boolean | No | true = flagged tasks only; false = unflagged only; omit = all. |
 | `completed` | one of: any | only | exclude | No | 'exclude' = active tasks only; 'only' = completed only; 'any' = both. Default 'any'. |
-| `limit` | number | No | Max results per page (1..500). Default 100. |
+| `limit` | number | No | Max results per page (1..500). Default 50. |
 | `cursor` | string | No | Opaque cursor from a previous search_query response. Must use identical filters — changing filters returns a ValidationError. |
 | `fields` | string[] | No | Restrict each returned task to this list of top-level fields (id is always returned). Omit for the full task shape. Empty array returns just id. Unknown names are dropped silently and surface in meta.warnings.WARN_UNKNOWN_FIELDS. Allowed: name, note, noteHtml, projectId, parentId, tagIds, deferDate, deferDateFloating, dueDate, dueDateFloating, estimatedMinutes, flagged, completed, completedAt, dropped, droppedAt, available, blocked, sequential, completedByChildren, repetition, notifications, createdAt, modifiedAt, _links. |
 
@@ -4415,7 +4415,7 @@ List tasks in OmniFocus with optional filters (project, tag, inbox, flagged, com
 | `dueAfter` | string | No | Tasks with dueDate strictly after this moment. ISO-8601 with offset. |
 | `deferredBefore` | string | No | Tasks deferred until before this moment (already unlocked or soon). ISO-8601 with offset. |
 | `parentId` | string | No | Restrict to direct children of this task (subtasks). Get the ID from task_get or task_list. |
-| `limit` | number | No | Max tasks per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages. |
+| `limit` | number | No | Max tasks per page (1..1000). Default 50. Use `cursor` to fetch subsequent pages. |
 | `sortBy` | one of: dueDate | createdAt | modifiedAt | name | No | Field to sort tasks by: 'createdAt' (default), 'dueDate', 'modifiedAt', or 'name'. Tasks with no value for the chosen field (e.g. no dueDate) sort last. |
 | `sortDirection` | one of: asc | desc | No | Sort direction: 'asc' (default, oldest/lowest first) or 'desc' (newest/highest first). |
 | `updatedSince` | string | No | Return only tasks modified strictly after this timestamp. Accepts ISO-8601 with offset (e.g. '2026-04-21T10:00:00-07:00') or a relative shortcut: today, yesterday, this-week, next-week, end-of-week, end-of-month. Use this for incremental sync: call without updatedSince on session start, then pass the previous response timestamp on subsequent calls. Note: deleted tasks cannot be detected — use a snapshot resource for deletion detection. |

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -112,7 +112,7 @@ export interface ProjectServiceDeps {
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 1000;
 
 // ---------------------------------------------------------------------------

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -9,7 +9,7 @@
  * - Tasks are sorted by `(createdAt ASC, id ASC)` — deterministic, insert-safe.
  * - Cursors encode `{ lastId, lastCreatedAt, filterHash }`. Swapping filter
  *   fields mid-sequence returns `ValidationError` (filterHash mismatch).
- * - Default page size: 100. Maximum: 500.
+ * - Default page size: 50. Maximum: 500.
  *
  * @see DESIGN.md §15 — pagination contract
  * @see src/pagination/cursor.ts
@@ -32,7 +32,7 @@ import {
 
 /** Input to {@link SearchService.search}. */
 export interface SearchInput extends SearchFilter {
-  /** Max results per page (1..500). Default 100. */
+  /** Max results per page (1..500). Default 50. */
   limit?: number;
   /** Opaque cursor from a previous search_query response. */
   cursor?: string;
@@ -50,7 +50,7 @@ export interface SearchResult {
 // Service
 // ---------------------------------------------------------------------------
 
-const DEFAULT_LIMIT = 100;
+const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 500;
 
 export interface SearchServiceDeps {

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -137,7 +137,7 @@ export interface TaskServiceDeps {
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 1000;
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/list.ts
+++ b/src/tools/project/list.ts
@@ -79,7 +79,7 @@ export const projectListInputSchema = z.object({
     .max(1000)
     .optional()
     .describe(
-      "Max projects per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages.",
+      "Max projects per page (1..1000). Default 50. Use `cursor` to fetch subsequent pages.",
     ),
   cursor: z
     .string()

--- a/src/tools/search/query.ts
+++ b/src/tools/search/query.ts
@@ -76,7 +76,7 @@ export const searchQueryInputSchema = z.object({
     .min(1)
     .max(500)
     .optional()
-    .describe("Max results per page (1..500). Default 100."),
+    .describe("Max results per page (1..500). Default 50."),
   cursor: z
     .string()
     .optional()

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -118,7 +118,7 @@ export const taskListInputSchema = z.object({
     .min(1)
     .max(1000)
     .optional()
-    .describe("Max tasks per page (1..1000). Default 200. Use `cursor` to fetch subsequent pages."),
+    .describe("Max tasks per page (1..1000). Default 50. Use `cursor` to fetch subsequent pages."),
   sortBy: TaskSortBySchema.optional().describe(
     "Field to sort tasks by: 'createdAt' (default), 'dueDate', 'modifiedAt', or 'name'. " +
       "Tasks with no value for the chosen field (e.g. no dueDate) sort last.",


### PR DESCRIPTION
## Summary

- `task_list` default `limit` lowered from 200 → **50**
- `project_list` default `limit` lowered from 200 → **50**
- `search_query` default `limit` lowered from 100 → **50**
- Updated tool descriptions and service JSDoc to reflect the new defaults
- Regenerated `docs/tools.md` and `src/tools/INDEX.md`

Max stays at 1000 (tasks/projects) and 500 (search). Callers who need larger pages pass `limit: N` explicitly.

**Why 50:** typical pages now fit comfortably under `OMNIFOCUS_RESPONSE_STATS_THRESHOLD_BYTES=51200`, reducing token pressure on every list turn without requiring explicit pagination.

## Test plan

- [ ] All existing tests pass (3540/3599)
- [ ] `task_list` with no `limit` → returns ≤50 tasks
- [ ] `project_list` with no `limit` → returns ≤50 projects
- [ ] `search_query` with no `limit` → returns ≤50 results
- [ ] `task_list({ limit: 200 })` → returns ≤200 tasks (override still works)

Closes #797