### PR TITLE
fix(scripts): seed-integration-db --clean tolerates zombie folder refs

### DIFF
--- a/scripts/seed-integration-db.js
+++ b/scripts/seed-integration-db.js
@@ -156,11 +156,25 @@ const seedOmniJs = `
   // Clean pass — wipe both seed-owned ("mcp-fixture:") and harness-owned
   // ("mcp-fixture-<runId>") items by matching the shared base prefix.
   // Projects before folders so OF doesn't orphan project contents.
+  //
+  // Same zombie-reference hazard as the \`findIn\` helper above (#962):
+  // deleting a parent folder/project cascades to children whose
+  // references are still in the .slice() snapshot. Touching .name on a
+  // cascaded-already child throws "X is no longer valid". Swallow that
+  // throw and continue — a zombie ref is by definition already deleted,
+  // so it doesn't need our delete call. See #975.
+  const tryDelete = (obj) => {
+    try {
+      if (obj.name && obj.name.startsWith(PREFIX_BASE)) deleteObject(obj);
+    } catch (_) {
+      // Zombie reference (parent's delete cascaded it). Already gone.
+    }
+  };
   if (cleanFirst) {
-    flattenedProjects.slice().forEach(p => { if (p.name && p.name.startsWith(PREFIX_BASE)) deleteObject(p); });
-    inbox.slice().forEach(t => { if (t.name && t.name.startsWith(PREFIX_BASE)) deleteObject(t); });
-    flattenedFolders.slice().forEach(f => { if (f.name && f.name.startsWith(PREFIX_BASE)) deleteObject(f); });
-    flattenedTags.slice().forEach(t => { if (t.name && t.name.startsWith(PREFIX_BASE)) deleteObject(t); });
+    flattenedProjects.slice().forEach(tryDelete);
+    inbox.slice().forEach(tryDelete);
+    flattenedFolders.slice().forEach(tryDelete);
+    flattenedTags.slice().forEach(tryDelete);
   }
 
   // Tags (5)


### PR DESCRIPTION
## Summary

- The seed-script's `--clean` pass extracted into a `tryDelete` helper that swallows the "X is no longer valid" throw OmniJS emits on cascaded child references whose parent was already deleted earlier in the same pass.
- Mirrors the existing pattern in the `findIn` helper added in #962. Three call sites collapse to one `tryDelete` definition.
- Verified locally against a synthesized nested fixture: clean pass now exits 0 (1.2s) where the bare iteration threw.

Closes #975.

## Issue

Implements [#975](https://github.com/torsday/omnifocus-mcp/issues/975). Surfaced on yesterday's PR #974 CI run — the integration check failed at the seed step, before tests even started, when the runner had accumulated nested `mcp-fixture-*` folder residue.

## Breaking change?

- [x] No — strictly additive resilience. The clean pass deletes the same set of objects; it now also doesn't crash when an object was already cascade-deleted.

## Test plan

- [x] Local repro: synthesized a `parent / child / grandchild / project / task` nested fixture, ran `node scripts/seed-integration-db.js --clean` — exits 0 in 1.2s, all canonical fixtures present, all `mcp-fixture-test-*` residue gone.
- [x] `pnpm typecheck`, `pnpm lint`, `actionlint` all green. `pnpm test` 3741 pass, 0 failures.
- [x] Self-reviewed via /review-pr. Diff is +18/−4 in one file.

## Expected CI impact

This PR's integration check should be the first green integration run of this session — the bug it fixes has been the gate-failing failure on the last several PRs.