### PR TITLE
chore(errors): audit and fix user-visible error coverage

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,78 @@
+# Error taxonomy
+
+Every error thrown by omnifocus-mcp is an instance of `OmniFocusError` (defined in `src/errors/index.ts`) with a stable `code`, a machine-readable `remediationClass`, and a human-readable `suggestion`. Generic `Error` is forbidden by custom lint rule.
+
+## Remediation classes
+
+Agents switch on `remediationClass` to decide next action without parsing text.
+
+| Class | Agent action |
+|---|---|
+| `environment` | Stop; user must act (launch OF, grant permission, upgrade) |
+| `input` | Fix the input and retry |
+| `transient` | Wait `details.retryAfterMs` ms then retry |
+| `infrastructure` | Retry once; if still failing, surface to user |
+| `lifecycle` | Reconnect to a fresh server instance |
+
+## Error codes
+
+### Environment — `remediationClass: "environment"`
+
+| Code | Class | Suggestion |
+|---|---|---|
+| `OF_NOT_RUNNING` | `OmniFocusNotRunning` | Launch OmniFocus and retry |
+| `OF_PERMISSION_DENIED` | `PermissionDenied` | Open System Settings → Privacy → Automation; grant access |
+| `OF_CALENDAR_PERMISSION_DENIED` | `CalendarPermissionDenied` | Open System Settings → Privacy → Calendars; grant access |
+| `OF_CALENDAR_BRIDGE_UNAVAILABLE` | `CalendarBridgeUnavailable` | Run `pnpm build:calendar-bridge` |
+| `OF_FEATURE_REQUIRES_PRO` | `FeatureRequiresPro` | Upgrade to OmniFocus Pro |
+| `OF_FEATURE_REQUIRES_VERSION` | `FeatureRequiresOfVersion` | Update OmniFocus |
+| `OF_WINDOW_UNAVAILABLE` | `WindowUnavailable` | Ask user to open an OmniFocus window |
+
+### Input — `remediationClass: "input"`
+
+| Code | Class | Suggestion |
+|---|---|---|
+| `OF_VALIDATION` | `ValidationError` | Fix the input; see `details` for field-level reasons |
+| `OF_NOT_FOUND` | `NotFound` | Confirm the ID with `*_list`; use persistent IDs, not names |
+| `OF_CONFLICT` | `ConflictError` | Re-read the resource, merge changes, retry with fresh `modifiedAt` |
+| `OF_LOOP_DETECTED` | `LoopDetected` | Act on the previous result before repeating this tool |
+
+### Transient — `remediationClass: "transient"`
+
+| Code | Class | Suggestion |
+|---|---|---|
+| `OF_TIMEOUT` | `Timeout` | Retry once; if repeated, relaunch OmniFocus |
+| `OF_RATE_LIMITED` | `RateLimited` | Wait `details.retryAfterMs` ms then retry |
+| `OF_QUEUE_FULL` | `QueueFull` | Wait for in-flight writes to drain, then retry |
+| `OF_CIRCUIT_OPEN` | `CircuitOpen` | Wait `details.retryAfterMs` ms for the circuit to half-open |
+
+### Infrastructure — `remediationClass: "infrastructure"`
+
+| Code | Class | Suggestion |
+|---|---|---|
+| `OF_TRANSPORT_UNAVAILABLE` | `TransportUnavailable` | Verify OmniFocus is running and responsive |
+| `OF_SCRIPT_ERROR` | `ScriptError` | Inspect `details.transport` and `details.reason` |
+| `OF_STRAY_STDOUT` | `StrayStdout` | Check for console.log or libraries writing to stdout; all logging must go to stderr |
+
+### Lifecycle — `remediationClass: "lifecycle"`
+
+| Code | Class | Suggestion |
+|---|---|---|
+| `OF_SHUTTING_DOWN` | `ServerShuttingDown` | Reconnect to a fresh server instance |
+
+## Template errors
+
+Template tools define domain-specific subclasses that inherit from the base taxonomy:
+
+| Error class | Base | Code | Suggestion |
+|---|---|---|---|
+| `TemplateNotFoundError` (templateInstantiate) | `NotFound` | `OF_NOT_FOUND` | List with `project_template_list`, retry with valid name |
+| `MissingTemplateParameterError` | `ValidationError` | `OF_VALIDATION` | Provide values for `details.missing` parameters |
+| `TemplateNotFoundError` (templateDelete) | `NotFound` | `OF_NOT_FOUND` | List with `project_template_list`, retry with valid name |
+| `TemplateExistsError` | `ConflictError` | `OF_CONFLICT` | Delete existing template or choose a different name |
+
+## Coverage notes
+
+- Every error class has `remediationClass` and `suggestion` defaults in the constructor.
+- Throw sites may override `suggestion` with context-specific guidance; consult `details` for structured payload.
+- Errors that have no actionable remediation state that explicitly in `suggestion` (e.g. `OF_STRAY_STDOUT` which requires developer investigation).

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -391,3 +391,23 @@ export class LoopDetected extends OmniFocusError {
     );
   }
 }
