### PR TITLE
perf(tools): drop noteHtml from default task and project responses

### DIFF
--- a/src/adapter/OmniFocusAdapter.ts
+++ b/src/adapter/OmniFocusAdapter.ts
@@ -328,6 +328,8 @@ export interface OmniFocusAdapter {
 
   listTasks(filter: TaskFilter): Promise<Task[]>;
   getTask(id: TaskId): Promise<Task>;
+  /** Fetch the HTML note for a task or project. Returns null when the item has no note or noteHtml is unavailable. */
+  getNoteHtml(kind: "task" | "project", id: TaskId | ProjectId): Promise<string | null>;
   /** Bulk fetch by ID list — returns tasks in input order. Missing IDs surface in `meta.warnings` at the service layer; the adapter signals them by returning `null` for those positions. */
   getTasksMany(ids: TaskId[]): Promise<(Task | null)[]>;
   createTask(input: CreateTaskInput): Promise<TaskId>;

--- a/src/adapter/inMemory/InMemoryAdapter.ts
+++ b/src/adapter/inMemory/InMemoryAdapter.ts
@@ -170,6 +170,16 @@ export class InMemoryAdapter implements OmniFocusAdapter {
     return this.withAlarms(task);
   }
 
+  async getNoteHtml(kind: "task" | "project", id: TaskId | ProjectId): Promise<string | null> {
+    if (kind === "task") {
+      // getTask throws NotFound if missing — delegate to keep error shape consistent
+      const task = await this.getTask(TaskIdCtor.of(String(id)));
+      return task.noteHtml ?? null;
+    }
+    const proj = await this.getProject(ProjectIdCtor.of(String(id)));
+    return proj.noteHtml ?? null;
+  }
+
   async getTasksMany(ids: TaskId[]): Promise<(Task | null)[]> {
     return ids.map((id) => {
       const t = this.tasks.get(id);

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -58,6 +58,7 @@ import folderGetScript from "../../scripts/jxa/folder_get.js";
 import folderListScript from "../../scripts/jxa/folder_list.js";
 import folderUpdateScript from "../../scripts/jxa/folder_update.js";
 import forecastGetScript from "../../scripts/jxa/forecast_get.js";
+import noteGetHtmlScript from "../../scripts/jxa/note_get_html.js";
 import perspectiveEvaluateScript from "../../scripts/jxa/perspective_evaluate.js";
 import perspectiveListScript from "../../scripts/jxa/perspective_list.js";
 import projectBatchCompleteScript from "../../scripts/jxa/project_batch_complete.js";
@@ -209,6 +210,15 @@ export class JxaTransport implements OmniFocusAdapter {
       { ...this.runOpts, scriptName: "task_get" },
     );
     return { ...result.task, id: TaskIdCtor.of(result.task.id) };
+  }
+
+  async getNoteHtml(kind: "task" | "project", id: TaskId | ProjectId): Promise<string | null> {
+    const result = await runJxaScript<{ noteHtml: string | null }>(
+      noteGetHtmlScript,
+      { kind, id },
+      { ...this.runOpts, scriptName: "note_get_html" },
+    );
+    return result.noteHtml;
   }
 
   async getTasksMany(ids: TaskId[]): Promise<(Task | null)[]> {

--- a/src/adapter/omnijs/OmniJsTransport.ts
+++ b/src/adapter/omnijs/OmniJsTransport.ts
@@ -148,6 +148,9 @@ export class OmniJsTransport implements OmniFocusAdapter {
   async getTask(_id: TaskId): Promise<Task> {
     return notYetWired("getTask");
   }
+  async getNoteHtml(_kind: "task" | "project", _id: TaskId | ProjectId): Promise<string | null> {
+    return notYetWired("getNoteHtml");
+  }
   async getTasksMany(_ids: TaskId[]): Promise<(Task | null)[]> {
     return notYetWired("getTasksMany");
   }

--- a/src/adapter/router.test.ts
+++ b/src/adapter/router.test.ts
@@ -41,6 +41,7 @@ function makeStub(name: Receiver): OmniFocusAdapter & { calls: string[] } {
     calls,
     listTasks: record("listTasks"),
     getTask: record("getTask"),
+    getNoteHtml: record("getNoteHtml"),
     getTasksMany: record("getTasksMany"),
     createTask: record("createTask"),
     updateTask: record("updateTask"),
@@ -136,6 +137,7 @@ function callsByMethod(r: TransportRouter): Record<AdapterMethod, () => Promise<
   return {
     listTasks: () => r.listTasks({}),
     getTask: () => r.getTask(T_ID),
+    getNoteHtml: () => r.getNoteHtml("task", T_ID),
     getTasksMany: () => r.getTasksMany([T_ID]),
     createTask: () => r.createTask({ name: "x" }),
     updateTask: () => r.updateTask(T_ID, { name: "y" }),

--- a/src/adapter/router.ts
+++ b/src/adapter/router.ts
@@ -92,6 +92,7 @@ export const ROUTING_TABLE: Readonly<Record<AdapterMethod, TransportName>> = Obj
   // -- Tasks ----------------------------------------------------------------
   listTasks: "jxa",
   getTask: "jxa",
+  getNoteHtml: "jxa",
   getTasksMany: "jxa",
   // Per ADR-0019: routes through OmniJS so the returned id is a persistent
   // primaryKey interoperable with both transports (vs JXA's transient
@@ -275,6 +276,9 @@ export class TransportRouter implements OmniFocusAdapter {
   }
   getTask(id: TaskId): Promise<Task> {
     return this.pick("getTask").getTask(id);
+  }
+  getNoteHtml(kind: "task" | "project", id: TaskId | ProjectId): Promise<string | null> {
+    return this.pick("getNoteHtml").getNoteHtml(kind, id);
   }
   getTasksMany(ids: TaskId[]): Promise<(Task | null)[]> {
     return this.pick("getTasksMany").getTasksMany(ids);

--- a/src/scripts/jxa/_helpers/build_project.js
+++ b/src/scripts/jxa/_helpers/build_project.js
@@ -110,12 +110,8 @@ function buildProject(proj) {
     /* OF 4.x: property access may not exist on all object types — default used */
   }
 
-  let noteHtml = null;
-  try {
-    if (proj.noteHtml) noteHtml = proj.noteHtml() || null;
-  } catch (_e) {
-    /* OF 4.x: property access may not exist on all object types — default used */
-  }
+  // noteHtml is intentionally omitted from all project responses — use note_get_html
+  // to retrieve HTML note content on demand. See perf issue #791.
 
   let flagged = false;
   try {
@@ -192,7 +188,7 @@ function buildProject(proj) {
     id: proj.id(),
     name: proj.name(),
     note: note,
-    noteHtml: noteHtml,
+    noteHtml: null,
     folderId: folderId,
     tagIds: tagIds,
     status: status,

--- a/src/scripts/jxa/_helpers/build_task.js
+++ b/src/scripts/jxa/_helpers/build_task.js
@@ -127,12 +127,8 @@ function buildTask(task, options) {
     /* OF 4.x: property access may not exist on all object types — default used */
   }
 
-  let noteHtml = null;
-  try {
-    if (task.noteHtml) noteHtml = task.noteHtml() || null;
-  } catch (_e) {
-    /* OF 4.x: property access may not exist on all object types — default used */
-  }
+  // noteHtml is intentionally omitted from all task responses — use note_get_html
+  // to retrieve HTML note content on demand. See perf issue #791.
 
   let flagged = false;
   try {
@@ -204,7 +200,7 @@ function buildTask(task, options) {
     id: task.id(),
     name: task.name(),
     note: note,
-    noteHtml: noteHtml,
+    noteHtml: null,
     projectId: projectId,
     parentId: parentId,
     tagIds: tagIds,

--- a/src/scripts/jxa/note_get_html.d.ts
+++ b/src/scripts/jxa/note_get_html.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Type shim for `note_get_html.js`.
+ * @see src/scripts/jxa/sync_trigger.d.ts — canonical pattern
+ */
+declare const source: string;
+export default source;

--- a/src/scripts/jxa/note_get_html.js
+++ b/src/scripts/jxa/note_get_html.js
@@ -1,0 +1,37 @@
+/**
+ * JXA: fetch the HTML note for a task or project by ID.
+ *
+ * Args (argv[0] JSON): { kind: "task" | "project", id: string }
+ * Returns JSON: { noteHtml: string | null }
+ *
+ * @see src/adapter/jxa/JxaTransport.ts — caller
+ * @see src/tools/note/get_html.ts — MCP tool
+ */
+
+// biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
+function run(argv) {
+  const args = JSON.parse(argv[0]);
+  const ofApp = Application("OmniFocus");
+  ofApp.includeStandardAdditions = false;
+
+  let item;
+  if (args.kind === "task") {
+    item = ofApp.defaultDocument.flattenedTasks.byId(args.id);
+  } else {
+    item = ofApp.defaultDocument.flattenedProjects.byId(args.id);
+  }
+
+  // biome-ignore lint/complexity/useOptionalChain: JXA runtime — optional chain breaks bridge calls
+  if (!item || !item.id || !item.id()) {
+    throw new Error(`NotFound: ${args.kind} not found: ${args.id}`);
+  }
+
+  let noteHtml = null;
+  try {
+    if (item.noteHtml) noteHtml = item.noteHtml() || null;
+  } catch (_e) {
+    /* OF 4.x: noteHtml may not exist on all item types — null used */
+  }
+
+  return JSON.stringify({ noteHtml });
+}

--- a/src/tools/note/get_html.ts
+++ b/src/tools/note/get_html.ts
@@ -65,12 +65,9 @@ export interface NoteGetHtmlContext {
  * @throws {NotFound} when the task or project ID does not exist
  */
 export async function handleNoteGetHtml(input: NoteGetHtmlToolInput, ctx: NoteGetHtmlContext) {
-  const noteHtml =
-    input.targetKind === "task"
-      ? (await ctx.adapter.getTask(TaskId.of(input.id))).noteHtml
-      : (await ctx.adapter.getProject(ProjectId.of(input.id))).noteHtml;
-
-  return ok({ noteHtml: noteHtml ?? null }, ctx.makeMeta());
+  const id = input.targetKind === "task" ? TaskId.of(input.id) : ProjectId.of(input.id);
+  const noteHtml = await ctx.adapter.getNoteHtml(input.targetKind, id);
+  return ok({ noteHtml }, ctx.makeMeta());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `noteHtml` is no longer populated in `build_task.js` or `build_project.js` — all task/project responses now return `noteHtml: null`
- Eliminates 3–10× byte overhead for users with rich-formatted notes across `task_list`, `task_get`, `task_get_many`, `task_search`, `project_list`, `project_get`, `project_get_many`, `forecast_get`, and `perspective_evaluate`
- Adds dedicated `getNoteHtml(kind, id)` adapter method backed by a new `note_get_html.js` JXA script that fetches HTML content on demand without materialising the full response envelope
- `note_get_html` MCP tool now calls the new adapter method directly instead of reading from `getTask().noteHtml`

## Breaking change

`task.noteHtml` and `project.noteHtml` in all list/get responses are now always `null`. Callers that need HTML note content must call `note_get_html` explicitly.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no violations  
- [x] `pnpm test` — 3500 tests pass
- [x] Pre-push hook passed

Closes #791