### PR TITLE
infra(ci): add synchronize trigger to board-sync.yml

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -16,7 +16,13 @@ on:
     # `ready_for_review` fires when a draft flips to ready — that's the right
     # moment to move linked issues to "In Review". Raw `opened`/`reopened` on
     # a draft is premature; the job below guards with draft == false.
-    types: [opened, reopened, ready_for_review, closed]
+    # `synchronize` fires on every push to a PR's head ref. Without it, the
+    # required `pr` status check is only attached to the head SHA at the time
+    # of `opened`/`reopened`, so any subsequent push leaves the PR
+    # `mergeStateStatus: BLOCKED` despite every other required check being
+    # green. Including it here keeps the `pr` check fresh on every push and
+    # makes the status-checks gate honest. (#905)
+    types: [opened, reopened, ready_for_review, closed, synchronize]
   issues:
     types: [closed, reopened]
 


### PR DESCRIPTION
## Summary

- Adds `synchronize` to `board-sync.yml`'s `pull_request.types` so the required `pr` status check re-runs on every push, instead of getting stranded on the SHA from the last `opened`/`reopened`.
- Drops the recurring "all checks green but `mergeStateStatus: BLOCKED`" friction that needed a manual close + reopen on every push (see #863, #865, #852 from earlier today).

## Why

`board-sync.yml` produces the required `pr` status check. Its triggers are:

```yaml
pull_request:
  types: [opened, reopened, ready_for_review, closed]
```

`synchronize` (push-to-PR-head) is not in the list. Required checks bind to a specific head SHA, so every push after the PR is opened invalidates the previous `pr` association without producing a new one — the PR shows BLOCKED with every other check green. The documented workaround was a manual close + reopen.

This is recorded in repo memory as `feedback_pr_check_synchronize.md` and is the root cause of three BLOCKED PRs we manually unstuck this morning.

## Safety

The `pr` job's two work-doing steps both guard:
- `PR opened (ready) → flip linked issues to In Review` only fires on `opened`/`reopened` (non-draft) or `ready_for_review` — not synchronize.
- `PR merged → flip linked issues to Done` only fires on `closed && merged == true`.

So synchronize triggers the job (producing the `pr` check) but does not flip any board state. Net cost: one extra ~5s job per push, in exchange for honest gate state.

## Test plan

- [x] `actionlint` passes locally.
- [ ] After merge, push another commit to any open PR and confirm the `pr` check fires automatically (no close+reopen needed).
- [ ] Confirm a draft PR receiving a synchronize doesn't move on the board (the `if: draft == false` guards still hold).

Closes #905