### PR TITLE
feat(scripts): wire Model Queue project field through file-issue.sh and verify-constants.sh

### DIFF
--- a/scripts/_project-constants.sh.example
+++ b/scripts/_project-constants.sh.example
@@ -44,6 +44,10 @@ F_PHASE="YOUR_PHASE_FIELD_ID"
 F_PRIORITY="YOUR_PRIORITY_FIELD_ID"
 F_SIZE="YOUR_SIZE_FIELD_ID"
 F_RISK="YOUR_RISK_FIELD_ID"
+# Model Queue — secondary single-select that drives the ModelBan view. Holds the model
+# tier for Backlog / Up Next items and mirrors Status for in-flight items. Optional —
+# leave empty if the project doesn't have a Model Queue field.
+F_MODEL_QUEUE="YOUR_MODEL_QUEUE_FIELD_ID"
 
 # Status option IDs  (from the discovery query above — "options[].id" on the Status field)
 STATUS_BACKLOG="YOUR_BACKLOG_OPTION_ID"
@@ -78,3 +82,15 @@ O_SIZE_XL="YOUR_SIZE_XL_OPTION_ID"
 O_RISK_HIGH="YOUR_RISK_HIGH_OPTION_ID"
 O_RISK_MED="YOUR_RISK_MED_OPTION_ID"
 O_RISK_LOW="YOUR_RISK_LOW_OPTION_ID"
+
+# Model Queue option IDs  (options[].id on the Model Queue field)
+# Tier columns — for Backlog / Up Next items, set from the `model: *` label
+O_MQ_SONNET_LOW="YOUR_MQ_SONNET_LOW_OPTION_ID"
+O_MQ_OPUS_MED="YOUR_MQ_OPUS_MED_OPTION_ID"
+O_MQ_OPUS_HIGH="YOUR_MQ_OPUS_HIGH_OPTION_ID"
+O_MQ_OPUS_1M_MAX="YOUR_MQ_OPUS_1M_MAX_OPTION_ID"
+# Lifecycle columns — for in-flight items, mirrors the Status field
+O_MQ_IN_PROGRESS="YOUR_MQ_IN_PROGRESS_OPTION_ID"
+O_MQ_IN_REVIEW="YOUR_MQ_IN_REVIEW_OPTION_ID"
+O_MQ_ON_HOLD="YOUR_MQ_ON_HOLD_OPTION_ID"
+O_MQ_DONE="YOUR_MQ_DONE_OPTION_ID"

--- a/scripts/file-issue.sh
+++ b/scripts/file-issue.sh
@@ -4,9 +4,10 @@
 # =============================================================================
 # One command, hard to get wrong. Creates the GitHub issue with the full label
 # set + milestone, adds it to project #4, sets the Status field, populates
-# Phase/Priority/Size/Risk from the labels, and verifies all wiring before
-# returning. Exits nonzero on any missing step so the caller can't proceed
-# under the illusion that the issue is fully tracked.
+# Phase/Priority/Size/Risk + Model Queue (tier column on view #3, derived from
+# --model) from the labels, and verifies all wiring before returning. Exits
+# nonzero on any missing step so the caller can't proceed under the illusion
+# that the issue is fully tracked.
 #
 # Required flags:
 #   --title       "<issue title>"                 — verb-first imperative
@@ -240,11 +241,18 @@ case "$SIZE" in
   L)  SIZE_OPT="$O_SIZE_L" ;;
   XL) SIZE_OPT="$O_SIZE_XL" ;;
 esac
+case "$MODEL" in
+  sonnet-low)  MQ_OPT="$O_MQ_SONNET_LOW" ;;
+  opus-med)    MQ_OPT="$O_MQ_OPUS_MED" ;;
+  opus-high)   MQ_OPT="$O_MQ_OPUS_HIGH" ;;
+  opus-1m-max) MQ_OPT="$O_MQ_OPUS_1M_MAX" ;;
+esac
 
-echo "==> Setting Phase=$PHASE, Priority=$PRIORITY, Size=$SIZE" >&2
-set_field "$F_PHASE"    "$PHASE_OPT" "Phase"
-set_field "$F_PRIORITY" "$PRI_OPT"   "Priority"
-set_field "$F_SIZE"     "$SIZE_OPT"  "Size"
+echo "==> Setting Phase=$PHASE, Priority=$PRIORITY, Size=$SIZE, Model Queue=$MODEL" >&2
+set_field "$F_PHASE"       "$PHASE_OPT" "Phase"
+set_field "$F_PRIORITY"    "$PRI_OPT"   "Priority"
+set_field "$F_SIZE"        "$SIZE_OPT"  "Size"
+set_field "$F_MODEL_QUEUE" "$MQ_OPT"    "Model Queue"
 
 if [ -n "$RISK" ]; then
   case "$RISK" in
