### PR TITLE
fix(attachment): reject null bytes and control chars in attachment paths (#824)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -21,9 +21,10 @@ omnifocus-mcp speaks **stdio** — there is no network listener, no open port, a
 - `src/attachment/assertAttachmentPath.ts` resolves symlinks via `realpath()` **before** checking the allowlist, defeating symlink-escape attacks.
 - An allowlist of path prefixes (default: `[$HOME]`) restricts all file operations to the user's home directory unless `OMNIFOCUS_ATTACHMENT_PATHS` explicitly extends it.
 - Hard-blocked system prefixes (`/System/`, `/Library/`, `/private/System/`, `/private/Library/`) are always rejected, regardless of the allowlist.
+- Null bytes and ASCII control characters (U+0000–U+001F, U+007F) are rejected at the boundary before any filesystem call. This surfaces a typed `ValidationError` instead of Node's generic `ERR_INVALID_ARG_VALUE` and prevents path bytes from confusing downstream tooling that treats certain control bytes as separators.
 - `assertAttachmentSize` enforces the `maxAttachmentMb` cap before the OmniFocus call.
 
-**Test coverage:** `src/attachment/assertAttachmentPath.test.ts` — includes symlink-escape, hard-blocked prefix, and allowlist boundary cases.
+**Test coverage:** `src/attachment/assertAttachmentPath.test.ts` — includes symlink-escape, hard-blocked prefix, allowlist boundary, and null-byte/control-char rejection cases.
 
 ---
 

--- a/src/attachment/assertAttachmentPath.test.ts
+++ b/src/attachment/assertAttachmentPath.test.ts
@@ -130,6 +130,39 @@ describe("assertAttachmentPath", () => {
     });
   });
 
