### PR TITLE
feat(scripts): ambient _types/jxa-helpers.d.ts for inlined helpers

### DIFF
--- a/src/scripts/jxa/CLAUDE.md
+++ b/src/scripts/jxa/CLAUDE.md
@@ -24,6 +24,7 @@ in `_types/`. Beachhead reference: `task_get.js` (#987 / #854). Prologue:
 // @ts-check
 /// <reference path="_types/omnifocus.d.ts" />
 /// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />  // only if the script @inlines any helper
 ```
 
 - `_types/omnifocus.d.ts` is **auto-generated** from `vendor/OmniFocus.sdef`
@@ -34,17 +35,23 @@ in `_types/`. Beachhead reference: `task_get.js` (#987 / #854). Prologue:
 - `_types/jxa-globals.d.ts` is **hand-maintained** — declares `Application`,
   `Path`, `delay`, `ObjC`, `$`. Keep small; if you find yourself adding
   OmniFocus-specific machinery here, the generator should emit it instead.
-- Both `.d.ts` files are **ambient** (no `export`). The moment any `export`
-  lands the file becomes a module and the types disappear from script-mode
-  consumers — the generator emits plain `interface X { ... }` for this reason.
+- `_types/jxa-helpers.d.ts` is **hand-maintained** — declares the inlined
+  helpers under `_helpers/` (`buildTask`, `buildRepetition`, `buildFolder`,
+  `buildProject`, `buildTag`, `lookupOrThrow`). Inlined symbols are
+  invisible to `tsc` (the splice happens after `tsc` sees the file per
+  ADR-0020); referencing this file is what makes them resolve. Only
+  reference when the script actually carries a `// @inline _helpers/*.js`
+  directive — otherwise the symbols leak into scope as unused globals.
+- All three `.d.ts` files are **ambient** (no `export`). The moment any
+  `export` lands the file becomes a module and the types disappear from
+  script-mode consumers — the generator emits plain `interface X { ... }`
+  for this reason; the hand-maintained files follow the same rule.
 - Sdef `<property>` blocks become parameterless methods (`defaultDocument(): Document`).
   At runtime JXA (and the sandbox mock) accept property access too —
   `jxa-globals.d.ts` adds an `Application & { defaultDocument: Document }`
   override so both `ofApp.defaultDocument.flattenedTasks()` and
   `ofApp.defaultDocument().flattenedTasks()` typecheck. Existing scripts use
   the property form; keep it consistent.
-- Symbols inlined at build time (per ADR-0020) are invisible to `tsc` —
-  declare them with `@type` JSDoc like `task_get.js` does for `buildTask`.
 - Gate: `tsconfig.jxa-tscheck.json` includes the opted-in scripts; CI runs
   `pnpm exec tsc -p tsconfig.jxa-tscheck.json`. Add new opt-ins to its
   `include` list as the rollout sweeps the directory.

--- a/src/scripts/jxa/_types/jxa-helpers.d.ts
+++ b/src/scripts/jxa/_types/jxa-helpers.d.ts
@@ -1,0 +1,81 @@
+// Hand-maintained declarations for the inlined JXA helpers under
+// `_helpers/`.
+//
+// Sibling of `omnifocus.d.ts` (sdef-derived) and `jxa-globals.d.ts`
+// (JXA runtime). These declarations describe symbols that are *not*
+// part of any script's own source — they're spliced into every
+// consumer at build time by the `scriptInlinerPlugin` (ADR-0020).
+// Because the splice happens after `tsc` sees the file,
+// `// @ts-check` consumers report `TS2304: Cannot find name 'buildTask'`
+// without this reference.
+//
+// Closes category (3) of #994: previously each consumer had to carry
+// a per-script `@type {…}` JSDoc declaration for every helper it
+// inlined (see the old shape in task_get.js, pre-#998). Centralizing
+// here means new opt-ins reference one `.d.ts` line instead of
+// stamping declarations into every consumer.
+//
+// JXA scripts opt in via:
+//
+//   // @ts-check
+//   /// <reference path="_types/omnifocus.d.ts" />
+//   /// <reference path="_types/jxa-globals.d.ts" />
+//   /// <reference path="_types/jxa-helpers.d.ts" />
+//
+// Ambient (script-mode) — no `export`. Adding one would make the file
+// a module and the declarations would disappear from consumer scope.
+//
+// Signatures are conservatively typed: inputs are the JXA specifiers
+// the helpers actually receive (`unknown` keeps the call site honest),
+// and returns are documented as the projected domain shape but typed
+// as `object` so consumers can JSON.stringify the result without
+// claiming a specific Task / Folder / etc. shape (the projection logic
+// inside each helper is the source of truth for the shape, not this
+// file).
+//
+// @see src/scripts/jxa/_helpers/*.js — runtime sources
+
+/**
+ * Build the canonical projected Task shape from a JXA task specifier.
+ * Spliced into consumers via `// @inline _helpers/build_task.js`.
+ *
+ * @see src/scripts/jxa/_helpers/build_task.js
+ */
+declare function buildTask(task: unknown, options?: { effectiveAvailability?: boolean }): object;
+
+/**
+ * Build the repetition sub-object of a Task (rrule + anchor +
+ * scheduleType). Spliced alongside `buildTask` via
+ * `// @inline _helpers/build_task.js`.
+ */
+declare function buildRepetition(task: unknown): object | null;
+
+/**
+ * Build the canonical projected Folder shape from a JXA folder specifier.
+ * Spliced via `// @inline _helpers/build_folder.js`.
+ */
+declare function buildFolder(folder: unknown, options?: object): object;
+
+/**
+ * Build the canonical projected Project shape from a JXA project specifier.
+ * Spliced via `// @inline _helpers/build_project.js`.
+ */
+declare function buildProject(proj: unknown): object;
+
+/**
+ * Build the canonical projected Tag shape from a JXA tag specifier.
+ * `docId` is the OmniFocus default-document id, used to distinguish
+ * top-level tags (container is the document) from nested tags.
+ * Spliced via `// @inline _helpers/build_tag.js`.
+ */
+declare function buildTag(tag: unknown, docId: string): object;
+
+/**
+ * Force a JXA `byId(...)` lookup and throw a structured
+ * `<kindLabel> not found: <idValue>` error if the id doesn't exist.
+ * JXA's `byId` returns a lazy specifier (#674); calling `.id()` here
+ * forces resolution. Spliced via `// @inline _helpers/lookup_or_throw.js`.
+ *
+ * @see src/scripts/jxa/_helpers/lookup_or_throw.js
+ */
+declare function lookupOrThrow<T = unknown>(specifier: T, kindLabel: string, idValue: string): T;

--- a/src/scripts/jxa/task_get.js
+++ b/src/scripts/jxa/task_get.js
@@ -1,6 +1,7 @@
 // @ts-check
 /// <reference path="_types/omnifocus.d.ts" />
 /// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
 
 /**
  * JXA: fetch one task by ID.
@@ -9,28 +10,22 @@
  * Returns JSON: { task: Task }
  *
  * Beachhead script for the JXA static-typing rollout (#987 / #854): the
- * `@ts-check` directive plus the triple-slash reference make this file
- * the first consumer of `_types/omnifocus.d.ts`. The reference resolves
- * `Application("OmniFocus")` to the typed `Application` interface, so
- * the `defaultDocument.flattenedTasks()` chain below is statically
- * checked against the .sdef-derived signatures. The OF 4.x quirks
- * (Folder/Tag have no `parent()`, etc.) surface at `tsc` time here, not
- * at runtime in production.
+ * `@ts-check` directive plus the triple-slash references make this file
+ * the first consumer of `_types/omnifocus.d.ts`. The references resolve
+ * `Application("OmniFocus")` to the typed `Application` interface and
+ * `buildTask` to its ambient declaration in `jxa-helpers.d.ts`, so the
+ * `defaultDocument.flattenedTasks()` chain below is statically checked
+ * against the .sdef-derived signatures. The OF 4.x quirks (Folder/Tag
+ * have no `parent()`, etc.) surface at `tsc` time here, not at runtime
+ * in production.
+ *
+ * The `// @inline _helpers/build_task.js` directive below splices the
+ * helper into the bundled script (ADR-0020); the `jxa-helpers.d.ts`
+ * reference is what lets `// @ts-check` resolve the call.
  *
  * @see src/adapter/jxa/JxaTransport.ts — caller
  * @see src/domain/task.ts — Task domain type
  */
-
-/**
- * `buildTask` is spliced into this file at build time by the
- * scriptInlinerPlugin (ADR-0020) via the `// @inline _helpers/build_task.js`
- * directive below. TypeScript can't see the inline expansion at typecheck
- * time, so declare the symbol explicitly. The helper's runtime contract
- * lives in `_helpers/build_task.js`.
- *
- * @type {(task: unknown, options?: { effectiveAvailability?: boolean }) => object}
- */
-let buildTask;
 
 /**
  * @param {string[]} argv — argv[0] is the JSON-encoded input payload.


### PR DESCRIPTION
## Summary
- New ambient `.d.ts` sibling (`_types/jxa-helpers.d.ts`) declaring the six inlined helpers (`buildTask`, `buildRepetition`, `buildFolder`, `buildProject`, `buildTag`, `lookupOrThrow`).
- `task_get.js` drops its per-script `@type` declaration for `buildTask` and adds the new `/// <reference>` instead — canonical pattern the rollout sweep will follow.
- `src/scripts/jxa/CLAUDE.md` documents the new reference and the "only reference if you `@inline`" rule.
- Closes category (3) of #994; only category (4) (sdef generator extensions for `fileAttachments` / element-query API) remains.

## Why centralize
Previously every consumer needed a per-script `@type` JSDoc declaration above the inline directive for each helper it used (38 such sites across the directory). Centralizing as a third ambient `.d.ts` matches the shape of `omnifocus.d.ts` and `jxa-globals.d.ts` — new opt-ins reference one file line instead of stamping JSDoc declarations into every consumer.

Closes #994 (will be **reopened post-merge** because category 4 is still pending — same multi-slice workflow as PRs #996 and #997).

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (task_get + ping + app_launch; task_get exercises the new reference)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, 16 warnings — unchanged)
- [x] `pnpm test` 3783 passed / 59 skipped
- [x] No runtime change (the inliner doesn't read `.d.ts` files; only `tsc` does)

Refs #989 (rollout)