### PR TITLE
infra(ci): cap integration.yml heavy job at 30m to prevent runner starvation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,6 +57,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, macos-omnifocus]
+    # Cap the heavy job so a wedged osascript / hung integration test surfaces
+    # as a clean failure instead of holding the single self-hosted runner for
+    # the GitHub default of 6h and starving every other PR's required checks.
+    # CI workflow has the same kind of cap (15m); this matches at 30m to give
+    # the suite + seeding headroom over its typical 8–12m wall time.
+    timeout-minutes: 30
 
     strategy:
       # Run all matrix entries even if one fails (collect full picture).


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 30` to the heavy integration job in `.github/workflows/integration.yml`.
- A wedged osascript or hung integration test no longer holds the only self-hosted macOS runner for the GitHub Actions 6-hour default; it surfaces as a clean failure at 30m and the queue keeps moving.

## Why

This was visibly painful today during the eight-PR perf merge wave + bundle-budget scramble. With one self-hosted macOS runner and no per-job cap, a single stuck integration test would block every other PR's required checks for the rest of the day. CI's `build (Node 24)` job already caps at 15m for exactly this reason; mirroring the pattern at 30m gives the integration suite + seeding step headroom over its typical 8–12m wall time.

## Origin

The patch was salvaged from an abandoned `claude/musing-fermi-…` session worktree during the 2026-05-10 grooming pass that pruned 12 stale Claude session branches. The diff is one `timeout-minutes: 30` line plus a comment explaining the reasoning. The original session never opened a PR; this one finishes the thought.

## Test plan

- [x] `actionlint` passes locally on the modified workflow.
- [ ] `actionlint` required check passes in CI.
- [ ] After merge, watch the next integration run — should complete normally well under 30m.

Closes #909