### PR TITLE
feat(scripts): add board-mutate.sh wrapper for project v2 field flips (#847)

### DIFF
--- a/scripts/board-mutate.sh
+++ b/scripts/board-mutate.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# =============================================================================
+# board-mutate.sh — single-item Project v2 field mutation with round-trip verify
+# =============================================================================
+# Replaces ~30 lines of inline `gh api graphql` boilerplate at every skill
+# call-site with: `scripts/board-mutate.sh <verb> <ITEM_ID> <value>`.
+#
+# Every mutation is followed by a re-read of the field, per the round-trip
+# invariant in ~/.claude/skills/shared/status-transition.md ("the round-trip
+# is the only proof"). A 200 OK without persistence exits 7.
+#
+# Usage: scripts/board-mutate.sh <verb> <ITEM_ID> <value>
+#        scripts/board-mutate.sh --help
+#
+# Verbs (canonical lower-case-with-hyphens; values accepted case-insensitively):
+#   flip-status      <ITEM_ID> {backlog|up-next|in-progress|in-review|on-hold|done}
+#   set-priority     <ITEM_ID> {P0|P1|P2|P3}
+#   set-size         <ITEM_ID> {XS|S|M|L|XL}
+#   set-phase        <ITEM_ID> {M0|M1|M2|M3|M4|M5}
+#   set-risk         <ITEM_ID> {low|medium|high}
+#   set-model-queue  <ITEM_ID> {sonnet-low|opus-med|opus-high|opus-1m-max
+#                              |in-progress|in-review|on-hold|done}
+#
+# Exit codes:
+#   0  success
+#   2  invalid usage / missing args
+#   3  scripts/_project-constants.sh not found (or missing required vars)
+#   4  unknown verb
+#   5  unknown value for verb (or value's option ID not configured locally)
+#   6  mutation API call failed
+#   7  round-trip verification failed — API claimed success, value did not persist
+# =============================================================================
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Help / usage
+# ---------------------------------------------------------------------------
+usage() {
+  sed -n '3,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $(basename "$0") <verb> <ITEM_ID> <value>" >&2
+  echo "       $(basename "$0") --help" >&2
+  exit 2
+fi
+
+VERB="$1"
+ITEM_ID="$2"
+RAW_VALUE="$3"
+
+# ---------------------------------------------------------------------------
+# Constants — sourced from scripts/_project-constants.sh (gitignored, local)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONSTANTS_FILE="$SCRIPT_DIR/_project-constants.sh"
+
+if [ ! -f "$CONSTANTS_FILE" ]; then
+  echo "FATAL: $CONSTANTS_FILE not found." >&2
+  echo "       Copy $CONSTANTS_FILE.example and fill in your project IDs." >&2
+  exit 3
+fi
+# shellcheck source=./_project-constants.sh
+source "$CONSTANTS_FILE"
+
+# Required for any verb
+for v in PROJECT_ID; do
+  if [ -z "${!v:-}" ] || [[ "${!v}" == YOUR_* ]]; then
+    echo "FATAL: $v is unset or unfilled in $CONSTANTS_FILE" >&2
+    exit 3
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Verb → field-id variable + value → option-id variable
+# ---------------------------------------------------------------------------
+# normalize value: lower-case, replace spaces with hyphens
+norm() { echo "$1" | tr '[:upper:] ' '[:lower:]-'; }
+
+# Resolve the field-id variable name + value-id variable name for a verb+value.
+# Echo two fields: "<FIELD_VAR> <OPT_VAR>". Exits 4 on unknown verb, 5 on
+# unknown value (the "value not in the verb's vocabulary" case — the second
+# variable-existence check below handles "value valid but option ID not set").
+resolve() {
+  local verb="$1" value
+  value="$(norm "$2")"
+
+  case "$verb" in
+    flip-status)
+      local field_var="F_STATUS"
+      case "$value" in
+        backlog)      echo "$field_var STATUS_BACKLOG" ;;
+        up-next)      echo "$field_var STATUS_UP_NEXT" ;;
+        in-progress)  echo "$field_var STATUS_IN_PROGRESS" ;;
+        in-review)    echo "$field_var STATUS_IN_REVIEW" ;;
+        on-hold)      echo "$field_var STATUS_ON_HOLD" ;;
+        done)         echo "$field_var STATUS_DONE" ;;
+        *) return 5 ;;
+      esac ;;
+    set-priority)
+      local field_var="F_PRIORITY"
+      case "$value" in
+        p0) echo "$field_var O_P0" ;;
+        p1) echo "$field_var O_P1" ;;
+        p2) echo "$field_var O_P2" ;;
+        p3) echo "$field_var O_P3" ;;
+        *) return 5 ;;
+      esac ;;
+    set-size)
+      local field_var="F_SIZE"
+      case "$value" in
+        xs) echo "$field_var O_SIZE_XS" ;;
+        s)  echo "$field_var O_SIZE_S" ;;
+        m)  echo "$field_var O_SIZE_M" ;;
+        l)  echo "$field_var O_SIZE_L" ;;
+        xl) echo "$field_var O_SIZE_XL" ;;
+        *) return 5 ;;
+      esac ;;
+    set-phase)
+      local field_var="F_PHASE"
+      case "$value" in
+        m0) echo "$field_var O_PHASE_M0" ;;
+        m1) echo "$field_var O_PHASE_M1" ;;
+        m2) echo "$field_var O_PHASE_M2" ;;
+        m3) echo "$field_var O_PHASE_M3" ;;
+        m4) echo "$field_var O_PHASE_M4" ;;
+        m5) echo "$field_var O_PHASE_M5" ;;
+        *) return 5 ;;
+      esac ;;
+    set-risk)
+      local field_var="F_RISK"
+      case "$value" in
+        low)            echo "$field_var O_RISK_LOW" ;;
+        medium|med)     echo "$field_var O_RISK_MED" ;;
+        high)           echo "$field_var O_RISK_HIGH" ;;
+        *) return 5 ;;
+      esac ;;
+    set-model-queue)
+      local field_var="F_MODEL_QUEUE"
+      case "$value" in
+        sonnet-low)   echo "$field_var O_MQ_SONNET_LOW" ;;
+        opus-med)     echo "$field_var O_MQ_OPUS_MED" ;;
+        opus-high)    echo "$field_var O_MQ_OPUS_HIGH" ;;
+        opus-1m-max)  echo "$field_var O_MQ_OPUS_1M_MAX" ;;
+        in-progress)  echo "$field_var O_MQ_IN_PROGRESS" ;;
+        in-review)    echo "$field_var O_MQ_IN_REVIEW" ;;
+        on-hold)      echo "$field_var O_MQ_ON_HOLD" ;;
+        done)         echo "$field_var O_MQ_DONE" ;;
+        *) return 5 ;;
+      esac ;;
+    *)
+      return 4 ;;
+  esac
+}
+
+set +e
+RESOLVED=$(resolve "$VERB" "$RAW_VALUE")
+RC=$?
+set -e
+
+if [ "$RC" -eq 4 ]; then
+  echo "FATAL: unknown verb '$VERB'. Run with --help for the verb surface." >&2
+  exit 4
+fi
+if [ "$RC" -eq 5 ]; then
+  echo "FATAL: unknown value '$RAW_VALUE' for verb '$VERB'. Run with --help." >&2
+  exit 5
+fi
+
+FIELD_VAR=$(echo "$RESOLVED" | awk '{print $1}')
+OPT_VAR=$(echo "$RESOLVED" | awk '{print $2}')
+
+FIELD_ID="${!FIELD_VAR:-}"
+OPT_ID="${!OPT_VAR:-}"
+
+if [ -z "$FIELD_ID" ] || [[ "$FIELD_ID" == YOUR_* ]]; then
+  echo "FATAL: $FIELD_VAR is unset in $CONSTANTS_FILE — cannot resolve verb '$VERB'." >&2
+  exit 3
+fi
+if [ -z "$OPT_ID" ] || [[ "$OPT_ID" == YOUR_* ]]; then
+  echo "FATAL: $OPT_VAR is unset in $CONSTANTS_FILE — value '$RAW_VALUE' has no option ID configured for this project." >&2
+  exit 5
+fi
+
+# ---------------------------------------------------------------------------
+# Mutate
+# ---------------------------------------------------------------------------
+if ! gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $p, itemId: $i, fieldId: $f,
+    value: { singleSelectOptionId: $o }
+  }) { projectV2Item { id } }
+}' -f p="$PROJECT_ID" -f i="$ITEM_ID" -f f="$FIELD_ID" -f o="$OPT_ID" > /dev/null 2>&1; then
+  echo "FATAL: mutation API call failed for item $ITEM_ID, field $FIELD_VAR, option $OPT_VAR." >&2
+  exit 6
+fi
+
+# ---------------------------------------------------------------------------
+# Round-trip verify — the only proof the mutation persisted
+# ---------------------------------------------------------------------------
+VERIFIED=$(gh api graphql -f query='query($id:ID!) {
+  node(id: $id) { ... on ProjectV2Item { fieldValues(first: 20) { nodes {
+    ... on ProjectV2ItemFieldSingleSelectValue {
+      field { ... on ProjectV2SingleSelectField { id } } optionId
+    } } } } }
+}' -F id="$ITEM_ID" --jq ".data.node.fieldValues.nodes[] | select(.field.id==\"$FIELD_ID\") | .optionId" 2>/dev/null || echo "")
+
+if [ "$VERIFIED" != "$OPT_ID" ]; then
+  echo "FATAL: $VERB on item $ITEM_ID did not persist (got: '${VERIFIED:-<empty>}', want: $OPT_ID)." >&2
+  exit 7
+fi
+
+echo "board: $VERB → $RAW_VALUE (item $ITEM_ID)"

