### PR TITLE
feat(scripts): hand-maintained sdef-overrides .d.ts for runtime extras

### DIFF
--- a/src/scripts/jxa/CLAUDE.md
+++ b/src/scripts/jxa/CLAUDE.md
@@ -24,34 +24,32 @@ in `_types/`. Beachhead reference: `task_get.js` (#987 / #854). Prologue:
 // @ts-check
 /// <reference path="_types/omnifocus.d.ts" />
 /// <reference path="_types/jxa-globals.d.ts" />
-/// <reference path="_types/jxa-helpers.d.ts" />  // only if the script @inlines any helper
+/// <reference path="_types/jxa-helpers.d.ts" />     // only if the script @inlines any helper
+/// <reference path="_types/sdef-overrides.d.ts" />   // only if the script uses a documented runtime extra
 ```
 
-- `_types/omnifocus.d.ts` is **auto-generated** from `vendor/OmniFocus.sdef`
-  via `pnpm generate:jxa-types`. Never hand-edit; re-run the generator and
-  commit the regenerated file. The OF 4.x quirks above (no `parent()` on
-  Folder/Tag, etc.) are encoded as missing methods on the generated
-  interfaces — `tsc` flags them at typecheck time.
-- `_types/jxa-globals.d.ts` is **hand-maintained** — declares `Application`,
-  `Path`, `delay`, `ObjC`, `$`. Keep small; if you find yourself adding
-  OmniFocus-specific machinery here, the generator should emit it instead.
+- `_types/omnifocus.d.ts` is **auto-generated** by `pnpm generate:jxa-types`
+  from `vendor/OmniFocus.sdef`. Never hand-edit; regenerate and commit. The
+  OF 4.x quirks above (no `parent()` on Folder/Tag, etc.) are encoded as
+  missing methods on the generated interfaces — `tsc` flags them at typecheck.
+- `_types/jxa-globals.d.ts` is **hand-maintained** — JXA runtime entrypoints
+  (`Application`, `Path`, `delay`, `ObjC`, `$`). Keep small; OmniFocus-specific
+  machinery belongs in the generator. Property-vs-method overrides also live
+  here: sdef `<property>` blocks emit as parameterless methods, but JXA (and
+  the sandbox mock) accept property access too — see the `defaultDocument`
+  intersection that lets both forms typecheck.
 - `_types/jxa-helpers.d.ts` is **hand-maintained** — declares the inlined
-  helpers under `_helpers/` (`buildTask`, `buildRepetition`, `buildFolder`,
-  `buildProject`, `buildTag`, `lookupOrThrow`). Inlined symbols are
-  invisible to `tsc` (the splice happens after `tsc` sees the file per
-  ADR-0020); referencing this file is what makes them resolve. Only
-  reference when the script actually carries a `// @inline _helpers/*.js`
-  directive — otherwise the symbols leak into scope as unused globals.
-- All three `.d.ts` files are **ambient** (no `export`). The moment any
-  `export` lands the file becomes a module and the types disappear from
-  script-mode consumers — the generator emits plain `interface X { ... }`
-  for this reason; the hand-maintained files follow the same rule.
-- Sdef `<property>` blocks become parameterless methods (`defaultDocument(): Document`).
-  At runtime JXA (and the sandbox mock) accept property access too —
-  `jxa-globals.d.ts` adds an `Application & { defaultDocument: Document }`
-  override so both `ofApp.defaultDocument.flattenedTasks()` and
-  `ofApp.defaultDocument().flattenedTasks()` typecheck. Existing scripts use
-  the property form; keep it consistent.
+  `_helpers/` helpers (`buildTask`, `buildRepetition`, `buildFolder`,
+  `buildProject`, `buildTag`, `lookupOrThrow`). Inlined symbols are invisible
+  to `tsc` (splice happens after, per ADR-0020). Reference only when the
+  script carries a `// @inline _helpers/*.js` directive.
+- `_types/sdef-overrides.d.ts` is **hand-maintained** — adds runtime
+  conveniences the OF JXA-DOM exposes but the sdef snapshot doesn't (e.g.
+  `task.fileAttachments()`) via interface declaration merging. Sdef-derived
+  fields stay generator-owned; only add here when the accessor works at
+  runtime AND the sdef doesn't declare it.
+- All four `.d.ts` files are **ambient** (no `export`). One stray `export`
+  makes the file a module and the types disappear from script-mode consumers.
 - Gate: `tsconfig.jxa-tscheck.json` includes the opted-in scripts; CI runs
   `pnpm exec tsc -p tsconfig.jxa-tscheck.json`. Add new opt-ins to its
   `include` list as the rollout sweeps the directory.

