### PR TITLE
test(integration): quarantine listTags-filters-by-parentid

### DIFF
--- a/tests/contract/adapter.contract.ts
+++ b/tests/contract/adapter.contract.ts
@@ -533,7 +533,14 @@ export function runAdapterContract(label: string, options: AdapterContractOption
         expect((await adapter.getTag(id)).name).toBe("house");
       });
 
-      test("listTags filters by parentId (nested tag hierarchy)", async () => {
+      // Quarantined against the live-OmniFocus mount (#978): `tag_list`'s
+      // first call against a cold OmniFocus repeatedly hits its 30s JXA
+      // timeout — the #969 responsiveness probe correctly surfaces it as
+      // `OFBusy`, but the test still fails for cold-start reasons
+      // unrelated to the contract under test. Observed on #968, #969,
+      // #973, #977. Underlying cold-start fix lives at #887; this test
+      // graduates back to plain `test()` when that lands.
+      quarantineTest("listTags filters by parentId (nested tag hierarchy)", async () => {
         const parentId = await adapter.createTag({ name: "parent" });
         const childId = await adapter.createTag({ name: "child", parentId });
         await adapter.createTag({ name: "top" });


### PR DESCRIPTION
## Summary

- Wraps the repeat-flaky `listTags filters by parentId (nested tag hierarchy)` test in `quarantineTest`. One-line application of the mechanism shipped in #974.
- Unit-tier mount against `InMemoryAdapter` still runs the test (48/48 contract pass, unchanged); integration mount skips it alongside the synthetic-ID test from #958.

Closes #978.

## Issue

Implements [#978](https://github.com/torsday/omnifocus-mcp/issues/978). This is the maintenance follow-up on the #914 umbrella's three-slice plan: with #959 (process reset), #973 (per-test isolation), #974 (quarantine mechanism), #975 (seed-clean fix), and this PR all merged, the integration check should land green on the resulting run — the first such green this session.

## Breaking change?

- [x] No — `quarantineTest` defaults preserve unit-tier coverage.

## Test plan

- [x] Unit `pnpm test`: 3741 pass, 0 failures.
- [x] Unit-mode `pnpm vitest run tests/contract/inMemory.contract.test.ts`: 48 pass (test runs against InMemory).
- [x] Integration-mode env (`OMNIFOCUS_INTEGRATION=1`): 46 pass + 2 skipped (the two quarantined tests).
- [x] `pnpm typecheck`, `pnpm lint`, `actionlint` all green.
- [x] Self-reviewed via /review-pr — diff is +8/−1 in one file.

## Expected CI impact

This PR should be the first green-end-to-end integration run of the session, proving the #914 umbrella landed.