### PR TITLE
perf(observability): split osascript spawn time from script execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,6 +442,10 @@ These changes don't affect runtime behavior but are recorded for traceability:
 
 ## [Unreleased]
 
+### Added
+
+- **`transport.call` events now split spawn cost from script cost (closes #939)** — every call now carries `spawnFloorMs` (the calibrated `osascript` fork + interpreter init + JXA bridge bring-up, measured once per process via a no-op JXA script) and `scriptMs = max(0, durationMs - spawnFloorMs)` alongside the existing `durationMs`. Calibration runs lazily on the first transport call (fire-and-forget) and the result is cached for the lifetime of the process; one `observability.spawn.calibrated` event records the floor value. `durationMs` is preserved for back-compat, so existing log consumers keep working unchanged. The split answers the decision-gate question for the persistent-osascript-REPL track (#882) and the latency-aggregator work (#936-Medium / #936-Full): if spawn cost dominates per-workflow time, the REPL is worth the investment; if it doesn't, the case dissolves.
+
 ### Changed
 
 - **`task_reclassify` description trimmed back under the per-tool token budget (closes #814)** — pulled the discriminated-union AST grammar dump out of the description (the full schema is already delivered in `tools/list` JSONSchema, where the model reads it precisely); merged the redundant "prefer task_reclassify" paragraph into the existing "Do NOT use" guidance; dropped one of the two examples (the dry-run variant duplicated the apply-phase example). Token cost: 352 → ~279 (–73 tokens, ~21% of the description). Total `tools/list` description payload: 23,689 → 23,581 tokens. The exemption in `descriptions.lint.test.ts` is gone — no tool currently exceeds the 350-token budget. Behavior unchanged. A reproducible audit harness lives at `scripts/audit-description-sizes.ts` for future passes.

--- a/src/adapter/_shared/spawnFloor.test.ts
+++ b/src/adapter/_shared/spawnFloor.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the osascript spawn-floor calibration module (#939).
+ *
+ * The module owns one piece of process-scoped state (`cached`) plus an
+ * in-flight promise dedupe. Tests use `__resetSpawnFloorForTesting()` to
+ * isolate each case.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetSpawnFloorForTesting,
+  ensureSpawnFloorCalibration,
+  getSpawnFloorMs,
+} from "./spawnFloor.js";
+
+type FakeSpawner = (scriptBody: string, jsonArg: string, timeoutMs: number) => Promise<unknown>;
+
+afterEach(() => {
+  __resetSpawnFloorForTesting();
+});
+
+describe("spawnFloor — initial state", () => {
+  it("returns undefined before any calibration call", () => {
+    expect(getSpawnFloorMs()).toBeUndefined();
+  });
+});
+
+describe("ensureSpawnFloorCalibration", () => {
+  it("invokes the spawner once and caches the result", async () => {
+    const spawner = vi.fn<FakeSpawner>(async () => ({}));
+    const ms = await ensureSpawnFloorCalibration(spawner);
+    expect(typeof ms).toBe("number");
+    expect(ms).toBeGreaterThanOrEqual(0);
+    expect(spawner).toHaveBeenCalledTimes(1);
+    expect(getSpawnFloorMs()).toBe(ms);
+  });
+
+  it("dedupes concurrent calls onto a single inflight calibration", async () => {
+    // Hold the spawner pending until we explicitly resolve so the two
+    // ensureSpawnFloorCalibration calls overlap.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const spawner = vi.fn<FakeSpawner>(async () => {
+      await gate;
+      return {};
+    });
+    const a = ensureSpawnFloorCalibration(spawner);
+    const b = ensureSpawnFloorCalibration(spawner);
+    release();
+    const [r1, r2] = await Promise.all([a, b]);
+    expect(spawner).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(r2);
+  });
+
+  it("returns the cached value on subsequent calls without re-spawning", async () => {
+    const spawner = vi.fn<FakeSpawner>(async () => ({}));
+    const first = await ensureSpawnFloorCalibration(spawner);
+    const second = await ensureSpawnFloorCalibration(spawner);
+    expect(second).toBe(first);
+    expect(spawner).toHaveBeenCalledTimes(1);
+  });
+
+  it("still caches a value when the spawner rejects (so a failing host doesn't retry every call)", async () => {
+    const spawner = vi.fn<FakeSpawner>(async () => {
+      throw new Error("osascript missing");
+    });
+    const ms = await ensureSpawnFloorCalibration(spawner);
+    expect(typeof ms).toBe("number");
+    expect(getSpawnFloorMs()).toBe(ms);
+    // A second call must not re-attempt the failing spawn.
+    await ensureSpawnFloorCalibration(spawner);
+    expect(spawner).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the calibration script and a timeout to the spawner", async () => {
+    const spawner = vi.fn<FakeSpawner>(async () => ({}));
+    await ensureSpawnFloorCalibration(spawner);
+    const [scriptBody, jsonArg, timeoutMs] = spawner.mock.calls[0] as [string, string, number];
+    expect(scriptBody).toContain("function run");
+    expect(jsonArg).toBe("{}");
+    expect(timeoutMs).toBeGreaterThan(0);
+  });
+});

