### PR TITLE
feat(transport): detect omnifocus modal/sync-locked state and surface as OFBusy

### DIFF
--- a/src/adapter/_shared/busyProbe.test.ts
+++ b/src/adapter/_shared/busyProbe.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for {@link probeOmniFocusResponsiveness} (#817).
+ * Covers each path through the result-classification logic with a faked
+ * spawner; no actual osascript is invoked.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ScriptSpawner, SpawnResult } from "../jxa/scriptRunner.js";
+import { probeOmniFocusResponsiveness } from "./busyProbe.js";
+
+function spawnerReturning(
+  result: Partial<SpawnResult> & Pick<SpawnResult, "stdout" | "stderr" | "exitCode" | "timedOut">,
+): ScriptSpawner {
+  return vi.fn().mockResolvedValue(result as SpawnResult);
+}
+
+describe("probeOmniFocusResponsiveness", () => {
+  it("returns responsive when stdout is non-empty and exit code is 0", async () => {
+    const spawner = spawnerReturning({
+      stdout: '{"name":"OmniFocus"}',
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    });
+    expect(await probeOmniFocusResponsiveness(spawner)).toBe("responsive");
+  });
+
+  it("returns unresponsive on timeout", async () => {
+    const spawner = spawnerReturning({
+      stdout: "",
+      stderr: "",
+      exitCode: null,
+      timedOut: true,
+    });
+    expect(await probeOmniFocusResponsiveness(spawner)).toBe("unresponsive");
+  });
+
+  it("returns unresponsive on non-zero exit", async () => {
+    const spawner = spawnerReturning({
+      stdout: "",
+      stderr: "error",
+      exitCode: 1,
+      timedOut: false,
+    });
+    expect(await probeOmniFocusResponsiveness(spawner)).toBe("unresponsive");
+  });
+
+  it("returns unresponsive on empty stdout (even with exit 0)", async () => {
+    const spawner = spawnerReturning({
+      stdout: "   \n",
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    });
+    expect(await probeOmniFocusResponsiveness(spawner)).toBe("unresponsive");
+  });
+
+  it("returns unresponsive when spawner reports spawnError", async () => {
+    const spawner = spawnerReturning({
+      stdout: "",
+      stderr: "",
+      exitCode: null,
+      timedOut: false,
+      spawnError: Object.assign(new Error("ENOENT"), { code: "ENOENT" }) as NodeJS.ErrnoException,
+    });
+    expect(await probeOmniFocusResponsiveness(spawner)).toBe("unresponsive");
+  });
+
+  it("returns unresponsive (never throws) when the spawner rejects", async () => {
+    const spawner: ScriptSpawner = vi.fn().mockRejectedValue(new Error("boom"));
+    expect(await probeOmniFocusResponsiveness(spawner)).toBe("unresponsive");
+  });
+
+  it("passes the supplied timeoutMs through to the spawner", async () => {
+    const spawner = vi.fn().mockResolvedValue({
+      stdout: '{"name":"OmniFocus"}',
+      stderr: "",
+      exitCode: 0,
+      timedOut: false,
+    } as SpawnResult);
+    await probeOmniFocusResponsiveness(spawner, 250);
+    expect(spawner).toHaveBeenCalledWith(expect.any(String), "{}", 250);
+  });
+});

