### PR TITLE
infra(ci): meta-lint hardening — workflow-timeouts gate + pnpm-audit warning

### DIFF
--- a/.github/workflows/board-sync.yml
+++ b/.github/workflows/board-sync.yml
@@ -41,6 +41,7 @@ jobs:
     # PROJECT_TOKEN by default, so blocking here is both security and correctness.)
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check token
         id: token
@@ -132,6 +133,7 @@ jobs:
   issue-closed:
     if: github.event_name == 'issues' && github.event.action == 'closed'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check token
         id: token

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -152,6 +152,7 @@ jobs:
     #   failure / cancelled                  → fail
     name: integration-gate
     runs-on: ubuntu-latest  # allow-hosted: gate must be reachable when self-hosted runner is offline (gap 2 of #679)
+    timeout-minutes: 5
     needs: integration
     if: always()
     steps:

--- a/.github/workflows/issue-lint.yml
+++ b/.github/workflows/issue-lint.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Skip if the edit was made by the filer script — it verifies its own output.
     if: github.event.issue.state == 'open'
     env:

--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -55,6 +55,7 @@ jobs:
   shellcheck:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Ensure shellcheck is installed
@@ -71,6 +72,7 @@ jobs:
   actionlint:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Ensure actionlint is installed
@@ -91,6 +93,7 @@ jobs:
     # workflow in this repo runs on `[self-hosted, macos]`.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Verify no GitHub-hosted runners are referenced
@@ -105,6 +108,7 @@ jobs:
     # miss four others; this guard removes the regression class.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Verify no tool-count strings in living docs
@@ -116,6 +120,7 @@ jobs:
     # Surfaces as an ::error:: annotation on the doc itself.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -145,6 +150,7 @@ jobs:
     # surfaces failures as `::error::` annotations directly on the PR.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
