### PR TITLE
infra(ci): soft-fail integration-gate on PR events under #932 contention

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -197,7 +197,8 @@ jobs:
     #   skipped + fork PR                                → pass  (forks lack runner access by design)
     #   skipped + canonical PR + paths-irrelevant        → pass  (diff doesn't touch adapter/test paths)
     #   skipped + canonical PR / push / dispatch (other) → fail  (runner expected, didn't run)
-    #   failure / cancelled                              → fail
+    #   failure / cancelled, pull_request event          → soft-fail (warn, exit 0) per #932/#955
+    #   failure / cancelled, push or dispatch            → fail
     name: integration-gate
     runs-on: ubuntu-latest  # allow-hosted: gate must be reachable when self-hosted runner is offline (gap 2 of #679)
     timeout-minutes: 5
@@ -224,5 +225,10 @@ jobs:
             echo "ok: diff touches no integration-relevant paths; skip-cause=paths-irrelevant"
             exit 0
           fi
-          echo "::error::Integration suite did not pass (result=$RESULT). On canonical-repo PRs this gate requires the macos-omnifocus runner to be online and the suite green."
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "::warning::Integration suite did not pass (result=$RESULT). Soft-failing on PR per #932 contention; merge gating relies on local-verify discipline (see #955). The integration job still ran and its failures are visible above — review them before merging."
+            # Soft-fail: re-enable as `exit 1` when #932 closes.
+            exit 0
+          fi
+          echo "::error::Integration suite did not pass (result=$RESULT). On push (tag) / workflow_dispatch this gate requires the macos-omnifocus runner to be online and the suite green."
           exit 1


### PR DESCRIPTION
## Summary

- Extends [#933](https://github.com/torsday/omnifocus-mcp/pull/933)'s soft-fail pattern from `release.yml` to `pull_request` events on the integration-gate job.
- Push (tag) and `workflow_dispatch` triggers retain hard-fail — those are intentional, explicit triggers that should require a green run.
- The integration job still runs; failures are still visible in PR check rollups; they just don't block merging when the failure is the known [#932](https://github.com/torsday/omnifocus-mcp/issues/932) contention pattern.

Closes #955.

## Why

Every code-touching PR has been blocked on `integration-gate` failing because the JXA bridge is saturated by 28–36 concurrent MCP-server processes on the runner host. Today's session merged 7 PRs ([#942](https://github.com/torsday/omnifocus-mcp/pull/942), [#943](https://github.com/torsday/omnifocus-mcp/pull/943), [#944](https://github.com/torsday/omnifocus-mcp/pull/944), [#946](https://github.com/torsday/omnifocus-mcp/pull/946), [#948](https://github.com/torsday/omnifocus-mcp/pull/948), [#952](https://github.com/torsday/omnifocus-mcp/pull/952), [#953](https://github.com/torsday/omnifocus-mcp/pull/953)) — every one required `--admin` plus a manual local-verify + rationale comment. ~5 min of ceremony per PR scales linearly with throughput; this change cuts it.

## Trade-off

A real code-side regression could ship to main without integration catching it. Mitigations already in place:
- Comprehensive unit + sandbox test coverage (3650+ tests on the JXA/OmniJS transports)
- Local-verify discipline (typecheck + lint + full test suite on the branch) — currently done as part of every admin-merge ceremony anyway; soft-fail just removes the ceremony around it
- CHANGELOG entries that name the change so post-hoc verification is targeted
- The integration job continues to run and its failures are still visible in the PR check rollup — operators can still react when something genuinely looks suspect

## Self-clean-up path

When [#932](https://github.com/torsday/omnifocus-mcp/issues/932) closes structurally (Option B `OMNIFOCUS_BRIDGE_QUIESCE` flag or Option C dedicated runner), revert this PR's logic to hard-fail. The `# Soft-fail: re-enable as 'exit 1' when #932 closes.` comment marks the exact line.

## Test plan

- [ ] CI: this PR's own check rollup — the new soft-fail branch will fire on its integration failure, gate exits 0, and the PR becomes mergeable without --admin
- [x] YAML syntax valid (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Logic preserved for: success, fork-skip, paths-irrelevant, push/dispatch fail-cases