### PR TITLE
feat(scripts): add argv jsdoc to every jxa script

### DIFF
--- a/src/scripts/jxa/attachment_add.js
+++ b/src/scripts/jxa/attachment_add.js
@@ -9,6 +9,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/attachment_list.js
+++ b/src/scripts/jxa/attachment_list.js
@@ -10,6 +10,7 @@
  * @see src/domain/attachment.ts — Attachment domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/attachment_remove.js
+++ b/src/scripts/jxa/attachment_remove.js
@@ -9,6 +9,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/attachment_save_to_path.js
+++ b/src/scripts/jxa/attachment_save_to_path.js
@@ -12,6 +12,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   ObjC.import("Foundation");

--- a/src/scripts/jxa/changes_since.js
+++ b/src/scripts/jxa/changes_since.js
@@ -37,6 +37,7 @@
  * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv)
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/folder_create.js
+++ b/src/scripts/jxa/folder_create.js
@@ -8,6 +8,7 @@
  * @see src/domain/folder.ts — Folder domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/folder_delete.js
+++ b/src/scripts/jxa/folder_delete.js
@@ -8,6 +8,7 @@
  * @see src/domain/folder.ts — Folder domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/folder_get.js
+++ b/src/scripts/jxa/folder_get.js
@@ -8,6 +8,7 @@
  * @see src/domain/folder.ts — Folder domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/folder_list.js
+++ b/src/scripts/jxa/folder_list.js
@@ -8,6 +8,7 @@
  * @see src/domain/folder.ts — Folder domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/folder_update.js
+++ b/src/scripts/jxa/folder_update.js
@@ -8,6 +8,7 @@
  * @see src/domain/folder.ts — Folder domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/forecast_get.js
+++ b/src/scripts/jxa/forecast_get.js
@@ -21,6 +21,7 @@
  * @see src/domain/task.ts — Task domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/note_get_html.js