@@ -269,7 +277,7 @@ if [ "$MODEL_LABEL_COUNT" != "1" ]; then
   exit 6
 fi
 
-# 2) Item is on project with Status, Phase, Priority, Size populated
+# 2) Item is on project with Status, Phase, Priority, Size, Model Queue populated
 VERIFY_JSON="$(gh api graphql -f query='
   query($id: ID!) {
     node(id: $id) {
@@ -288,7 +296,7 @@ VERIFY_JSON="$(gh api graphql -f query='
   }' -f id="$ITEM_ID")"
 
 missing=()
-for field in Status Phase Priority Size; do
+for field in Status Phase Priority Size "Model Queue"; do
   value="$(echo "$VERIFY_JSON" | jq -r --arg f "$field" \
     '[.data.node.fieldValues.nodes[] | select(.field.name == $f)][0].name // empty')"
   if [ -z "$value" ]; then
@@ -303,7 +311,7 @@ fi
 
 echo "    ✓ model: label (exactly 1)" >&2
 echo "    ✓ on project #$PROJECT_NUM" >&2
-echo "    ✓ Status, Phase, Priority, Size all populated" >&2
+echo "    ✓ Status, Phase, Priority, Size, Model Queue all populated" >&2
 echo "" >&2
 echo "Filed #$ISSUE_NUM → $ISSUE_URL" >&2
 

--- a/scripts/verify-constants.sh
+++ b/scripts/verify-constants.sh
@@ -58,6 +58,7 @@ expected=(
   "F_PRIORITY=Priority"
   "F_SIZE=Size"
   "F_RISK=Risk"
+  "F_MODEL_QUEUE=Model Queue"
   "STATUS_BACKLOG=Status::Backlog"
   "STATUS_UP_NEXT=Status::Up Next"
   "STATUS_IN_PROGRESS=Status::In Progress"
@@ -82,6 +83,14 @@ expected=(
   "O_RISK_HIGH=Risk::High"
   "O_RISK_MED=Risk::Medium"
   "O_RISK_LOW=Risk::Low"
+  "O_MQ_SONNET_LOW=Model Queue::sonnet-low"
+  "O_MQ_OPUS_MED=Model Queue::opus-med"
+  "O_MQ_OPUS_HIGH=Model Queue::opus-high"
+  "O_MQ_OPUS_1M_MAX=Model Queue::opus-1m-max"
+  "O_MQ_IN_PROGRESS=Model Queue::In Progress"
+  "O_MQ_IN_REVIEW=Model Queue::In Review"
+  "O_MQ_ON_HOLD=Model Queue::On Hold"
+  "O_MQ_DONE=Model Queue::Done"
 )
 
 # Resolve a "<field>" or "<field>::<option>" selector against the live payload.


### PR DESCRIPTION
## Summary

- `file-issue.sh` now sets the Model Queue secondary single-select on every new issue, derived from `--model` — closes the gap that left this week's filings (#937, #938, #939, #940, #941) needing `/groom` Phase 4.7 backfill
- `verify-constants.sh` extends its `expected[]` so the existing weekly drift-check now covers Model Queue field + 8 option IDs the same way it covers Status / Phase / Priority / Size
- `_project-constants.sh.example` documents the field + options so the pattern is reproducible for any project bootstrapping the same secondary-field setup

Closes #945

## Test plan

- [x] `./scripts/verify-constants.sh` passes after the change (no false positives from the expanded `expected[]`)
- [x] `./scripts/file-issue.sh` end-to-end: filed [#945](https://github.com/torsday/omnifocus-mcp/issues/945) using this branch's script — output now reads `Setting Phase=…, Priority=…, Size=…, Model Queue=opus-med` and the post-create verification line includes `Model Queue all populated`. Confirmed [#945](https://github.com/torsday/omnifocus-mcp/issues/945) lands in the opus-med column on view #3 ModelBan
- [ ] CI: lint, build, verify-constants

## Notes

- The script assumes `F_MODEL_QUEUE` is set; projects without the Model Queue field will need to add defensive handling (out of scope here — this repo always has the field).