+
+// ---------------------------------------------------------------------------
+// Protocol guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a stray byte is detected on stdout — which is the MCP transport
+ * channel and must remain clean. Any write to stdout (from a console.log,
+ * third-party library, etc.) corrupts the JSON-RPC framing.
+ */
+export class StrayStdout extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_STRAY_STDOUT", message, {
+      remediationClass: "infrastructure",
+      suggestion:
+        "A process wrote to stdout, which corrupts the MCP transport. Check for console.log calls or third-party libraries that write to stdout. All logging must go to stderr.",
+      ...options,
+    });
+  }
+}

--- a/src/tools/project/templateInstantiate.ts
+++ b/src/tools/project/templateInstantiate.ts
@@ -27,6 +27,7 @@ import {
   substituteTemplateParameters,
 } from "../../domain/projectTemplates.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { NotFound, ValidationError } from "../../errors/index.js";
 import { ExportService } from "../../services/exportService.js";
 
 // ---------------------------------------------------------------------------
@@ -74,20 +75,28 @@ export type ProjectTemplateInstantiateToolInput = z.infer<
 // Errors
 // ---------------------------------------------------------------------------
 
-export class TemplateNotFoundError extends Error {
-  readonly code = "TEMPLATE_NOT_FOUND";
+export class TemplateNotFoundError extends NotFound {
   constructor(name: string) {
-    super(`No template named "${name}" was found in the Templates folder.`);
-    this.name = "TemplateNotFoundError";
+    super(`No template named "${name}" was found in the Templates folder.`, {
+      suggestion:
+        "List available templates with project_template_list, then retry with a valid name.",
+      details: { templateName: name },
+    });
   }
 }
 
-export class MissingTemplateParameterError extends Error {
-  readonly code = "MISSING_TEMPLATE_PARAMETER";
+export class MissingTemplateParameterError extends ValidationError {
+  /** Names of the missing parameters (also available in `details.missing`). */
   readonly missing: string[];
   constructor(missing: string[]) {
-    super(`Template requires parameters not supplied: ${missing.map((n) => `"${n}"`).join(", ")}.`);
-    this.name = "MissingTemplateParameterError";
+    super(
+      `Template requires parameters not supplied: ${missing.map((n) => `"${n}"`).join(", ")}.`,
+      {
+        suggestion:
+          "Provide values for all required template parameters listed in `details.missing`.",
+        details: { missing },
+      },
+    );
     this.missing = missing;
   }
 }

--- a/src/tools/project/templateSave.ts
+++ b/src/tools/project/templateSave.ts
@@ -28,6 +28,7 @@ import {
   type ProjectTemplateMeta,
 } from "../../domain/projectTemplates.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { ConflictError } from "../../errors/index.js";
 import { renderTaskPaper } from "../../services/export/taskpaper.js";
 import { fetchProjectTaskTree, partitionTasksByParent } from "../../services/export/tree.js";
 
@@ -66,11 +67,13 @@ export type ProjectTemplateSaveToolInput = z.infer<typeof projectTemplateSaveInp
 // Errors
 // ---------------------------------------------------------------------------
 
-export class TemplateExistsError extends Error {
-  readonly code = "TEMPLATE_EXISTS";
+export class TemplateExistsError extends ConflictError {
   constructor(name: string) {
-    super(`A template named "${name}" already exists in the Templates folder.`);
-    this.name = "TemplateExistsError";
+    super(`A template named "${name}" already exists in the Templates folder.`, {
+      suggestion:
+        "Delete the existing template with project_template_delete first, or choose a different name.",
+      details: { templateName: name },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes `TemplateNotFoundError` (in `templateInstantiate.ts`) and `MissingTemplateParameterError` to extend `NotFound` / `ValidationError` — they previously extended bare `Error` and would not serialize correctly in the MCP response envelope
- Fixes `TemplateExistsError` to extend `ConflictError` with `remediationClass` and `suggestion`
- Adds `StrayStdout` error class for the existing `OF_STRAY_STDOUT` code (was in the `ErrorCode` union but had no concrete class)
- Creates `docs/errors.md` documenting the full error taxonomy: remediation classes, all error codes with agent guidance

## All error classes now have `remediationClass` and `suggestion` defaults

## Test plan

- [x] `pnpm test` — 3500 tests pass (templateInstantiate tests still pass; `missing` property preserved on `MissingTemplateParameterError`)
- [x] `pnpm lint` — clean
- [x] Pre-push hook passed

Closes #828