### PR TITLE
feat(scripts): opt ping.js into ts-check (#989 slice 1)

### DIFF
--- a/src/scripts/jxa/ping.js
+++ b/src/scripts/jxa/ping.js
@@ -1,3 +1,7 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+
 // Fixture JXA script used to verify the script-inlining loader.
 // Accepts no arguments; returns a simple pong payload.
 (() => {

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -11,5 +11,5 @@
     "lib": ["es2020"],
     "types": []
   },
-  "include": ["src/scripts/jxa/task_get.js"]
+  "include": ["src/scripts/jxa/ping.js", "src/scripts/jxa/task_get.js"]
 }


### PR DESCRIPTION
## Summary
- Opts \`ping.js\` (smallest, self-contained JXA fixture) into the static-typing gate alongside the #987 beachhead.
- Surfaces the type-system gaps that block the rest of #989's sweep; categorized and filed as #994.
- Does NOT close #989 — the parent sweep remains open until #994 lands and the wider batch can be opted in.

## What this is, in one paragraph
A dry-run of slice 1's planned 9-script batch produced 30+ errors in 5 distinct gap categories that span the type system, not the scripts themselves (\`argv\` has no JSDoc; \`jxa-globals.d.ts\` missing \`activate\`/\`processes\`; inlined helpers like \`buildFolder\`/\`lookupOrThrow\` not declared; sdef-derived \`.d.ts\` missing \`fileAttachments\` and element-query methods; \`\$.NSURL(path)\` Foundation bridge typing too loose to be callable). These need to be solved once at the type-system level — working around them per-script would distort the production scripts to fit the type system rather than the other way round. Filed as #994 with per-category acceptance criteria; this PR ships the only script that needs zero workarounds (\`ping.js\`) so the gate keeps growing and #994 has a concrete next-step starting point.

## Test plan
- [x] \`pnpm exec tsc -p tsconfig.jxa-tscheck.json\` passes clean (task_get + ping)
- [x] \`pnpm typecheck\` clean
- [x] \`tests/scripts/generate-jxa-types.test.ts\` (11/11) green
- [x] CI \`jxa-tsc\` job will pick up the new include automatically

Refs #989; #994 (gaps blocker)