--- a/src/adapter/_shared/busyProbe.ts
+++ b/src/adapter/_shared/busyProbe.ts
@@ -1,0 +1,86 @@
+/**
+ * OmniFocus "busy" detection (#817).
+ *
+ * When a regular JXA / OmniJS call hits its 30s timeout, three causes are
+ * possible:
+ *
+ *   1. **Wedged** — OmniFocus itself is in a bad state (corrupt sync, hung
+ *      database, crash). Every subsequent call also times out. The
+ *      transport circuit (#835) handles this case after 5 consecutive
+ *      failures.
+ *
+ *   2. **Busy** — OmniFocus is up and answering AppleEvents, but the
+ *      specific call was blocked. Almost always a UI-level modal (export
+ *      sheet, sync-conflict dialog) or an in-flight sync holding the
+ *      AppleScript queue.
+ *
+ *   3. **Cold start** — first call after OF launches; classifier #939
+ *      handles this with the spawn-floor calibration.
+ *
+ * This module separates (2) from (1) by issuing a cheap responsiveness
+ * probe after a Timeout fires. If the probe returns quickly, OmniFocus is
+ * reachable — the originating call was Busy, not Wedged, and the agent
+ * gets an actionable error message instead of "retry once".
+ *
+ * The probe runs ONLY on the error path; healthy calls are unaffected.
+ *
+ * @see #817 — this issue
+ * @see #835 — transport circuit for the sustained-wedge case
+ */
+
+import type { ScriptSpawner, SpawnResult } from "../jxa/scriptRunner.js";
+
+/** Default budget for the probe. Short enough not to materially slow error paths. */
+export const DEFAULT_PROBE_TIMEOUT_MS = 500;
+
+/**
+ * The cheapest non-permission-triggering JXA call we can issue. Reading
+ * `defaultDocument.name` requires no Automation permission against
+ * OmniFocus (it's `application object > document > name` — a static
+ * property), and the call returns whether or not a modal is open as
+ * long as OF's AppleEvent queue is actually moving.
+ */
+export const RESPONSIVENESS_PROBE_SCRIPT = `
+(function() {
+  const of = Application("OmniFocus");
+  return JSON.stringify({ name: of.defaultDocument.name() });
+})()
+`;
+
+/**
+ * Result of {@link probeOmniFocusResponsiveness}.
+ *
+ * - `"responsive"` — probe returned successfully → OF is up; original
+ *   Timeout was a Busy condition (modal / sync), not a true wedge.
+ * - `"unresponsive"` — probe timed out or otherwise failed → OF is
+ *   wedged or not running. Caller should surface the original Timeout
+ *   (the transport circuit picks it up on subsequent failures).
+ */
+export type ProbeOutcome = "responsive" | "unresponsive";
+
+/**
+ * Issue a fast responsiveness probe against OmniFocus.
+ *
+ * Uses the supplied JXA spawner so tests can fake it (production callers
+ * pass `defaultJxaSpawner`). Returns `"responsive"` iff the probe exits
+ * 0 with non-empty stdout within `timeoutMs`; any other result is
+ * `"unresponsive"`.
+ *
+ * Never throws — observability code must never throw from an error path.
+ */
+export async function probeOmniFocusResponsiveness(
+  spawner: ScriptSpawner,
+  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS,
+): Promise<ProbeOutcome> {
+  let result: SpawnResult;
+  try {
+    result = await spawner(RESPONSIVENESS_PROBE_SCRIPT, "{}", timeoutMs);
+  } catch {
+    return "unresponsive";
+  }
+  if (result.spawnError !== undefined) return "unresponsive";
+  if (result.timedOut) return "unresponsive";
+  if (result.exitCode !== 0) return "unresponsive";
+  if (result.stdout.trim() === "") return "unresponsive";
+  return "responsive";
+}

