### PR TITLE
feat(scripts): jxa-collection<t> typed element-query api

### DIFF
--- a/scripts/generate-jxa-types.ts
+++ b/scripts/generate-jxa-types.ts
@@ -285,14 +285,18 @@ function emitClass(cls: ClassDef, knownClasses: Set<string>): string {
     lines.push(`  ${tsAccessor(p.name)}(): ${tsType};`);
   }
 
-  // Elements: child collections. Type is the *element-of* class.
+  // Elements: child collections. Type is the *element-of* class wrapped in
+  // `JxaCollection<T>` so the JXA element-query API (`byId`, `whose`, `at`)
+  // is exposed to `// @ts-check` consumers — see the JxaCollection comment
+  // at the top of this file. A plain `T[]` would lose those methods even
+  // though they exist at runtime.
   for (const e of cls.elements) {
     const tsType = mapTypeToTs(e.type, knownClasses);
     // Plural — JXA convention: `flattenedTasks()`, `tags()`, etc.
     // The sdef element name is singular; pluralization is mechanical.
     const plural = pluralizeAccessor(e.type);
     lines.push(`  /** child collection of '${e.type}' */`);
-    lines.push(`  ${plural}(): ${tsType}[];`);
+    lines.push(`  ${plural}(): JxaCollection<${tsType}>;`);
   }
 
   lines.push(`}`);
@@ -339,9 +343,36 @@ function main(): void {
     "",
   ].join("\n");
 
+  // JxaCollection<T> — the shape every element-collection accessor returns.
+  // The sdef declares element relationships (`<element type="task"/>` etc.)
+  // but says nothing about the query methods JXA exposes on the returned
+  // collection. At runtime `flattenedTasks()` is an array AND has `.byId(id)`,
+  // `.whose(filter)`, `.at(idx)` — none of which TypeScript can infer from a
+  // plain `T[]` return. This interface lets `// @ts-check` consumers call
+  // those methods without surfacing as `TS2339`. Ambient (no `export`) so
+  // it joins script-mode scope automatically when the .d.ts is referenced.
+  //
+  // `whose(filter)` returns a thunk (a function that, when called, yields
+  // matching specifiers) — the JXA query API is lazy. `byId` throws (-1728)
+  // at the next method call when the id is unknown rather than returning
+  // null; callers wrap with the `lookupOrThrow` helper from
+  // \`_helpers/lookup_or_throw.js\` to surface that as a structured error
+  // (#674 / #687).
+  const collectionType = [
+    `interface JxaCollection<T> extends Array<T> {`,
+    `  /** JXA element-query: fetch a specifier by id. Lazy — throws (-1728) on next access if id is unknown. */`,
+    `  byId(id: string): T;`,
+    `  /** JXA element-query: filter by sdef-attribute predicate. Returns a thunk; call it to evaluate. */`,
+    `  whose(filter: Record<string, unknown>): () => T[];`,
+    `  /** JXA element-query: random access. */`,
+    `  at(idx: number): T;`,
+    `}`,
+    "",
+  ].join("\n");
+
   const body = classes.map((c) => emitClass(c, knownClasses)).join("\n\n");
 
-  const out = `${header}\n${body}\n`;
+  const out = `${header}\n${collectionType}\n${body}\n`;
   mkdirSync(dirname(OUT_PATH), { recursive: true });
   writeFileSync(OUT_PATH, out);
 

--- a/src/scripts/jxa/_types/omnifocus.d.ts
+++ b/src/scripts/jxa/_types/omnifocus.d.ts
@@ -8,6 +8,15 @@
 //           199 properties,
 //           54 elements.
 
