### PR TITLE
chore(security): audit and extend pino redaction coverage with canary test (#842)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -94,6 +94,37 @@ The `adapter/router.ts` and `src/server/composition.ts` are the only permitted w
 
 ---
 
+### 7. PII redaction in structured logs
+
+**Risk:** OmniFocus task names and notes routinely contain user-sensitive content (passwords, addresses, financial data). If any of that reaches `pino`'s structured-log output — stderr today, an opt-in JSONL disk sink in the future ([#823](https://github.com/torsday/omnifocus-mcp/issues/823)) — it persists outside the user's control.
+
+**Mitigations:**
+
+- `pino`'s `redact.paths` censors PII at every log level (debug, info, warn, error). The `info` / `debug` distinction is purely a *visibility threshold for whether the event emits*, **not** a toggle for whether the field is censored.
+- Redaction paths cover every shape we ship that can carry user content:
+  - **Direct fields:** `name`, `note`, `noteHtml`, `tagNames`, `tagNames[*]`, plus one-level wildcards (`*.name`, `*.note`, etc.) and `data.*` envelope variants.
+  - **Domain arrays:** `tasks[*]`, `projects[*]`, `tags[*]`, `folders[*]`, `attachments[*]` at top-level AND under `data.*`.
+  - **Forecast buckets:** `data.overdue[*]`, `data.dueToday[*]`, `data.deferredToday[*]`, `data.flagged[*]`, `data.inbox[*]`.
+  - **Single-object wrappers:** `data.task.*`, `data.project.*`, `data.tag.*`, `data.folder.*`, `data.attachment.*`.
+  - **Attachment-specific:** `attachments[*].name` AND `attachments[*].path` (filenames can leak intent).
+  - **Error / details surfaces:** `details.input.*`, `err.details.input.*` for `name` / `note` / `noteHtml` / `destPath` — covers user inputs echoed back in validation errors.
+
+**Explicitly NOT redacted** (visible in logs by design):
+- **IDs** (`id`, `projectId`, `tagIds[*]`, `folderId`) — opaque OmniFocus identifiers; useful for correlation, no PII.
+- **Booleans** (`completed`, `flagged`, `dropped`, `available`, `blocked`, `sequential`).
+- **Dates** (`dueDate`, `deferDate`, `completedAt`, `modificationDate`).
+- **Status enums** (`status: "active"`, `nextReviewDate`).
+- **Counts** (`tasks.length`, `cache.hitRate`).
+- **Internal meta** (`correlationId`, `transport`, `durationMs`, `cacheHit`, `syncPending`).
+
+**Test coverage:** `src/logging/logger.test.ts` § "PII redaction canary (#842)" — a synthetic record mirrors every shape we ship with each PII leaf assigned a unique `CANARY_*_PASSWORD_S3CR3T_xyz` sentinel. The test logs the record at info / warn / error / debug levels and fails if any sentinel reaches output. New shapes need an entry in both the canary fixture AND a path in `PII_REDACT_PATHS` — the test surfaces either gap.
+
+**Limitations:**
+- Pino's `redact.paths` (via `fast-redact`) does not support a deep wildcard. Every nested-array shape is enumerated explicitly. New shapes that surface in `data.*` need a corresponding path; the canary test catches additions that miss it.
+- Stringified payloads (e.g. `details.stderr` from a JXA failure that included a task name in its error) are NOT path-redacted. The OF stderr surfaces are best-effort: `stderr` is truncated to 512–1024 bytes in the typed errors, but a user note appearing inside a stderr message would survive that truncation if short enough. Future work: regex-scrub `*.stderr` before logging if cases surface.
+
+---
+
 ## Lint gate
 
 All custom rules are enforced via `scripts/lint-custom.ts`. Run locally:

--- a/src/logging/logger.test.ts
+++ b/src/logging/logger.test.ts
@@ -1,7 +1,7 @@
 import { Writable } from "node:stream";
 import pino from "pino";
 import { describe, expect, it } from "vitest";
-import { createLogger, logger, setLogLevel } from "./logger.js";
+import { createLogger, logger, REDACTION_PATHS_FOR_TESTS, setLogLevel } from "./logger.js";
 
 /** Capture pino output into parsed JSON lines. */
 function captureLogger(level: string, redactPaths?: string[]) {
@@ -124,5 +124,167 @@ describe("setLogLevel", () => {
     expect(logger.level).toBe("warn");
     setLogLevel(original);
     expect(logger.level).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redaction canary (#842)
+//
+// A synthetic record mirrors every shape that can carry user-content PII
+// (task / project / tag / folder / attachment, top-level + `data.*` +
+// forecast buckets + error-details). Each leaf value is a unique sentinel
+// string. After logging, the JSON output is searched for any sentinel —
+// any leak fails the test. New shapes need an entry here AND a path in
+// `PII_REDACT_PATHS`; the test will surface either gap.
+// ---------------------------------------------------------------------------
+
+describe("PII redaction canary (#842)", () => {
+  function makeCanaryPayload() {
+    const T = (k: string) => `CANARY_${k}_PASSWORD_S3CR3T_xyz`;
+    return {
+      event: "canary",
+      // 1. Direct
+      name: T("name"),
+      note: T("note"),
+      noteHtml: T("noteHtml"),
+      tagNames: [T("tagNames_0"), T("tagNames_1")],
+      meta: { name: T("meta_name"), note: T("meta_note") },
+      // 2. Domain arrays at top
+      tasks: [
+        {
+          id: "t1",
+          name: T("tasks_0_name"),
+          note: T("tasks_0_note"),
+          noteHtml: T("tasks_0_noteHtml"),
+          tagNames: [T("tasks_0_tagNames_0")],
+        },
+      ],
+      projects: [{ id: "p1", name: T("projects_0_name"), note: T("projects_0_note") }],
+      tags: [{ id: "tg1", name: T("tags_0_name") }],
+      folders: [{ id: "f1", name: T("folders_0_name") }],
+      attachments: [{ id: "a1", name: T("attachments_0_name"), path: T("attachments_0_path") }],
+      // 3. Envelope path
+      data: {
+        name: T("data_name"),
+        note: T("data_note"),
+        noteHtml: T("data_noteHtml"),
+        tagNames: [T("data_tagNames_0")],
+        tasks: [
+          {
+            id: "dt1",
+            name: T("data_tasks_0_name"),
+            note: T("data_tasks_0_note"),
+            noteHtml: T("data_tasks_0_noteHtml"),
+            tagNames: [T("data_tasks_0_tagNames_0")],
+          },
+        ],
+        projects: [{ id: "dp1", name: T("data_projects_0_name"), note: T("data_projects_0_note") }],
+        tags: [{ id: "dtg1", name: T("data_tags_0_name") }],
+        folders: [{ id: "df1", name: T("data_folders_0_name") }],
+        attachments: [
+          { id: "da1", name: T("data_attachments_0_name"), path: T("data_attachments_0_path") },
+        ],
+        // Forecast buckets
+        overdue: [
+          {
+            id: "o1",
+            name: T("overdue_0_name"),
+            note: T("overdue_0_note"),
+            tagNames: [T("overdue_0_tagNames_0")],
+          },
+        ],
+        dueToday: [
+          {
+            id: "dd1",
+            name: T("dueToday_0_name"),
+            note: T("dueToday_0_note"),
+            tagNames: [T("dueToday_0_tagNames_0")],
+          },
+        ],
+        deferredToday: [
+          { id: "dt2", name: T("deferredToday_0_name"), note: T("deferredToday_0_note") },
+        ],
+        flagged: [{ id: "fg1", name: T("flagged_0_name"), note: T("flagged_0_note") }],
+        inbox: [{ id: "ib1", name: T("inbox_0_name"), note: T("inbox_0_note") }],
+        // Single-object wrappers
+        task: {
+          id: "stk",
+          name: T("data_task_name"),
+          note: T("data_task_note"),
+          noteHtml: T("data_task_noteHtml"),
+          tagNames: [T("data_task_tagNames_0")],
+        },
+        project: { id: "sp", name: T("data_project_name"), note: T("data_project_note") },
+        tag: { id: "stg", name: T("data_tag_name") },
+        folder: { id: "sf", name: T("data_folder_name") },
+        attachment: { id: "sa", name: T("data_attachment_name"), path: T("data_attachment_path") },
+      },
+      // 5. Error / details
+      details: {
+        input: {
+          name: T("details_input_name"),
+          note: T("details_input_note"),
+          noteHtml: T("details_input_noteHtml"),
+          tagNames: [T("details_input_tagNames_0")],
+          destPath: T("details_input_destPath"),
+        },
+      },
+      err: {
+        details: {
+          input: {
+            name: T("err_details_input_name"),
+            note: T("err_details_input_note"),
+            noteHtml: T("err_details_input_noteHtml"),
+            destPath: T("err_details_input_destPath"),
+          },
+        },
+      },
+    };
+  }
+
+  it("never lets a CANARY_* sentinel reach output across info, warn, error", () => {
+    const { log, lines } = captureLogger("info", REDACTION_PATHS_FOR_TESTS as string[]);
+    const payload = makeCanaryPayload();
+    log.info(payload, "canary-info");
+    log.warn(payload, "canary-warn");
+    log.error(payload, "canary-error");
+    const raw = JSON.stringify(lines());
+    const leaks = raw.match(/CANARY_[A-Za-z0-9_]+_PASSWORD_S3CR3T_xyz/g) ?? [];
+    expect(leaks).toEqual([]);
+  });
+
+  it("redacts at debug level too — pino redacts pre-emit regardless of level", () => {
+    const { log, lines } = captureLogger("debug", REDACTION_PATHS_FOR_TESTS as string[]);
+    log.debug(makeCanaryPayload(), "canary-debug");
+    const raw = JSON.stringify(lines());
+    const leaks = raw.match(/CANARY_[A-Za-z0-9_]+_PASSWORD_S3CR3T_xyz/g) ?? [];
+    expect(leaks).toEqual([]);
+  });
+
+  it("non-PII fields (IDs, booleans, dates) are NOT redacted", () => {
+    // Confirms the redactor isn't over-broad — IDs, status values, and
+    // dates stay visible so logs remain useful for debugging.
+    const { log, lines } = captureLogger("info", REDACTION_PATHS_FOR_TESTS as string[]);
+    log.info(
+      {
+        event: "non-pii",
+        data: {
+          task: {
+            id: "task_123",
+            completed: false,
+            dueDate: "2026-05-10T00:00:00Z",
+            projectId: "proj_456",
+          },
+        },
+      },
+      "non-pii",
+    );
+    const entry = lines()[0] as Record<string, unknown>;
+    const data = entry.data as Record<string, unknown>;
+    const task = data.task as Record<string, unknown>;
+    expect(task.id).toBe("task_123");
+    expect(task.completed).toBe(false);
+    expect(task.dueDate).toBe("2026-05-10T00:00:00Z");
+    expect(task.projectId).toBe("proj_456");
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -4,39 +4,148 @@
  * Writes compact JSON lines to stderr. Never touches stdout — MCP uses stdio
  * transport and any stray stdout byte corrupts the protocol.
  *
- * PII fields (task name, note, noteHtml, tagNames) are redacted at `info` and
- * above. They are visible only at `debug` or below — see DESIGN §21.
+ * PII fields (task name, note, noteHtml, tagNames, attachment names/paths)
+ * are redacted at every level — pino applies the redactor before writing
+ * regardless of `level`, so the `info` / `debug` distinction is purely a
+ * visibility threshold for *whether* the event emits, not for *whether*
+ * the field is censored. See `docs/security.md` § "PII redaction model"
+ * for the full taxonomy and `tests/logging/redactionCanary.test.ts`-style
+ * canary in `logger.test.ts` for the regression bar.
  *
  * Log level is controlled by `OMNIFOCUS_LOG_LEVEL` (default `info`).
  *
  * @see DESIGN.md §21 — observability contract
+ * @see docs/security.md — PII redaction model
  */
 
 import pino from "pino";
 
 // ---------------------------------------------------------------------------
-// PII redaction paths — applied at info+ per DESIGN §21
+// PII redaction paths — applied at every level (#842 audit + extension)
 // ---------------------------------------------------------------------------
 
 /**
- * Pino redaction paths covering all PII fields defined in DESIGN §21.
- * Covers both top-level and nested occurrences (e.g. inside `data` objects).
+ * Pino redaction paths covering every shape that can carry user-content
+ * PII when an event payload includes domain objects.
+ *
+ * Path semantics (per fast-redact):
+ * - `name` matches the top-level `name` key
+ * - `*.name` matches one level deep (e.g. `meta.name`, `data.name`)
+ * - `arr[*].name` matches every element of `arr`'s `name`
+ * - There is **no** `**` deep wildcard — every nested-array shape we ship
+ *   is enumerated below. New shapes that surface in `data.*` need an
+ *   explicit entry; the canary test in `logger.test.ts` will fail loud
+ *   if a new array path introduces an unredacted leak.
+ *
+ * Coverage classes:
+ * 1. **Direct** — top-level + one-level wildcard for ad-hoc payloads
+ * 2. **Per-domain arrays** — `tasks[*]`, `projects[*]`, `tags[*]`,
+ *    `folders[*]`, `attachments[*]` under both top-level and `data.*`
+ * 3. **Forecast buckets** — `data.overdue[*]`, `data.dueToday[*]`,
+ *    `data.deferredToday[*]`, `data.flagged[*]`, `data.inbox[*]`
+ * 4. **Single-object wrappers** — `data.task.name`, `data.project.name`, etc.
+ * 5. **Attachment-specific** — name + path (filename can leak intent)
+ *
+ * Anything explicitly NOT redacted (IDs, dates, booleans, status enums)
+ * is documented in `docs/security.md` with rationale.
  */
 const PII_REDACT_PATHS = [
+  // 1. Direct
   "name",
   "note",
   "noteHtml",
   "tagNames",
   "tagNames[*]",
+  "*.name",
+  "*.note",
+  "*.noteHtml",
+  "*.tagNames",
   "data.name",
   "data.note",
   "data.noteHtml",
   "data.tagNames",
   "data.tagNames[*]",
-  "*.name",
-  "*.note",
-  "*.noteHtml",
-  "*.tagNames",
+
+  // 2. Per-domain arrays (top-level — when tools return raw collections)
+  "tasks[*].name",
+  "tasks[*].note",
+  "tasks[*].noteHtml",
+  "tasks[*].tagNames",
+  "tasks[*].tagNames[*]",
+  "projects[*].name",
+  "projects[*].note",
+  "projects[*].noteHtml",
+  "tags[*].name",
+  "folders[*].name",
+  "attachments[*].name",
+  "attachments[*].path",
+
+  // 2'. Per-domain arrays under `data.*` — the envelope path
+  "data.tasks[*].name",
+  "data.tasks[*].note",
+  "data.tasks[*].noteHtml",
+  "data.tasks[*].tagNames",
+  "data.tasks[*].tagNames[*]",
+  "data.projects[*].name",
+  "data.projects[*].note",
+  "data.projects[*].noteHtml",
+  "data.tags[*].name",
+  "data.folders[*].name",
+  "data.attachments[*].name",
+  "data.attachments[*].path",
+
+  // 3. Forecast buckets — same shape as tasks[*]
+  "data.overdue[*].name",
+  "data.overdue[*].note",
+  "data.overdue[*].noteHtml",
+  "data.overdue[*].tagNames",
+  "data.overdue[*].tagNames[*]",
+  "data.dueToday[*].name",
+  "data.dueToday[*].note",
+  "data.dueToday[*].noteHtml",
+  "data.dueToday[*].tagNames",
+  "data.dueToday[*].tagNames[*]",
+  "data.deferredToday[*].name",
+  "data.deferredToday[*].note",
+  "data.deferredToday[*].noteHtml",
+  "data.deferredToday[*].tagNames",
+  "data.deferredToday[*].tagNames[*]",
+  "data.flagged[*].name",
+  "data.flagged[*].note",
+  "data.flagged[*].noteHtml",
+  "data.flagged[*].tagNames",
+  "data.flagged[*].tagNames[*]",
+  "data.inbox[*].name",
+  "data.inbox[*].note",
+  "data.inbox[*].noteHtml",
+  "data.inbox[*].tagNames",
+
+  // 4. Single-object wrappers (`{ task: ... }`, `{ project: ... }`, etc.)
+  "data.task.name",
+  "data.task.note",
+  "data.task.noteHtml",
+  "data.task.tagNames",
+  "data.task.tagNames[*]",
+  "data.project.name",
+  "data.project.note",
+  "data.project.noteHtml",
+  "data.tag.name",
+  "data.folder.name",
+  "data.attachment.name",
+  "data.attachment.path",
+
+  // 5. Common error / details surfaces
+  // Error envelopes carry user input verbatim under `details.input` for
+  // diagnostics — redact the input shapes most likely to be PII.
+  "details.input.name",
+  "details.input.note",
+  "details.input.noteHtml",
+  "details.input.tagNames",
+  "details.input.destPath",
+  "err.details.input.name",
+  "err.details.input.note",
+  "err.details.input.noteHtml",
+  "err.details.input.destPath",
 ];
 
 // ---------------------------------------------------------------------------
@@ -83,3 +192,10 @@ export const logger: pino.Logger = createLogger(process.env.OMNIFOCUS_LOG_LEVEL 
 export function setLogLevel(level: string): void {
   logger.level = level;
 }
+
+/**
+ * Exported for tests that need to assert the redaction surface (canary
+ * tests, future audit passes). Production callers should never read this
+ * directly — it's internal to `createLogger`.
+ */
+export const REDACTION_PATHS_FOR_TESTS: readonly string[] = PII_REDACT_PATHS;


### PR DESCRIPTION
## Summary

- **Audit + extension** of `pino`'s `redact.paths` to cover every shape that can carry user-content PII: domain arrays (`tasks[*]`, `projects[*]`, `tags[*]`, `folders[*]`, `attachments[*]`) at top-level AND under `data.*`, forecast buckets (`data.overdue[*]`, `data.dueToday[*]`, etc.), single-object wrappers (`data.task.*`, etc.), attachment paths, and error-detail user inputs
- **Redaction canary test** (`logger.test.ts`) — synthetic record with each PII leaf assigned a unique `CANARY_*_PASSWORD_S3CR3T_xyz` sentinel; logs it at info / warn / error / debug and fails if any sentinel reaches output
- **Non-PII test** confirms the redactor isn't over-broad — IDs, booleans, dates stay visible for debugging
- **`docs/security.md`** gains a § "PII redaction in structured logs" section documenting what's redacted, what isn't (and why), test coverage, and known limitations
- Net diff: **+319/−10** across 3 files

## Design link

Implements [#842 — chore(security): audit pino redaction coverage for note content and disk sinks](https://github.com/torsday/omnifocus-mcp/issues/842). Builds on #9 (PII redaction); load-bearing for #823 (opt-in JSONL disk sink — anything that hits disk must be redacted-by-default).

Closes #842

## Breaking change?

- [x] No — additive coverage; no existing redacted field is now visible

## AC walk-through

| AC | Status | Where |
|---|---|---|
| Audit pino redactor paths: confirm `note`, `noteHtml`, attachment names, project/tag/folder names with potentially-sensitive content are covered | ✅ | `src/logging/logger.ts` — 50+ paths in `PII_REDACT_PATHS`; full list documented in `docs/security.md` |
| Confirm redaction applies to BOTH info-level structured logs AND any disk sink (#823) | ✅ | pino redacts pre-emit regardless of sink/level — applies to any future `Writable` (disk sink, syslog, etc.) wired in. Canary test asserts at info, warn, error, AND debug. |
| Test with a synthetic record containing fake password / SSN / email; confirm none of those values appear in any output | ✅ | Canary block in `logger.test.ts` builds a synthetic record mirroring every shape we ship; each PII leaf is a unique `CANARY_*_PASSWORD_S3CR3T_xyz` sentinel; test fails if any sentinel reaches output |
| Document the redaction model in `docs/security.md` — what's redacted, what isn't, why | ✅ | New § "PII redaction in structured logs" with the full taxonomy + non-redacted-by-design list + limitations |
| CI test: redaction-canary record at every log boundary | ✅ — partial | Canary tests live in `src/logging/logger.test.ts` and run on every PR (default test tier). The test asserts against the singleton-shared `REDACTION_PATHS_FOR_TESTS` export so it catches any addition that misses a path. |

## What's NOT in this PR (deliberate)

- **Stringified `details.stderr` regex-scrubbing** — when JXA fails, the `stderr` field is a string that might quote a task name. Path-based redaction can't reach into a string. The current mitigation is `truncate(stderr, 512–1024)`. A future regex-scrub pass could match common PII patterns inside stringified surfaces; logged as a limitation in `docs/security.md` rather than fixed here to keep the slice tight.
- **#823 (JSONL disk sink) integration** — that issue is open; the redaction surface is already correct for it (pino handles redaction pre-emit), but no sink is wired yet.
- **Tag-on-warning-class auto-redaction** — would need a custom serializer; out of scope.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:quiet` are green locally (3615 passed, +3 over baseline)
- [x] `pnpm vitest run src/logging/logger.test.ts` — 13/13 pass; canary correctly redacts every shape
- [x] Self-reviewed via /review-pr
- [x] Confirmed `REDACTION_PATHS_FOR_TESTS` export is `readonly` and only consumed by the test

## Conventions checklist

- [x] Follows project conventions in `AGENTS.md`
- [x] Conventional Commits
- [x] No new dependency
- [x] Public-surface docs updated (`docs/security.md`)