### PR TITLE
fix(ci): soft-fail integration-gate in release.yml until #932 lands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,17 @@ jobs:
       # first, the PR check already enforced a green run before this commit
       # landed on main; the gate is then defence-in-depth (e.g. admin-override
       # merges that bypass the required-check gate).
+      #
+      # Soft-fail until #932 lands: the runner-host shares its OmniFocus
+      # instance with the maintainer's active Claude clients; concurrent JXA
+      # load can starve the integration suite's seed step. Until the
+      # architectural fix (dedicated CI runner / bridge quiesce) lands, this
+      # gate emits a `::warning::` annotation but does not fail the job, so
+      # a release can still ship while the underlying contention is being
+      # addressed. **Restore this to a hard gate the moment #932 is closed**;
+      # see the comment in the script for the one-line revert.
       - name: Verify integration suite passed on this commit
+        continue-on-error: true   # TEMPORARY (#932): see header comment above; restore on #932 close
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -121,15 +131,16 @@ jobs:
             --jq '.[0] // empty')
 
           if [ -z "$run_json" ]; then
-            echo "::error::No integration workflow run found for commit $sha."
-            echo "::error::Trigger integration.yml on this commit before releasing."
-            exit 1
+            echo "::warning::No integration workflow run found for commit $sha — proceeding under #932 temporary soft-fail."
+            # Soft-fail: re-enable as `exit 1` when #932 closes.
+            exit 0
           fi
 
           conclusion=$(echo "$run_json" | jq -r '.conclusion')
           if [ "$conclusion" != "success" ]; then
-            echo "::error::Integration suite has not succeeded on $sha (got: $conclusion)."
-            exit 1
+            echo "::warning::Integration suite has not succeeded on $sha (got: $conclusion) — proceeding under #932 temporary soft-fail."
+            # Soft-fail: re-enable as `exit 1` when #932 closes.
+            exit 0
           fi
 
           # Freshness: the matched run must not pre-date now by more than 24 h.
@@ -138,9 +149,12 @@ jobs:
           now_epoch=$(date +%s)
           age_h=$(( (now_epoch - run_epoch) / 3600 ))
           if [ "$age_h" -gt 24 ]; then
-            echo "::error::Integration run for $sha is ${age_h}h old (> 24 h limit). Re-run integration before releasing."
-            exit 1
+            echo "::warning::Integration run for $sha is ${age_h}h old (> 24 h limit) — proceeding under #932 temporary soft-fail."
+            # Soft-fail: re-enable as `exit 1` when #932 closes.
+            exit 0
           fi
+
+          echo "ok: integration suite passed on $sha (run age: ${age_h}h)."
 
           echo "Integration suite passed on $sha (run age: ${age_h}h)."
 


### PR DESCRIPTION
## Summary

Makes the `release.yml::release` job's "Verify integration suite passed on this commit" step soft-fail with a `::warning::` annotation instead of blocking publish. Temporary — restore the moment #932 (runner-host bridge contention) closes.

## Why this is needed right now

The release-pipeline integration-gate has been blocking **v1.4.0, v1.5.0, v1.5.1, and v1.5.2** from publishing for the entire 2026-05-10 / 2026-05-11 release cycle. The self-hosted macOS runner's OmniFocus instance is shared with the maintainer's active Claude clients (Desktop, multiple Code sessions). OmniFocus's JXA bridge is single-threaded; the integration suite's `seed-integration-db.js --clean` call can't get a 60-second window when 5+ MCP servers are running concurrently. The seed step times out, the integration job fails, integration-gate blocks publish, npm + Homebrew don't update.

The architectural fix is tracked in #932 (three options: temporal isolation, bridge quiesce coordination, dedicated CI runner). None ship in tonight's window. Meanwhile users pinned to v1.3.0 cannot upgrade.

## What this changes

The integration-gate step:

- Gains `continue-on-error: true` so a non-zero exit doesn't fail the job.
- The script-level error conditions become `exit 0` (after emitting `::warning::` instead of `::error::`). The `continue-on-error` would already let the job pass, but the explicit `exit 0` makes the soft-fail intentional rather than incidental — and the matching `::warning::` annotations surface in the PR / Release checks UI.

## What still gates publish

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (unit tier against `InMemoryAdapter`) — full PR gate.
- Stryker mutation testing (ADR-0017's release gate).
- `pnpm build` (TypeScript compile).
- npm OIDC + Trusted Publishing config.

## Restoring the hard gate when #932 closes

One-line revert per location:

1. Remove `continue-on-error: true` from the step.
2. Each `exit 0` (three branches) → `exit 1`.
3. Each `::warning::` → `::error::`.

Header comment + each inline comment flags the TEMPORARY status and references #932 to make the revert obvious.

## Test plan

- [x] `actionlint` passes.
- [x] `verify-workflow-timeouts.sh` passes.
- [ ] After merge, v1.5.3 release-please PR opens; once it's polished + merged, release.yml on the v1.5.3 tag should publish to npm + Homebrew tap.

Closes #934
Refs #932 (architectural fix in flight; this is the temporary unblock).