@@ -154,3 +160,48 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint:nl-quality
+
+  workflow-timeouts:
+    # Regression guard — fails if any workflow job lacks an explicit
+    # `timeout-minutes:`. Without one a hung step holds the runner for
+    # GitHub's 6-hour default; the 2026-05-10 incident hit this exactly
+    # (#912 capped integration.yml at 30m after a hung osascript held the
+    # macOS runner for 70+ minutes). This guard codifies the lesson at the
+    # workflow-author level. See scripts/verify-workflow-timeouts.sh.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify every workflow job declares timeout-minutes
+        run: scripts/verify-workflow-timeouts.sh
+
+  pnpm-audit:
+    # Surface dependabot-style advisories on every dep-touching PR — this
+    # is the followup from #918 (pnpm overrides cleared 8 advisories that
+    # had been showing up on every push for weeks). Informational, not
+    # blocking: an unfixable upstream advisory shouldn't gate unrelated
+    # PRs, but the warning surface keeps the security panel honest at PR
+    # time instead of letting noise accumulate at push time.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: pnpm audit (informational — surfaces moderate+ advisories)
+        run: |
+          set +e
+          pnpm audit --audit-level=moderate
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::pnpm audit found moderate-or-higher advisories — run \`pnpm audit\` locally and consider a pnpm.overrides bump"
+          fi
+          # Always exit 0 — informational only.
+          exit 0

--- a/.github/workflows/post-merge-close.yml
+++ b/.github/workflows/post-merge-close.yml
@@ -62,6 +62,7 @@ jobs:
     # PAT is provisioned, and the operator opts in by setting the variable.
     if: vars.AUTO_CLOSE_ENABLED == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check token
         id: token

--- a/.github/workflows/pr-link.yml
+++ b/.github/workflows/pr-link.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   require-issue-link:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Waivers (any one match → skip):
     #   1. `no-issue` label on the PR — explicit waiver for pure-infra PRs.
     #   2. Fork-PR guard — fork code cannot execute on the self-hosted runner.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -21,6 +21,7 @@ jobs:
     # execute on the self-hosted runner.
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,6 +41,7 @@ jobs:
     # directly, but the guard is consistent with other workflows.)
     if: github.repository == 'torsday/omnifocus-mcp'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write       # create commits + branches for the Release PR
       pull-requests: write  # open / update the Release PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest   # required by `pnpm publish --provenance` (see header)
+    timeout-minutes: 20
     permissions:
       contents: write   # needed to create a GitHub Release
       id-token: write   # needed for npm provenance (and future OIDC publish)

--- a/.github/workflows/validate-deps-nightly.yml
+++ b/.github/workflows/validate-deps-nightly.yml
@@ -24,6 +24,7 @@ permissions:
 jobs:
   audit:
     runs-on: [self-hosted, macos]
+    timeout-minutes: 10
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       AUDIT_LABEL: "audit: dep-graph"

--- a/.github/workflows/verify-constants.yml
+++ b/.github/workflows/verify-constants.yml
@@ -33,6 +33,7 @@ jobs:
     # schedule and workflow_dispatch triggers continue to run normally.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
     steps:

--- a/scripts/verify-workflow-timeouts.sh
+++ b/scripts/verify-workflow-timeouts.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# verify-workflow-timeouts.sh — fail if any workflow job lacks `timeout-minutes`.
+#
+# A job without `timeout-minutes` falls back to GitHub's 6-hour default,
+# which on a single self-hosted runner means a wedged step can starve the
+# queue for the rest of the day. The 2026-05-10 incident hit this exactly
+# (#912 added a 30m cap on `integration.yml`'s heavy job after a hung
+# osascript held the runner for 70+ minutes). This guard codifies the
+# lesson: every job declares an explicit timeout, picked by the workflow
+# author against the work they actually do, with a regression catch at PR
+# time so the next workflow can't drift back.
+#
+# Wired into meta-lint.yml's `workflow-timeouts` job. Runs on ubuntu-latest
+# under PR; uses python3 + PyYAML, both preinstalled on GitHub-hosted
+# runners.
+#
+# Skips reusable-workflow callers (`uses:` job entries) — those carry
+# their timeouts inside the called workflow.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+python3 - <<'PY'
+import sys
+import yaml
+from pathlib import Path
+
+violations = []
+for f in sorted(Path(".github/workflows").glob("*.yml")):
+    try:
+        data = yaml.safe_load(f.read_text())
+    except yaml.YAMLError as e:
+        print(f"::error file={f}::failed to parse YAML: {e}", file=sys.stderr)
+        sys.exit(1)
+    jobs = (data or {}).get("jobs") or {}
+    for job_name, job_def in jobs.items():
+        if not isinstance(job_def, dict):
+            continue
+        # Reusable-workflow caller — timeout lives inside the called workflow.
+        if "uses" in job_def:
+            continue
+        if "timeout-minutes" not in job_def:
+            violations.append(f"{f}::{job_name}")
+
+if violations:
+    print("::error::Workflow jobs missing timeout-minutes:", file=sys.stderr)
+    for v in violations:
+        print(f"  - {v}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Every job needs an explicit `timeout-minutes:` value picked against the work it does.", file=sys.stderr)
+    print("Without one a hung step holds the runner for the GitHub default of 6h. Pick a value", file=sys.stderr)
+    print("a few times the typical wall time so a true stall surfaces as a clean failure.", file=sys.stderr)
+    print("See `.github/workflows/integration.yml` or `ci.yml` for examples.", file=sys.stderr)
+    sys.exit(1)
+
+print("ok: every workflow job declares timeout-minutes")
+PY


### PR DESCRIPTION
## Summary

Two regression guards codifying lessons from the 2026-05-10 incident:

1. **`workflow-timeouts`** (hard gate) — `scripts/verify-workflow-timeouts.sh` parses every workflow YAML and fails if any job lacks `timeout-minutes:`. Wired into `meta-lint.yml`.
2. **`pnpm-audit`** (informational) — runs `pnpm audit --audit-level=moderate` on every PR; emits `::warning::` if advisories appear. Always exits 0 (same stance as #911 for bundle-size).

Plus adds `timeout-minutes:` to the 17 jobs across this repo's workflows that were missing one. Defaults picked against typical wall-time per category:
- Lightweight admin/lint (board-sync, meta-lint sub-jobs, pr-link, pr-title, post-merge-close, issue-lint, verify-constants): **5 min**
- Jobs that do `pnpm install` (release-please, validate-deps-nightly, this PR's new audit): **10 min**
- `release.yml` (npm publish + GitHub Release): **20 min**

## Why

- **Workflow timeouts:** [#912](https://github.com/torsday/omnifocus-mcp/issues/912) capped `integration.yml`'s heavy job at 30m after a hung `osascript` held the macOS runner for 70+ minutes. 17 other jobs across this repo had no timeout-minutes, defaulting to GitHub's 6h. Most are admin/lint jobs that won't realistically hang, but the gap is real defense-in-depth.
- **pnpm-audit:** [#918](https://github.com/torsday/omnifocus-mcp/pull/918) cleared 8 stale advisories that had been showing up on every push for weeks. The followup it called out was: catch new advisories at PR time. Soft-warning stance means an unfixable upstream advisory doesn't block unrelated PRs.

## Verification (local)

```
$ bash scripts/verify-workflow-timeouts.sh
ok: every workflow job declares timeout-minutes

$ pnpm exec actionlint .github/workflows/*.yml
(no output — clean)

$ pnpm audit --audit-level=moderate
No known vulnerabilities found
```

## Test plan

- [x] Verifier fails clearly when a timeout is missing (smoke-tested before patching the 17 jobs).
- [x] Verifier passes after all 17 are patched.
- [x] All workflows still parse via actionlint.
- [ ] CI on this PR runs both new jobs green.
- [ ] First PR after merge surfaces the `workflow-timeouts` check on its required-checks list.

Closes #919