### PR TITLE
infra(ci): path-filter integration suite to skip on docs/scripts-only prs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,8 @@ jobs:
     # tests. Runs only on pull_request events; skipped on push/dispatch so
     # those triggers always run the full suite regardless.
     name: Detect paths needing integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest  # allow-hosted: path detection only — no OmniFocus access needed
+    timeout-minutes: 2
     if: github.event_name == 'pull_request'
     outputs:
       needs_integration: ${{ steps.filter.outputs.integration }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,8 @@ name: Integration Tests
 #   2. Tag push matching v* — automatically runs before a release
 #   3. Pull requests targeting `main` — gated to canonical-repo branches; fork
 #      PRs short-circuit the heavy job (no self-hosted runner access from forks).
+#      Path-filtered: the suite only runs when the diff touches adapter, transport,
+#      test, or build-config paths (see `paths-changed` job below).
 #
 # Requirements:
 #   A self-hosted runner labeled `macos-omnifocus` with OmniFocus installed
@@ -18,7 +20,9 @@ name: Integration Tests
 #   reports a single stable check name that branch protection on `main`
 #   requires. On canonical-repo PRs it fails unless the integration job
 #   succeeded; on fork PRs the integration job is intentionally skipped and
-#   the gate accepts the skip so external contributors aren't blocked.
+#   the gate accepts the skip so external contributors aren't blocked. On
+#   PRs whose diff touches no integration-relevant paths, the gate accepts
+#   the skip with skip-cause=paths-irrelevant (see #880).
 
 on:
   workflow_dispatch:
@@ -47,15 +51,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  paths-changed:
+    # Determines whether the PR diff touches paths that require integration
+    # tests. Runs only on pull_request events; skipped on push/dispatch so
+    # those triggers always run the full suite regardless.
+    name: Detect paths needing integration
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      needs_integration: ${{ steps.filter.outputs.integration }}
+    steps:
+      - name: Check paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            integration:
+              - 'src/adapter/**'
+              - 'src/domain/**'
+              - 'src/transport/**'
+              - 'tests/integration/**'
+              - 'tests/contract/**'
+              - 'tests/e2e/**'
+              - 'tests/fixtures/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig*.json'
+              - 'scripts/seed-integration-db.js'
+              - 'scripts/check-automation-permission.sh'
+              - '.github/workflows/integration.yml'
+
   integration:
     name: Integration tests (OmniFocus ${{ matrix.of-version }})
     # Skip the heavy job on fork PRs — self-hosted runners are not available
     # to forked workflows by GitHub's security model. The `integration-gate`
     # job below tolerates this skip when the PR is from a fork; on canonical-
     # repo PRs the skip becomes a failure (the runner is expected).
+    #
+    # Also skip on pull_request events whose diff touches no integration-
+    # relevant paths (paths-changed job above sets needs_integration=false).
+    # On push (tags) and workflow_dispatch the suite always runs regardless
+    # of paths — needs.paths-changed.outputs.needs_integration is '' for
+    # those events, so the first clause covers them.
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event_name != 'pull_request') ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       needs.paths-changed.outputs.needs_integration == 'true')
+    needs: [paths-changed]
     runs-on: [self-hosted, macos-omnifocus]
     # Cap the heavy job so a wedged osascript / hung integration test surfaces
     # as a clean failure instead of holding the single self-hosted runner for
@@ -149,15 +191,16 @@ jobs:
     # `macos-omnifocus` runner is offline — that's exactly the failure mode
     # this gate is designed to surface (gap 2 of #679).
     #
-    # Decision matrix (input: integration job result + PR origin):
-    #   success                              → pass
-    #   skipped + fork PR                    → pass  (forks lack runner access by design)
-    #   skipped + canonical PR / push / dispatch → fail (runner expected, didn't run)
-    #   failure / cancelled                  → fail
+    # Decision matrix (input: integration job result + PR origin + path relevance):
+    #   success                                          → pass
+    #   skipped + fork PR                                → pass  (forks lack runner access by design)
+    #   skipped + canonical PR + paths-irrelevant        → pass  (diff doesn't touch adapter/test paths)
+    #   skipped + canonical PR / push / dispatch (other) → fail  (runner expected, didn't run)
+    #   failure / cancelled                              → fail
     name: integration-gate
     runs-on: ubuntu-latest  # allow-hosted: gate must be reachable when self-hosted runner is offline (gap 2 of #679)
     timeout-minutes: 5
-    needs: integration
+    needs: [integration, paths-changed]
     if: always()
     steps:
       - name: Evaluate integration outcome
@@ -165,14 +208,19 @@ jobs:
           RESULT: ${{ needs.integration.result }}
           EVENT: ${{ github.event_name }}
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          PATHS_RELEVANT: ${{ needs.paths-changed.outputs.needs_integration }}
         run: |
-          echo "integration result: $RESULT (event=$EVENT is_fork=$IS_FORK)"
+          echo "integration result: $RESULT (event=$EVENT is_fork=$IS_FORK paths_relevant=$PATHS_RELEVANT)"
           if [ "$RESULT" = "success" ]; then
-            echo "ok: integration suite passed"
+            echo "ok: integration suite passed; skip-cause=none"
             exit 0
           fi
           if [ "$RESULT" = "skipped" ] && [ "$IS_FORK" = "true" ]; then
-            echo "ok: fork PR — integration skipped is acceptable (no self-hosted runner access)"
+            echo "ok: fork PR — integration skipped is acceptable (no self-hosted runner access); skip-cause=fork-skip"
+            exit 0
+          fi
+          if [ "$RESULT" = "skipped" ] && [ "$EVENT" = "pull_request" ] && [ "$PATHS_RELEVANT" = "false" ]; then
+            echo "ok: diff touches no integration-relevant paths; skip-cause=paths-irrelevant"
             exit 0
           fi
           echo "::error::Integration suite did not pass (result=$RESULT). On canonical-repo PRs this gate requires the macos-omnifocus runner to be online and the suite green."


### PR DESCRIPTION
## Summary

- Adds a `paths-changed` job (dorny/paths-filter@v3) that detects whether a PR diff touches integration-relevant paths
- Gates the `integration` job on `needs_integration == 'true'` for pull_request events; push (tags) and workflow_dispatch always run the full suite
- Extends `integration-gate` with a third pass case: `skipped + canonical PR + paths-irrelevant → pass`; adds `skip-cause` log token to distinguish fork-skip / paths-irrelevant for easier triage

Closes #880.

## Issue

Implements [#880 — infra(ci): path-filter integration suite to skip on docs/scripts-only PRs](https://github.com/torsday/omnifocus-mcp/issues/880).

## Breaking change?
- [x] No

## Test plan
- [ ] CI passes on this PR (YAML change only — no integration paths touched, so `paths-irrelevant` skip should fire and gate should pass green)
- [ ] Self-reviewed via /review-pr
- [ ] No new dependencies (dorny/paths-filter@v3 is a GitHub Action, not a package dep)