### PR TITLE
fix(ci): bump release.yml timeout 20m → 35m to fit Stryker (unblocks v1.5.x publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,14 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest   # required by `pnpm publish --provenance` (see header)
-    timeout-minutes: 20
+    # Sized for the slowest historically-observed successful release run
+    # (~26 min on 2026-05-09 / c551320) with 9 min headroom. Stryker
+    # mutation testing alone takes ~19 min on this codebase; the prior
+    # 20-min cap was tight enough to cancel v1.5.0 mid-Stryker on
+    # 2026-05-10, leaving the tag + GitHub Release in place but no
+    # publish to npm or Homebrew. Bump as Stryker scope grows; don't
+    # tighten without checking historical run durations first.
+    timeout-minutes: 35
     permissions:
       contents: write   # needed to create a GitHub Release
       id-token: write   # needed for npm provenance (and future OIDC publish)


### PR DESCRIPTION
## Summary

Bumps `release.yml::release` job-level `timeout-minutes` from **20 → 35**. Sized for the slowest observed successful release run (~26 min on 2026-05-09) plus 9 min headroom for Stryker scope growth.

## Why

Both 2026-05-10 releases — **v1.4.0** and **v1.5.0** — were tagged but never published to npm or Homebrew:

- **npm:** `1.3.0` (still)
- **Homebrew:** `1.3.0` (still)
- **GitHub Releases:** `v1.5.0` shows as Latest (phantom — never published downstream)
- **Repo `package.json`:** `1.5.0`

v1.4.0 failed at the `Verify integration suite passed on this commit` gate (integration flake, same as #914). v1.5.0 failed at `Stryker mutation testing (release gate)` — cancelled at 19m22s by my own 20-min `timeout-minutes` cap from #919, before Stryker could finish.

Stryker alone takes ~19 min on the current scope; historical successful releases run 23–26 min total. The 20-min cap I picked in #919 was wrong — I sized it without checking historical durations. This PR corrects that.

## Follow-up

Cutting v1.5.1 carrying the same payload v1.5.0 was supposed to ship, plus this fix. Once that publishes, npm + Homebrew jump from 1.3.0 → 1.5.1, and GitHub's "Latest" marker moves there (`make_latest: true` in `softprops/action-gh-release`). The phantom v1.4.0 and v1.5.0 GitHub Releases will be annotated post-1.5.1-publish with a pointer.

Closes #921