--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -1,0 +1,79 @@
+// Hand-maintained overrides for sdef-snapshot drift.
+//
+// The OmniFocus JXA runtime exposes accessors that don't exist on the
+// matching `<class>` in `vendor/OmniFocus.sdef` — typically because the
+// runtime walks through a related object (e.g. `task.note.fileAttachments`
+// is exposed as `task.fileAttachments` at the JXA-DOM level). The generator
+// can't infer those conveniences from the sdef alone, so they're declared
+// here via TypeScript's interface declaration merging.
+//
+// Joins the generated `interface Task { … }` (and friends) from
+// `omnifocus.d.ts` at type-check time. Ambient (no `export`) so the
+// merging happens in script-mode scope automatically.
+//
+// **Add an entry only when**:
+//   - the accessor works at runtime (verified against the live OmniFocus
+//     app or `src/adapter/jxa/sandbox/`), AND
+//   - the sdef doesn't declare it on the same class.
+//
+// **Don't add** sdef-derived fields here — those stay generator-owned.
+// If a field IS in the sdef but the generator missed it, the generator
+// is wrong; fix `scripts/generate-jxa-types.ts` instead.
+//
+// JXA scripts opt in by adding this reference to the prologue (alongside
+// `omnifocus.d.ts`, `jxa-globals.d.ts`, and `jxa-helpers.d.ts` as needed):
+//
+//   /// <reference path="_types/sdef-overrides.d.ts" />
+//
+// Only reference when the script actually consumes one of the overrides
+// below — otherwise the addition is dead context.
+//
+// @see #999 — provenance for the file
+// @see #994 — broader type-system gap inventory
+
+// ---------------------------------------------------------------------------
+// File-attachment accessors (#999)
+//
+// At runtime, `task.fileAttachments()` and `project.fileAttachments()` work
+// directly even though the sdef attaches `<element type="file attachment"/>`
+// only to `rich text`. The JXA-DOM exposes them as a convenience over
+// `task.note.fileAttachments`. Used by `attachment_list.js`,
+// `attachment_add.js`, `attachment_save_to_path.js`, `attachment_remove.js`.
+// ---------------------------------------------------------------------------
+
+interface Task {
+  /** Runtime convenience over `note.fileAttachments` — see file header. */
+  fileAttachments(): JxaCollection<FileAttachment>;
+}
+
+interface Project {
+  /** Runtime convenience over `note.fileAttachments` — see file header. */
+  fileAttachments(): JxaCollection<FileAttachment>;
+}
+
+// ---------------------------------------------------------------------------
+// Attachment runtime extras (#999)
+//
+// The sdef's `<class name="attachment">` and `<class name="file attachment">`
+// declare only `fileName()` and `embedded()`. At runtime, OF additionally
+// exposes the standard JXA-object surface (`id`, `name`, `creationDate`) and
+// a small set of attachment-specific accessors (`fileType`, `fileSize`,
+// `linked`). The OF 4.x runtime is unreliable about these — `attachment_list.js`
+// defensively try/catches each one — so the declarations are advisory:
+// they let `// @ts-check` consumers compile, not assert availability.
+// ---------------------------------------------------------------------------
+
+interface Attachment {
+  /** Object identifier. May throw on some Attachment subtypes — guard with try/catch. */
+  id(): string;
+  /** Display name. May throw — guard with try/catch. */
+  name(): string;
+  /** Creation date as a JS Date. May throw — guard with try/catch. */
+  creationDate(): Date;
+  /** MIME type. May throw — guard with try/catch. */
+  fileType(): string | null;
+  /** Size in bytes. May throw — guard with try/catch. */
+  fileSize(): number | null;
+  /** `true` when the attachment is an alias rather than embedded. May throw. */
+  linked(): boolean;
+}

--- a/src/scripts/jxa/attachment_list.js
+++ b/src/scripts/jxa/attachment_list.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: list all attachments on a task or project.
  *
@@ -36,6 +41,7 @@ function run(argv) {
     throw new Error("One of taskId or projectId is required");
   }
 
+  /** @param {Attachment} att — a FileAttachment specifier off the owner. */
   function buildAttachment(att) {
     let name = "";
     try {

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -13,6 +13,7 @@
   },
   "include": [
     "src/scripts/jxa/app_launch.js",
+    "src/scripts/jxa/attachment_list.js",
     "src/scripts/jxa/ping.js",
     "src/scripts/jxa/task_get.js"
   ]


### PR DESCRIPTION
## Summary
- Adds the fourth ambient `.d.ts` reference file: `_types/sdef-overrides.d.ts`, joining the existing trio via TypeScript interface declaration merging.
- Documents the runtime extras that work at the JXA-DOM level but the .sdef doesn't declare: `task.fileAttachments() / project.fileAttachments()` (convenience over `note.fileAttachments`) and the `Attachment.{id,name,creationDate,fileType,fileSize,linked}()` surface that OF 4.x exposes unreliably.
- Opts `attachment_list.js` into the gate as proof-of-work (`#989` slice 2 of the rollout).
- `src/scripts/jxa/CLAUDE.md` documents the new reference and the "only reference if you consume an override" rule.

Closes #999

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (task_get + ping + app_launch + attachment_list — 4 opt-ins now)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (lint-doc-sizes was over budget at 86 lines; trimmed to 76)
- [x] `pnpm test` 3783 passed / 59 skipped

Refs #989 (rollout); #994 (omnibus gap inventory)