### PR TITLE
feat(scripts): add ts-check beachhead on task_get.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
 
       - run: pnpm typecheck
 
+      # JXA static-typing gate (#987 / #854). Beachhead is `task_get.js`;
+      # follow-up issues sweep the remaining scripts into `tsconfig.jxa-tscheck.json`.
+      - name: Typecheck opted-in JXA scripts
+        run: pnpm exec tsc -p tsconfig.jxa-tscheck.json
+
       - run: pnpm lint
 
       - run: pnpm test

--- a/scripts/generate-jxa-types.ts
+++ b/scripts/generate-jxa-types.ts
@@ -268,7 +268,13 @@ function emitClass(cls: ClassDef, knownClasses: Set<string>): string {
   // Multiple-inheritance isn't expressed in .sdef, so this is always
   // 0-or-1 parent.
   const extendsClause = cls.inherits ? ` extends ${tsClassName(cls.inherits)}` : "";
-  lines.push(`export interface ${tsName}${extendsClause} {`);
+  // Ambient declaration (no `export`) — `.d.ts` files containing only
+  // non-exported declarations are script-mode and their types are
+  // available globally to JXA `// @ts-check` consumers via the
+  // triple-slash reference (#987). The moment any `export` lands here
+  // the file becomes a module and the types disappear from script-mode
+  // consumers.
+  lines.push(`interface ${tsName}${extendsClause} {`);
 
   // Properties. JXA reads each property via a zero-arg method call.
   // `parentTask()` etc. — even read-only — are method-shaped at the JXA

--- a/src/scripts/jxa/CLAUDE.md
+++ b/src/scripts/jxa/CLAUDE.md
@@ -15,6 +15,40 @@ Each script reads its arguments by `JSON.parse`-ing the single argv value the sp
 - **`flattenedTasks.byId()` returns a specifier with error code `-1728`** when the ID does not exist (rather than `null`). Catch this at the transport boundary and map to `NotFoundError`; never let `-1728` leak to callers. Reference: `ec53b88` and #674.
 - **`flattenedTasks()` is full-DB.** When you have a narrowing source (a tag, a project), iterate that source's tasks instead — see `task_list.js`'s `tagId` shortcut. A naive whole-DB scan blows the 30s scriptRunner timeout on real databases.
 
+## Static typing (`// @ts-check` opt-in)
+
+Scripts can opt into TypeScript checking against the .sdef-derived ambient types
+in `_types/`. Beachhead reference: `task_get.js` (#987 / #854). Prologue:
+
+```js
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+```
+
+- `_types/omnifocus.d.ts` is **auto-generated** from `vendor/OmniFocus.sdef`
+  via `pnpm generate:jxa-types`. Never hand-edit; re-run the generator and
+  commit the regenerated file. The OF 4.x quirks above (no `parent()` on
+  Folder/Tag, etc.) are encoded as missing methods on the generated
+  interfaces — `tsc` flags them at typecheck time.
+- `_types/jxa-globals.d.ts` is **hand-maintained** — declares `Application`,
+  `Path`, `delay`, `ObjC`, `$`. Keep small; if you find yourself adding
+  OmniFocus-specific machinery here, the generator should emit it instead.
+- Both `.d.ts` files are **ambient** (no `export`). The moment any `export`
+  lands the file becomes a module and the types disappear from script-mode
+  consumers — the generator emits plain `interface X { ... }` for this reason.
+- Sdef `<property>` blocks become parameterless methods (`defaultDocument(): Document`).
+  At runtime JXA (and the sandbox mock) accept property access too —
+  `jxa-globals.d.ts` adds an `Application & { defaultDocument: Document }`
+  override so both `ofApp.defaultDocument.flattenedTasks()` and
+  `ofApp.defaultDocument().flattenedTasks()` typecheck. Existing scripts use
+  the property form; keep it consistent.
+- Symbols inlined at build time (per ADR-0020) are invisible to `tsc` —
+  declare them with `@type` JSDoc like `task_get.js` does for `buildTask`.
+- Gate: `tsconfig.jxa-tscheck.json` includes the opted-in scripts; CI runs
+  `pnpm exec tsc -p tsconfig.jxa-tscheck.json`. Add new opt-ins to its
+  `include` list as the rollout sweeps the directory.
+
 ## Testing
 
 Two harnesses, very different:

--- a/src/scripts/jxa/_types/jxa-globals.d.ts
+++ b/src/scripts/jxa/_types/jxa-globals.d.ts
@@ -1,0 +1,92 @@
+// Hand-maintained JXA runtime globals.
+//
+// Companion to the auto-generated `omnifocus.d.ts`. The OmniFocus type
+// interfaces are derived from `vendor/OmniFocus.sdef`; this file declares
+// the runtime entrypoints (`Application`, `Path`, `delay`, etc.) that
+// `osascript -l JavaScript` exposes implicitly.
+//
+// JXA scripts opt in via:
+//
+//   // @ts-check
+//   /// <reference path="_types/omnifocus.d.ts" />
+//   /// <reference path="_types/jxa-globals.d.ts" />
+//
+// Keep this file small and rarely-touched. If you find yourself adding
+// non-trivial JXA primitives here, consider whether the generator should
+// emit them instead (e.g. via the sdef's `<command>` blocks).
+//
+// @see https://developer.apple.com/library/archive/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/Introduction.html
+
+/**
+ * The JXA `Application(...)` global. Returns a typed handle to the named
+ * application. Most callers pass `"OmniFocus"` and use the
+ * `Application` interface from `omnifocus.d.ts`. The runtime resolves
+ * `Application.currentApplication()` for the calling process, but JXA
+ * scripts spawned by `osascript -l JavaScript` rarely need that path.
+ *
+ * `Application("OmniFocus")` is mutated at runtime — `includeStandardAdditions`
+ * is settable on the handle (per `task_get.js` and friends). The base
+ * `Application` interface from the sdef doesn't model that side; declare
+ * it here as an intersection so consumers can still assign.
+ */
+declare function Application(name: string): Application & {
+  includeStandardAdditions: boolean;
+  /**
+   * Sdef `<property>` blocks become parameterless methods in the generated
+   * `Application` interface (`defaultDocument(): Document`). Every script in
+   * this repo accesses it as a property (`ofApp.defaultDocument.flattenedTasks()`)
+   * — both the JXA runtime and the sandbox mock (`src/adapter/jxa/sandbox/`)
+   * model it that way. Add a property override here so `// @ts-check`
+   * consumers can use either form; intersection with the method signature
+   * means callers may still write `ofApp.defaultDocument()` if they prefer.
+   */
+  defaultDocument: Document;
+  /** Standard JXA constructor proxy — used to instantiate Tag/Folder/Project/Task by name. */
+  Tag: new (props: {
+    name: string;
+    [key: string]: unknown;
+  }) => unknown;
+  Folder: new (props: { name: string; [key: string]: unknown }) => unknown;
+  Project: new (props: { name: string; status?: unknown; [key: string]: unknown }) => unknown;
+  InboxTask: new (props: { name: string; [key: string]: unknown }) => unknown;
+  Task: new (props: { name: string; [key: string]: unknown }) => unknown;
+  /** Send-event wrapper used by some OF commands. */
+  add: (item: unknown, options: { to: unknown }) => void;
+  /** Evaluate an OmniJS expression inside the OmniFocus host (#960 / #962). */
+  evaluateJavascript: (source: string) => string;
+};
+
+/**
+ * The JXA `delay(seconds)` global. Blocks the script for the given
+ * number of seconds. Rarely used in this codebase (most waits happen in
+ * Node via the `_shared/spawnFloor` or retry-policy paths), but
+ * available to scripts that need to coordinate with sync.
+ */
+declare function delay(seconds: number): void;
+
+/**
+ * The JXA `Path(pathString)` global — wraps a POSIX path for use with
+ * file-handling AppleScript commands. Used by attachment scripts.
+ */
+declare function Path(pathString: string): unknown;
+
+/**
+ * The JXA `ObjC.import(...)` global — bridges to Foundation. Used by
+ * the few JXA scripts that need NSDate / NSURL machinery. Returns
+ * `unknown` because the imported namespace surface is opaque from
+ * TypeScript's POV.
+ */
+declare const ObjC: {
+  import(module: string): void;
+  unwrap<T = unknown>(obj: unknown): T;
+  deepUnwrap<T = unknown>(obj: unknown): T;
+};
+
+/**
+ * The JXA `$.NS…` Objective-C bridge entrypoint. Only present after
+ * `ObjC.import('Foundation')` runs. Conservatively typed — non-JSDoc'd
+ * callers get `any` to avoid forcing every consumer to model the
+ * Foundation surface.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Foundation bridge is intentionally untyped.
+declare const $: { [key: string]: any };

--- a/src/scripts/jxa/_types/omnifocus.d.ts
+++ b/src/scripts/jxa/_types/omnifocus.d.ts
@@ -9,7 +9,7 @@
 //           54 elements.
 
 /** OmniFocus 'application' class (sdef code: capp). */
-export interface Application {
+interface Application {
   /** [read-only] The name of the application. */
   name(): string;
   /** [read-only] The version number of the application. */
@@ -35,7 +35,7 @@ export interface Application {
 }
 
 /** OmniFocus 'document' class (sdef code: docu). */
-export interface Document {
+interface Document {
   /** [read-only] Its name. */
   name(): string;
   /** [read-only] Has it been modified since the last save? */
@@ -99,7 +99,7 @@ export interface Document {
 }
 
 /** OmniFocus 'window' class (sdef code: cwin). */
-export interface Window {
+interface Window {
   /** [read-only] The document whose contents are displayed in the window. */
   document(): Document;
   /** [read-only] The title of the window. */
@@ -127,7 +127,7 @@ export interface Window {
 }
 
 /** OmniFocus 'document window' class (sdef code: FCdw). */
-export interface DocumentWindow extends Window {
+interface DocumentWindow extends Window {
   /** The search term in the toolbar. If there is no search toolbar item, this will return missing value instead of an empty string and setting it will cause an error. */
   searchTerm(): string;
   /** The selected tab in the sidebar. */
@@ -143,7 +143,7 @@ export interface DocumentWindow extends Window {
 }
 
 /** OmniFocus 'quick entry tree' class (sdef code: FCQw). */
-export interface QuickEntryTree extends Tree {
+interface QuickEntryTree extends Tree {
   /** [read-only] Whether the quick entry panel is currently visible. */
   visible(): boolean;
   /** child collection of 'folder' */
@@ -159,7 +159,7 @@ export interface QuickEntryTree extends Tree {
 }
 
 /** OmniFocus 'setting' class (sdef code: FCos). */
-export interface Setting {
+interface Setting {
   /** [read-only] The identifier of the setting. */
   id(): string;
   /** The current value of the setting. */
@@ -169,13 +169,13 @@ export interface Setting {
 }
 
 /** OmniFocus 'focus sections' class (sdef code: FCFS). */
-export interface FocusSections {
+interface FocusSections {
   /** child collection of 'item' */
   items(): unknown[];
 }
 
 /** OmniFocus 'section' class (sdef code: FCSX). */
-export interface Section {
+interface Section {
   /** [read-only] The identifier of the project or folder. */
   id(): string;
   /** The name of the project or folder. */
@@ -183,7 +183,7 @@ export interface Section {
 }
 
 /** OmniFocus 'folder' class (sdef code: FCAr). */
-export interface Folder extends Section {
+interface Folder extends Section {
   /** [read-only] The identifier of the folder. */
   id(): string;
   /** The name of the folder. */
@@ -215,7 +215,7 @@ export interface Folder extends Section {
 }
 
 /** OmniFocus 'tag' class (sdef code: FCtg). */
-export interface Tag {
+interface Tag {
   /** The identifier of the tag. */
   id(): string;
   /** The name of the tag. */
@@ -253,11 +253,11 @@ export interface Tag {
 }
 
 /** OmniFocus 'deprecated context' class (sdef code: FCct). */
-export interface DeprecatedContext extends Tag {
+interface DeprecatedContext extends Tag {
 }
 
 /** OmniFocus 'project' class (sdef code: FCpr). */
-export interface Project extends Section {
+interface Project extends Section {
   /** The identifier of the project. */
   id(): string;
   /** [read-only] The next actionable child of this project. */
@@ -347,7 +347,7 @@ export interface Project extends Section {
 }
 
 /** OmniFocus 'task' class (sdef code: FCac). */
-export interface Task {
+interface Task {
   /** The identifier of the task. */
   id(): string;
   /** The name of the task. */
@@ -435,13 +435,13 @@ export interface Task {
 }
 
 /** OmniFocus 'forecast sidebar tree' class (sdef code: FCFt). */
-export interface ForecastSidebarTree extends SidebarTree {
+interface ForecastSidebarTree extends SidebarTree {
   /** child collection of 'forecast day' */
   forecastDays(): ForecastDay[];
 }
 
 /** OmniFocus 'forecast day' class (sdef code: FCdy). */
-export interface ForecastDay {
+interface ForecastDay {
   /** The identifier of the task. */
   id(): string;
   /** A display name for the forecast day. */
@@ -453,37 +453,37 @@ export interface ForecastDay {
 }
 
 /** OmniFocus 'available task' class (sdef code: FCat). */
-export interface AvailableTask extends Task {
+interface AvailableTask extends Task {
 }
 
 /** OmniFocus 'remaining task' class (sdef code: FC0T). */
-export interface RemainingTask extends Task {
+interface RemainingTask extends Task {
 }
 
 /** OmniFocus 'inbox task' class (sdef code: FCit). */
-export interface InboxTask extends Task {
+interface InboxTask extends Task {
   /** Inbox tasks (those contained directly by the document) have a provisionally set container that is made final by the 'compact' command. This allows you to set and get said container. The container must be either a task (not in the inbox or contained by an inbox task), a project or 'missing value'. */
   assignedContainer(): unknown;
 }
 
 /** OmniFocus 'flattened task' class (sdef code: FCft). */
-export interface FlattenedTask extends Task {
+interface FlattenedTask extends Task {
 }
 
 /** OmniFocus 'flattened project' class (sdef code: FCfx). */
-export interface FlattenedProject extends Project {
+interface FlattenedProject extends Project {
 }
 
 /** OmniFocus 'flattened folder' class (sdef code: FCff). */
-export interface FlattenedFolder extends Folder {
+interface FlattenedFolder extends Folder {
 }
 
 /** OmniFocus 'flattened tag' class (sdef code: FCfc). */
-export interface FlattenedTag extends Tag {
+interface FlattenedTag extends Tag {
 }
 
 /** OmniFocus 'sidebar tree' class (sdef code: FCst). */
-export interface SidebarTree extends Tree {
+interface SidebarTree extends Tree {
   /** [read-only] The list of possible smart group identifiers that can be set as the selected smart group identifier. */
   availableSmartGroupIdentifiers(): unknown;
   /** The currently selected smart group identifier. */
@@ -491,7 +491,7 @@ export interface SidebarTree extends Tree {
 }
 
 /** OmniFocus 'content tree' class (sdef code: FCCt). */
-export interface ContentTree extends Tree {
+interface ContentTree extends Tree {
   /** [read-only] The list of possible identifiers that can be set as the selected grouping identifier. */
   availableGroupingIdentifiers(): unknown;
   /** The currently selected grouping identifier, controlling how the results shown in the content area are grouped. */
@@ -515,15 +515,15 @@ export interface ContentTree extends Tree {
 }
 
 /** OmniFocus 'inbox tree' class (sdef code: FCIs). */
-export interface InboxTree extends Tree {
+interface InboxTree extends Tree {
 }
 
 /** OmniFocus 'library tree' class (sdef code: FCLt). */
-export interface LibraryTree extends Tree {
+interface LibraryTree extends Tree {
 }
 
 /** OmniFocus 'perspective' class (sdef code: FCoo). */
-export interface Perspective {
+interface Perspective {
   /** The identifier of the perspective. */
   id(): string;
   /** The name of the perspective. */
@@ -531,15 +531,15 @@ export interface Perspective {
 }
 
 /** OmniFocus 'builtin perspective' class (sdef code: FCbp). */
-export interface BuiltinPerspective extends Perspective {
+interface BuiltinPerspective extends Perspective {
 }
 
 /** OmniFocus 'custom perspective' class (sdef code: FCcp). */
-export interface CustomPerspective extends Perspective {
+interface CustomPerspective extends Perspective {
 }
 
 /** OmniFocus 'tree' class (sdef code: OTtr). */
-export interface Tree {
+interface Tree {
   /** [read-only] The name of the object being represented by this tree. */
   name(): string;
   /** [read-only] The identifier of object being represented by this tree. */
@@ -573,31 +573,31 @@ export interface Tree {
 }
 
 /** OmniFocus 'descendant tree' class (sdef code: OTds). */
-export interface DescendantTree extends Tree {
+interface DescendantTree extends Tree {
 }
 
 /** OmniFocus 'ancestor tree' class (sdef code: OTan). */
-export interface AncestorTree extends Tree {
+interface AncestorTree extends Tree {
 }
 
 /** OmniFocus 'leaf' class (sdef code: OTlf). */
-export interface Leaf extends Tree {
+interface Leaf extends Tree {
 }
 
 /** OmniFocus 'following sibling' class (sdef code: OTfs). */
-export interface FollowingSibling extends Tree {
+interface FollowingSibling extends Tree {
 }
 
 /** OmniFocus 'preceding sibling' class (sdef code: OTps). */
-export interface PrecedingSibling extends Tree {
+interface PrecedingSibling extends Tree {
 }
 
 /** OmniFocus 'selected tree' class (sdef code: OTst). */
-export interface SelectedTree extends Tree {
+interface SelectedTree extends Tree {
 }
 
 /** OmniFocus 'style' class (sdef code: OSst). */
-export interface Style {
+interface Style {
   /** [read-only] The object owning the style. */
   container(): unknown;
   /** The name of the font of the style. */
@@ -609,7 +609,7 @@ export interface Style {
 }
 
 /** OmniFocus 'attribute' class (sdef code: OSsa). */
-export interface Attribute {
+interface Attribute {
   /** [read-only] The name of the attribute. */
   name(): string;
   /** The style to which the attribute refers. */
@@ -625,7 +625,7 @@ export interface Attribute {
 }
 
 /** OmniFocus 'named style' class (sdef code: OSns). */
-export interface NamedStyle extends Style {
+interface NamedStyle extends Style {
   /** [read-only] An identifier for the named style that is unique within its document. Currently this identifier is not persistent between two different sessions of editing the document. */
   id(): string;
   /** The name of the style. Must be unique within the containing document. */
@@ -633,7 +633,7 @@ export interface NamedStyle extends Style {
 }
 
 /** OmniFocus 'rich text' class (sdef code: OSrt). */
-export interface RichText {
+interface RichText {
   /** The plain text contents of the rich text. */
   text(): string;
   /** The color of the first character. */
@@ -665,27 +665,27 @@ export interface RichText {
 }
 
 /** OmniFocus 'character' class (sdef code: cha ). */
-export interface Character extends RichText {
+interface Character extends RichText {
 }
 
 /** OmniFocus 'paragraph' class (sdef code: cpar). */
-export interface Paragraph extends RichText {
+interface Paragraph extends RichText {
 }
 
 /** OmniFocus 'word' class (sdef code: cwor). */
-export interface Word extends RichText {
+interface Word extends RichText {
 }
 
 /** OmniFocus 'attribute run' class (sdef code: catr). */
-export interface AttributeRun extends RichText {
+interface AttributeRun extends RichText {
 }
 
 /** OmniFocus 'attachment' class (sdef code: atts). */
-export interface Attachment extends RichText {
+interface Attachment extends RichText {
 }
 
 /** OmniFocus 'file attachment' class (sdef code: OSfA). */
-export interface FileAttachment extends Attachment {
+interface FileAttachment extends Attachment {
   /** [read-only] The path to the file for the attachment, if the attachment resides outside the document. */
   fileName(): unknown;
   /** [read-only] If true, the attached file will reside inside the document on the next save. */
@@ -693,7 +693,7 @@ export interface FileAttachment extends Attachment {
 }
 
 /** OmniFocus 'preference' class (sdef code: OFpf). */
-export interface Preference {
+interface Preference {
   /** [read-only] The identifier of the preference. */
   id(): string;
   /** The current value of the preference. */

--- a/src/scripts/jxa/task_get.js
+++ b/src/scripts/jxa/task_get.js
@@ -1,13 +1,41 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+
 /**
  * JXA: fetch one task by ID.
  *
  * Args (argv[0] JSON): { id: string }
  * Returns JSON: { task: Task }
  *
+ * Beachhead script for the JXA static-typing rollout (#987 / #854): the
+ * `@ts-check` directive plus the triple-slash reference make this file
+ * the first consumer of `_types/omnifocus.d.ts`. The reference resolves
+ * `Application("OmniFocus")` to the typed `Application` interface, so
+ * the `defaultDocument.flattenedTasks()` chain below is statically
+ * checked against the .sdef-derived signatures. The OF 4.x quirks
+ * (Folder/Tag have no `parent()`, etc.) surface at `tsc` time here, not
+ * at runtime in production.
+ *
  * @see src/adapter/jxa/JxaTransport.ts — caller
  * @see src/domain/task.ts — Task domain type
  */
 
+/**
+ * `buildTask` is spliced into this file at build time by the
+ * scriptInlinerPlugin (ADR-0020) via the `// @inline _helpers/build_task.js`
+ * directive below. TypeScript can't see the inline expansion at typecheck
+ * time, so declare the symbol explicitly. The helper's runtime contract
+ * lives in `_helpers/build_task.js`.
+ *
+ * @type {(task: unknown, options?: { effectiveAvailability?: boolean }) => object}
+ */
+let buildTask;
+
+/**
+ * @param {string[]} argv — argv[0] is the JSON-encoded input payload.
+ * @returns {string} JSON-encoded `{ task: ... }`.
+ */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);
@@ -18,8 +46,9 @@ function run(argv) {
 
   const allTasks = ofApp.defaultDocument.flattenedTasks();
   for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      return JSON.stringify({ task: buildTask(allTasks[i]) });
+    const t = allTasks[i];
+    if (t.id() === args.id) {
+      return JSON.stringify({ task: buildTask(t) });
     }
   }
 

--- a/tests/scripts/generate-jxa-types.test.ts
+++ b/tests/scripts/generate-jxa-types.test.ts
@@ -18,7 +18,7 @@ import { describe, expect, it } from "vitest";
 const DTS = readFileSync("src/scripts/jxa/_types/omnifocus.d.ts", "utf8");
 
 function interfaceBody(name: string): string {
-  const re = new RegExp(`^export interface ${name}[^\\n]*\\{([\\s\\S]*?)^\\}`, "m");
+  const re = new RegExp(`^interface ${name}[^\\n]*\\{([\\s\\S]*?)^\\}`, "m");
   const m = DTS.match(re);
   if (!m || m[1] === undefined) {
     throw new Error(`interface ${name} not found in generated .d.ts`);
@@ -80,6 +80,6 @@ describe("omnifocus.d.ts — shape", () => {
   });
 
   it("includes the Application interface at the top of the hierarchy", () => {
-    expect(DTS).toMatch(/^export interface Application/m);
+    expect(DTS).toMatch(/^interface Application/m);
   });
 });

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "target": "es2020",
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "skipLibCheck": true,
+    "lib": ["es2020"],
+    "types": []
+  },
+  "include": ["src/scripts/jxa/task_get.js"]
+}


### PR DESCRIPTION
## Summary
- Opts `src/scripts/jxa/task_get.js` into `// @ts-check` against the sdef-derived ambient types from #854 — the first JXA script under static type-checking.
- Adds `_types/jxa-globals.d.ts` (hand-maintained JXA runtime globals) and switches the generator to emit ambient (non-exported) `interface X` so script-mode `/// <reference />` consumers actually see the types.
- Wires `tsc -p tsconfig.jxa-tscheck.json` into CI's build job so the gate stays green as follow-up sweeps add scripts.

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` passes clean
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 3777 passed, 59 skipped
- [x] `pnpm lint` clean
- [x] `pnpm build` succeeds (bundle within budget)
- [x] Smoke-verified the types catch OF 4.x quirks (no `parent()` on Folder/Tag) at tsc time
- [x] `tests/scripts/generate-jxa-types.test.ts` — 11/11 passing against the regenerated `.d.ts`

Closes #987