### PR TITLE
perf(jxa): push flagged + forecast filters into whose() in perspective_evaluate (#894)

### DIFF
--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -2816,6 +2816,93 @@ describe("JXA sandbox — perspective_evaluate", () => {
     // the surrounding integration suite, not this unit slice.
     expect(result).toEqual({ tasks: [] });
   });
+
+  // -------------------------------------------------------------------------
+  // whose() pushdown coverage (#789 / #894)
+  //
+  // The `flagged` and `forecast` branches now push their predicates into
+  // OF's runtime via `flattenedTasks.whose({...})()`. The sandbox honors
+  // the same predicate semantics, so the long tail of non-matching tasks
+  // never has its `buildTask` accessors invoked.
+  // -------------------------------------------------------------------------
+
+  it("'flagged' pushes the predicate — non-matching tasks aren't iterated by user code", () => {
+    let unflaggedNameCalls = 0;
+    const unflagged = fakeTask({
+      flagged: () => false,
+      completed: () => false,
+      dropped: () => false,
+      name: () => {
+        unflaggedNameCalls++;
+        return "unflagged";
+      },
+    });
+    const flagged = fakeTask({
+      id: () => "task_match",
+      flagged: () => true,
+      completed: () => false,
+      dropped: () => false,
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "flagged" },
+      { tasks: [unflagged, flagged] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_match"]);
+    // unflagged was filtered out by whose() — buildTask never read its name
+    expect(unflaggedNameCalls).toBe(0);
+  });
+
+  it("'flagged' excludes completed/dropped via whose()", () => {
+    const completedFlagged = fakeTask({
+      flagged: () => true,
+      completed: () => true,
+      name: () => "completed",
+    });
+    const droppedFlagged = fakeTask({
+      flagged: () => true,
+      dropped: () => true,
+      name: () => "dropped",
+    });
+    const active = fakeTask({
+      id: () => "task_active",
+      flagged: () => true,
+      completed: () => false,
+      dropped: () => false,
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "flagged" },
+      { tasks: [completedFlagged, droppedFlagged, active] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_active"]);
+  });
+
+  it("'forecast' pushes dueDate <= endOfDay into whose() — future tasks aren't iterated", () => {
+    let futureNameCalls = 0;
+    const future = fakeTask({
+      dueDate: () => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      completed: () => false,
+      dropped: () => false,
+      name: () => {
+        futureNameCalls++;
+        return "future";
+      },
+    });
+    const past = fakeTask({
+      id: () => "task_past",
+      dueDate: () => new Date(Date.now() - 24 * 60 * 60 * 1000),
+      completed: () => false,
+      dropped: () => false,
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "forecast" },
+      { tasks: [future, past] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_past"]);
+    expect(futureNameCalls).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/jxa/perspective_evaluate.js
+++ b/src/scripts/jxa/perspective_evaluate.js
@@ -4,8 +4,22 @@
  * Args (argv[0] JSON): { "perspectiveId": "inbox" | "projects" | "tags" | "forecast" | "flagged" | "nearby" | "review" }
  * Returns JSON: { tasks: Task[] }
  *
+ * Performance: the `flagged` and `forecast` branches push their predicates
+ * into OF's runtime via `whose({...})` (#789 / #894), mirroring the
+ * `forecast_get.js` 25× speedup pattern. Try/catch fallback to the
+ * full-scan keeps results correct on whose() rejection.
+ *
+ * The `projects` and `tags` branches still scan `flattenedTasks()` because
+ * their predicates ("has a containingProject" / "has at least one tag")
+ * don't translate to whose() — OF's whose() rejects `_isnt: null`
+ * (documented in `forecast_get.js`'s comment block) and there's no clean
+ * cardinality predicate. Source-collection rethink (e.g. iterating
+ * `flattenedProjects()` per project, or `flattenedTags().tasks()` per
+ * tag) is tracked separately — see #894's follow-up.
+ *
  * @see src/adapter/jxa/JxaTransport.ts — caller
  * @see src/domain/task.ts — Task domain type
+ * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
@@ -23,6 +37,17 @@ function run(argv) {
 
     // @inline _helpers/build_task.js
 
+    // whose() pushdown helper — try the predicate, fall back to a full
+    // scan on rejection so the post-loop guard still produces correct
+    // results.
+    function tasksMatching(predicate) {
+      try {
+        return ofApp.defaultDocument.flattenedTasks.whose(predicate)();
+      } catch (_e) {
+        return ofApp.flattenedTasks();
+      }
+    }
+
     const result = [];
 
     if (perspectiveId === "inbox") {
@@ -32,22 +57,30 @@ function run(argv) {
         result.push(buildTask(inboxTasks[i]));
       }
     } else if (perspectiveId === "flagged") {
-      // Flagged: flagged tasks that are not completed/dropped
-      const allTasks = ofApp.flattenedTasks();
-      for (let i = 0; i < allTasks.length; i++) {
-        const t = allTasks[i];
+      // Flagged: flagged tasks that are not completed/dropped — pushed into
+      // whose() so the long tail of unflagged tasks is never iterated.
+      const matches = tasksMatching({ flagged: true, completed: false, dropped: false });
+      for (let i = 0; i < matches.length; i++) {
+        const t = matches[i];
         const built = buildTask(t);
+        // Post-loop guard kept as a safety net in case whose() silently
+        // falls back to client-side matching for a given operator.
         if (built.flagged && !built.completed && !built.dropped) {
           result.push(built);
         }
       }
     } else if (perspectiveId === "forecast") {
-      // Forecast: tasks with dueDate <= end of today and not completed/dropped
+      // Forecast: tasks with dueDate <= end of today and not completed/dropped.
+      // The dueDate predicate naturally excludes tasks with no dueDate.
       const now = new Date();
       const endOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
-      const allTasks = ofApp.flattenedTasks();
-      for (let i = 0; i < allTasks.length; i++) {
-        const t = allTasks[i];
+      const matches = tasksMatching({
+        completed: false,
+        dropped: false,
+        dueDate: { _lessThanEquals: endOfDay },
+      });
+      for (let i = 0; i < matches.length; i++) {
+        const t = matches[i];
         const built = buildTask(t);
         if (built.dueDate && !built.completed && !built.dropped) {
           const due = new Date(built.dueDate);
@@ -57,7 +90,10 @@ function run(argv) {
         }
       }
     } else if (perspectiveId === "projects") {
-      // Projects: top-level tasks of active projects (not completed/dropped)
+      // Projects: top-level tasks of active projects (not completed/dropped).
+      // No clean whose() predicate — `containingProject` is not nullable
+      // through OF's whose() (rejects _isnt: null). Stays a full scan;
+      // see #894's follow-up for source-collection rethink.
       const allTasks = ofApp.flattenedTasks();
       for (let i = 0; i < allTasks.length; i++) {
         const t = allTasks[i];
@@ -67,7 +103,9 @@ function run(argv) {
         }
       }
     } else if (perspectiveId === "tags") {
-      // Tags: tasks that have at least one tag and are not completed/dropped
+      // Tags: tasks that have at least one tag and are not completed/dropped.
+      // Same constraint as `projects` — no clean cardinality predicate via
+      // whose(). Stays a full scan; see #894's follow-up.
       const allTasks = ofApp.flattenedTasks();
       for (let i = 0; i < allTasks.length; i++) {
         const t = allTasks[i];


### PR DESCRIPTION
## Summary

- `perspective_evaluate.js` `flagged` and `forecast` branches now push their predicates into OF's runtime via `whose({...})` (mirrors `forecast_get.js` / `task_list.js` / `changes_since.js` pattern from #789)
- Small `tasksMatching(predicate)` helper wraps whose() with try/catch fallback to `flattenedTasks()` for safety
- Post-loop guards retained as a defense against silent client-side fallback
- 3 new sandbox tests pin the pushdown via accessor-count assertions — non-matching tasks (e.g. unflagged tasks for the `flagged` branch) have their `name()` accessors verified zero-called
- Net diff: **+135/−10** across 2 files

## Design link

Implements [#894 — perf(jxa): push filters into whose() in perspective_evaluate (slice 3 of #789)](https://github.com/torsday/omnifocus-mcp/issues/894). Slice 3a of 4 from the parent #789 audit. Closes #894 with a follow-up filed for the remaining `projects` + `tags` branches.

Closes #894

## Breaking change?

- [x] No — semantically identical; just faster on `flagged`/`forecast` perspectives

## What's NOT in this PR (intentional)

The `projects` and `tags` branches **stay full-scan** in this PR. Their predicates don't translate to OF's `whose()`:

- **`projects`** needs `containingProject !== null` — OF's `whose()` rejects `_isnt: null` ([documented in `forecast_get.js`'s comment block from #500](https://github.com/torsday/omnifocus-mcp/blob/main/src/scripts/jxa/forecast_get.js))
- **`tags`** needs `tagCount > 0` — no clean cardinality predicate via `whose()`

The right fix for both is a **source-collection rethink** (iterating `flattenedProjects()` / `flattenedTags().tasks()` instead of `flattenedTasks()`). That's a tighter, more focused change than this PR — filed as **[#899](https://github.com/torsday/omnifocus-mcp/issues/899)** with concrete AC for each branch.

So #789's audit lands as four shipped slices:
- ✅ Slice 1: `changes_since` (#896)
- ✅ Slice 2: `task_list` (#898)
- ✅ Slice 3a: `flagged` + `forecast` branches of `perspective_evaluate` (this PR)
- ⏳ Slice 3b: `projects` + `tags` branches of `perspective_evaluate` (#899)
- ⏳ Slice 4: `task_search` (#895)

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3607 passed, +3 over baseline)
- [x] `pnpm vitest run -t "perspective_evaluate"` — 8/8 pass (5 existing + 3 new pushdown coverage)
- [x] Self-reviewed via /review-pr
- [ ] Live integration tier — CI's `Integration tests (OmniFocus current)` covers this

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Public-surface docs unchanged (script behavior is identical; new internal docblock notes the pushdown rationale and the deferred branches)
