### PR TITLE
infra(ci): add label-gated allowlist for token-cost regression gate (#822)

### DIFF
--- a/.github/workflows/token-cost-bench.yml
+++ b/.github/workflows/token-cost-bench.yml
@@ -1,9 +1,19 @@
 name: Token-cost benchmark
 
-# Non-required check (#771). Runs the hermetic in-memory benchmark suite
-# against the checked-in baseline; fails on ≥ 5% drift in any tracked
-# field. Promote to required once the baseline has held for one week of
-# unrelated PR traffic — see tests/benchmark/token-cost/README.md.
+# Per-PR regression gate (#822). Runs the hermetic in-memory benchmark suite
+# against the checked-in baseline; fails on ≥ 5% drift in any tracked field.
+#
+# Allowlist: PRs labeled `bench: regression-allowed` skip the failure path —
+# the bench still runs for visibility and the drift is reported in the job
+# summary, but the job exits 0 so the PR is not blocked. Use sparingly: the
+# label is for *intentional* byte-cost increases (a feature that genuinely
+# needs more wire bytes; a security mitigation that adds metadata). Always
+# explain the regression in the PR description.
+#
+# Promote to a *required* check via:
+#   gh api repos/{owner}/{repo}/branches/main/protection/required_status_checks/contexts \
+#     -X POST -f 'contexts[]=token-cost bench'
+# See CONTRIBUTING.md § "Token-cost regression gate" for the full policy.
 
 on:
   pull_request:
@@ -19,6 +29,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: token-cost-bench-${{ github.ref }}
@@ -38,4 +49,48 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test:bench:tokens
+
+      # Run the benchmark. On `pull_request`, capture the exit status and let
+      # the next step decide whether the regression is allowlisted. On `push`
+      # / `merge_group`, just fail directly — main has no PR label to consult.
+      - name: Run token-cost benchmark
+        id: bench
+        run: |
+          set +e
+          pnpm test:bench:tokens
+          status=$?
+          set -e
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+            exit "$status"
+          fi
+
+      # Allowlist gate: PRs labeled `bench: regression-allowed` exit 0 even on
+      # benchmark failure. Both the regression and the allowlist are recorded
+      # in the job summary so reviewers see exactly what was waived.
+      - name: Apply regression allowlist
+        if: github.event_name == 'pull_request'
+        env:
+          STATUS: ${{ steps.bench.outputs.status }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+        run: |
+          allowlisted=$(echo "$PR_LABELS" | jq -r '
+            [.[] | select(.name == "bench: regression-allowed")] | length > 0
+          ')
+          {
+            echo "## Token-cost benchmark"
+            echo ""
+            if [ "$STATUS" = "0" ]; then
+              echo "✅ No regression beyond the 5% threshold."
+            elif [ "$allowlisted" = "true" ]; then
+              echo "🟡 **Regression detected, but allowlisted via \`bench: regression-allowed\` label.**"
+              echo ""
+              echo "The drift breakdown is in the step log above. The PR description should explain why this regression is intentional."
+            else
+              echo "❌ Regression beyond the 5% threshold. Either fix the regression or add the \`bench: regression-allowed\` label with a justification in the PR description."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$STATUS" != "0" ] && [ "$allowlisted" != "true" ]; then
+            exit "$STATUS"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,21 @@ if (!parsed.success) {
 5. **Conventional Commits.** Follow [`commit.md`](https://github.com/torsday/llm_prompts/blob/main/commit.md). One concern per commit. Split multi-concern diffs.
 6. **Update the design.** If your change invalidates something in `DESIGN.md`, `SPEC.md`, or an ADR, update it in the same PR. A PR that diverges from its design doc is not ready to merge.
 
+## Token-cost regression gate
+
+The `Token-cost benchmark` workflow (`.github/workflows/token-cost-bench.yml`) runs the hermetic in-memory benchmark suite against `tests/benchmark/token-cost/__snapshots__/baseline.snap.json` on every PR that touches `src/**`, the benchmark itself, or the workflow / lockfile. It **fails the PR** when any tracked field drifts ≥ 5% from baseline. The tracked fields are `toolListBytes`, per-workflow `totalRequestBytes` / `totalResponseBytes` / `totalRoundTripBytes` / `totalTokens`, and per-tool `byTool[<name>].responseBytes`. See [`tests/benchmark/token-cost/README.md`](./tests/benchmark/token-cost/README.md) for the full list and how to re-baseline.
+
+**Fixing a regression** — the diff in the failing job step is the byte-by-byte breakdown. Most regressions are an envelope field that should be elided, a verbose error message, or a default value that grew. Iterate locally with `OMNIFOCUS_BENCH=1 pnpm test:bench:tokens` until the diff is back under threshold.
+
+**Intentional regressions** — when a feature genuinely needs more wire bytes (a new field, a security mitigation that adds metadata, a richer error envelope), apply the **`bench: regression-allowed`** label to the PR. The workflow still runs the benchmark for visibility — the drift breakdown lands in the job summary — but the job exits 0 so the PR is not blocked. Always explain the regression in the PR description so the next reviewer can confirm the cost is justified. Re-baseline in a follow-up PR per the README.
+
+**Promoting to required check** — the gate is an opt-in advisory check by default. To make it block merge, add it to branch protection:
+
+```bash
+gh api repos/torsday/omnifocus-mcp/branches/main/protection/required_status_checks/contexts \
+  -X POST -f 'contexts[]=token-cost bench'
+```
+
 ## Pull request template
 
 ```markdown


### PR DESCRIPTION
## Summary

- Adds `bench: regression-allowed` label as the allowlist signal for the Token-cost benchmark workflow
- When labeled, the workflow runs the benchmark for visibility (drift in job summary + step log) but exits 0 so the PR isn't blocked
- New CONTRIBUTING.md § "Token-cost regression gate" explains the 5% threshold, how to fix regressions, when to use the allowlist, and the one-liner to promote the check to required
- Net diff: **+75/−5** across 2 files (workflow + CONTRIBUTING)

## Design link

Implements [#822 — infra(ci): gate prs on token-cost benchmark regression beyond threshold](https://github.com/torsday/omnifocus-mcp/issues/822). Compounds with #780 (the benchmark itself, already shipped) and the perf-improvement issues under #770.

Closes #822

## Breaking change?

- [x] No

## AC walk-through

| AC | Status | Where |
|---|---|---|
| CI step runs the `#780` benchmark suite on every PR against the merge base | ✅ Already done by [`token-cost-bench.yml`](./.github/workflows/token-cost-bench.yml) | Workflow runs on `pull_request` for src/ + bench changes |
| Defines per-metric regression thresholds (default: ±5% on key workloads) | ✅ Already done — `tests/benchmark/token-cost/run.test.ts` enforces 5% drift via `diffSnapshots` | Tracked fields: `toolListBytes`, per-workflow `total*Bytes`/`totalTokens`, per-tool `byTool[].responseBytes` |
| Fails the PR with a diff showing which metrics regressed and by how much | ✅ Already done — `formatDrift` output appears in the step log | Job summary now also surfaces a one-line classification |
| **Allowlist mechanism for intentional regressions (label or commit-trailer)** | ✅ **This PR** | New `bench: regression-allowed` label; workflow checks `github.event.pull_request.labels` |
| Self-hosted runner has the OmniFocus environment | ✅ Already done — workflow runs on `[self-hosted, macos]` (suite is hermetic, doesn't need OF, but co-located with the integration runner) | |
| Documented in `docs/contributing.md` or equivalent | ✅ **This PR** | New § "Token-cost regression gate" in `CONTRIBUTING.md` |

## What's NOT in this PR (deliberate)

- **Promotion to `required` status check** — adding the workflow to branch protection is a one-line `gh api` call but mutates shared infrastructure outside the standing `/ship-next` grant. The CONTRIBUTING.md doc includes the exact command for the project owner to run when ready:

  ```bash
  gh api repos/torsday/omnifocus-mcp/branches/main/protection/required_status_checks/contexts \
    -X POST -f 'contexts[]=token-cost bench'
  ```

  The workflow is already wired correctly to be promoted — the only step is the API call. The existing comment in the workflow ("Promote to required once the baseline has held for one week of unrelated PR traffic") indicated the user wanted to gate this on observed stability; #822 being filed signals readiness.

- **Re-baselining script CLI** — `pnpm bench:tokens -- --update` is referenced in `tests/benchmark/token-cost/README.md`; CONTRIBUTING.md links there for the re-baseline procedure rather than restating it.

## Side-effect: label created

`gh label create "bench: regression-allowed" --color "FFA500" --description "..."` was run before opening this PR. The label is repo-state, not in-tree, so re-creating from a fresh clone is one `gh label create` command.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3588 passed; no benchmark changes — bench is gated by `OMNIFOCUS_BENCH=1`)
- [x] YAML syntax is valid (`actionlint` will run in CI)
- [x] The allowlist logic mirrors the existing `integration-gate` pattern (per-PR label check via `toJSON(github.event.pull_request.labels)`) — same shape, same trigger surface
- [x] `gh label list | grep regression-allowed` confirms the label exists

## How to test the allowlist after merge

1. Open a PR that intentionally regresses the bench (e.g. add a default field to a heavy read response)
2. Confirm the workflow fails red
3. Add the `bench: regression-allowed` label to the PR
4. Confirm the workflow re-runs (or close+reopen) and the bench step shows 🟡 in the job summary, with the job exiting 0

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Public-surface docs are the change itself