### PR TITLE
feat(transport): retry-once on transient OmniJS failures (#890)

### DIFF
--- a/src/adapter/_shared/retryPolicy.ts
+++ b/src/adapter/_shared/retryPolicy.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared retry-once-on-transient-failure policy for the JXA and OmniJS
+ * script runners (#816 + #890).
+ *
+ * Both runners apply the same policy: when a read-only script fails with a
+ * transient signal (timeout or a known transport-error code), wait
+ * `delayMs` and try once more. The list of read-only scripts and the
+ * transient-error signatures are transport-specific and live in each
+ * runner; the *policy* — enabled flag and backoff duration — is shared so
+ * a single env-var pair (`OMNIFOCUS_TRANSIENT_RETRY_ENABLED`,
+ * `OMNIFOCUS_TRANSIENT_RETRY_DELAY_MS`) controls both transports.
+ *
+ * @see src/adapter/jxa/scriptRunner.ts — JXA half (#816)
+ * @see src/adapter/omnijs/scriptRunner.ts — OmniJS half (#890)
+ */
+
+/** Runtime knobs controlling whether and how long the retry waits. */
+export interface RetryPolicy {
+  enabled: boolean;
+  delayMs: number;
+}
+
+/**
+ * Module-level default policy, sourced from env vars at process start.
+ * `configureRetryPolicy` overrides this once at server boot from the
+ * parsed `Config`; tests bypass via per-call `RunScriptOptions.retry`.
+ */
+let defaultRetryPolicy: RetryPolicy = {
+  enabled: process.env.OMNIFOCUS_TRANSIENT_RETRY_ENABLED !== "0",
+  delayMs: Number(process.env.OMNIFOCUS_TRANSIENT_RETRY_DELAY_MS ?? 100),
+};
+
+/**
+ * Replace the process-wide retry defaults. Called once from server
+ * startup (`startServer()` in `mcpServer.ts`) with the validated config;
+ * subsequent calls are a no-op for tests that just want to read the
+ * current state.
+ */
+export function configureRetryPolicy(policy: Partial<RetryPolicy>): void {
+  defaultRetryPolicy = { ...defaultRetryPolicy, ...policy };
+}
+
+/**
+ * Resolve the effective policy for a single call: per-call overrides
+ * win, then the module-level defaults fill in the rest.
+ */
+export function resolveRetryPolicy(override?: Partial<RetryPolicy>): RetryPolicy {
+  return { ...defaultRetryPolicy, ...(override ?? {}) };
+}

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -38,6 +38,7 @@ import {
 } from "../../errors/index.js";
 import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
+import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
 
 // ---------------------------------------------------------------------------
 // Spawner seam (injectable for tests)
@@ -175,29 +176,11 @@ function transientReason(
   return "other";
 }
 
-/**
- * Runtime knobs for the retry-once policy. Defaults are sourced from env
- * vars (`OMNIFOCUS_TRANSIENT_RETRY_ENABLED`,
- * `OMNIFOCUS_TRANSIENT_RETRY_DELAY_MS`) at server boot but unit tests
- * override directly via `RunScriptOptions.retry`.
- */
-export interface RetryPolicy {
-  enabled: boolean;
-  delayMs: number;
-}
-
-let defaultRetryPolicy: RetryPolicy = {
-  enabled: process.env.OMNIFOCUS_TRANSIENT_RETRY_ENABLED !== "0",
-  delayMs: Number(process.env.OMNIFOCUS_TRANSIENT_RETRY_DELAY_MS ?? 100),
-};
-
-/**
- * Configure the default retry policy. Called once from server startup with
- * the parsed env config; otherwise the env-derived defaults above apply.
- */
-export function configureRetryPolicy(policy: Partial<RetryPolicy>): void {
-  defaultRetryPolicy = { ...defaultRetryPolicy, ...policy };
-}
+// `RetryPolicy`, the module-level defaults, and `configureRetryPolicy` live
+// in `../_shared/retryPolicy.ts` so the OmniJS runner can use the same env
+// vars and runtime override (#890). Re-exported here for callers that
+// already imported them through this module pre-#890.
+export { configureRetryPolicy, type RetryPolicy } from "../_shared/retryPolicy.js";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -234,7 +217,7 @@ export async function runJxaScript<T = unknown>(
   const timeoutMs = options.timeoutMs ?? 30_000;
   const jsonArg = JSON.stringify(args ?? {});
   const scriptName = options.scriptName;
-  const retry: RetryPolicy = { ...defaultRetryPolicy, ...(options.retry ?? {}) };
+  const retry = resolveRetryPolicy(options.retry);
 
   const startedAt = performance.now();
   let result = await spawner(scriptBody, jsonArg, timeoutMs);

--- a/src/adapter/omnijs/scriptRunner.test.ts
+++ b/src/adapter/omnijs/scriptRunner.test.ts
@@ -204,3 +204,150 @@ describe("wrapOmniJsForJxa", () => {
     expect(decoded).toBe(`globalThis.__args = {};\n${tricky}`);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Retry-once on transient failures (#890; mirror of #816 for JXA)
+// ---------------------------------------------------------------------------
+
+describe("runOmniJsScript — retry-once on transient failures", () => {
+  /**
+   * Sequenced spawner: returns the first result on call N=1, the second on
+   * N=2, etc. Asserts the right number of attempts via `mock.calls.length`.
+   */
+  function sequenceSpawner(
+    ...results: Partial<SpawnResult>[]
+  ): ScriptSpawner & ReturnType<typeof vi.fn> {
+    const sequence: SpawnResult[] = results.map((r) => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+      ...r,
+    }));
+    let i = 0;
+    return vi.fn(
+      async (_b: string, _a: string, _t: number): Promise<SpawnResult> =>
+        sequence[i++] as SpawnResult,
+    ) as ScriptSpawner & ReturnType<typeof vi.fn>;
+  }
+
+  it("retries a read-only script on timeout and returns the second-attempt result", async () => {
+    const spawner = sequenceSpawner({ timedOut: true }, { stdout: '{"ok":true}' });
+    const out = await runOmniJsScript<{ ok: true }>(
+      "script",
+      {},
+      { spawner, scriptName: "perspective_evaluate", retry: { delayMs: 0 } },
+    );
+    expect(out).toEqual({ ok: true });
+    expect(spawner.mock.calls).toHaveLength(2);
+  });
+
+  it("does NOT retry a write-shaped script even on transient failure", async () => {
+    const spawner = sequenceSpawner({ timedOut: true });
+    await expect(
+      runOmniJsScript(
+        "script",
+        {},
+        {
+          spawner,
+          scriptName: "task_create",
+          retry: { delayMs: 0 },
+        },
+      ),
+    ).rejects.toBeInstanceOf(OmniFocusError);
+    expect(spawner.mock.calls).toHaveLength(1);
+  });
+
+  it("does NOT retry when scriptName is unknown (safe default)", async () => {
+    const spawner = sequenceSpawner({ timedOut: true });
+    await expect(
+      runOmniJsScript("script", {}, { spawner, retry: { delayMs: 0 } }),
+    ).rejects.toBeInstanceOf(OmniFocusError);
+    expect(spawner.mock.calls).toHaveLength(1);
+  });
+
+  it("does NOT retry when retry.enabled is false", async () => {
+    const spawner = sequenceSpawner({ timedOut: true });
+    await expect(
+      runOmniJsScript(
+        "script",
+        {},
+        {
+          spawner,
+          scriptName: "perspective_evaluate",
+          retry: { enabled: false, delayMs: 0 },
+        },
+      ),
+    ).rejects.toBeInstanceOf(OmniFocusError);
+    expect(spawner.mock.calls).toHaveLength(1);
+  });
+
+  it("does NOT retry on non-transient errors (e.g. PermissionDenied via stderr)", async () => {
+    const spawner = sequenceSpawner({
+      exitCode: 1,
+      stderr: "Not authorized to send Apple events",
+    });
+    await expect(
+      runOmniJsScript(
+        "script",
+        {},
+        {
+          spawner,
+          scriptName: "perspective_evaluate",
+          retry: { delayMs: 0 },
+        },
+      ),
+    ).rejects.toBeInstanceOf(PermissionDenied);
+    expect(spawner.mock.calls).toHaveLength(1);
+  });
+
+  it("on second-attempt timeout, throws Timeout (no wrapping)", async () => {
+    const spawner = sequenceSpawner({ timedOut: true }, { timedOut: true });
+    const err = await runOmniJsScript(
+      "script",
+      {},
+      {
+        spawner,
+        scriptName: "perspective_evaluate",
+        retry: { delayMs: 0 },
+      },
+    ).catch((e: unknown) => e);
+    expect((err as Error).constructor.name).toBe("Timeout");
+    expect(spawner.mock.calls).toHaveLength(2);
+  });
+
+  it("does NOT retry on spawn failure (binary missing — not transient)", async () => {
+    const spawnErr = Object.assign(new Error("ENOENT"), {
+      code: "ENOENT",
+    }) as NodeJS.ErrnoException;
+    const spawner = sequenceSpawner({ exitCode: 127, spawnError: spawnErr });
+    await expect(
+      runOmniJsScript(
+        "script",
+        {},
+        {
+          spawner,
+          scriptName: "perspective_evaluate",
+          retry: { delayMs: 0 },
+        },
+      ),
+    ).rejects.toBeInstanceOf(TransportUnavailable);
+    expect(spawner.mock.calls).toHaveLength(1);
+  });
+});
+
+describe("READ_ONLY_OMNIJS_SCRIPTS — coverage pin", () => {
+  it("includes every documented read-shaped OmniJS script name", async () => {
+    const { READ_ONLY_OMNIJS_SCRIPTS } = await import("./scriptRunner.js");
+    // Pin the set so additions are visible in review. New read-shaped
+    // OmniJS scripts need to be added here to benefit from the
+    // retry-once policy.
+    expect([...READ_ONLY_OMNIJS_SCRIPTS].sort()).toEqual([
+      "forecast_get_tag",
+      "perspective_evaluate",
+      "perspective_evaluate_dry_run",
+      "perspective_get",
+      "ping",
+    ]);
+  });
+});

--- a/src/adapter/omnijs/scriptRunner.ts
+++ b/src/adapter/omnijs/scriptRunner.ts
@@ -39,6 +39,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
 import {
   OmniFocusNotRunning,
   PermissionDenied,
@@ -46,7 +47,9 @@ import {
   Timeout,
   TransportUnavailable,
 } from "../../errors/index.js";
+import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
+import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
 
 // ---------------------------------------------------------------------------
 // Spawner seam (injectable for tests)
@@ -118,6 +121,51 @@ export const defaultOmniJsSpawner: ScriptSpawner = (wrappedJxaBody, _argsJson, t
   });
 
 // ---------------------------------------------------------------------------
+// Retry-once on known-transient failures (#890 — mirror of #816)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only OmniJS scripts whose retry on transient failure is safe by
+ * definition (no side effects). Mirrors `READ_ONLY_JXA_SCRIPTS` in the JXA
+ * runner. Writes are intentionally omitted; retrying a non-idempotent write
+ * risks duplicate side effects.
+ *
+ * Coverage check: every entry must correspond to a real file under
+ * `src/scripts/omnijs/<name>.js`. The smoke test in `scriptRunner.test.ts`
+ * pins this set so silent additions surface in review.
+ */
+export const READ_ONLY_OMNIJS_SCRIPTS: ReadonlySet<string> = new Set([
+  "forecast_get_tag",
+  "perspective_evaluate",
+  "perspective_evaluate_dry_run",
+  "perspective_get",
+  "ping",
+]);
+
+/**
+ * Transient-failure detection for OmniJS. Unlike JXA, OmniJS doesn't surface
+ * `errAEAccessorNotFound` / `-1728` style codes via `osascript` stderr — the
+ * URL-handler bridge swallows those into generic JS exceptions. So the
+ * retry trigger here is conservative: hard timeout only. That's the most
+ * common transient on a sluggish runner anyway, and matches the mitigation
+ * for #887 (integration-tier flakes on slow first calls).
+ *
+ * If future investigation surfaces additional retryable signals (e.g. a
+ * specific stderr substring from the URL-handler bridge), expand
+ * `isTransientFailure` to recognize them — same shape as the JXA half.
+ */
+function isTransientFailure(result: SpawnResult): boolean {
+  if (result.spawnError !== undefined) return false;
+  return result.timedOut;
+}
+
+/** Telemetry-friendly classification of why a retry fired. */
+function transientReason(result: SpawnResult): "timeout" | "other" {
+  if (result.timedOut) return "timeout";
+  return "other";
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -128,6 +176,13 @@ export interface RunScriptOptions {
   spawner?: ScriptSpawner;
   /** Optional script name for error context (`details.scriptName`). */
   scriptName?: string;
+  /**
+   * Per-call override for the retry-once policy. Production callers omit;
+   * tests pass `{ enabled: false }` to deterministically observe the
+   * first-attempt failure path, or `{ delayMs: 0 }` to skip the backoff
+   * and keep tests fast.
+   */
+  retry?: Partial<RetryPolicy>;
 }
 
 /**
@@ -148,10 +203,45 @@ export async function runOmniJsScript<T = unknown>(
   const timeoutMs = options.timeoutMs ?? 45_000;
   const argsJson = JSON.stringify(args ?? {});
   const scriptName = options.scriptName;
+  const retry = resolveRetryPolicy(options.retry);
 
   const wrapped = wrapOmniJsForJxa(omniJsScriptBody, argsJson);
   const startedAt = performance.now();
-  const result = await spawner(wrapped, argsJson, timeoutMs);
+  let result = await spawner(wrapped, argsJson, timeoutMs);
+
+  // Retry-once on transient failures for read-only scripts (#890; mirrors
+  // the JXA half in #816). Writes and unknown scripts skip retry to avoid
+  // duplicate side effects.
+  const isReadOnly = scriptName !== undefined && READ_ONLY_OMNIJS_SCRIPTS.has(scriptName);
+  const shouldRetry = retry.enabled && isReadOnly && isTransientFailure(result);
+  if (shouldRetry) {
+    const reason = transientReason(result);
+    const retryStartedAt = performance.now();
+    if (retry.delayMs > 0) await sleep(retry.delayMs);
+    const retryResult = await spawner(wrapped, argsJson, timeoutMs);
+    const retryDurationMs = Math.round(performance.now() - retryStartedAt);
+    const retryOutcome: "ok" | "error" =
+      retryResult.spawnError !== undefined ||
+      retryResult.timedOut ||
+      retryResult.exitCode !== 0 ||
+      retryResult.stdout.trim() === ""
+        ? "error"
+        : "ok";
+    logger.info(
+      {
+        event: "transport.retry",
+        transport: "omnijs",
+        scriptName,
+        reason,
+        outcome: retryOutcome,
+        delayMs: retry.delayMs,
+        durationMs: retryDurationMs,
+      },
+      "transport.retry",
+    );
+    result = retryResult;
+  }
+
   const durationMs = Math.round(performance.now() - startedAt);
   const outcome: "ok" | "error" =
     result.spawnError !== undefined ||

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -31,8 +31,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 // `resolveJsonModule` in tsconfig and tsup's bundler both inline the JSON,
 // so this stays a compile-time constant — no runtime fs read.
 import packageJson from "../../package.json" with { type: "json" };
+import { configureRetryPolicy } from "../adapter/_shared/retryPolicy.js";
 import { wrapWithConcurrency } from "../adapter/concurrent.js";
-import { configureRetryPolicy } from "../adapter/jxa/scriptRunner.js";
 import { ReadPool } from "../concurrency/ReadPool.js";
 import { WriteQueue } from "../concurrency/WriteQueue.js";
 import { parseConfig, redactConfig } from "../config/env.js";


### PR DESCRIPTION
## Summary

- Mirrors the JXA retry-once pattern from #816 for the OmniJS scriptRunner
- Extracts `RetryPolicy` + `configureRetryPolicy` into `src/adapter/_shared/retryPolicy.ts` so both transports share the same env-var pair and runtime override
- New `READ_ONLY_OMNIJS_SCRIPTS` allowlist (5 scripts: `forecast_get_tag`, `perspective_evaluate`, `perspective_evaluate_dry_run`, `perspective_get`, `ping`)
- Conservative trigger: hard timeout only (see "Why timeout-only" below)
- Same `transport.retry` event with `transport: "omnijs"`
- 9 new tests + coverage pin
- Net diff: **+295/−26** across 5 files (4 modified + 1 new shared module)

## Design link

Implements [#890 — feat(transport): retry-once on transient OmniJS failures (mirror of #816)](https://github.com/torsday/omnifocus-mcp/issues/890). Mirror PR for [#889](https://github.com/torsday/omnifocus-mcp/pull/889) (the JXA half).

Closes #890

## Breaking change?

- [x] No — JXA `RetryPolicy` and `configureRetryPolicy` are re-exported from the JXA scriptRunner module, so any pre-existing import path (`from "../adapter/jxa/scriptRunner"`) keeps working

## Why timeout-only for OmniJS

The JXA half retries on three signals: hard timeout + stderr matching `-1728`/`-10024`/`-10003`. OmniJS doesn't surface those AppleEvent error codes via `osascript` stderr — the URL-handler bridge swallows them into generic JS exceptions that hit the catch-all `ScriptError` path. Trying to pattern-match those would be fragile and overreach into errors that aren't actually transient.

Hard timeout is still the most common transient on a sluggish runner — that's exactly the failure mode #887 (the integration-tier `task_get` flake) was reporting. So timeout-only retry is a meaningful win even without the broader stderr coverage. Future investigation can expand `isTransientFailure` if a specific OmniJS-side transient signal is identified — same shape as the JXA half.

## AC walk-through

| AC | Status | Where |
|---|---|---|
| `src/adapter/omnijs/scriptRunner.ts` follows the same retry-once-with-backoff pattern as the JXA runner | ✅ | New section under "Retry-once on known-transient failures" |
| `READ_ONLY_OMNIJS_SCRIPTS` allowlist | ✅ | 5 scripts: `forecast_get_tag`, `perspective_evaluate`, `perspective_evaluate_dry_run`, `perspective_get`, `ping`. Coverage pin in test file. |
| Retry triggers on the same OmniJS-equivalent transient signals — at minimum a hard timeout | ✅ | `isTransientFailure` returns true on `result.timedOut`. Stderr-pattern signals deliberately omitted (see "Why timeout-only" above). |
| Reuses the env vars from #816: no new env vars | ✅ | `OMNIFOCUS_TRANSIENT_RETRY_ENABLED` and `OMNIFOCUS_TRANSIENT_RETRY_DELAY_MS` are read once into the shared `defaultRetryPolicy` |
| Emits the same `transport.retry` event with `transport: "omnijs"` | ✅ | Same shape: `{ event, transport, scriptName, reason, outcome, delayMs, durationMs }` |
| Coverage pin test on the read-only set | ✅ | Mirrors the JXA test |
| All existing OmniJS-runner tests pass unchanged | ✅ | 14 existing + 9 new = 23 passing |
| **Recommended approach: shared module** for `configureRetryPolicy` | ✅ | New `src/adapter/_shared/retryPolicy.ts`; both runners import from it. JXA re-exports for backwards compat. |

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3598 passed, +9 over baseline)
- [x] `pnpm vitest run src/adapter/omnijs/scriptRunner.test.ts` — 23/23 pass; `transport.retry` event observed in stderr
- [x] `pnpm vitest run src/adapter/jxa/scriptRunner.test.ts` — JXA half still 36/36 pass (no regression from shared-module refactor)
- [x] Self-reviewed via /review-pr

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Docs are inline (per-runner docblocks in both scriptRunners + the new shared-module docblock)