### PR TITLE
infra(ci): add informational jxa-tsc job to meta-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,6 @@ jobs:
 
       - run: pnpm typecheck
 
-      # JXA static-typing gate (#987 / #854). Beachhead is `task_get.js`;
-      # follow-up issues sweep the remaining scripts into `tsconfig.jxa-tscheck.json`.
-      - name: Typecheck opted-in JXA scripts
-        run: pnpm exec tsc -p tsconfig.jxa-tscheck.json
-
       - run: pnpm lint
 
       - run: pnpm test

--- a/.github/workflows/meta-lint.yml
+++ b/.github/workflows/meta-lint.yml
@@ -47,6 +47,11 @@ on:
       # the merge requiring an admin bypass (#736).
       - "package.json"
       - "pnpm-lock.yaml"
+      # jxa-tsc job below also runs when the sdef snapshot or the
+      # opt-in tsconfig change (the generator + scripts/ are already
+      # covered by `scripts/**` / `src/**` above).
+      - "vendor/OmniFocus.sdef"
+      - "tsconfig.jxa-tscheck.json"
 
 permissions:
   contents: read
@@ -175,6 +180,47 @@ jobs:
       - uses: actions/checkout@v6
       - name: Verify every workflow job declares timeout-minutes
         run: scripts/verify-workflow-timeouts.sh
+
+  jxa-tsc:
+    # JXA static-typing gate (#988 / #854 / #987). Two guards in one job:
+    #
+    #   1. Regen-drift — re-runs `pnpm generate:jxa-types` and fails if the
+    #      committed `src/scripts/jxa/_types/omnifocus.d.ts` differs. The
+    #      generator is deterministic, so a non-empty diff means someone
+    #      edited the .d.ts by hand or forgot to regenerate after touching
+    #      `vendor/OmniFocus.sdef`.
+    #   2. Type-check — `tsc -p tsconfig.jxa-tscheck.json` over the scripts
+    #      that have opted into `// @ts-check` (beachhead: task_get.js).
+    #      The opt-in list grows in `tsconfig.jxa-tscheck.json` as #989
+    #      sweeps the directory.
+    #
+    # Informational at first per #647's CI promotion policy: failures
+    # surface as warnings and a job-summary annotation, but do not block
+    # the merge. Promote to required via branch-protection after a clean
+    # week — at which point flip `continue-on-error` to `false` and add
+    # the check to branch protection's required list.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Regen-drift — generated .d.ts matches committed copy
+        run: |
+          pnpm generate:jxa-types
+          if ! git diff --quiet -- src/scripts/jxa/_types/omnifocus.d.ts; then
+            echo "::warning file=src/scripts/jxa/_types/omnifocus.d.ts::Generated .d.ts drifted from committed copy — run \`pnpm generate:jxa-types\` and commit the result"
+            git --no-pager diff -- src/scripts/jxa/_types/omnifocus.d.ts | head -50
+            exit 1
+          fi
+      - name: Typecheck opted-in JXA scripts
+        run: pnpm exec tsc -p tsconfig.jxa-tscheck.json
 
   pnpm-audit:
     # Surface dependabot-style advisories on every dep-touching PR — this

--- a/docs/design/testing-and-ci.md
+++ b/docs/design/testing-and-ci.md
@@ -122,3 +122,11 @@ Every PR must pass these CI contexts before merge — `gh pr merge --auto` waits
 | `shellcheck` | Shell scripts under `scripts/` lint clean | `.github/workflows/meta-lint.yml` |
 
 `strict` is intentionally `false` (PR branches don't need to be up-to-date with `main`) — that's friction for solo dev that buys nothing the rest of the gate set isn't already covering. `enforce_admins` is also `false` (admin override is a deliberate escape hatch, not a default gate).
+
+#### Informational gates (run, surface, don't block)
+
+These checks run on every applicable PR but are configured with `continue-on-error: true` and are **not** in the branch-protection required list. Failures appear as warnings and a `::warning::` annotation; the merge is not blocked. After a clean soak week the gate is promoted by flipping `continue-on-error: false` and adding the check to the required list — this is the [#647](https://github.com/torsday/omnifocus-mcp/issues/647) CI promotion policy.
+
+| Context | What it gates | Source |
+|---|---|---|
+| `jxa-tsc` | (1) Regen-drift on `src/scripts/jxa/_types/omnifocus.d.ts` vs `pnpm generate:jxa-types`; (2) `tsc` over the JXA scripts opted into `// @ts-check` (`tsconfig.jxa-tscheck.json`). Path-filtered to PRs touching `src/scripts/jxa/**`, `vendor/OmniFocus.sdef`, `scripts/generate-jxa-types.ts`, or `tsconfig.jxa-tscheck.json`. Beachhead landed in [#987](https://github.com/torsday/omnifocus-mcp/issues/987); rollout to remaining scripts tracked in [#989](https://github.com/torsday/omnifocus-mcp/issues/989). | `.github/workflows/meta-lint.yml` |


### PR DESCRIPTION
## Summary
- New path-filtered `jxa-tsc` job in `meta-lint.yml` running regen-drift + `tsc` over the opted-in JXA scripts; informational (`continue-on-error: true`) per #647's CI promotion policy.
- Removes the equivalent step from `ci.yml` (added in #991) — co-locating with the meta-lint regression guards is a better fit and keeps the required `build (Node 24)` check unaffected during the soak week.
- Widens path filter to include `vendor/OmniFocus.sdef` and `tsconfig.jxa-tscheck.json` so sdef updates and opt-in expansions both fire the job.
- Documents the gate under a new "Informational gates" subsection in `docs/design/testing-and-ci.md`.

Closes #988

## Test plan
- [x] \`actionlint\` clean on the modified workflows
- [x] \`pnpm generate:jxa-types\` is idempotent — re-run produces empty diff
- [x] \`pnpm exec tsc -p tsconfig.jxa-tscheck.json\` passes clean
- [x] \`pnpm typecheck\`, \`pnpm lint\`, \`pnpm test\` (3777 passed, 59 skipped) all green