### PR TITLE
perf(jxa): push filters into whose() in task_list no-filter branch (#893)

### DIFF
--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -275,6 +275,132 @@ describe("JXA sandbox — task_list", () => {
     );
     expect(result.tasks[0]?.completed).toBe(false);
   });
+
+  // -------------------------------------------------------------------------
+  // whose() pushdown coverage (#789 / #893)
+  //
+  // The no-filter branch now pushes pushable predicates (`flagged`,
+  // `completed`, `dueBefore`/`After`, `deferredBefore`/`After`) into
+  // OF's runtime via `flattenedTasks.whose({...})()`. The sandbox honors
+  // the same predicate semantics, so a tighter assertion is possible:
+  // tasks excluded by the predicate should never have their `buildTask`
+  // accessors invoked.
+  // -------------------------------------------------------------------------
+
+  it("pushes flagged: true into whose() — unflagged tasks never have buildTask called", () => {
+    let unflaggedNameCalls = 0;
+    let flaggedNameCalls = 0;
+    const unflagged = fakeTask({
+      flagged: () => false,
+      name: () => {
+        unflaggedNameCalls++;
+        return "task_unflagged";
+      },
+    });
+    const flagged = fakeTask({
+      flagged: () => true,
+      name: () => {
+        flaggedNameCalls++;
+        return "task_flagged";
+      },
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { flagged: boolean }[] }>(
+      taskListScript,
+      { flagged: true },
+      { tasks: [unflagged, flagged] },
+    );
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]?.flagged).toBe(true);
+    // unflagged was filtered by whose() — buildTask never called name()
+    expect(unflaggedNameCalls).toBe(0);
+    // flagged passed the predicate — name() was called by buildTask
+    expect(flaggedNameCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it("pushes completed: false into whose() — completed tasks excluded at the source", () => {
+    let completedNameCalls = 0;
+    const done = fakeTask({
+      completed: () => true,
+      name: () => {
+        completedNameCalls++;
+        return "task_done";
+      },
+    });
+    const open = fakeTask({ completed: () => false, name: () => "task_open" });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskListScript,
+      { completed: false },
+      { tasks: [done, open] },
+    );
+    expect(result.tasks.map((t) => t.name)).toEqual(["task_open"]);
+    expect(completedNameCalls).toBe(0);
+  });
+
+  it("pushes dueDate < dueBefore into whose() — tasks past the bound stay out", () => {
+    const earlier = fakeTask({
+      dueDate: () => new Date("2026-04-01T00:00:00Z"),
+      name: () => "task_earlier",
+    });
+    const later = fakeTask({
+      dueDate: () => new Date("2026-06-01T00:00:00Z"),
+      name: () => "task_later",
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskListScript,
+      { dueBefore: "2026-05-01T00:00:00Z" },
+      { tasks: [earlier, later] },
+    );
+    expect(result.tasks.map((t) => t.name)).toEqual(["task_earlier"]);
+  });
+
+  it("composes multiple predicates: flagged + dueBefore", () => {
+    const a = fakeTask({
+      flagged: () => true,
+      dueDate: () => new Date("2026-04-01T00:00:00Z"),
+      name: () => "task_a",
+    });
+    const b = fakeTask({
+      flagged: () => false,
+      dueDate: () => new Date("2026-04-01T00:00:00Z"),
+      name: () => "task_b",
+    });
+    const c = fakeTask({
+      flagged: () => true,
+      dueDate: () => new Date("2026-06-01T00:00:00Z"),
+      name: () => "task_c",
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskListScript,
+      { flagged: true, dueBefore: "2026-05-01T00:00:00Z" },
+      { tasks: [a, b, c] },
+    );
+    expect(result.tasks.map((t) => t.name)).toEqual(["task_a"]);
+  });
+
+  it("falls back to the full scan when no pushable predicate is provided", () => {
+    // No filter at all — no whose() predicate is built; `flattenedTasks()`
+    // is the source. Confirms the no-filter path still returns everything.
+    const t = fakeTask({ name: () => "task_default" });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskListScript,
+      {},
+      { tasks: [t] },
+    );
+    expect(result.tasks.map((t) => t.name)).toEqual(["task_default"]);
+  });
+
+  it("source-narrowing branches (projectId/tagId/parentId/inbox) are unchanged — no whose() applied", () => {
+    // `inbox: true` uses inboxTasks() — the whose() pushdown branch is not
+    // taken even when filters are present. The post-loop filters still apply.
+    const inboxA = fakeTask({ flagged: () => true, name: () => "inbox_flagged" });
+    const inboxB = fakeTask({ flagged: () => false, name: () => "inbox_unflagged" });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskListScript,
+      { inbox: true, flagged: true },
+      { inboxTasks: [inboxA, inboxB] },
+    );
+    expect(result.tasks.map((t) => t.name)).toEqual(["inbox_flagged"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -10,8 +10,21 @@
  * }
  * Returns JSON: { tasks: Task[] }
  *
+ * Performance: when no source-narrowing branch applies (`projectId` /
+ * `tagId` / `parentId` / `inbox`), the no-filter branch pushes the
+ * boolean and date-range predicates into OF's runtime via `whose({...})`
+ * (#789 / #893; mirrors the 25× speedup pattern from `forecast_get.js`
+ * and `changes_since.js`). On a real-user DB (10k+ tasks) this avoids
+ * materializing the long tail of unrelated tasks. The `try`/`catch`
+ * fallback to a full scan keeps the script correct if OF rejects the
+ * predicate for any reason; the post-loop filters are kept intact as a
+ * safety net and to handle filters that don't push down (`tagId`,
+ * `available`, `blocked`, `completedSince` — all need `buildTask`'s
+ * computed values).
+ *
  * @see src/adapter/jxa/JxaTransport.ts — caller
  * @see src/domain/task.ts — Task domain type
+ * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
@@ -22,6 +35,12 @@ function run(argv) {
 
   // @inline _helpers/build_task.js
   // @inline _helpers/lookup_or_throw.js
+
+  const completedSince = args.completedSince ? new Date(args.completedSince) : null;
+  const dueBefore = args.dueBefore ? new Date(args.dueBefore) : null;
+  const dueAfter = args.dueAfter ? new Date(args.dueAfter) : null;
+  const deferredBefore = args.deferredBefore ? new Date(args.deferredBefore) : null;
+  const deferredAfter = args.deferredAfter ? new Date(args.deferredAfter) : null;
 
   let tasks;
   if (args.inbox) {
@@ -57,14 +76,40 @@ function run(argv) {
     );
     tasks = tag.tasks();
   } else {
-    tasks = ofApp.defaultDocument.flattenedTasks();
+    // No source-narrowing branch — push every pushable predicate into
+    // OF's runtime via whose(). Predicates that don't push down (tag /
+    // available / blocked / completedSince — all need buildTask's
+    // computed values) stay client-side in the loop below.
+    const predicate = {};
+    if (args.flagged !== null && args.flagged !== undefined) {
+      predicate.flagged = args.flagged;
+    }
+    if (args.completed !== null && args.completed !== undefined) {
+      predicate.completed = args.completed;
+    }
+    if (dueBefore !== null || dueAfter !== null) {
+      predicate.dueDate = {};
+      if (dueBefore !== null) predicate.dueDate._lessThan = dueBefore;
+      if (dueAfter !== null) predicate.dueDate._greaterThan = dueAfter;
+    }
+    if (deferredBefore !== null || deferredAfter !== null) {
+      predicate.deferDate = {};
+      if (deferredBefore !== null) predicate.deferDate._lessThan = deferredBefore;
+      if (deferredAfter !== null) predicate.deferDate._greaterThan = deferredAfter;
+    }
+    const hasPushable = Object.keys(predicate).length > 0;
+    if (hasPushable) {
+      try {
+        tasks = ofApp.defaultDocument.flattenedTasks.whose(predicate)();
+      } catch (_e) {
+        // OF rejected the predicate for some reason — fall back to the
+        // full scan so the post-loop filters still produce correct results.
+        tasks = ofApp.defaultDocument.flattenedTasks();
+      }
+    } else {
+      tasks = ofApp.defaultDocument.flattenedTasks();
+    }
   }
-
-  const completedSince = args.completedSince ? new Date(args.completedSince) : null;
-  const dueBefore = args.dueBefore ? new Date(args.dueBefore) : null;
-  const dueAfter = args.dueAfter ? new Date(args.dueAfter) : null;
-  const deferredBefore = args.deferredBefore ? new Date(args.deferredBefore) : null;
-  const deferredAfter = args.deferredAfter ? new Date(args.deferredAfter) : null;
 
   const result = [];
   for (let i = 0; i < tasks.length; i++) {


### PR DESCRIPTION
## Summary

- `task_list.js` no-filter branch now pushes pushable predicates (`flagged`, `completed`, `dueBefore`/`After`, `deferredBefore`/`After`) into OF's runtime via `whose({...})` — mirrors the `forecast_get.js` and `changes_since.js` pattern
- Try/catch fallback to the original full-scan if OF rejects the predicate
- Source-narrowing branches (`projectId`/`tagId`/`parentId`/`inbox`) unchanged — already bounded by their source collection
- `tag`/`available`/`blocked`/`completedSince` stay client-side (need `buildTask`'s computed values; no clean OF predicate)
- Six new sandbox tests pin the pushdown via accessor-count assertions
- Net diff: **+178/−7** across 2 files

## Design link

Implements [#893 — perf(jxa): push filters into whose() in task_list (slice 2 of #789)](https://github.com/torsday/omnifocus-mcp/issues/893). Slice 2 of 4 from the parent #789 audit. Closes #893; remaining slices: [#894](https://github.com/torsday/omnifocus-mcp/issues/894) (perspective_evaluate), [#895](https://github.com/torsday/omnifocus-mcp/issues/895) (task_search).

Closes #893

## Breaking change?

- [x] No — semantically identical; just faster on no-filter list calls

## What pushes down vs stays client-side

| Filter | Pushed into `whose()` | Why |
|---|---|---|
| `flagged` | ✅ | Direct OF property |
| `completed` | ✅ | Direct OF property |
| `dueBefore` | ✅ as `dueDate._lessThan` | Same shape as `forecast_get.js`'s dueToday bucket |
| `dueAfter` | ✅ as `dueDate._greaterThan` | ditto |
| `deferredBefore` | ✅ as `deferDate._lessThan` | Same as forecast_get |
| `deferredAfter` | ✅ as `deferDate._greaterThan` | ditto |
| `tagId` | ❌ client-side | Needs `built.tagIds` from `buildTask` |
| `available` | ❌ client-side | Computed by `buildTask` from blocked + dropped + dates |
| `blocked` | ❌ client-side | Computed by `buildTask` |
| `completedSince` | ❌ client-side | OF whose() support for `completionDate` is uncertain; #789 audit recommended verifying first — deferred to a follow-up if the win materializes |

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3604 passed, +6 over baseline)
- [x] `pnpm vitest run -t "task_list"` — 14/14 pass (8 existing + 6 new pushdown coverage)
- [x] Self-reviewed via /review-pr
- [x] Source-narrowing branches verified by the new "inbox + flagged" test — `inboxTasks()` is the source, no whose() applied, post-loop filter still works
- [ ] Live integration tier — CI's `Integration tests (OmniFocus current)` job covers this

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Public-surface docs unchanged (script behavior is identical; new internal docblock notes the pushdown rationale)