+++ b/src/scripts/jxa/note_get_html.js
@@ -8,6 +8,7 @@
  * @see src/tools/note/get_html.ts — MCP tool
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/perspective_evaluate.js
+++ b/src/scripts/jxa/perspective_evaluate.js
@@ -22,6 +22,7 @@
  * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   try {

--- a/src/scripts/jxa/perspective_list.js
+++ b/src/scripts/jxa/perspective_list.js
@@ -11,6 +11,7 @@
  * @see src/domain/perspective.ts — Perspective domain type
  */
 
+/** @param {string[]} _argv — unused; this script takes no arguments. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(_argv) {
   const ofApp = Application("OmniFocus");

--- a/src/scripts/jxa/project_batch_complete.js
+++ b/src/scripts/jxa/project_batch_complete.js
@@ -14,6 +14,7 @@
  * @see src/scripts/jxa/project_batch_drop.js — sibling pattern
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_batch_drop.js
+++ b/src/scripts/jxa/project_batch_drop.js
@@ -15,6 +15,7 @@
  * @see src/scripts/jxa/project_batch_complete.js — sibling pattern
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_complete.js
+++ b/src/scripts/jxa/project_complete.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_create.js
+++ b/src/scripts/jxa/project_create.js
@@ -10,6 +10,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_delete.js
+++ b/src/scripts/jxa/project_delete.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_drop.js
+++ b/src/scripts/jxa/project_drop.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_get.js
+++ b/src/scripts/jxa/project_get.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_get_many.js
+++ b/src/scripts/jxa/project_get_many.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_list.js
+++ b/src/scripts/jxa/project_list.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_mark_reviewed.js
+++ b/src/scripts/jxa/project_mark_reviewed.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_move.js
+++ b/src/scripts/jxa/project_move.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_set_next_review_date.js
+++ b/src/scripts/jxa/project_set_next_review_date.js
@@ -20,6 +20,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_set_review_interval.js
+++ b/src/scripts/jxa/project_set_review_interval.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/project_update.js
+++ b/src/scripts/jxa/project_update.js
@@ -11,6 +11,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/review_list_due.js
+++ b/src/scripts/jxa/review_list_due.js
@@ -8,6 +8,7 @@
  * @see src/domain/project.ts — Project domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   JSON.parse(argv[0]); // validate JSON even though no args needed

--- a/src/scripts/jxa/sync_trigger.js
+++ b/src/scripts/jxa/sync_trigger.js
@@ -13,6 +13,7 @@
  * @see src/adapter/OmniFocusAdapter.ts — `syncTrigger()` contract
  */
 
+/** @param {string[]} _argv — unused; this script takes no arguments. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(_argv) {
   const ofApp = Application("OmniFocus");

--- a/src/scripts/jxa/tag_create.js
+++ b/src/scripts/jxa/tag_create.js
@@ -8,6 +8,7 @@
  * @see src/domain/tag.ts — Tag domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/tag_delete.js
+++ b/src/scripts/jxa/tag_delete.js
@@ -8,6 +8,7 @@
  * @see src/domain/tag.ts — Tag domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/tag_get.js
+++ b/src/scripts/jxa/tag_get.js
@@ -8,6 +8,7 @@
  * @see src/domain/tag.ts — Tag domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/tag_get_many.js
+++ b/src/scripts/jxa/tag_get_many.js
@@ -8,6 +8,7 @@
  * @see src/domain/tag.ts — Tag domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/tag_list.js
+++ b/src/scripts/jxa/tag_list.js
@@ -8,6 +8,7 @@
  * @see src/domain/tag.ts — Tag domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/tag_update.js
+++ b/src/scripts/jxa/tag_update.js
@@ -8,6 +8,7 @@
  * @see src/domain/tag.ts — Tag domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_batch_complete.js
+++ b/src/scripts/jxa/task_batch_complete.js
@@ -10,6 +10,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_batch_create.js
+++ b/src/scripts/jxa/task_batch_create.js
@@ -11,6 +11,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_batch_delete.js
+++ b/src/scripts/jxa/task_batch_delete.js
@@ -11,6 +11,7 @@
  * @see src/scripts/jxa/task_batch_complete.js — sibling pattern
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_batch_drop.js
+++ b/src/scripts/jxa/task_batch_drop.js
@@ -12,6 +12,7 @@
  * @see src/scripts/jxa/task_drop.js — singular counterpart
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_batch_uncomplete.js
+++ b/src/scripts/jxa/task_batch_uncomplete.js
@@ -16,6 +16,7 @@
  * @see src/scripts/jxa/task_uncomplete.js — singular counterpart
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_batch_undrop.js
+++ b/src/scripts/jxa/task_batch_undrop.js
@@ -12,6 +12,7 @@
  * @see src/scripts/jxa/task_undrop.js — singular counterpart
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_batch_update.js
+++ b/src/scripts/jxa/task_batch_update.js
@@ -11,6 +11,7 @@
  * @see src/scripts/jxa/task_update.js — single-update reference
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_complete.js
+++ b/src/scripts/jxa/task_complete.js
@@ -7,6 +7,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -13,6 +13,7 @@
  * @see src/domain/task.ts — Task domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_delete.js
+++ b/src/scripts/jxa/task_delete.js
@@ -7,6 +7,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_drop.js
+++ b/src/scripts/jxa/task_drop.js
@@ -7,6 +7,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_duplicate.js
+++ b/src/scripts/jxa/task_duplicate.js
@@ -12,6 +12,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_get_many.js
+++ b/src/scripts/jxa/task_get_many.js
@@ -8,6 +8,7 @@
  * @see src/domain/task.ts — Task domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -27,6 +27,7 @@
  * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_move.js
+++ b/src/scripts/jxa/task_move.js
@@ -7,6 +7,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_reorder.js
+++ b/src/scripts/jxa/task_reorder.js
@@ -16,6 +16,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -28,6 +28,7 @@
  * @see src/scripts/jxa/forecast_get.js — same whose() pushdown pattern
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_uncomplete.js
+++ b/src/scripts/jxa/task_uncomplete.js
@@ -7,6 +7,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_undrop.js
+++ b/src/scripts/jxa/task_undrop.js
@@ -7,6 +7,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -15,6 +15,7 @@
  * @see src/domain/task.ts — Task domain type
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/window_get_state.js
+++ b/src/scripts/jxa/window_get_state.js
@@ -11,6 +11,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — getWindowState() caller
  */
 
+/** @param {string[]} _argv — unused; this script takes no arguments. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run() by convention.
 function run(_argv) {
   const ofApp = Application("OmniFocus");

--- a/src/scripts/jxa/window_set_focus.js
+++ b/src/scripts/jxa/window_set_focus.js
@@ -19,6 +19,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — setWindowFocus() caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);

--- a/src/scripts/jxa/window_set_perspective.js
+++ b/src/scripts/jxa/window_set_perspective.js
@@ -12,6 +12,7 @@
  * @see src/adapter/jxa/JxaTransport.ts — setWindowPerspective() caller
  */
 
+/** @param {string[]} argv — argv[0] is the JSON-encoded input payload. */
 // biome-ignore lint/correctness/noUnusedVariables: osascript invokes run(argv) by convention.
 function run(argv) {
   const args = JSON.parse(argv[0]);


### PR DESCRIPTION
## Summary
- Mechanical codemod: every `function run(argv)` (or `_argv`) in `src/scripts/jxa/*.js` now carries a one-line `@param {string[]} argv` JSDoc directly above the biome-ignore comment.
- Closes category (1) of the 5-category type-system gap inventory in #994.
- 59 scripts modified; task_get.js, app_launch.js, and ping.js already had (or didn't need) the annotation.

## Why
Strict-mode `tsc` reports `TS7006: Parameter 'argv' implicitly has an 'any' type` on every untyped `run(argv)`. A single annotation pass is the prerequisite for opting any script into `// @ts-check`, and doing it once is cheaper than per-script edits as the rollout sweep progresses.

## What this is NOT
No scripts are opted into `// @ts-check` in this PR. The JSDoc lands first; opt-ins follow as the remaining #994 categories (3, 4) land. Behavioral change: zero. Lint change: zero (biome-ignore stays).

Closes #994 (will be **reopened post-merge** because categories 3 and 4 are still pending — same multi-slice workflow as PR #996).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, 16 warnings — unchanged from main)
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean
- [x] `pnpm test` 3783 passed / 59 skipped

Refs #989 (rollout)