### PR TITLE
perf(jxa): use Set for tag membership checks in task_search multi-tag filter

### DIFF
--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -80,9 +80,12 @@ function run(argv) {
       if (dueAfter !== null && due <= dueAfter) continue;
     }
 
-    // Tag filter — task must carry ALL listed tags
+    // Tag filter — task must carry ALL listed tags.
+    // Build a Set<string> once per task for O(1) membership checks instead of
+    // O(filterTags × taskTags) nested scan (#803).
     if (args.tagIds && args.tagIds.length > 0) {
-      const allPresent = args.tagIds.every((tid) => built.tagIds.includes(tid));
+      const taskTagSet = new Set(built.tagIds);
+      const allPresent = args.tagIds.every((tid) => taskTagSet.has(tid));
       if (!allPresent) continue;
     }
 


### PR DESCRIPTION
## Summary

- Replaces the `O(filterTags × taskTags)` nested scan (`built.tagIds.includes(tid)`) with a `Set<string>` built once per task, reducing membership checks to `O(1)` per filter tag
- No correctness change — the same set of tasks matches the same filters

## Test plan

- [x] `pnpm test` — all 3500 tests pass
- [x] Pre-push hook passed

Closes #803