+interface JxaCollection<T> extends Array<T> {
+  /** JXA element-query: fetch a specifier by id. Lazy — throws (-1728) on next access if id is unknown. */
+  byId(id: string): T;
+  /** JXA element-query: filter by sdef-attribute predicate. Returns a thunk; call it to evaluate. */
+  whose(filter: Record<string, unknown>): () => T[];
+  /** JXA element-query: random access. */
+  at(idx: number): T;
+}
+
 /** OmniFocus 'application' class (sdef code: capp). */
 interface Application {
   /** [read-only] The name of the application. */
@@ -25,13 +34,13 @@ interface Application {
   /** [read-only] The names of all available perspectives in the default document. */
   perspectiveNames(): unknown;
   /** child collection of 'document' */
-  documents(): Document[];
+  documents(): JxaCollection<Document>;
   /** child collection of 'window' */
-  windows(): Window[];
+  windows(): JxaCollection<Window>;
   /** child collection of 'perspective' */
-  perspectives(): Perspective[];
+  perspectives(): JxaCollection<Perspective>;
   /** child collection of 'preference' */
-  preferences(): Preference[];
+  preferences(): JxaCollection<Preference>;
 }
 
 /** OmniFocus 'document' class (sdef code: docu). */
@@ -69,33 +78,33 @@ interface Document {
   /** [read-only] The names of all available perspectives in this document. */
   perspectiveNames(): unknown;
   /** child collection of 'setting' */
-  settings(): Setting[];
+  settings(): JxaCollection<Setting>;
   /** child collection of 'document window' */
-  documentWindows(): DocumentWindow[];
+  documentWindows(): JxaCollection<DocumentWindow>;
   /** child collection of 'section' */
-  sections(): Section[];
+  sections(): JxaCollection<Section>;
   /** child collection of 'folder' */
-  folders(): Folder[];
+  folders(): JxaCollection<Folder>;
   /** child collection of 'project' */
-  projects(): Project[];
+  projects(): JxaCollection<Project>;
   /** child collection of 'tag' */
-  tags(): Tag[];
+  tags(): JxaCollection<Tag>;
   /** child collection of 'deprecated context' */
-  deprecatedContexts(): DeprecatedContext[];
+  deprecatedContexts(): JxaCollection<DeprecatedContext>;
   /** child collection of 'inbox task' */
-  inboxTasks(): InboxTask[];
+  inboxTasks(): JxaCollection<InboxTask>;
   /** child collection of 'task' */
-  tasks(): Task[];
+  tasks(): JxaCollection<Task>;
   /** child collection of 'flattened task' */
-  flattenedTasks(): FlattenedTask[];
+  flattenedTasks(): JxaCollection<FlattenedTask>;
   /** child collection of 'flattened project' */
-  flattenedProjects(): FlattenedProject[];
+  flattenedProjects(): JxaCollection<FlattenedProject>;
   /** child collection of 'flattened folder' */
-  flattenedFolders(): FlattenedFolder[];
+  flattenedFolders(): JxaCollection<FlattenedFolder>;
   /** child collection of 'flattened tag' */
-  flattenedTags(): FlattenedTag[];
+  flattenedTags(): JxaCollection<FlattenedTag>;
   /** child collection of 'perspective' */
-  perspectives(): Perspective[];
+  perspectives(): JxaCollection<Perspective>;
 }
 
 /** OmniFocus 'window' class (sdef code: cwin). */
@@ -147,15 +156,15 @@ interface QuickEntryTree extends Tree {
   /** [read-only] Whether the quick entry panel is currently visible. */
   visible(): boolean;
   /** child collection of 'folder' */
-  folders(): Folder[];
+  folders(): JxaCollection<Folder>;
   /** child collection of 'project' */
-  projects(): Project[];
+  projects(): JxaCollection<Project>;
   /** child collection of 'tag' */
-  tags(): Tag[];
+  tags(): JxaCollection<Tag>;
   /** child collection of 'deprecated context' */
-  deprecatedContexts(): DeprecatedContext[];
+  deprecatedContexts(): JxaCollection<DeprecatedContext>;
   /** child collection of 'inbox task' */
-  inboxTasks(): InboxTask[];
+  inboxTasks(): JxaCollection<InboxTask>;
 }
 
 /** OmniFocus 'setting' class (sdef code: FCos). */
@@ -171,7 +180,7 @@ interface Setting {
 /** OmniFocus 'focus sections' class (sdef code: FCFS). */
 interface FocusSections {
   /** child collection of 'item' */
-  items(): unknown[];
+  items(): JxaCollection<unknown>;
 }
 
 /** OmniFocus 'section' class (sdef code: FCSX). */
@@ -203,15 +212,15 @@ interface Folder extends Section {
   /** [read-only] The containing document or quick entry tree of the object. */
   containingDocument(): Document;
   /** child collection of 'section' */
-  sections(): Section[];
+  sections(): JxaCollection<Section>;
   /** child collection of 'folder' */
-  folders(): Folder[];
+  folders(): JxaCollection<Folder>;
   /** child collection of 'project' */
-  projects(): Project[];
+  projects(): JxaCollection<Project>;
   /** child collection of 'flattened project' */
-  flattenedProjects(): FlattenedProject[];
+  flattenedProjects(): JxaCollection<FlattenedProject>;
   /** child collection of 'flattened folder' */
-  flattenedFolders(): FlattenedFolder[];
+  flattenedFolders(): JxaCollection<FlattenedFolder>;
 }
 
 /** OmniFocus 'tag' class (sdef code: FCtg). */
@@ -239,17 +248,17 @@ interface Tag {
   /** The physical location associated with the tag. */
   location(): unknown;
   /** child collection of 'tag' */
-  tags(): Tag[];
+  tags(): JxaCollection<Tag>;
   /** child collection of 'deprecated context' */
-  deprecatedContexts(): DeprecatedContext[];
+  deprecatedContexts(): JxaCollection<DeprecatedContext>;
   /** child collection of 'flattened tag' */
-  flattenedTags(): FlattenedTag[];
+  flattenedTags(): JxaCollection<FlattenedTag>;
   /** child collection of 'task' */
-  tasks(): Task[];
+  tasks(): JxaCollection<Task>;
   /** child collection of 'available task' */
-  availableTasks(): AvailableTask[];
+  availableTasks(): JxaCollection<AvailableTask>;
   /** child collection of 'remaining task' */
-  remainingTasks(): RemainingTask[];
+  remainingTasks(): JxaCollection<RemainingTask>;
 }
 
 /** OmniFocus 'deprecated context' class (sdef code: FCct). */
@@ -427,17 +436,17 @@ interface Task {
   /** A simple textual archive of a task that can be used to create, update and distributed tasks. Please see the documentation for more information. */
   transportText(): string;
   /** child collection of 'tag' */
-  tags(): Tag[];
+  tags(): JxaCollection<Tag>;
   /** child collection of 'task' */
-  tasks(): Task[];
+  tasks(): JxaCollection<Task>;
   /** child collection of 'flattened task' */
-  flattenedTasks(): FlattenedTask[];
+  flattenedTasks(): JxaCollection<FlattenedTask>;
 }
 
 /** OmniFocus 'forecast sidebar tree' class (sdef code: FCFt). */
 interface ForecastSidebarTree extends SidebarTree {
   /** child collection of 'forecast day' */
-  forecastDays(): ForecastDay[];
+  forecastDays(): JxaCollection<ForecastDay>;
 }
 
 /** OmniFocus 'forecast day' class (sdef code: FCdy). */
@@ -557,19 +566,19 @@ interface Tree {
   /** A list of the types that can be used when reading nodes from the pasteboard (i.e., pasteing). */
   readablePasteboardTypes(): unknown;
   /** child collection of 'tree' */
-  trees(): Tree[];
+  trees(): JxaCollection<Tree>;
   /** child collection of 'descendant tree' */
-  descendantTrees(): DescendantTree[];
+  descendantTrees(): JxaCollection<DescendantTree>;
   /** child collection of 'ancestor tree' */
-  ancestorTrees(): AncestorTree[];
+  ancestorTrees(): JxaCollection<AncestorTree>;
   /** child collection of 'leaf' */
-  leafs(): Leaf[];
+  leafs(): JxaCollection<Leaf>;
   /** child collection of 'preceding sibling' */
-  precedingSiblings(): PrecedingSibling[];
+  precedingSiblings(): JxaCollection<PrecedingSibling>;
   /** child collection of 'following sibling' */
-  followingSiblings(): FollowingSibling[];
+  followingSiblings(): JxaCollection<FollowingSibling>;
   /** child collection of 'selected tree' */
-  selectedTrees(): SelectedTree[];
+  selectedTrees(): JxaCollection<SelectedTree>;
 }
 
 /** OmniFocus 'descendant tree' class (sdef code: OTds). */
@@ -603,9 +612,9 @@ interface Style {
   /** The name of the font of the style. */
   font(): string;
   /** child collection of 'named style' */
-  namedStyles(): NamedStyle[];
+  namedStyles(): JxaCollection<NamedStyle>;
   /** child collection of 'attribute' */
-  attributes(): Attribute[];
+  attributes(): JxaCollection<Attribute>;
 }
 
 /** OmniFocus 'attribute' class (sdef code: OSsa). */
@@ -651,17 +660,17 @@ interface RichText {
   /** Alignment of the text. */
   alignment(): unknown;
   /** child collection of 'character' */
-  characters(): Character[];
+  characters(): JxaCollection<Character>;
   /** child collection of 'paragraph' */
-  paragraphs(): Paragraph[];
+  paragraphs(): JxaCollection<Paragraph>;
   /** child collection of 'word' */
-  words(): Word[];
+  words(): JxaCollection<Word>;
   /** child collection of 'attribute run' */
-  attributeRuns(): AttributeRun[];
+  attributeRuns(): JxaCollection<AttributeRun>;
   /** child collection of 'attachment' */
-  attachments(): Attachment[];
+  attachments(): JxaCollection<Attachment>;
   /** child collection of 'file attachment' */
-  fileAttachments(): FileAttachment[];
+  fileAttachments(): JxaCollection<FileAttachment>;
 }
 
 /** OmniFocus 'character' class (sdef code: cha ). */


### PR DESCRIPTION
## Summary
- Generator (`scripts/generate-jxa-types.ts`) emits a new ambient `interface JxaCollection<T> extends Array<T>` at the top of `omnifocus.d.ts`, exposing `byId(id: string): T`, `whose(filter): () => T[]`, and `at(idx: number): T`.
- Every element accessor changes from `flattenedTasks(): FlattenedTask[]` to `flattenedTasks(): JxaCollection<FlattenedTask>`. Existing iteration still works (extends `Array<T>`).
- Closes the last open category of #994; the three existing opt-in scripts typecheck cleanly. The wider rollout sweep (#989) is now unblocked at the type-system level.
- Remaining sdef-snapshot drift (runtime extras like `task.fileAttachments`) tracked as #999 — hand-maintained override, separate from the generator.

Closes #994

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (task_get + ping + app_launch)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, 16 warnings unchanged)
- [x] `pnpm test` 3783 passed / 59 skipped
- [x] `tests/scripts/generate-jxa-types.test.ts` 11/11 (sanity test verifies regenerated `.d.ts` shape)
- [x] `pnpm generate:jxa-types` is idempotent — re-running produces empty diff

Refs #989 (rollout); #999 (runtime-extras override)