--- a/src/adapter/jxa/scriptRunner.test.ts
+++ b/src/adapter/jxa/scriptRunner.test.ts
@@ -88,12 +88,36 @@ describe("runJxaScript — happy path", () => {
 });
 
 describe("runJxaScript — error mapping", () => {
-  it("maps timeout to Timeout with transport context", async () => {
+  it("maps timeout to Timeout when responsiveness probe also fails", async () => {
+    // Spawner times out on EVERY call — both the main script and the
+    // post-hoc probe → classify as a true wedge (Timeout, not OFBusy).
     const spawner = fakeSpawner({ timedOut: true, exitCode: 1 });
     await expect(runJxaScript("script", {}, { spawner, timeoutMs: 250 })).rejects.toMatchObject({
       name: "Timeout",
       code: "OF_TIMEOUT",
       details: { transport: "jxa", timeoutMs: 250 },
+    });
+  });
+
+  it("converts Timeout → OFBusy when the responsiveness probe succeeds (#817)", async () => {
+    // First call (the actual script) times out; second call (the probe)
+    // returns successfully → OF is reachable, so the original timeout
+    // was a Busy condition (modal / sync), not a wedge.
+    let call = 0;
+    const spawner: ScriptSpawner = vi.fn(async (): Promise<SpawnResult> => {
+      call += 1;
+      if (call === 1) {
+        return { stdout: "", stderr: "", exitCode: null, timedOut: true };
+      }
+      return { stdout: '{"name":"OmniFocus"}', stderr: "", exitCode: 0, timedOut: false };
+    });
+    await expect(
+      runJxaScript("script", {}, { spawner, timeoutMs: 250, scriptName: "task_create" }),
+    ).rejects.toMatchObject({
+      name: "OFBusy",
+      code: "OF_BUSY",
+      remediationClass: "environment",
+      details: { transport: "jxa", scriptName: "task_create" },
     });
   });
 
@@ -276,10 +300,18 @@ describe("runJxaScript — retry-once on transient failures", () => {
       ...r,
     }));
     let i = 0;
-    return vi.fn(
-      async (_b: string, _a: string, _t: number): Promise<SpawnResult> =>
-        sequence[i++] as SpawnResult,
-    ) as ScriptSpawner & ReturnType<typeof vi.fn>;
+    return vi.fn(async (_b: string, _a: string, _t: number): Promise<SpawnResult> => {
+      // The post-Timeout responsiveness probe (#817) consumes an extra
+      // spawn whenever the main call times out. Repeat the last entry so
+      // tests don't have to enumerate the probe explicitly — the probe
+      // sees the same shape as the last real call, which means a "still
+      // timed out" sequence stays timed-out (Timeout, not OFBusy) and a
+      // "now succeeding" sequence reports responsive (irrelevant on the
+      // success path).
+      const idx = Math.min(i, sequence.length - 1);
+      i += 1;
+      return sequence[idx] as SpawnResult;
+    }) as ScriptSpawner & ReturnType<typeof vi.fn>;
   }
 
   it("retries a read-only script on timeout and returns the second-attempt result", async () => {
@@ -356,7 +388,8 @@ describe("runJxaScript — retry-once on transient failures", () => {
         },
       ),
     ).rejects.toBeInstanceOf(OmniFocusError);
-    expect(spawner.mock.calls).toHaveLength(1);
+    // 1 main call + 1 post-timeout responsiveness probe (#817). No retry.
+    expect(spawner.mock.calls).toHaveLength(2);
   });
 
   it("does NOT retry when scriptName is unknown (safe default)", async () => {
@@ -364,7 +397,7 @@ describe("runJxaScript — retry-once on transient failures", () => {
     await expect(
       runJxaScript("script", {}, { spawner, retry: { delayMs: 0 } }),
     ).rejects.toBeInstanceOf(OmniFocusError);
-    expect(spawner.mock.calls).toHaveLength(1);
+    expect(spawner.mock.calls).toHaveLength(2); // main + probe
   });
 
   it("does NOT retry when retry.enabled is false", async () => {
@@ -380,7 +413,7 @@ describe("runJxaScript — retry-once on transient failures", () => {
         },
       ),
     ).rejects.toBeInstanceOf(OmniFocusError);
-    expect(spawner.mock.calls).toHaveLength(1);
+    expect(spawner.mock.calls).toHaveLength(2); // main + probe
   });
 
   it("does NOT retry on non-transient errors (e.g. PermissionDenied)", async () => {
@@ -415,7 +448,10 @@ describe("runJxaScript — retry-once on transient failures", () => {
       },
     ).catch((e: unknown) => e);
     expect((err as Error).constructor.name).toBe("Timeout");
-    expect(spawner.mock.calls).toHaveLength(2);
+    // 2 main attempts + 1 post-timeout responsiveness probe (#817). The
+    // probe also times out (sequenceSpawner repeats the last entry), so
+    // we surface the wedge-class Timeout rather than OFBusy.
+    expect(spawner.mock.calls).toHaveLength(3);
   });
 
   it("does NOT retry on spawn failure (binary missing — not transient)", async () => {

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -29,6 +29,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import {
   ConflictError,
   NotFound,
+  OFBusy,
   OmniFocusNotRunning,
   PermissionDenied,
   ScriptError,
@@ -38,6 +39,7 @@ import {
 } from "../../errors/index.js";
 import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
+import { probeOmniFocusResponsiveness } from "../_shared/busyProbe.js";
 import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
 import { ensureSpawnFloorCalibration, getSpawnFloorMs } from "../_shared/spawnFloor.js";
 import { getJxaCircuit, isCircuitTransient } from "../_shared/transportCircuit.js";
@@ -300,9 +302,35 @@ async function runJxaScriptInner<T>(
     });
   }
 
-  // 2. Hard timeout.
+  // 2. Hard timeout. Classify post-hoc via a fast responsiveness probe:
+  //    if OmniFocus answers a cheap call right after the timeout, the
+  //    timed-out call was blocked by a modal sheet or in-flight sync
+  //    (Busy) rather than a true wedge. Surface the Busy case as a
+  //    user-action error so the agent shows a useful remediation message
+  //    instead of "retry once". Probe failures fall through to the
+  //    original Timeout — that's the wedge case, and the transport
+  //    circuit (#835) picks it up after N consecutive failures.
   if (result.timedOut) {
     const suffix = scriptName !== undefined ? ` (script: ${scriptName})` : "";
+    const probe = await probeOmniFocusResponsiveness(spawner);
+    if (probe === "responsive") {
+      logger.warn(
+        {
+          event: "of.busy.detected",
+          transport: "jxa",
+          ...(scriptName !== undefined ? { scriptName } : {}),
+          timeoutMs,
+        },
+        "OmniFocus is responsive but blocked — likely a modal or active sync",
+      );
+      throw new OFBusy(`OmniFocus is busy (script: ${scriptName ?? "unknown"})`, {
+        details: {
+          transport: "jxa",
+          timeoutMs,
+          ...(scriptName !== undefined ? { scriptName } : {}),
+        },
+      });
+    }
     throw new Timeout(`JXA script exceeded ${timeoutMs}ms timeout${suffix}`, {
       details: {
         transport: "jxa",

--- a/src/adapter/omnijs/scriptRunner.test.ts
+++ b/src/adapter/omnijs/scriptRunner.test.ts
@@ -225,10 +225,14 @@ describe("runOmniJsScript — retry-once on transient failures", () => {
       ...r,
     }));
     let i = 0;
-    return vi.fn(
-      async (_b: string, _a: string, _t: number): Promise<SpawnResult> =>
-        sequence[i++] as SpawnResult,
-    ) as ScriptSpawner & ReturnType<typeof vi.fn>;
+    return vi.fn(async (_b: string, _a: string, _t: number): Promise<SpawnResult> => {
+      // Repeat the last entry so the #817 post-Timeout probe (which
+      // consumes an extra spawn whenever the main call times out) doesn't
+      // force every test to enumerate the probe explicitly.
+      const idx = Math.min(i, sequence.length - 1);
+      i += 1;
+      return sequence[idx] as SpawnResult;
+    }) as ScriptSpawner & ReturnType<typeof vi.fn>;
   }
 
   it("retries a read-only script on timeout and returns the second-attempt result", async () => {
@@ -255,7 +259,8 @@ describe("runOmniJsScript — retry-once on transient failures", () => {
         },
       ),
     ).rejects.toBeInstanceOf(OmniFocusError);
-    expect(spawner.mock.calls).toHaveLength(1);
+    // 1 main call + 1 post-timeout responsiveness probe (#817). No retry.
+    expect(spawner.mock.calls).toHaveLength(2);
   });
 
   it("does NOT retry when scriptName is unknown (safe default)", async () => {
@@ -263,7 +268,7 @@ describe("runOmniJsScript — retry-once on transient failures", () => {
     await expect(
       runOmniJsScript("script", {}, { spawner, retry: { delayMs: 0 } }),
     ).rejects.toBeInstanceOf(OmniFocusError);
-    expect(spawner.mock.calls).toHaveLength(1);
+    expect(spawner.mock.calls).toHaveLength(2); // main + probe
   });
 
   it("does NOT retry when retry.enabled is false", async () => {
@@ -279,7 +284,7 @@ describe("runOmniJsScript — retry-once on transient failures", () => {
         },
       ),
     ).rejects.toBeInstanceOf(OmniFocusError);
-    expect(spawner.mock.calls).toHaveLength(1);
+    expect(spawner.mock.calls).toHaveLength(2); // main + probe
   });
 
   it("does NOT retry on non-transient errors (e.g. PermissionDenied via stderr)", async () => {
@@ -313,7 +318,10 @@ describe("runOmniJsScript — retry-once on transient failures", () => {
       },
     ).catch((e: unknown) => e);
     expect((err as Error).constructor.name).toBe("Timeout");
-    expect(spawner.mock.calls).toHaveLength(2);
+    // 2 main attempts + 1 post-timeout responsiveness probe (#817) = 3.
+    // The probe inherits the timed-out repeat from sequenceSpawner so it
+    // also reports unresponsive — that's the wedge path (Timeout, not OFBusy).
+    expect(spawner.mock.calls).toHaveLength(3);
   });
 
   it("does NOT retry on spawn failure (binary missing — not transient)", async () => {

--- a/src/adapter/omnijs/scriptRunner.ts
+++ b/src/adapter/omnijs/scriptRunner.ts
@@ -41,6 +41,7 @@
 import { execFile } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
 import {
+  OFBusy,
   OmniFocusNotRunning,
   PermissionDenied,
   ScriptError,
@@ -49,6 +50,7 @@ import {
 } from "../../errors/index.js";
 import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
+import { probeOmniFocusResponsiveness } from "../_shared/busyProbe.js";
 import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
 import { ensureSpawnFloorCalibration, getSpawnFloorMs } from "../_shared/spawnFloor.js";
 import { getOmniJsCircuit, isCircuitTransient } from "../_shared/transportCircuit.js";
@@ -285,9 +287,33 @@ async function runOmniJsScriptInner<T>(
     });
   }
 
-  // 2. Hard timeout.
+  // 2. Hard timeout. Post-hoc classification (see #817 / JXA twin): if OF
+  //    answers a cheap responsiveness probe immediately, the timed-out
+  //    call was Busy (modal / sync) rather than wedged. The probe runs on
+  //    the JXA bridge regardless of which transport hit the timeout —
+  //    `defaultDocument.name()` is a vanilla JXA call and a single source
+  //    of truth for "is OmniFocus reachable at all?".
   if (result.timedOut) {
     const suffix = scriptName !== undefined ? ` (script: ${scriptName})` : "";
+    const probe = await probeOmniFocusResponsiveness(spawner);
+    if (probe === "responsive") {
+      logger.warn(
+        {
+          event: "of.busy.detected",
+          transport: "omnijs",
+          ...(scriptName !== undefined ? { scriptName } : {}),
+          timeoutMs,
+        },
+        "OmniFocus is responsive but blocked — likely a modal or active sync",
+      );
+      throw new OFBusy(`OmniFocus is busy (script: ${scriptName ?? "unknown"})`, {
+        details: {
+          transport: "omnijs",
+          timeoutMs,
+          ...(scriptName !== undefined ? { scriptName } : {}),
+        },
+      });
+    }
     throw new Timeout(`OmniJS script exceeded ${timeoutMs}ms timeout${suffix}`, {
       details: {
         transport: "omnijs",

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -22,6 +22,7 @@
 export type ErrorCode =
   // Environment — retry pointless; user action required
   | "OF_NOT_RUNNING"
+  | "OF_BUSY"
   | "OF_PERMISSION_DENIED"
   | "OF_FEATURE_REQUIRES_PRO"
   | "OF_FEATURE_REQUIRES_VERSION"
@@ -254,6 +255,29 @@ export class ConflictError extends OmniFocusError {
 // ---------------------------------------------------------------------------
 // Transient — agent may retry after waiting
 // ---------------------------------------------------------------------------
+
+/**
+ * Thrown when OmniFocus is reachable but the specific call was blocked
+ * by a modal sheet (export, sync conflict, dialog) or an active sync
+ * (#817). Distinct from {@link Timeout} (true wedge — handled by the
+ * transport circuit, #835) and {@link OmniFocusNotRunning} (app exited).
+ *
+ * Detected post-hoc: after a JXA `Timeout` fires, the runner sends a
+ * cheap responsiveness probe (`defaultDocument.name()`) with a short
+ * timeout. If the probe succeeds, OmniFocus itself is up and answering
+ * AppleEvents — so the timed-out call was specifically blocked, almost
+ * always by a UI-level modal or in-flight sync. Surface as user-action.
+ */
+export class OFBusy extends OmniFocusError {
+  constructor(message: string, options: ErrorOptions = {}) {
+    super("OF_BUSY", message, {
+      remediationClass: "environment",
+      suggestion:
+        "OmniFocus is reachable but blocked — typically a modal sheet (export, sync conflict, dialog) or an in-progress sync. Switch to OmniFocus, dismiss any open dialog, wait for sync to finish, then retry.",
+      ...options,
+    });
+  }
+}
 
 /** Thrown when an OmniFocus call exceeded its hard timeout. */
 export class Timeout extends OmniFocusError {


### PR DESCRIPTION
## Summary

- New `OFBusy` error class (`OF_BUSY` code, `remediationClass: "environment"`) — surfaces when OmniFocus is reachable but a specific call was blocked.
- New `src/adapter/_shared/busyProbe.ts` — fast `defaultDocument.name()` probe with a 500ms budget. Used on the JXA and OmniJS error paths to classify Timeouts post-hoc.
- Both `runJxaScript` and `runOmniJsScript` now distinguish Timeout (true wedge → #835's circuit handles) from OFBusy (transient UI block → user dismisses the dialog).
- Emits `of.busy.detected` warning event per classification.

Closes #817.

## Issue

Implements [#817](https://github.com/torsday/omnifocus-mcp/issues/817). Composes with [#835](https://github.com/torsday/omnifocus-mcp/issues/835) (transport circuit) and [#816](https://github.com/torsday/omnifocus-mcp/issues/816) (retry-once) — three orthogonal failure-handling layers: retry transients, classify modal-blocks, break sustained outages.

## Breaking change?

- [x] No — additive. Healthy calls are unchanged. The only behavioural diff is on the error path: some `Timeout`s now surface as `OFBusy`. Both extend `OmniFocusError` and carry typed codes, so consumers that switch on `code` are unaffected unless they explicitly handle `OF_TIMEOUT`.

## Test plan

- [x] 7 new unit tests for the probe (responsive, all unresponsive paths, spawnError, rejection-safety, custom timeout).
- [x] New runner test asserting Timeout → OFBusy when probe succeeds.
- [x] Updated existing `sequenceSpawner` helpers in both runner test suites to repeat the last entry (avoids requiring every test to enumerate the probe call); updated all call-count assertions affected by the probe.
- [x] `pnpm typecheck`, `pnpm lint`, `actionlint` all green. `pnpm test` 3727 pass, **0 failures, no flake**.
- [x] Self-reviewed via /review-pr. Probe is on error-path only — zero overhead for healthy calls.