### PR TITLE
feat(scripts): fill jxa-globals + foundation typing gaps

### DIFF
--- a/src/scripts/jxa/_types/jxa-globals.d.ts
+++ b/src/scripts/jxa/_types/jxa-globals.d.ts
@@ -54,6 +54,25 @@ declare function Application(name: string): Application & {
   add: (item: unknown, options: { to: unknown }) => void;
   /** Evaluate an OmniJS expression inside the OmniFocus host (#960 / #962). */
   evaluateJavascript: (source: string) => string;
+  /**
+   * Standard JXA `activate()` — brings the application to the foreground.
+   * Used by `app_launch.js` after spawning OmniFocus. Available on every
+   * JXA Application handle, not just OmniFocus, so it lives in the global
+   * intersection. Returns void at runtime.
+   */
+  activate: () => void;
+  /**
+   * `processes` belongs to System Events, exposed via
+   * `Application("System Events").processes.whose({ name: "OmniFocus" })()`.
+   * Returning it from the generic Application intersection is broad-but-correct:
+   * it never resolves on OmniFocus, so a stray access there would fail at
+   * runtime anyway. The `whose(filter)` query returns a thunk that, when
+   * called, yields the matching specifiers — conservatively typed as
+   * `unknown[]` since the script only checks `.length` (`app_launch.js`).
+   */
+  processes: {
+    whose(filter: Record<string, unknown>): () => unknown[];
+  };
 };
 
 /**
@@ -84,9 +103,15 @@ declare const ObjC: {
 
 /**
  * The JXA `$.NS…` Objective-C bridge entrypoint. Only present after
- * `ObjC.import('Foundation')` runs. Conservatively typed — non-JSDoc'd
- * callers get `any` to avoid forcing every consumer to model the
- * Foundation surface.
+ * `ObjC.import('Foundation')` runs. Typed as plain `any` (rather than
+ * `{ [key: string]: any }`) because the Foundation surface is mostly
+ * used as `$.NSURL(path).fileURLWithPath_(…)` — chained callable proxies.
+ * The keyed-index form lets you read a member but the resulting value's
+ * call-signature isn't preserved by TypeScript, which trips a
+ * `TS2349: This expression is not callable.` on every `$.NSFoo(...)` site.
+ * `any` short-circuits that without forcing every consumer to model
+ * Foundation. We accept the lost intellisense in exchange for letting
+ * `// @ts-check` scripts compile (`attachment_save_to_path.js` etc.).
  */
-// biome-ignore lint/suspicious/noExplicitAny: Foundation bridge is intentionally untyped.
-declare const $: { [key: string]: any };
+// biome-ignore lint/suspicious/noExplicitAny: Foundation bridge is intentionally untyped — see comment above.
+declare const $: any;

--- a/src/scripts/jxa/app_launch.js
+++ b/src/scripts/jxa/app_launch.js
@@ -1,3 +1,7 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+
 /**
  * app_launch.js — launch OmniFocus explicitly (never automatic).
  *
@@ -13,6 +17,10 @@
  * @see docs/adr/0005-scripts-as-first-class-files.md
  */
 
+/**
+ * @param {string[]} _argv — unused; this script takes no arguments.
+ * @returns {string} JSON-encoded `{ launched, alreadyRunning }`.
+ */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run() by convention.
 function run(_argv) {
   const SystemEvents = Application("System Events");

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -11,5 +11,9 @@
     "lib": ["es2020"],
     "types": []
   },
-  "include": ["src/scripts/jxa/ping.js", "src/scripts/jxa/task_get.js"]
+  "include": [
+    "src/scripts/jxa/app_launch.js",
+    "src/scripts/jxa/ping.js",
+    "src/scripts/jxa/task_get.js"
+  ]
 }


### PR DESCRIPTION
## Summary
- Addresses categories (2) jxa-globals primitives and (5) Foundation bridge typing from the 5-category inventory filed in #994.
- Adds `activate()` and `processes.whose()` to the `Application` intersection in `_types/jxa-globals.d.ts`.
- Loosens `$` Foundation bridge from `{ [key: string]: any }` to plain `any` — fixes `TS2349` on every `$.NSFoo(...)` site without forcing consumers to model Foundation.
- Opts `app_launch.js` into the gate (size-1 slice toward #989); the new typing makes it pass with only the standard prologue + JSDoc `@param {string[]} _argv`.

Closes #994 (but the issue will be **reopened post-merge** because categories 1/3/4 are still pending — using `Closes` to satisfy the `require-issue-link` gate; this is the documented multi-slice workflow for this repo).

## Remaining #994 gaps (deferred to next slices, issue will be reopened)
- (1) per-script `argv` JSDoc codemod — mechanical sweep
- (3) inlined-helper declaration policy (`buildFolder`, `lookupOrThrow`, …) — needs an `_helpers/CLAUDE.md` decision
- (4) sdef generator extensions for `fileAttachments` and the element-query API (`byId`, `whose`)

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` passes (task_get + ping + app_launch)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, 16 warnings — unchanged from main)
- [x] `pnpm test` 3783 passed / 59 skipped
- [x] `tests/scripts/generate-jxa-types.test.ts` 11/11

Refs #989 (rollout)