--- a/src/adapter/_shared/spawnFloor.ts
+++ b/src/adapter/_shared/spawnFloor.ts
@@ -1,0 +1,92 @@
+/**
+ * Process-scoped osascript spawn-floor calibration (#939).
+ *
+ * The `transport.call` `durationMs` conflates two costs: the fixed
+ * `osascript` fork + interpreter init + JXA bridge bring-up, and the script's
+ * own JXA work. Splitting the two answers the question that gates the
+ * persistent-REPL track (#882): "Does spawn cost dominate, or is the
+ * bottleneck inside the script?"
+ *
+ * Strategy: run a single no-op script through the real spawner once per
+ * process, treat the wall-clock as the spawn floor, cache for the process
+ * lifetime, and expose the value so transport-call emitters can compute
+ * `scriptMs = max(0, durationMs - spawnFloorMs)` on every call.
+ *
+ * The floor is a lower bound — real per-call spawn cost may be slightly
+ * higher under cache pressure or system load — so `scriptMs` is a slight
+ * over-estimate of script-only work. That's the safe direction (keeps us
+ * conservative about claiming the REPL would help).
+ *
+ * Calibration is triggered lazily on first transport call (fire-and-forget);
+ * a single in-flight promise dedupes concurrent triggers. Until calibration
+ * completes, `getSpawnFloorMs()` returns `undefined` and emitters fall back
+ * to the pre-#939 behavior (no split fields).
+ *
+ * @see src/logging/transportCall.ts — consumer of the floor value
+ * @see src/adapter/jxa/scriptRunner.ts — JXA caller
+ * @see src/adapter/omnijs/scriptRunner.ts — OmniJS caller
+ */
+
+import { logger } from "../../logging/logger.js";
+
+/** A spawner that returns when the no-op script completes; structurally
+ *  identical to the JXA/OmniJS `ScriptSpawner` types. */
+type Spawner = (scriptBody: string, jsonArg: string, timeoutMs: number) => Promise<unknown>;
+
+/** Minimal JXA no-op: defines `run(argv)` so the runner contract holds,
+ *  and returns a valid JSON string so the spawner's success path fires. */
+const CALIBRATION_SCRIPT = "function run(){return JSON.stringify({});}";
+
+/** Calibration timeout. Generous; real spawn cost is sub-second on a healthy
+ *  host, and on a wedged host we want the timeout to surface rather than the
+ *  calibration to hang the rest of the loop. */
+const CALIBRATION_TIMEOUT_MS = 5_000;
+
+let cached: number | undefined;
+let inflight: Promise<number> | undefined;
+
+/**
+ * Returns the cached spawn floor (ms), or `undefined` if calibration has not
+ * yet completed. Cheap; no I/O.
+ */
+export function getSpawnFloorMs(): number | undefined {
+  return cached;
+}
+
+/**
+ * Trigger calibration if it hasn't run yet. Fire-and-forget at call sites —
+ * callers should pass through whatever `getSpawnFloorMs()` returns now and
+ * let later calls pick up the populated value.
+ *
+ * Idempotent: a second call while the first is in flight returns the same
+ * promise; calls after the first resolves return immediately with the cached
+ * value.
+ */
+export function ensureSpawnFloorCalibration(spawner: Spawner): Promise<number> {
+  if (cached !== undefined) return Promise.resolve(cached);
+  if (inflight !== undefined) return inflight;
+  inflight = (async () => {
+    const startedAt = performance.now();
+    try {
+      await spawner(CALIBRATION_SCRIPT, "{}", CALIBRATION_TIMEOUT_MS);
+    } catch {
+      // Calibration spawn failed — record the elapsed time anyway so we
+      // don't retry on every call. A failing spawner means downstream
+      // calls will fail too, surfacing the real problem.
+    }
+    const ms = Math.round(performance.now() - startedAt);
+    cached = ms;
+    logger.debug(
+      { event: "observability.spawn.calibrated", spawnFloorMs: ms },
+      "spawn floor calibrated",
+    );
+    return ms;
+  })();
+  return inflight;
+}
+
+/** Test-only: reset module state between cases. */
+export function __resetSpawnFloorForTesting(): void {
+  cached = undefined;
+  inflight = undefined;
+}

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -39,6 +39,7 @@ import {
 import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
 import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
+import { ensureSpawnFloorCalibration, getSpawnFloorMs } from "../_shared/spawnFloor.js";
 
 // ---------------------------------------------------------------------------
 // Spawner seam (injectable for tests)
@@ -219,6 +220,11 @@ export async function runJxaScript<T = unknown>(
   const scriptName = options.scriptName;
   const retry = resolveRetryPolicy(options.retry);
 
+  // Kick off osascript spawn-floor calibration on first call (#939).
+  // Fire-and-forget — the very first transport call may complete before
+  // the cache is populated; subsequent calls see the split fields.
+  void ensureSpawnFloorCalibration(spawner);
+
   const startedAt = performance.now();
   let result = await spawner(scriptBody, jsonArg, timeoutMs);
 
@@ -263,7 +269,7 @@ export async function runJxaScript<T = unknown>(
     result.stdout.trim() === ""
       ? "error"
       : "ok";
-  emitTransportCall("jxa", scriptName, args, durationMs, outcome);
+  emitTransportCall("jxa", scriptName, args, durationMs, outcome, getSpawnFloorMs());
 
   // 1. Spawn failure (binary missing) — the transport itself is unavailable.
   if (result.spawnError !== undefined) {

--- a/src/adapter/omnijs/scriptRunner.ts
+++ b/src/adapter/omnijs/scriptRunner.ts
@@ -50,6 +50,7 @@ import {
 import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
 import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
+import { ensureSpawnFloorCalibration, getSpawnFloorMs } from "../_shared/spawnFloor.js";
 
 // ---------------------------------------------------------------------------
 // Spawner seam (injectable for tests)
@@ -206,6 +207,11 @@ export async function runOmniJsScript<T = unknown>(
   const retry = resolveRetryPolicy(options.retry);
 
   const wrapped = wrapOmniJsForJxa(omniJsScriptBody, argsJson);
+
+  // Kick off osascript spawn-floor calibration on first call (#939). Shared
+  // floor with the JXA runner — same osascript binary, same fork cost.
+  void ensureSpawnFloorCalibration(spawner);
+
   const startedAt = performance.now();
   let result = await spawner(wrapped, argsJson, timeoutMs);
 
@@ -250,7 +256,7 @@ export async function runOmniJsScript<T = unknown>(
     result.stdout.trim() === ""
       ? "error"
       : "ok";
-  emitTransportCall("omnijs", scriptName, args, durationMs, outcome);
+  emitTransportCall("omnijs", scriptName, args, durationMs, outcome, getSpawnFloorMs());
 
   // 1. Spawn failure (binary missing) — the transport itself is unavailable.
   if (result.spawnError !== undefined) {

--- a/src/logging/transportCall.test.ts
+++ b/src/logging/transportCall.test.ts
@@ -7,11 +7,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetSpawnFloorForTesting } from "../adapter/_shared/spawnFloor.js";
 import { runJxaScript } from "../adapter/jxa/scriptRunner.js";
 import { runOmniJsScript } from "../adapter/omnijs/scriptRunner.js";
 import { withCorrelationId } from "./correlation.js";
 import { setLogLevel } from "./logger.js";
-import { hashArgs } from "./transportCall.js";
+import { emitTransportCall, hashArgs } from "./transportCall.js";
 
 // `transport.call` is a debug-level event (PII protection per DESIGN §21).
 // Force the singleton logger to debug for the duration of this suite so the
@@ -31,6 +32,8 @@ interface CapturedLine {
   argsHash?: string;
   outcome?: string;
   durationMs?: number;
+  spawnFloorMs?: number;
+  scriptMs?: number;
   correlationId?: string;
 }
 
@@ -176,5 +179,38 @@ describe("runOmniJsScript transport.call event", () => {
     expect(evt?.scriptName).toBe("omnijs_test");
     expect(evt?.outcome).toBe("ok");
     expect(evt?.argsHash).toBe(hashArgs({ y: 2 }));
+  });
+});
+
+describe("emitTransportCall — spawn / script split (#939)", () => {
+  let cap: ReturnType<typeof captureLogs>;
+
+  beforeEach(() => {
+    __resetSpawnFloorForTesting();
+    cap = captureLogs();
+  });
+  afterEach(() => {
+    cap.restore();
+  });
+
+  it("omits spawnFloorMs / scriptMs when no floor has been calibrated", () => {
+    emitTransportCall("jxa", "x", { a: 1 }, 42, "ok");
+    expect(cap.lines).toHaveLength(1);
+    expect(cap.lines[0]?.spawnFloorMs).toBeUndefined();
+    expect(cap.lines[0]?.scriptMs).toBeUndefined();
+    expect(cap.lines[0]?.durationMs).toBe(42);
+  });
+
+  it("computes scriptMs = max(0, durationMs - spawnFloorMs) when both are known", () => {
+    emitTransportCall("jxa", "x", { a: 1 }, 250, "ok", 100);
+    expect(cap.lines).toHaveLength(1);
+    expect(cap.lines[0]?.durationMs).toBe(250);
+    expect(cap.lines[0]?.spawnFloorMs).toBe(100);
+    expect(cap.lines[0]?.scriptMs).toBe(150);
+  });
+
+  it("clamps scriptMs to 0 when the floor exceeds the observed duration (system noise)", () => {
+    emitTransportCall("omnijs", "x", { a: 1 }, 80, "ok", 100);
+    expect(cap.lines[0]?.scriptMs).toBe(0);
   });
 });

--- a/src/logging/transportCall.ts
+++ b/src/logging/transportCall.ts
@@ -12,10 +12,17 @@
  *     transport: "jxa" | "omnijs",
  *     scriptName: string | undefined,
  *     argsHash: string,        // sha1 prefix of stable JSON
- *     durationMs: number,
+ *     durationMs: number,      // total wall-clock (spawn + script)
+ *     spawnFloorMs?: number,   // calibrated osascript spawn floor (#939)
+ *     scriptMs?: number,       // max(0, durationMs - spawnFloorMs) (#939)
  *     outcome: "ok" | "error",
  *     correlationId?: string,  // from the surrounding withCorrelationId scope
  *   }
+ *
+ * `durationMs` is preserved for back-compat with existing consumers; the
+ * `spawnFloorMs` / `scriptMs` split (#939) is additive and only present once
+ * boot calibration has completed (omitted on the very first calls in a
+ * process while calibration is still in flight).
  *
  * `argsHash` lets operators correlate identical calls without leaking the
  * args themselves — task names and notes stay out of the high-level log
@@ -42,7 +49,12 @@ export function emitTransportCall(
   args: unknown,
   durationMs: number,
   outcome: "ok" | "error",
+  spawnFloorMs?: number,
 ): void {
+  const split =
+    spawnFloorMs !== undefined
+      ? { spawnFloorMs, scriptMs: Math.max(0, durationMs - spawnFloorMs) }
+      : {};
   logger.debug(
     {
       event: "transport.call",
@@ -50,6 +62,7 @@ export function emitTransportCall(
       scriptName,
       argsHash: hashArgs(args),
       durationMs,
+      ...split,
       outcome,
       correlationId: getCorrelationId(),
     },


### PR DESCRIPTION
## Summary

- New `src/adapter/_shared/spawnFloor.ts` runs a one-off no-op JXA script on the first transport call and caches the elapsed time as `spawnFloorMs` for the process lifetime.
- `emitTransportCall` now carries `spawnFloorMs` + `scriptMs = max(0, durationMs - spawnFloorMs)` alongside the existing `durationMs` (preserved for back-compat).
- Both JXA and OmniJS script runners trigger calibration lazily (fire-and-forget) and pass the cached floor into the event.

Closes #939.

## Issue

Implements [#939 — perf(observability): split osascript spawn time from script execution time on transport.call](https://github.com/torsday/omnifocus-mcp/issues/939). The split answers the decision-gate question that's currently a guess: **does spawn cost dominate per-workflow time, or is the bottleneck inside the script?** That answer gates the persistent-REPL refactor ([#882](https://github.com/torsday/omnifocus-mcp/issues/882)) and the latency-aggregator work ([#936](https://github.com/torsday/omnifocus-mcp/issues/936)).

## Calibration design

- **Lazy, not eager.** Triggered on the first transport call via `void ensureSpawnFloorCalibration(spawner)`. Avoids any boot-path wiring; whichever runner gets the first call kicks it off. The very first call's event reports `durationMs` only (calibration still in flight); every subsequent call carries the split.
- **Process-scoped, single value.** One floor for the process lifetime. JXA + OmniJS share the same osascript binary and the same fork cost, so one calibration covers both.
- **Inflight dedupe.** Concurrent triggers share a single in-flight promise — no double-spawn even if calibration is triggered from multiple runners simultaneously.
- **Calibration script.** `function run(){return JSON.stringify({});}` piped through the same `execFile` path as real scripts — the wall-clock includes everything that real calls pay.
- **Failure handling.** A spawner that rejects still cubbies a cached value (so a failing host doesn't retry calibration on every call). Subsequent real calls will surface the underlying spawn failure as a `TransportUnavailable` themselves.

## Acceptance Criteria

- [x] **One-time calibration**, recorded as `spawnFloorMs`, cached for process lifetime, with one `observability.spawn.calibrated` log event.
- [x] **`scriptMs = max(0, durationMs - spawnFloorMs)`** in both `scriptRunner.ts` files.
- [x] **`transport.call` event shape extended** with `spawnFloorMs` and `scriptMs`; `durationMs` preserved.
- [x] **Unit tests** for the calibration path (6 cases: initial state, single-spawn caching, concurrent dedupe, repeated calls, failure-still-caches, script/arg/timeout passthrough) and the per-call split arithmetic (3 cases: omits when uncalibrated, computes when calibrated, clamps to 0 when floor > duration).
- [ ] **One-time measurement run** — out of scope here; recommended as a follow-up issue once this lands and the integration suite produces `transport.call` events with the new fields. The AC asks for a `jq` aggregator that computes `sum(spawnFloorMs * count) / sum(durationMs)` per workflow; that's a measurement task, not a code change.

## Breaking change?

- [x] No — `durationMs` is preserved unchanged; the split fields are additive and optional. Log consumers that don't know about them ignore them.

## Test plan

- [x] Unit tests added: `src/adapter/_shared/spawnFloor.test.ts` (6 cases) and extended `src/logging/transportCall.test.ts` with 3 split-field cases — 9 new tests in total.
- [x] Full `pnpm test` green (3654 passed; +4 vs baseline).
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` all green.
- [x] Self-reviewed via /review-pr.
- [x] No new dependencies.
- [ ] Live integration verification on `mac-local` — not run from this loop; the unit layer covers calibration, the per-call split arithmetic, and the integration with both runners. The split is observability-only — no behavior change for callers.