### PR TITLE
test(integration): introduce flaky-test quarantine track

### DIFF
--- a/docs/design/testing-and-ci.md
+++ b/docs/design/testing-and-ci.md
@@ -47,6 +47,32 @@ Not a percentage. The target is: **every error path in every service method is e
 
 Coverage is not enforced because it's gameable. Test *fidelity* is enforced at release time via Stryker mutation testing on a curated allowlist of high-value paths (`src/domain/`, `src/errors/`, `src/middleware/`, `src/server/`, tool input-validation schemas). The gate runs in `release.yml` after the test suite and before the npm publish step; thresholds are calibrated to `baseline − 5` so the gate enforces non-regression. See [ADR-0017](../adr/0017-mutation-testing-release-gate.md).
 
+### Flaky-test quarantine ([#958](https://github.com/torsday/omnifocus-mcp/issues/958))
+
+Tests that flake intermittently against the live-OmniFocus integration mount — cold-start JXA latency, sync timing, synthetic-ID collisions on a polluted runner — are quarantined via the `quarantineTest` helper at `tests/lib/quarantine.ts`. Quarantine is a triage tool, not a fix: it keeps the gating integration check honest while flake repairs land separately.
+
+**To move a test into quarantine:**
+
+1. Replace its `test("name", fn)` call with `quarantineTest("name", fn)`. The helper is a drop-in for `test`.
+2. Add an inline comment above the call explaining what flakes (the failure mode and why it's confined to the integration mount).
+3. File or reference the issue tracking the underlying repair.
+
+The helper appends `[quarantine]` to the test name so reviewers scanning a CI log can immediately tell which failures are gating vs. informational.
+
+**Behavior of quarantined tests:**
+
+| Tier / script | Behavior |
+|---|---|
+| Unit (default `pnpm test`) | **Runs** — the same contract harness is also mounted against `InMemoryAdapter`, which has no flake confound; unit-tier coverage of the method is preserved. |
+| Integration normal (`pnpm test:integration`) | **Skipped** — main check stays green when the reliable suite passes. |
+| Integration quarantine (`pnpm test:integration:quarantine`) | **Runs**; the script tolerates non-zero exit so a real failure here is informational. Run locally to confirm repairs before promoting a test back to plain `test()`. |
+
+**To graduate a test out of quarantine:**
+
+1. Repair the underlying flake (fix the cold-start latency, sync-timing race, or test-design issue — whatever was identified in the tracking issue).
+2. Run `pnpm test:integration:quarantine` locally and confirm the quarantined test now passes reliably.
+3. Replace `quarantineTest(...)` with plain `test(...)` and drop the explanatory comment. The graduation happens in the same PR as the repair so the test rejoins the gate immediately.
+
 ---
 
 ## CI/CD

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:loud": "VITEST_REPORTER=verbose vitest run",
     "test:watch": "vitest",
     "test:integration": "OMNIFOCUS_INTEGRATION=1 vitest run tests/integration --testTimeout=90000",
+    "test:integration:quarantine": "OMNIFOCUS_INTEGRATION=1 OMNIFOCUS_QUARANTINE=1 vitest run tests/integration --testTimeout=90000 || true",
     "test:perf": "OMNIFOCUS_PERF=1 vitest run tests/perf",
     "test:e2e": "OMNIFOCUS_E2E=1 vitest run tests/e2e",
     "test:bench:tokens": "OMNIFOCUS_BENCH=1 vitest run tests/benchmark/token-cost",

--- a/tests/contract/adapter.contract.ts
+++ b/tests/contract/adapter.contract.ts
@@ -37,6 +37,7 @@ import type {
 } from "../../src/adapter/OmniFocusAdapter.js";
 import type { FolderId, TagId, TaskId } from "../../src/domain/ids.js";
 import { NotFound, ValidationError } from "../../src/errors/index.js";
+import { quarantineTest } from "../lib/quarantine.js";
 
 /**
  * Options accepted by {@link runAdapterContract}.
@@ -365,16 +366,27 @@ export function runAdapterContract(label: string, options: AdapterContractOption
         expect(clone.completedAt).toBeNull();
       });
 
-      test("getTasksMany preserves input order and returns null for missing IDs", async () => {
-        const a = await adapter.createTask({ name: "a" });
-        const b = await adapter.createTask({ name: "b" });
-        const missing = a.replace(/.$/, "z") as typeof a; // structurally valid branded ID that isn't assigned
-        const result = await adapter.getTasksMany([b, missing, a]);
-        expect(result).toHaveLength(3);
-        expect(result[0]?.id).toBe(b);
-        expect(result[1]).toBeNull();
-        expect(result[2]?.id).toBe(a);
-      });
+      // Quarantined against the live-OmniFocus mount (#958): the
+      // `missing` ID is synthesized by mutating the last char of a
+      // real ID, which is structurally valid and — on a runner with
+      // many pre-existing tasks — has a non-zero chance of colliding
+      // with an unrelated real task. That makes `result[1] !== null`
+      // and the assertion fails for reasons unrelated to the contract
+      // being tested. InMemoryAdapter has no such collision, so the
+      // unit-tier mount still exercises this method reliably.
+      quarantineTest(
+        "getTasksMany preserves input order and returns null for missing IDs",
+        async () => {
+          const a = await adapter.createTask({ name: "a" });
+          const b = await adapter.createTask({ name: "b" });
+          const missing = a.replace(/.$/, "z") as typeof a; // structurally valid branded ID that isn't assigned
+          const result = await adapter.getTasksMany([b, missing, a]);
+          expect(result).toHaveLength(3);
+          expect(result[0]?.id).toBe(b);
+          expect(result[1]).toBeNull();
+          expect(result[2]?.id).toBe(a);
+        },
+      );
     });
 
     // ---------------------------------------------------------------------

--- a/tests/lib/quarantine.ts
+++ b/tests/lib/quarantine.ts
@@ -1,0 +1,72 @@
+/**
+ * Flaky-test quarantine helper (#958).
+ *
+ * Tests with confirmed flake history are wrapped in {@link quarantineTest}
+ * instead of vitest's `test`. The wrapper makes them invisible to the
+ * main `pnpm test:integration` run (skipped via `test.skipIf`) and only
+ * visible to the dedicated `pnpm test:integration:quarantine` script,
+ * which runs the whole suite with `OMNIFOCUS_QUARANTINE=1` and tolerates
+ * non-zero exit codes (informational-only).
+ *
+ * The main integration check stays green when the reliable suite passes
+ * — quarantined-but-still-broken tests no longer pollute the gate
+ * signal. Quarantine is a triage tool, not a fix: every entry should
+ * carry an inline reference to the issue tracking its repair, and the
+ * test should graduate back to plain `test()` once the underlying
+ * problem is gone.
+ *
+ * The `[quarantine]` suffix appended to the test name makes the
+ * quarantine status visible in vitest reporter output without needing
+ * to inspect the source — a reviewer scanning a CI log can immediately
+ * tell which failures are gating vs. informational.
+ *
+ * @see #958 — this issue
+ * @see #914 — integration-flake umbrella (parent)
+ * @see docs/design/testing-and-ci.md — full process for moving in/out
+ */
+
+import { test } from "vitest";
+
+/** True when running under the dedicated quarantine script. */
+const QUARANTINE_MODE = process.env.OMNIFOCUS_QUARANTINE === "1";
+/** True when running the live-OmniFocus integration mount. */
+const INTEGRATION_MODE = process.env.OMNIFOCUS_INTEGRATION === "1";
+
+/**
+ * Register a test that's currently flaky against the **live OmniFocus**
+ * integration mount. Identical signature to vitest's
+ * `test(name, fn, timeout)` so it's a drop-in replacement.
+ *
+ * The quarantine targets the integration tier specifically — the same
+ * contract harness is also mounted against `InMemoryAdapter` in the
+ * unit tier, which is deterministic and has no flake history. Skipping
+ * everywhere would lose unit-tier coverage of the underlying contract
+ * method for free.
+ *
+ * Behavior:
+ * - **Unit tier** (no `OMNIFOCUS_INTEGRATION`): always runs. The
+ *   InMemoryAdapter has no runner-pollution / cold-start / sync-timing
+ *   confound, so the test exercises the contract reliably here.
+ * - **Integration tier, normal run** (`OMNIFOCUS_INTEGRATION=1`,
+ *   no `OMNIFOCUS_QUARANTINE`): **skipped**. The main
+ *   `pnpm test:integration` script can stay green when the reliable
+ *   suite passes.
+ * - **Integration tier, quarantine run** (`OMNIFOCUS_INTEGRATION=1`,
+ *   `OMNIFOCUS_QUARANTINE=1`): runs. The wrapping
+ *   `pnpm test:integration:quarantine` script tolerates non-zero exit
+ *   so a real failure here is informational, not gating.
+ */
+export function quarantineTest(
+  name: string,
+  fn: () => void | Promise<void>,
+  timeout?: number,
+): void {
+  const suffixed = `${name} [quarantine]`;
+  // Integration tier under the normal script — quarantined out.
+  if (INTEGRATION_MODE && !QUARANTINE_MODE) {
+    test.skip(suffixed, fn, timeout);
+    return;
+  }
+  // Unit tier OR explicit quarantine run — execute the test.
+  test(suffixed, fn, timeout);
+}


### PR DESCRIPTION
## Summary

- New `quarantineTest` helper at `tests/lib/quarantine.ts` — drop-in replacement for `test()` that skips against the live-OmniFocus integration mount while keeping the unit-tier mount running (so `InMemoryAdapter` coverage is preserved).
- New `pnpm test:integration:quarantine` script — sets `OMNIFOCUS_QUARANTINE=1`, runs the whole integration suite, tolerates non-zero exit (informational-only).
- One known-flaky test (`getTasksMany preserves input order…`) moved into quarantine as proof.
- `docs/design/testing-and-ci.md` documents the full in/out-of-quarantine process.

Closes #958.

## Issue

Implements slice 3 of [#914](https://github.com/torsday/omnifocus-mcp/issues/914) per [#958](https://github.com/torsday/omnifocus-mcp/issues/958). With this PR, the umbrella's three slices are complete (slice 1 = #959 workflow process reset; slice 2 = #973 per-test sub-folder isolation; slice 3 = this PR).

## Breaking change?

- [x] No — additive helper + new script.

## Test plan

- [x] Unit tier (`pnpm test` no env): 48 contract tests pass against `InMemoryAdapter`, including the now-renamed `getTasksMany … [quarantine]` test.
- [x] Integration normal (`OMNIFOCUS_INTEGRATION=1 pnpm vitest …`): 47 pass + 1 skipped (the quarantined one) — main check stays green when the reliable suite passes.
- [x] Integration quarantine (`OMNIFOCUS_INTEGRATION=1 OMNIFOCUS_QUARANTINE=1 …`): 48 pass — quarantined tests rejoin.
- [x] Full `pnpm test` → 3741 pass, 0 failures, no flake.
- [x] `pnpm typecheck`, `pnpm lint`, `actionlint` all green; docs lint passes.
- [x] Self-reviewed via /review-pr. Helper is 25 LOC + docs; no shared-state surface touched outside the contract harness import.