### PR TITLE
perf(jxa): push flagged + completed + dueDate filters into whose() in task_search (#895)

### DIFF
--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -1377,6 +1377,130 @@ describe("JXA sandbox — task_search", () => {
       ),
     ).toThrow("Project not found: missing");
   });
+
+  // -------------------------------------------------------------------------
+  // whose() pushdown coverage (#789 / #895)
+  //
+  // Without `projectId`, the script now pushes pushable predicates
+  // (`flagged`, `completed` from "exclude"/"only", `dueDate` range) into
+  // OF's runtime via `flattenedTasks.whose({...})()`. Tag, available, and
+  // text-search predicates stay client-side — they need `buildTask`'s
+  // computed values.
+  // -------------------------------------------------------------------------
+
+  it("pushes flagged: true into whose() — unflagged tasks aren't iterated", () => {
+    let unflaggedNameCalls = 0;
+    const unflagged = fakeTask({
+      flagged: () => false,
+      completed: () => false,
+      name: () => {
+        unflaggedNameCalls++;
+        return "unflagged";
+      },
+    });
+    const flagged = fakeTask({
+      id: () => "task_match",
+      flagged: () => true,
+      completed: () => false,
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      { flagged: true },
+      { tasks: [unflagged, flagged] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_match"]);
+    expect(unflaggedNameCalls).toBe(0);
+  });
+
+  it("pushes completed: false (the default 'exclude' mapping) into whose()", () => {
+    let doneNameCalls = 0;
+    const done = fakeTask({
+      completed: () => true,
+      name: () => {
+        doneNameCalls++;
+        return "done";
+      },
+    });
+    const open = fakeTask({ id: () => "task_open", completed: () => false });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      {}, // no completed arg → default "exclude" → whose({completed: false})
+      { tasks: [done, open] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_open"]);
+    expect(doneNameCalls).toBe(0);
+  });
+
+  it("pushes completed: true when completed='only'", () => {
+    let openNameCalls = 0;
+    const open = fakeTask({
+      completed: () => false,
+      name: () => {
+        openNameCalls++;
+        return "open";
+      },
+    });
+    const done = fakeTask({ id: () => "task_done", completed: () => true });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      { completed: "only" },
+      { tasks: [done, open] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_done"]);
+    expect(openNameCalls).toBe(0);
+  });
+
+  it("composes flagged + dueBefore into a single whose() — multi-predicate path", () => {
+    const a = fakeTask({
+      flagged: () => true,
+      completed: () => false,
+      dueDate: () => new Date("2026-04-01T00:00:00Z"),
+      name: () => "task_a",
+    });
+    const b = fakeTask({
+      flagged: () => false,
+      completed: () => false,
+      dueDate: () => new Date("2026-04-01T00:00:00Z"),
+      name: () => "task_b",
+    });
+    const c = fakeTask({
+      flagged: () => true,
+      completed: () => false,
+      dueDate: () => new Date("2026-06-01T00:00:00Z"),
+      name: () => "task_c",
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { name: string }[] }>(
+      taskSearchScript,
+      { flagged: true, dueBefore: "2026-05-01T00:00:00Z" },
+      { tasks: [a, b, c] },
+    );
+    expect(result.tasks.map((t) => t.name)).toEqual(["task_a"]);
+  });
+
+  it("projectId branch source-narrows — no whose() applied to flattenedTasks", () => {
+    // When projectId is provided, the source is proj.flattenedTasks() and
+    // the whose() pushdown branch is not taken. Filters apply post-loop.
+    const projTask = fakeTask({
+      id: () => "in_proj",
+      flagged: () => true,
+      completed: () => false,
+    });
+    const otherTask = fakeTask({
+      id: () => "not_in_proj",
+      flagged: () => true,
+      completed: () => false,
+    });
+    const proj = fakeProject({
+      id: () => "p1",
+      flattenedTasks: () => [projTask],
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      taskSearchScript,
+      { projectId: "p1", flagged: true },
+      { projects: [proj], tasks: [otherTask] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["in_proj"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -14,8 +14,18 @@
  * }
  * Returns JSON: { tasks: Task[] }
  *
+ * Performance: when no `projectId` is provided, the script pushes
+ * `flagged` / `completed` / `dueDate` predicates into OF's runtime via
+ * `whose({...})` (#789 / #895; mirrors the `forecast_get.js` pattern).
+ * Tag, available, and text-search predicates stay client-side because
+ * they need `buildTask`'s computed values. The text-search `_contains`
+ * pushdown is intentionally skipped for v1 — `_contains` support in OF
+ * 4.x's whose() is unverified; landing it would need a hands-on test
+ * against live OF that's outside this loop. See the parent #789 audit.
+ *
  * @see src/adapter/jxa/JxaTransport.ts — searchTasks() caller
  * @see src/domain/task.ts — Task domain type
+ * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
@@ -40,6 +50,9 @@ function run(argv) {
 
   let tasks;
   if (args.projectId) {
+    // Source-narrowed: project's own tasks. The whose() pushdown still
+    // applies but we'd need to attach it to proj.flattenedTasks — skip
+    // for v1 since the project scope is already bounded.
     const proj = lookupOrThrow(
       ofApp.defaultDocument.flattenedProjects.byId(args.projectId),
       "Project",
@@ -47,11 +60,40 @@ function run(argv) {
     );
     tasks = proj.flattenedTasks();
   } else {
-    tasks = ofApp.defaultDocument.flattenedTasks();
+    // No source-narrowing — push pushable predicates into whose() so the
+    // long tail of non-matching tasks is never iterated.
+    const predicate = {};
+    if (args.flagged !== null && args.flagged !== undefined) {
+      predicate.flagged = args.flagged;
+    }
+    if (completed === "exclude") {
+      predicate.completed = false;
+    } else if (completed === "only") {
+      predicate.completed = true;
+    }
+    // "any" passes through — no completed predicate.
+    if (dueBefore !== null || dueAfter !== null) {
+      predicate.dueDate = {};
+      if (dueBefore !== null) predicate.dueDate._lessThan = dueBefore;
+      if (dueAfter !== null) predicate.dueDate._greaterThan = dueAfter;
+    }
+    const hasPushable = Object.keys(predicate).length > 0;
+    if (hasPushable) {
+      try {
+        tasks = ofApp.defaultDocument.flattenedTasks.whose(predicate)();
+      } catch (_e) {
+        // OF rejected the predicate — fall back to the full scan so the
+        // post-loop filters still produce correct results.
+        tasks = ofApp.defaultDocument.flattenedTasks();
+      }
+    } else {
+      tasks = ofApp.defaultDocument.flattenedTasks();
+    }
   }
 
   // ---------------------------------------------------------------------------
-  // Filter
+  // Filter (post-loop guards — defensive against whose() partial coverage,
+  // and required for predicates that didn't push down: tag, available, q)
   // ---------------------------------------------------------------------------
 
   const result = [];


### PR DESCRIPTION
## Summary

- `task_search.js` no-`projectId` branch pushes `flagged` / `completed` / `dueDate` predicates into OF's runtime via `whose({...})` (mirrors `task_list.js` from #893)
- `completed` mapping: `"exclude"` → `whose({completed: false})`, `"only"` → `whose({completed: true})`, `"any"` → omit (passes through both)
- Try/catch fallback to the original full-scan if OF rejects the predicate
- Text-search `_contains` pushdown intentionally **deferred** — needs hands-on verification with live OF (see "What's NOT in this PR" below)
- 5 new sandbox tests pin the pushdown via accessor-count assertions; 6 existing tests pass unchanged
- Net diff: **+168/−2** across 2 files

## Design link

Implements [#895 — perf(jxa): push filters into whose() in task_search (slice 4 of #789)](https://github.com/torsday/omnifocus-mcp/issues/895). **Completes the four-slice #789 audit:**

| Slice | Issue | PR |
|---|---|---|
| 1 — `changes_since` | #789 | #896 ✅ |
| 2 — `task_list` | #893 | #898 ✅ |
| 3a — `perspective_evaluate` (flagged + forecast) | #894 | #900 ✅ |
| 3b — `perspective_evaluate` (projects + tags) | #899 | ⏳ |
| 4 — `task_search` | #895 | this PR ✅ |

Closes #895

## Breaking change?

- [x] No — semantically identical; just faster on no-projectId search paths

## What's NOT in this PR (deliberate)

- **`name { _contains: q }` pushdown** — uncertain whether OF 4.x's whose() actually pushes `_contains` down to the runtime or silently falls back to client-side iteration. Verifying needs hands-on testing against live OF (enable `transport.call` debug logs, run a fixture-DB search, compare the script duration). That work is outside the `/ship-next` loop's tier — file a focused issue if the verification matters.
- **whose() on `proj.flattenedTasks()`** in the `projectId` branch — already source-narrowed; the win there would be smaller and the JXA collection semantics for `whose()` on a project-scoped collection deserve their own check. Out of scope for #789's parent audit.

## What pushes down vs stays client-side

| Filter | Pushed | Why |
|---|---|---|
| `flagged` | ✅ | Direct OF property |
| `completed` ("exclude"/"only") | ✅ | Direct OF property; mapped to `false`/`true` |
| `dueBefore` | ✅ as `dueDate._lessThan` | Same shape as `forecast_get.js`'s buckets |
| `dueAfter` | ✅ as `dueDate._greaterThan` | ditto |
| `available` | ❌ client-side | Computed by `buildTask` from blocked + dropped + dates |
| `tagIds[]` | ❌ client-side | Set membership; small-cardinality |
| `q` (text search) | ❌ client-side | `_contains` pushdown deferred (see above) |

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3612 passed, +5 over baseline)
- [x] `pnpm vitest run -t "task_search"` — 11/11 pass (6 existing + 5 new pushdown coverage)
- [x] Self-reviewed via /review-pr
- [ ] Live integration tier — CI's `Integration tests (OmniFocus current)` covers this

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Public-surface docs unchanged