### PR TITLE
perf(review): project review_list_due to documented fields by default

### DIFF
--- a/src/tools/review/listDue.ts
+++ b/src/tools/review/listDue.ts
@@ -44,7 +44,17 @@ export async function handleReviewListDue(
 ) {
   const result = await ctx.reviewService.listDue();
   const meta = ctx.makeMeta({ cacheHit: result.cacheHit });
-  return ok({ projects: result.projects }, meta);
+  // Project to the documented 5 fields only — full Project[] shape carries
+  // noteHtml, taskCount, completedTaskCount, etc. that inflate token cost
+  // without adding review-workflow value. Use project_get for heavy fields.
+  const projects = result.projects.map((p) => ({
+    id: p.id,
+    name: p.name,
+    nextReviewDate: p.nextReviewDate,
+    lastReviewDate: p.lastReviewDate,
+    reviewIntervalDays: p.reviewIntervalDays,
+  }));
+  return ok({ projects }, meta);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-09",
-  "toolListBytes": 173570,
+  "generatedAt": "2026-05-10",
+  "toolListBytes": 174064,
   "workflows": {
     "inbox-triage": {
       "callCount": 6,
       "totalRequestBytes": 29603,
       "totalResponseBytes": 38226,
       "totalRoundTripBytes": 67829,
-      "totalTokens": 60350,
+      "totalTokens": 60473,
       "byTool": {
         "tag_create": {
           "calls": 1,
@@ -36,7 +36,7 @@
       "totalRequestBytes": 2609,
       "totalResponseBytes": 26154,
       "totalRoundTripBytes": 28763,
-      "totalTokens": 50583,
+      "totalTokens": 50707,
       "byTool": {
         "project_create": {
           "calls": 1,
@@ -67,9 +67,9 @@
     "weekly-review": {
       "callCount": 11,
       "totalRequestBytes": 292,
-      "totalResponseBytes": 24000,
-      "totalRoundTripBytes": 24292,
-      "totalTokens": 49466,
+      "totalResponseBytes": 19130,
+      "totalRoundTripBytes": 19422,
+      "totalTokens": 48372,
       "byTool": {
         "project_mark_reviewed": {
           "calls": 5,
@@ -77,7 +77,7 @@
         },
         "review_list_due": {
           "calls": 1,
-          "responseBytes": 6780
+          "responseBytes": 1910
         },
         "task_list": {
           "calls": 5,


### PR DESCRIPTION
## Summary

- `review_list_due` now returns only `{ id, name, nextReviewDate, lastReviewDate, reviewIntervalDays }` per project, matching the documented response shape
- The full `Project[]` shape included `noteHtml`, `taskCount`, `completedTaskCount`, etc. that inflate token cost without review-workflow value
- Description already accurately described the projected 5 fields; the handler now matches it

## Test plan

- [x] `pnpm test` — 3500 tests pass
- [x] Pre-push hook passed

Closes #801