### PR TITLE
fix(scripts): pass --clean to seed-integration-db.js in integration.yml; fix docstring

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,15 +113,19 @@ jobs:
 
       - name: Seed integration fixtures
         # The integration suite operates on `mcp-fixture:`-prefixed
-        # folders, projects, tasks, and tags. The seed script is
-        # idempotent — it removes any existing fixtures with that prefix
-        # before re-creating the canonical set, so re-running it across
-        # runs (or partial runs, after a previous failure) leaves the
-        # database in the same known-good state every time. Without
-        # this step the integration suite hits ~23 failures of the form
-        # `expected '<id>' to be null` and `Hook timed out in 30000ms`
-        # — symptoms of tests asserting against missing or stale fixtures.
-        run: node scripts/seed-integration-db.js
+        # folders, projects, tasks, and tags. `--clean` first wipes any
+        # leftover fixtures from prior cancelled / partial runs, then
+        # re-creates the canonical set — so the test suite starts from a
+        # known state every run. Without `--clean`, `mcp-fixture:` orphans
+        # accumulate across cancelled runs (today's 2026-05-10 release-
+        # pipeline incident hit 25 stale fixture tags before someone
+        # noticed), and tests that assert "this is the only fixture
+        # with name X" start failing intermittently. See #929 for the
+        # mode-comments / docstring fix in the seed script itself, and
+        # #928 for the matching runner-side job-started hook (defense
+        # in depth — works even if a new runner doesn't have this flag
+        # plumbed through).
+        run: node scripts/seed-integration-db.js --clean
 
       - name: Run integration tests
         env:

--- a/scripts/seed-integration-db.js
+++ b/scripts/seed-integration-db.js
@@ -1,18 +1,23 @@
 #!/usr/bin/env node
 // Seed the integration-test fixtures into a live OmniFocus database.
 //
-// **Idempotent.** Every call removes any existing entities with the
-// `mcp-fixture:` prefix before re-creating the canonical set, so it is
-// safe to re-run across CI invocations and after partial / failed runs
-// without accumulating stale state. `integration.yml` invokes it before
-// every test run for this reason.
+// Modes:
+//   default      — skip-if-exists. Creates only the canonical fixtures that
+//                  aren't already present. Does NOT remove orphan
+//                  `mcp-fixture:` items from prior runs.
+//   `--clean`    — remove ALL `mcp-fixture:`-prefixed items (tags, folders,
+//                  projects, tasks) before re-creating the canonical set.
+//                  Use this when prior cancelled / partial runs may have left
+//                  orphans that would collide with current-run expectations.
+//                  `integration.yml` passes `--clean` so CI starts from a
+//                  known state every run (#929).
 //
-// Production OmniFocus data is untouched: only `mcp-fixture:`-prefixed
-// objects are touched. Pass `--clean` to delete fixtures without
-// re-creating them (used by interactive cleanup).
+// Production OmniFocus data is untouched in both modes: only
+// `mcp-fixture:`-prefixed objects are touched.
 //
 // Run locally with:
-//   node scripts/seed-integration-db.js
+//   node scripts/seed-integration-db.js          # additive seed
+//   node scripts/seed-integration-db.js --clean  # wipe and re-seed
 // Then run the integration suite:
 //   OMNIFOCUS_INTEGRATION=1 pnpm test:integration
 
@@ -33,7 +38,13 @@ const cleanFirst = args.includes("--clean");
 function jxa(script) {
   const result = spawnSync("osascript", ["-l", "JavaScript", "-e", script], {
     encoding: "utf8",
-    timeout: 30_000,
+    // 60s — the per-item .delete() loop in the clean pass can run 25+ tags on
+    // a polluted runner, and OmniFocus's per-Tag deletion triggers a
+    // synchronous index update that costs ~1s each. 30s was tight enough to
+    // time out today (2026-05-10) with 25 stale fixture tags; doubled to 60s.
+    // Long-term, batching the cleanup via `whose({}).delete()` instead of the
+    // per-item loop would let us drop this back — tracked in #929 followup.
+    timeout: 60_000,
   });
 
   if (result.error) {


### PR DESCRIPTION
## Summary

Three small changes that fix the underlying cause of today's release-pipeline integration flake:

1. `integration.yml` now invokes `seed-integration-db.js --clean` instead of the bare command. CI starts every run from a known state.
2. `seed-integration-db.js`'s opening docstring rewritten — previously claimed cleanup on every call, but cleanup only runs under `--clean`. Now documents both modes accurately.
3. The script's internal `osascript` timeout bumped from 30s → 60s so the `--clean` per-item `.delete()` loop has headroom on polluted runners (today's 25 stale fixture tags timed it out).

## Why

`integration.yml`'s seed step was running without `--clean`. Result: `mcp-fixture:`-prefixed orphans accumulated across cancelled / partial runs. Today's pollution: 25 stale fixture tags + 2 stale folders + orphan tasks/projects, enough to break v1.5.1's release pipeline at the integration-gate check (13 → 15 test failures across consecutive runs on the same SHA — that's not flake, it's accumulated state).

The docstring lying about default behavior is partly why this gap existed: a reader scanning the script confidently sees "Idempotent. Every call removes any existing entities..." and concludes the defaults are safe. They aren't.

## Pairs with (filed separately)

- **#928** — runner-side `ACTIONS_RUNNER_HOOK_JOB_STARTED` for OmniFocus state reset. Defense in depth: even a new self-hosted runner without this workflow flag plumbed through stays clean.
- **#914** — per-test project namespaces in the contract suite. Proper test-level isolation; makes the runtime cleanup belt-and-suspenders.

## Test plan

- [x] `actionlint` passes on `integration.yml`.
- [x] `verify-workflow-timeouts.sh` passes.
- [ ] CI on this PR runs the modified `integration.yml`. If integration tests pass on this PR, the fix is working.

Closes #929