+  describe("control characters and null bytes", () => {
+    it("rejects a path containing a null byte", async () => {
+      const err = await assertAttachmentPath(`${HOME}/file\x00.pdf`, ALLOWED).catch((e) => e);
+      expect(err).toBeInstanceOf(ValidationError);
+      expect(err.message).toContain("control characters");
+      // realpath must NOT have been called — the rejection happens at the boundary.
+      expect(mockRealpath).not.toHaveBeenCalled();
+    });
+
+    it("rejects a path containing a tab", async () => {
+      const err = await assertAttachmentPath(`${HOME}/file\t.pdf`, ALLOWED).catch((e) => e);
+      expect(err).toBeInstanceOf(ValidationError);
+      expect(err.message).toContain("control characters");
+    });
+
+    it("rejects a path containing a newline", async () => {
+      const err = await assertAttachmentPath(`${HOME}/file\n.pdf`, ALLOWED).catch((e) => e);
+      expect(err).toBeInstanceOf(ValidationError);
+    });
+
+    it("rejects a path containing DEL (U+007F)", async () => {
+      const err = await assertAttachmentPath(`${HOME}/file\x7f.pdf`, ALLOWED).catch((e) => e);
+      expect(err).toBeInstanceOf(ValidationError);
+    });
+
+    it("accepts paths with high-bit / UTF-8 characters (non-ASCII is fine)", async () => {
+      // U+00E9 (é) and U+1F600 (😀) are not control chars; macOS HFS+/APFS
+      // accept Unicode filenames. The guard must not reject these.
+      resolveAs(`${HOME}/résumé😀.pdf`);
+      await expect(assertAttachmentPath(`${HOME}/résumé😀.pdf`, ALLOWED)).resolves.toBeUndefined();
+    });
+  });
+
   describe("error quality", () => {
     it("out-of-scope error mentions OMNIFOCUS_ATTACHMENT_PATHS in suggestion", async () => {
       resolveAs("/etc/hosts");

--- a/src/attachment/assertAttachmentPath.ts
+++ b/src/attachment/assertAttachmentPath.ts
@@ -54,6 +54,25 @@ export async function assertAttachmentPath(
   filePath: string,
   allowedPaths: readonly string[],
 ): Promise<void> {
+  // Reject null bytes and ASCII control chars before any filesystem call.
+  // Node's fs treats `\0` as a string terminator and rejects it with a
+  // generic ERR_INVALID_ARG_VALUE; surfacing a typed ValidationError here
+  // gives callers a clearer remediation hint and keeps the rejection at the
+  // boundary. Control chars (U+0000..U+001F, U+007F) have no legitimate use
+  // in a real macOS file path; their presence indicates a bug or an attempt
+  // to confuse downstream tooling that treats certain bytes as separators.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: that's exactly what we're rejecting
+  if (/[\x00-\x1f\x7f]/.test(filePath)) {
+    throw new ValidationError(
+      `Attachment path contains control characters: ${JSON.stringify(filePath)}`,
+      {
+        suggestion:
+          "Remove null bytes and ASCII control characters from the path; use only printable ASCII or UTF-8.",
+        details: { field: "filePath", value: filePath },
+      },
+    );
+  }
+
   // Resolve symlinks — this is the critical step that defeats traversal.
   let resolved: string;
   try {


### PR DESCRIPTION
## Summary

- `assertAttachmentPath` now rejects any path containing U+0000–U+001F or U+007F **before** any filesystem call — typed `ValidationError` instead of Node's generic `ERR_INVALID_ARG_VALUE`
- 5 new tests: null byte, tab, newline, DEL (U+007F), plus a positive case asserting non-ASCII (é, 😀) is accepted
- `docs/security.md` updated with the new mitigation line and corresponding test-coverage note
- Net diff: **+54/−1**, three files

## Design link

Implements [#824 — fix(attachment): canonicalize and bound destination paths in attachment_save_to_path](https://github.com/torsday/omnifocus-mcp/issues/824). Risk-flagged as `risk: high`; downgraded scope per issue's own footnote ("if the existing implementation already canonicalizes safely, downgrade").

Closes #824

## Breaking change?

- [x] No

## AC walk-through

| AC | Status | Where |
|---|---|---|
| 1. Path canonicalized via `path.resolve` (or equivalent) before write | ✅ Already done | `realpath()` in `assertAttachmentPath.ts` does this — `realpath` is `path.resolve` + symlink resolution + existence check |
| 2. Reject paths whose canonical form is outside an allowed root | ✅ Already done | Allowlist prefix-match after realpath; default `[$HOME]` extensible via `OMNIFOCUS_ATTACHMENT_PATHS` |
| 3. Reject paths that resolve through a symlink leaving the allowed root | ✅ Already done | This is the **point** of doing realpath *before* the prefix check |
| 4. Reject paths containing null bytes or control chars | ✅ **This PR** | New regex check at the boundary; 5 new tests |
| 5. Existing successful workflows preserved | ✅ Already done | Existing 15-test suite passes unchanged; new tests are additive |
| 6. Document the security model in `docs/security.md` | ✅ Already done; **this PR** updates it for the new mitigation | `docs/security.md` § "Attachment path traversal" |

The two AC sub-items that intentionally **diverge** from the issue:

- **Env-var name** stays `OMNIFOCUS_ATTACHMENT_PATHS` (issue suggested `OMNIFOCUS_ATTACHMENT_ALLOWED_ROOTS`). Rename would be breaking; existing convention is documented in `DESIGN.md §22`.
- **Default scope** stays `[$HOME]` (issue suggested `~/Downloads, ~/Documents`). Tighter default would break anyone using `~/Desktop`, project-specific scratch paths, etc. Operators tighten via the env var if they want.

If either divergence is wrong, file as a separate issue — not bundled here.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3577 passed, +5 over baseline)
- [x] `pnpm vitest run src/attachment/assertAttachmentPath.test.ts` — 20/20 pass
- [x] Verified `realpath` is **not** called when the path is rejected for control chars (early-return at the boundary; assertion in test)

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Public-surface docs updated (`docs/security.md`)