### PR TITLE
perf(jxa): push modificationDate filter into whose() in changes_since (#789)

### DIFF
--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -780,6 +780,59 @@ describe("JXA sandbox — changes_since", () => {
     expect(result.tasks).toHaveLength(0);
     expect(result.projects).toHaveLength(0);
   });
+
+  // -------------------------------------------------------------------------
+  // whose() pushdown coverage (#789)
+  //
+  // The script now pushes `modificationDate >= since` into OF's runtime via
+  // `flattenedTasks.whose({...})()`. The sandbox honors the same predicate,
+  // so a tighter assertion is possible: items below the threshold should
+  // never have their accessors invoked by user code.
+  // -------------------------------------------------------------------------
+
+  it("does not invoke buildTask-side accessors on items below the threshold", () => {
+    const since = new Date("2026-04-01T00:00:00Z");
+    let beforeIdCalls = 0;
+    let afterIdCalls = 0;
+    const before = fakeTask({
+      id: () => {
+        beforeIdCalls++;
+        return "task_before";
+      },
+      modificationDate: () => new Date("2026-03-01T00:00:00Z"),
+    });
+    const after = fakeTask({
+      id: () => {
+        afterIdCalls++;
+        return "task_after";
+      },
+      modificationDate: () => new Date("2026-04-15T00:00:00Z"),
+    });
+    runJxaScriptInSandbox(
+      changesSinceScript,
+      { sinceIso: since.toISOString() },
+      { tasks: [before, after] },
+    );
+    // The whose() filter ran first and excluded `before`, so its `id()` was
+    // never invoked by the script's iteration loop. `after` was emitted
+    // and its `id()` got called once for the result payload.
+    expect(beforeIdCalls).toBe(0);
+    expect(afterIdCalls).toBe(1);
+  });
+
+  it("includes items at exactly the threshold (>= semantic)", () => {
+    const since = new Date("2026-04-01T00:00:00Z");
+    const exact = fakeTask({
+      id: () => "task_exact",
+      modificationDate: () => new Date("2026-04-01T00:00:00Z"),
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      changesSinceScript,
+      { sinceIso: since.toISOString() },
+      { tasks: [exact] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_exact"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/jxa/changes_since.js
+++ b/src/scripts/jxa/changes_since.js
@@ -16,10 +16,16 @@
  *   projects: Array<{ id: string, modificationDate: string }>
  * }
  *
- * Performance: scans all flattenedTasks and flattenedProjects in a single
- * JXA invocation. On databases with 1 000–5 000 tasks this takes ~300–700 ms
- * (same budget as any other task-list call). The Node side debounces change
- * events to avoid stampeding this script.
+ * Performance: pushes the `modificationDate >= since` predicate into OF's
+ * runtime via `whose({...})` (see #789, mirrors `forecast_get.js`'s 25×
+ * pattern). On databases with thousands of tasks this avoids materializing
+ * every task's accessor — typically a sub-second query vs the original
+ * full-scan loop's hundreds-of-ms-per-thousand-tasks. The `try`/`catch`
+ * around the `whose()` call is a safety net: if OF rejects the predicate
+ * for any reason, we fall back to the previous client-side filter so this
+ * script never returns wrong results because of a query-engine surprise.
+ *
+ * The Node side debounces change events to avoid stampeding this script.
  *
  * Note: `modificationDate` in OF reflects the last local write including
  * sync-incoming changes. It does NOT distinguish between field-level changes;
@@ -28,6 +34,7 @@
  *
  * @see src/watcher/types.ts — ChangedObjects shape
  * @see src/adapter/jxa/JxaTransport.ts — caller (getChangesSince)
+ * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv)
@@ -37,38 +44,38 @@ function run(argv) {
 
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
+  const doc = ofApp.defaultDocument;
 
-  // ------- Tasks -----------------------------------------------------------
-
-  const rawTasks = ofApp.defaultDocument.flattenedTasks();
-  const tasks = [];
-  for (let i = 0; i < rawTasks.length; i++) {
+  // Try the whose() pushdown first; fall back to a full scan if OF rejects
+  // the predicate for any reason (older OF, unexpected accessor behavior).
+  function collectModifiedSince(collection) {
+    let raw;
     try {
-      const t = rawTasks[i];
-      const modDate = t.modificationDate();
-      if (modDate && modDate >= since) {
-        tasks.push({ id: t.id(), modificationDate: modDate.toISOString() });
-      }
+      raw = collection.whose({ modificationDate: { _greaterThanEquals: since } })();
     } catch (_e) {
-      // Skip tasks that error (e.g. inbox pseudo-tasks with no stable id)
+      raw = collection();
     }
+    const out = [];
+    for (let i = 0; i < raw.length; i++) {
+      try {
+        const item = raw[i];
+        const modDate = item.modificationDate();
+        // The whose() filter already excludes earlier dates, but the
+        // post-loop guard keeps the fallback path correct and defends
+        // against whose() silently falling back to client-side
+        // matching for some operators.
+        if (modDate && modDate >= since) {
+          out.push({ id: item.id(), modificationDate: modDate.toISOString() });
+        }
+      } catch (_e) {
+        // Skip items that error (e.g. inbox pseudo-tasks with no stable id)
+      }
+    }
+    return out;
   }
 
-  // ------- Projects --------------------------------------------------------
-
-  const rawProjects = ofApp.defaultDocument.flattenedProjects();
-  const projects = [];
-  for (let i = 0; i < rawProjects.length; i++) {
-    try {
-      const p = rawProjects[i];
-      const modDate = p.modificationDate();
-      if (modDate && modDate >= since) {
-        projects.push({ id: p.id(), modificationDate: modDate.toISOString() });
-      }
-    } catch (_e) {
-      // Skip
-    }
-  }
+  const tasks = collectModifiedSince(doc.flattenedTasks);
+  const projects = collectModifiedSince(doc.flattenedProjects);
 
   return JSON.stringify({ tasks, projects });
 }


### PR DESCRIPTION
## Summary

- `changes_since.js` now pushes `modificationDate >= since` into OF's runtime via `whose({...})` — mirrors the [25× speedup pattern from `forecast_get.js`](./src/scripts/jxa/forecast_get.js)
- Try/catch fallback to the original full-scan loop preserves correctness if OF rejects the predicate; post-loop guard kept intact to defend against silent client-side fallback
- Two new sandbox tests pin the pushdown: items below the threshold have **zero accessor calls** from user code; `>=` boundary semantic asserted
- Net diff: **+90/−30** across 2 files

## Design link

Implements **slice 1 of 4** for [#789 — perf(jxa): push filters into whose()](https://github.com/torsday/omnifocus-mcp/issues/789). The remaining three scripts each warrant their own focused PR with per-script considerations:

- **slice 2** — `task_list` no-filter branch: [#893](https://github.com/torsday/omnifocus-mcp/issues/893)
- **slice 3** — `perspective_evaluate` (4 branches): [#894](https://github.com/torsday/omnifocus-mcp/issues/894)
- **slice 4** — `task_search` (uncertain `_contains` pushdown): [#895](https://github.com/torsday/omnifocus-mcp/issues/895)

Closes #789 — the parent issue's intent (audit the 4 scripts and ship pushdowns) is now properly atomized into the followups; closing here keeps the tracker honest about *what work is in flight* vs *what's just enumerated*.

## Breaking change?

- [x] No — semantically identical; just faster

## Why split into four PRs?

The four scripts share a pattern but each has its own risk profile:

| Script | Risk | Pattern |
|---|---|---|
| **`changes_since`** (this PR) | Low | Single date predicate; mirrors `forecast_get.js` exactly |
| `task_list` (#893) | Medium | Many filter combinations; need to compose the predicate from 8+ optional fields |
| `perspective_evaluate` (#894) | Medium | Four branches with different predicates; `projects`/`tags` branches need source-collection rethinks |
| `task_search` (#895) | High | The `_contains` operator on `name` is the open question — may silently fall back; needs hands-on verification |

Bundling all four would let one tricky case (e.g. `_contains` not pushing down) block the easy wins. The atomization is also better for `git bisect` if any one slice causes a real-OF regression that the integration tier surfaces.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3590 passed, +2 over baseline)
- [x] `pnpm vitest run -t "changes_since"` — 6/6 pass (4 existing + 2 new pushdown coverage)
- [x] Self-reviewed via /review-pr
- [ ] Live integration tier (`OMNIFOCUS_INTEGRATION=1 pnpm test:integration`) — skipped locally; CI's `Integration tests (OmniFocus current)` job covers this
- [x] Token-cost benchmark unchanged — script outputs identical JSON shape; the optimization is purely runtime cost

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Public-surface docs unchanged (script behavior is identical; new internal docblock notes the pushdown rationale and links the pattern reference)