### PR TITLE
test(integration): per-test sub-folder isolation in contract harness

### DIFF
--- a/tests/contract/adapter.contract.ts
+++ b/tests/contract/adapter.contract.ts
@@ -84,6 +84,23 @@ export interface SandboxOptions {
    * crashed runs eventually get cleaned up. Defaults to `"mcp-fixture"`.
    */
   prefix?: string;
+  /**
+   * Opt in to **per-test sub-folder isolation** (#957). When `true`,
+   * the harness creates a fresh sub-folder under the suite sandbox on
+   * every `beforeEach`, routes that test's top-level project/folder
+   * creates into it, and deletes the sub-folder on `afterEach` —
+   * cascading any contained projects/tasks in a single Apple Event.
+   * Suite-level teardown still runs (idempotent on empty residue).
+   *
+   * Inbox tasks (`createTask` without `projectId`/`parentId`) and
+   * top-level tags continue to use the real OF inbox / root tag list
+   * regardless — re-routing them would break the assertions tests use
+   * to verify inbox-membership semantics (`task.projectId === null`).
+   * Suite-level bulk cleanup still tracks and removes them.
+   *
+   * Default `false` — preserves the previous suite-only sandbox shape.
+   */
+  perTest?: boolean;
 }
 
 /** Internal accumulator for sandbox-mode bulk teardown. */
@@ -106,10 +123,17 @@ interface SandboxAccumulated {
 export function runAdapterContract(label: string, options: AdapterContractOptions): void {
   const hookTimeout = options.hookTimeoutMs;
   const sandboxEnabled = options.sandbox !== undefined;
+  const perTestEnabled = sandboxEnabled && options.sandbox?.perTest === true;
 
   describe(`adapter contract — ${label}`, () => {
     let adapter: OmniFocusAdapter;
     let sandboxFolderId: FolderId | null = null;
+    /**
+     * Per-test sub-folder ID when `sandbox.perTest === true` (#957). Created
+     * in `beforeEach`, deleted in `afterEach`. Distinct from `sandboxFolderId`
+     * which is the suite-level root. Null when per-test mode is off.
+     */
+    let perTestFolderId: FolderId | null = null;
     const accumulated: SandboxAccumulated = { inboxTaskIds: [], tagIds: [] };
 
     // Suite-scoped sandbox — one fixture folder for all tests in this
@@ -127,10 +151,33 @@ export function runAdapterContract(label: string, options: AdapterContractOption
 
     beforeEach(async () => {
       const base = await options.createAdapter();
-      adapter = sandboxFolderId ? wrapWithSandbox(base, sandboxFolderId, accumulated) : base;
+      // Route target — the suite folder by default, or a freshly-created
+      // per-test sub-folder when `perTest` mode is on (#957). Per-test
+      // mode gives each test a brand-new namespace, so accumulated fixture
+      // state from prior tests can't bleed into this one's assertions.
+      let routeTarget: FolderId | null = sandboxFolderId;
+      if (perTestEnabled && sandboxFolderId) {
+        const setupAdapter = await options.createAdapter();
+        const testId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+        perTestFolderId = await setupAdapter.createFolder({
+          name: `t-${testId}`,
+          parentId: sandboxFolderId,
+        });
+        routeTarget = perTestFolderId;
+      }
+      adapter = routeTarget ? wrapWithSandbox(base, routeTarget, accumulated) : base;
     }, hookTimeout);
 
     afterEach(async () => {
+      // Per-test sub-folder cleanup (#957) — one Apple Event, cascades
+      // every project / nested folder / task this test created inside.
+      // Errors swallowed: the test may have already deleted contents
+      // explicitly (e.g. deleteFolder assertions).
+      if (perTestEnabled && perTestFolderId) {
+        const teardownAdapter = await options.createAdapter();
+        await teardownAdapter.deleteFolder(perTestFolderId).catch(() => {});
+        perTestFolderId = null;
+      }
       // Per-test cleanup only fires for non-sandbox drivers. Sandbox mode
       // accumulates IDs and bulk-deletes once in afterAll.
       if (!sandboxEnabled && options.cleanup) await options.cleanup(adapter);

--- a/tests/integration/transportRouter.contract.test.ts
+++ b/tests/integration/transportRouter.contract.test.ts
@@ -46,11 +46,21 @@ if (!INTEGRATION) {
 
   runAdapterContract("TransportRouter (live OmniFocus)", {
     createAdapter: () => router,
-    sandbox: { prefix: "mcp-fixture" },
+    sandbox: {
+      prefix: "mcp-fixture",
+      // Per-test sub-folder isolation (#957). Each test gets a fresh
+      // sub-folder under the suite sandbox so accumulated state from
+      // earlier tests can't bleed into this one's assertions. Inbox
+      // tasks still hit the real OF inbox (preserves the
+      // task.projectId === null assertions); suite-level bulk cleanup
+      // still tracks them.
+      perTest: true,
+    },
     // Cleanup deletes entities through osascript; the bulk teardown lands
     // a single recursive folder delete (cascades projects + contained
     // tasks) and parallel sweeps for inbox tasks + tags. 90s is generous
-    // headroom — typical teardown is ≤ 5s.
+    // headroom — typical teardown is ≤ 5s. Per-test teardown is one
+    // additional folder-delete each, still tractable inside the cap.
     hookTimeoutMs: 90_000,
   });
 }


### PR DESCRIPTION
## Summary

- New opt-in `perTest: true` flag on `SandboxOptions` in `tests/contract/adapter.contract.ts`. Each test gets a fresh sub-folder under the suite sandbox; `afterEach` deletes the sub-folder in one Apple Event (cascades all contained projects / nested folders / tasks).
- Integration mount (`tests/integration/transportRouter.contract.test.ts`) opts in. InMemory mount is unchanged.
- Cross-PR cold-start residue can no longer bleed into project/folder-shaped per-test assertions.

Closes #957.

## Issue

Implements slice 2 of [#914](https://github.com/torsday/omnifocus-mcp/issues/914) per [#957](https://github.com/torsday/omnifocus-mcp/issues/957). Composes with the reliability triad already in this v1 cycle (#816/#835/#817) — together with the workflow-level process reset (#959) and the seed-OmniJS migration (#961/#963), the integration suite now has end-to-end isolation top-to-bottom.

## Breaking change?

- [x] No — additive. `perTest` defaults to `false`, preserving the previous suite-only sandbox shape.

## Test plan

- [x] InMemory mount still passes the harness unmodified (sandbox option is omitted, perTest branch is dead code there).
- [x] Targeted run of `tests/contract/` + `tests/integration/` → 48 pass, 2 skip (the integration mount skips without `OMNIFOCUS_INTEGRATION=1`).
- [x] Full `pnpm test` → 3741 pass, **0 failures, no flake**.
- [x] `pnpm typecheck`, `pnpm lint`, `actionlint` all green.
- [x] Self-reviewed via /review-pr. The harness's existing `wrapWithSandbox` proxy is reused verbatim — only the route-target is per-test instead of suite-level.

## Notes on inbox-touching tests

Inbox tasks (`createTask` with no projectId/parentId) and top-level tags still write to the real OF inbox / root tag list. Re-routing them would break the `task.projectId === null` assertions several inbox-shaped tests rely on. Suite-level bulk cleanup still tracks and removes them. The synthetic-ID-collision concern in `getTasksMany preserves input order…` is a separate flake class best fixed at the test-side (deterministic out-of-band ID format) — not folded into this PR.