--- a/scripts/board-mutate.sh
+++ b/scripts/board-mutate.sh
@@ -69,12 +69,10 @@ fi
 source "$CONSTANTS_FILE"
 
 # Required for any verb
-for v in PROJECT_ID; do
-  if [ -z "${!v:-}" ] || [[ "${!v}" == YOUR_* ]]; then
-    echo "FATAL: $v is unset or unfilled in $CONSTANTS_FILE" >&2
-    exit 3
-  fi
-done
+if [ -z "${PROJECT_ID:-}" ] || [[ "${PROJECT_ID}" == YOUR_* ]]; then
+  echo "FATAL: PROJECT_ID is unset or unfilled in $CONSTANTS_FILE" >&2
+  exit 3
+fi
 
 # ---------------------------------------------------------------------------
 # Verb → field-id variable + value → option-id variable

--- a/tests/scripts/board-mutate.test.ts
+++ b/tests/scripts/board-mutate.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Smoke tests for scripts/board-mutate.sh (#847).
+ *
+ * Spawns the bash script as a subprocess. Mocks `gh` via a shim on PATH so
+ * mutation/verify paths run without hitting the live GitHub API.
+ *
+ * Coverage targets (per #847 AC):
+ *   exit 0  success — every verb in the surface
+ *   exit 2  invalid usage / missing args
+ *   exit 3  _project-constants.sh missing or required vars unfilled
+ *   exit 4  unknown verb
+ *   exit 5  unknown value for verb
+ *   exit 6  mutation API call failed
+ *   exit 7  round-trip verification failed
+ */
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const SCRIPT = resolve(__dirname, "../../scripts/board-mutate.sh");
+
+/**
+ * Build a self-contained sandbox: a temp dir with a copy of board-mutate.sh,
+ * a stub _project-constants.sh, and a mock `gh` whose behavior is controlled
+ * by a per-test flag file.
+ *
+ * `ghMode` controls how the mock gh responds:
+ *   "ok"        — mutation succeeds, verify returns the option ID just written
+ *   "fail"      — mutation exits non-zero
+ *   "drift"     — mutation succeeds, verify returns a different option ID
+ */
+function makeSandbox(ghMode: "ok" | "fail" | "drift") {
+  const dir = mkdtempSync(join(tmpdir(), "board-mutate-test-"));
+  const scripts = join(dir, "scripts");
+  const bin = join(dir, "bin");
+  mkdirSync(scripts);
+  mkdirSync(bin);
+
+  // Copy the script under test into place so its SCRIPT_DIR resolves to our scripts/
+  const scriptCopy = join(scripts, "board-mutate.sh");
+  const fs = require("node:fs") as typeof import("node:fs");
+  fs.copyFileSync(SCRIPT, scriptCopy);
+  chmodSync(scriptCopy, 0o755);
+
+  // Stub constants — every variable the script may resolve, with synthetic IDs
+  // so we can assert what option ID flows into the mock gh.
+  writeFileSync(
+    join(scripts, "_project-constants.sh"),
+    [
+      `OWNER="testorg"`,
+      `PROJECT_ID="PVT_test"`,
+      `F_STATUS="F_STATUS_ID"`,
+      `F_PRIORITY="F_PRIORITY_ID"`,
+      `F_SIZE="F_SIZE_ID"`,
+      `F_PHASE="F_PHASE_ID"`,
+      `F_RISK="F_RISK_ID"`,
+      `F_MODEL_QUEUE="F_MODEL_QUEUE_ID"`,
+      `STATUS_BACKLOG="opt_status_backlog"`,
+      `STATUS_UP_NEXT="opt_status_up_next"`,
+      `STATUS_IN_PROGRESS="opt_status_in_progress"`,
+      `STATUS_IN_REVIEW="opt_status_in_review"`,
+      `STATUS_ON_HOLD="opt_status_on_hold"`,
+      `STATUS_DONE="opt_status_done"`,
+      `O_P0="opt_p0"`,
+      `O_P1="opt_p1"`,
+      `O_P2="opt_p2"`,
+      `O_P3="opt_p3"`,
+      `O_SIZE_XS="opt_size_xs"`,
+      `O_SIZE_S="opt_size_s"`,
+      `O_SIZE_M="opt_size_m"`,
+      `O_SIZE_L="opt_size_l"`,
+      `O_SIZE_XL="opt_size_xl"`,
+      `O_PHASE_M0="opt_phase_m0"`,
+      `O_PHASE_M1="opt_phase_m1"`,
+      `O_PHASE_M2="opt_phase_m2"`,
+      `O_PHASE_M3="opt_phase_m3"`,
+      `O_PHASE_M4="opt_phase_m4"`,
+      `O_PHASE_M5="opt_phase_m5"`,
+      `O_RISK_LOW="opt_risk_low"`,
+      `O_RISK_MED="opt_risk_med"`,
+      `O_RISK_HIGH="opt_risk_high"`,
+      `O_MQ_SONNET_LOW="opt_mq_sonnet_low"`,
+      `O_MQ_OPUS_MED="opt_mq_opus_med"`,
+      `O_MQ_OPUS_HIGH="opt_mq_opus_high"`,
+      `O_MQ_OPUS_1M_MAX="opt_mq_opus_1m_max"`,
+      `O_MQ_IN_PROGRESS="opt_mq_in_progress"`,
+      `O_MQ_IN_REVIEW="opt_mq_in_review"`,
+      `O_MQ_ON_HOLD="opt_mq_on_hold"`,
+      `O_MQ_DONE="opt_mq_done"`,
+      "",
+    ].join("\n"),
+  );
+
+  // Mock gh — distinguishes mutation vs query by the presence of `mutation(` in
+  // the -f query argument. The mutation captures the `-f o=...` value into a
+  // sidecar file so the query path can echo it back (or a deliberate drift).
+  const stateFile = join(dir, "last-mutation-opt");
+  const ghScript = `#!/usr/bin/env bash
+# Mock gh for board-mutate.sh tests.
+# Mode: ${ghMode}
+mode="${ghMode}"
+
+# Slurp args. Look for: -f query=..., -f o=..., --jq <expr>.
+# Real \`gh ... --jq <expr>\` filters server-side; our mock applies it locally
+# via the system \`jq\` so the script's parsing logic sees the same shape.
+query=""
+opt_arg=""
+jq_expr=""
+prev=""
+for a in "$@"; do
+  case "$prev" in
+    -f)
+      case "$a" in
+        query=*) query="\${a#query=}" ;;
+        o=*)     opt_arg="\${a#o=}" ;;
+      esac ;;
+    --jq) jq_expr="$a" ;;
+  esac
+  prev="$a"
+done
+
+is_mutation=0
+case "$query" in *mutation*) is_mutation=1 ;; esac
+
+emit() {
+  if [ -n "$jq_expr" ]; then
+    /usr/bin/env jq -r "$jq_expr"
+  else
+    cat
+  fi
+}
+
+if [ "$is_mutation" = "1" ]; then
+  if [ "$mode" = "fail" ]; then
+    echo "mock gh: simulated mutation failure" >&2
+    exit 1
+  fi
+  echo "$opt_arg" > "${stateFile}"
+  echo '{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"x"}}}}' | emit
+  exit 0
+fi
+
+# query path — emit one entry per field id with the option captured at mutation
+# time (or a deliberate drift). The script's --jq filter selects the right one.
+last="$(cat "${stateFile}" 2>/dev/null || echo "")"
+if [ "$mode" = "drift" ]; then
+  last="DRIFT_DIFFERENT_OPT"
+fi
+cat <<EOF | emit
+{"data":{"node":{"fieldValues":{"nodes":[
+  {"field":{"id":"F_STATUS_ID"},"optionId":"$last"},
+  {"field":{"id":"F_PRIORITY_ID"},"optionId":"$last"},
+  {"field":{"id":"F_SIZE_ID"},"optionId":"$last"},
+  {"field":{"id":"F_PHASE_ID"},"optionId":"$last"},
+  {"field":{"id":"F_RISK_ID"},"optionId":"$last"},
+  {"field":{"id":"F_MODEL_QUEUE_ID"},"optionId":"$last"}
+]}}}}
+EOF
+`;
+  writeFileSync(join(bin, "gh"), ghScript);
+  chmodSync(join(bin, "gh"), 0o755);
+
+  return { dir, scriptCopy, bin };
+}
+
+function run(scriptPath: string, bin: string, args: string[]) {
+  return spawnSync("bash", [scriptPath, ...args], {
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
+    encoding: "utf8",
+  });
+}
+
+let sandboxes: string[] = [];
+
+afterEach(() => {
+  // Clean up sandboxes created in this test
+  const fs = require("node:fs") as typeof import("node:fs");
+  for (const dir of sandboxes) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  sandboxes = [];
+});
+
+describe("board-mutate.sh", () => {
+  describe("usage / arg validation", () => {
+    it("--help exits 0 and prints the verb surface", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      const r = run(scriptCopy, bin, ["--help"]);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("flip-status");
+      expect(r.stdout).toContain("set-model-queue");
+    });
+
+    it("no args exits 2 with usage line", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      const r = run(scriptCopy, bin, []);
+      expect(r.status).toBe(2);
+      expect(r.stderr).toContain("usage:");
+    });
+
+    it("two args exits 2", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      const r = run(scriptCopy, bin, ["flip-status", "ITEM_X"]);
+      expect(r.status).toBe(2);
+    });
+  });
+
+  describe("missing constants → exit 3", () => {
+    it("exits 3 when _project-constants.sh is absent", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      const fs = require("node:fs") as typeof import("node:fs");
+      fs.rmSync(join(dir, "scripts/_project-constants.sh"));
+      const r = run(scriptCopy, bin, ["flip-status", "ITEM_X", "done"]);
+      expect(r.status).toBe(3);
+      expect(r.stderr).toContain("not found");
+    });
+
+    it("exits 3 when PROJECT_ID is unfilled (placeholder)", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      writeFileSync(
+        join(dir, "scripts/_project-constants.sh"),
+        `PROJECT_ID="YOUR_PROJECT_NODE_ID"\n`,
+      );
+      const r = run(scriptCopy, bin, ["flip-status", "ITEM_X", "done"]);
+      expect(r.status).toBe(3);
+      expect(r.stderr).toContain("PROJECT_ID");
+    });
+  });
+
+  describe("verb / value validation", () => {
+    it("unknown verb exits 4", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      const r = run(scriptCopy, bin, ["bogus-verb", "ITEM_X", "value"]);
+      expect(r.status).toBe(4);
+      expect(r.stderr).toContain("unknown verb");
+    });
+
+    it("unknown value for known verb exits 5", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      const r = run(scriptCopy, bin, ["flip-status", "ITEM_X", "warp-speed"]);
+      expect(r.status).toBe(5);
+      expect(r.stderr).toContain("unknown value");
+    });
+
+    it("value valid by name but option ID unset locally exits 5", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("ok");
+      sandboxes.push(dir);
+      // Wipe the specific option ID; everything else stays valid
+      const fs = require("node:fs") as typeof import("node:fs");
+      const constants = fs.readFileSync(join(dir, "scripts/_project-constants.sh"), "utf8");
+      fs.writeFileSync(
+        join(dir, "scripts/_project-constants.sh"),
+        constants.replace(/STATUS_DONE="[^"]*"/, `STATUS_DONE=""`),
+      );
+      const r = run(scriptCopy, bin, ["flip-status", "ITEM_X", "done"]);
+      expect(r.status).toBe(5);
+      expect(r.stderr).toContain("STATUS_DONE");
+    });
+  });
+
+  describe("API failures", () => {
+    it("mutation failure exits 6", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("fail");
+      sandboxes.push(dir);
+      const r = run(scriptCopy, bin, ["flip-status", "ITEM_X", "done"]);
+      expect(r.status).toBe(6);
+      expect(r.stderr).toContain("mutation API call failed");
+    });
+
+    it("round-trip verification failure exits 7", () => {
+      const { scriptCopy, bin, dir } = makeSandbox("drift");
+      sandboxes.push(dir);
+      const r = run(scriptCopy, bin, ["flip-status", "ITEM_X", "done"]);
+      expect(r.status).toBe(7);
+      expect(r.stderr).toContain("did not persist");
+    });
+  });
+
+  describe("happy paths — every verb resolves to the right option ID", () => {
+    const cases: Array<{ verb: string; value: string; expectOpt: string }> = [
+      { verb: "flip-status", value: "backlog", expectOpt: "opt_status_backlog" },
+      { verb: "flip-status", value: "up-next", expectOpt: "opt_status_up_next" },
+      {
+        verb: "flip-status",
+        value: "in-progress",
+        expectOpt: "opt_status_in_progress",
+      },
+      { verb: "flip-status", value: "in-review", expectOpt: "opt_status_in_review" },
+      { verb: "flip-status", value: "on-hold", expectOpt: "opt_status_on_hold" },
+      { verb: "flip-status", value: "done", expectOpt: "opt_status_done" },
+      // case-insensitivity
+      { verb: "flip-status", value: "DONE", expectOpt: "opt_status_done" },
+      { verb: "flip-status", value: "Up Next", expectOpt: "opt_status_up_next" },
+
+      { verb: "set-priority", value: "P0", expectOpt: "opt_p0" },
+      { verb: "set-priority", value: "p3", expectOpt: "opt_p3" },
+
+      { verb: "set-size", value: "XS", expectOpt: "opt_size_xs" },
+      { verb: "set-size", value: "L", expectOpt: "opt_size_l" },
+
+      { verb: "set-phase", value: "M0", expectOpt: "opt_phase_m0" },
+      { verb: "set-phase", value: "m5", expectOpt: "opt_phase_m5" },
+
+      { verb: "set-risk", value: "low", expectOpt: "opt_risk_low" },
+      { verb: "set-risk", value: "medium", expectOpt: "opt_risk_med" },
+      { verb: "set-risk", value: "med", expectOpt: "opt_risk_med" },
+      { verb: "set-risk", value: "high", expectOpt: "opt_risk_high" },
+
+      {
+        verb: "set-model-queue",
+        value: "sonnet-low",
+        expectOpt: "opt_mq_sonnet_low",
+      },
+      { verb: "set-model-queue", value: "opus-med", expectOpt: "opt_mq_opus_med" },
+      {
+        verb: "set-model-queue",
+        value: "opus-1m-max",
+        expectOpt: "opt_mq_opus_1m_max",
+      },
+      { verb: "set-model-queue", value: "done", expectOpt: "opt_mq_done" },
+    ];
+
+    for (const c of cases) {
+      it(`${c.verb} ${c.value} → ${c.expectOpt}`, () => {
+        const { scriptCopy, bin, dir } = makeSandbox("ok");
+        sandboxes.push(dir);
+        const r = run(scriptCopy, bin, [c.verb, "ITEM_X", c.value]);
+        expect(r.status, `stdout=${r.stdout}\nstderr=${r.stderr}`).toBe(0);
+        const fs = require("node:fs") as typeof import("node:fs");
+        const captured = fs.readFileSync(join(dir, "last-mutation-opt"), "utf8").trim();
+        expect(captured).toBe(c.expectOpt);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/board-mutate.sh <verb> <ITEM_ID> <value>` — single-item Project v2 field mutator with mandatory round-trip verification per `~/.claude/skills/shared/status-transition.md`.
- Verbs: `flip-status`, `set-priority`, `set-size`, `set-phase`, `set-risk`, `set-model-queue` (case-insensitive values, canonical lower-case-with-hyphens).
- Distinct exit codes (`0/2/3/4/5/6/7`) so callers can distinguish usage error, missing constants, unknown verb/value, mutation failure, and verification failure.
- Smoke tests in `tests/scripts/board-mutate.test.ts` mock `gh` via a PATH shim — exercise every verb's success path plus each failure-mode exit code (32 cases, all green).

## Design link

Implements [#847 — feat(scripts): generalize set-ready-status.sh into scripts/board-mutate.sh](https://github.com/torsday/omnifocus-mcp/issues/847). Sub-issue of #804.

Closes #847

## Breaking change?

- [x] No

## Test plan

- [x] Unit tests cover happy + edge + error (32 cases — verb resolution, arg validation, missing constants, mutation/verify failures)
- [x] `pnpm typecheck && pnpm lint && pnpm test` are green locally (3572 passed, 59 skipped, 0 failed)
- [x] Self-reviewed via /review-pr
- [x] No new dependencies

## Scope notes — partial AC; follow-ups intended

The issue's AC has 8 items. This PR delivers the core script + tests. Three items are intentionally out of scope; none block the value of the wrapper itself, but follow-ups should be filed to cover them:

1. **`set-ready-status.sh` → thin wrapper conversion (AC item 5).** The current `set-ready-status.sh` is a *bulk-bootstrap* script — it iterates every project item and flips each to Up Next or Backlog based on a hardcoded `UNBLOCKED_NUMBERS` array. It does not accept a single item ID. Converting it to ``board-mutate.sh flip-status \$1 up-next`` would silently break its bulk semantics. Recommend a follow-up to either retire the bulk script (it appears to be a one-off) or rename it to ``bootstrap-status.sh`` for clarity, then optionally add a separate thin alias if a single-item ``set-ready-status`` entry point is wanted.

2. **Skill call-site updates (AC item 6).** Skills live at `~/.claude/skills/` and are not tracked in this repo (per CLAUDE.md). Updating call-sites in `/ship-next`, `/groom`, `/ship-debug`, `/ship-refactor`, `/hunt-bugs` is a separate, local-only edit pass — orthogonal to landing the script itself.

3. **`scripts/README.md` listing (AC item 8).** That file does not exist on `main` yet; #829 is the in-flight PR that creates it. Once #829 lands, a one-liner can be appended either as part of #829 or as a follow-up.

## Tension worth flagging

`~/.claude/skills/shared/status-transition.md` explicitly argues *against* abstracting board flips behind a helper — the prior helper-comment pattern caused silent drift when the LLM didn't translate the comment into actual code. The wrapper here is a different failure mode (an actual subprocess invocation, not a comment placeholder), but the trade-off is real and deserves a `/groom` pass before mass-converting skills. Recommend trying the wrapper at one or two call-sites first, observing for one cycle, then expanding if no drift surfaces.

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Docs are inline in the script's `--help` and the test file's header docstring (no public-surface docs change)