### PR TITLE
perf(tools): make _links opt-in via includeLinks flag, default off

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2039,6 +2039,7 @@ Fetch a single OmniFocus project by persistent ID. Do NOT use for queries across
 | `includeTaskTree` | boolean | No | Whether to attach the project's tasks (flat array; clients rebuild the tree via parentId). Default true. Set to false for a fast project-only read. |
 | `verbose` | boolean | No | When true, return the full unelided shape (project + tasks). Default: false — fields equal to their documented default are omitted from both. See docs/token-cost.md for the defaults table. |
 | `fields` | string[] | No | Restrict the returned project to this list of top-level fields (id is always returned). Omit for the full project shape. Empty array returns just id. Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS. Note: only the project record is projected — attached tasks keep their full shape. |
+| `includeLinks` | boolean | No | When true, the project (and each attached task, if includeTaskTree=true) carries a `_links` HATEOAS block. Default false — the block is omitted to save payload size. Use the underlying ID fields (`id`, `folderId`, `projectId`, `parentId`, `tagIds`) directly instead. |
 
 ### Example call
 
@@ -2110,6 +2111,7 @@ List projects in OmniFocus with optional filters. Use for queries across project
 | `cursor` | string | No | Opaque cursor from a previous project_list response. Must use the same filters — changing filters mid-sequence returns a ValidationError. |
 | `verbose` | boolean | No | When true, return the full unelided project shape. Default: false — fields equal to their documented default (status: 'active', completionCriterion: 'parallel', flagged: false, tagIds: [], note: null, etc.) are omitted. See docs/token-cost.md for the defaults table. |
 | `fields` | string[] | No | Restrict each returned project to this list of top-level fields (id is always returned). Omit for the full project shape. Empty array returns just id. Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS. |
+| `includeLinks` | boolean | No | When true, each project carries a `_links` HATEOAS block (self, folder). Default false — the block is omitted to save payload size. Use the project's `id` and `folderId` fields directly instead. |
 
 ### Example call
 
@@ -2650,6 +2652,7 @@ Full-text search across OmniFocus task names and/or notes. Use for finding tasks
 | `limit` | number | No | Max results per page (1..500). Default 50. |
 | `cursor` | string | No | Opaque cursor from a previous search_query response. Must use identical filters — changing filters returns a ValidationError. |
 | `fields` | string[] | No | Restrict each returned task to this list of top-level fields (id is always returned). Omit for the full task shape. Empty array returns just id. Unknown names are dropped silently and surface in meta.warnings.WARN_UNKNOWN_FIELDS. Allowed: name, note, noteHtml, projectId, parentId, tagIds, deferDate, deferDateFloating, dueDate, dueDateFloating, estimatedMinutes, flagged, completed, completedAt, dropped, droppedAt, available, blocked, sequential, completedByChildren, repetition, notifications, createdAt, modifiedAt, _links. |
+| `includeLinks` | boolean | No | When true, each task carries a `_links` HATEOAS block (self, project, parent, tags). Default false — the block is omitted to save payload size. Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead. |
 
 ### Example call
 
@@ -4349,6 +4352,7 @@ Fetch a single OmniFocus task by persistent ID. Use when you have a known task I
 | `notePreviewChars` | number | No | Maximum characters of the task's note (and each subtask's note) to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
 | `verbose` | boolean | No | When true, return the full unelided task shape (every field present, even at defaults). Default: false — fields equal to their documented default are omitted. See docs/token-cost.md for the defaults table. |
 | `fields` | string[] | No | Restrict the returned task (and each subtask) to this list of top-level fields (id is always returned). Omit for the full task shape. Empty array returns just id. Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS. |
+| `includeLinks` | boolean | No | When true, the task (and each subtask, if requested) carries a `_links` HATEOAS block (self, project, parent, tags). Default false — the block is omitted to save payload size. Use `id`, `projectId`, `parentId`, and `tagIds` directly instead. |
 
 ### Example call
 
@@ -4460,6 +4464,7 @@ List tasks in OmniFocus with optional filters (project, tag, inbox, flagged, com
 | `notePreviewChars` | number | No | Maximum characters of each task's note to return. Default 200. When a note exceeds this length, the response replaces `note` with `notePreview` (the truncated text), `noteTruncated: true`, and `noteLength` (full UTF-8 byte length) — fetch the full text with note_get. Pass -1 to disable truncation and return full notes inline. |
 | `verbose` | boolean | No | When true, return the full unelided task shape (every field present, even at defaults). Default: false — fields equal to their documented default (flagged: false, completed: false, tagIds: [], note: null, dueDate: null, etc.) are omitted from the wire payload. An omitted field means the default applies. See docs/token-cost.md for the full defaults table. |
 | `fields` | string[] | No | Restrict each returned task to this list of top-level fields (id is always returned). Omit for the full task shape. Empty array returns just id. Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS. |
+| `includeLinks` | boolean | No | When true, each task carries a `_links` HATEOAS block (self, project, parent, tags). Default false — the block is omitted to save payload size. Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead. |
 
 ### Example call
 
@@ -4674,6 +4679,7 @@ Search OmniFocus tasks by keyword and/or structured filters, with cursor paginat
 | `completed` | one of: any | only | exclude | No | 'exclude' = active tasks only (default); 'only' = completed tasks only; 'any' = both. |
 | `limit` | number | No | Max results per page (1..500). Default 100. Use cursor to fetch subsequent pages. |
 | `cursor` | string | No | Opaque cursor from a previous task_search response. Must use the same filters — changing filters mid-sequence returns a ValidationError. |
+| `includeLinks` | boolean | No | When true, each task carries a `_links` HATEOAS block (self, project, parent, tags). Default false — the block is omitted to save payload size. Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead. |
 
 ### Example call
 

--- a/src/domain/links.ts
+++ b/src/domain/links.ts
@@ -7,6 +7,12 @@
  *
  * URI scheme: `omnifocus://<noun>/<id>`
  *
+ * Opt-in (issue #792): `_links` is omitted from list/get tool responses
+ * unless the caller passes `includeLinks: true`. The block re-encodes IDs
+ * already present on the response (`id`, `projectId`, `parentId`, `tagIds`,
+ * `folderId`), so LLM agents that act on IDs directly pay zero bytes for it
+ * by default. HTTP clients that follow the links opt back in per-call.
+ *
  * @see src/domain/task.ts — TaskLinks field
  * @see src/domain/project.ts — ProjectLinks field
  */

--- a/src/services/projectService.test.ts
+++ b/src/services/projectService.test.ts
@@ -281,6 +281,47 @@ describe("ProjectService.get", () => {
   });
 });
 
+describe("ProjectService — _links opt-in", () => {
+  it("get() omits _links by default", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "P" });
+    const out = await service.get({ id: p });
+    expect(out.project._links).toBeUndefined();
+  });
+
+  it("get() includes _links on project and tasks when includeLinks=true", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "P" });
+    await adapter.createTask({ name: "t1", projectId: p });
+    const out = await service.get({ id: p, includeLinks: true });
+    expect(out.project._links?.self).toBe(`omnifocus://project/${p}`);
+    expect(out.tasks?.[0]?._links).toBeDefined();
+  });
+
+  it("list() omits _links by default", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createProject({ name: "A" });
+    const out = await service.list({ limit: 10 });
+    expect(out.projects[0]?._links).toBeUndefined();
+  });
+
+  it("list() includes _links when includeLinks=true", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "A" });
+    const out = await service.list({ limit: 10, includeLinks: true });
+    expect(out.projects[0]?._links?.self).toBe(`omnifocus://project/${p}`);
+  });
+
+  it("toggling includeLinks does not fragment the get() cache", async () => {
+    const { service, adapter } = makeHarness();
+    const p = await adapter.createProject({ name: "P" });
+    const spy = vi.spyOn(adapter, "getProject");
+    await service.get({ id: p });
+    await service.get({ id: p, includeLinks: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Type-level smoke: FolderId filter is the branded type
 // ---------------------------------------------------------------------------

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -69,6 +69,12 @@ export interface ProjectListInput {
   /** 1..1000; service default is 200 when caller omits and any filter is set. */
   limit?: number;
   cursor?: string;
+  /**
+   * When `true`, returned projects carry a `_links` HATEOAS block (self, folder).
+   * Default `false` — the block is omitted entirely to save payload size.
+   * Get the underlying IDs from `id` and `folderId` on the project directly.
+   */
+  includeLinks?: boolean;
 }
 
 /** Result of {@link ProjectService.list}. Same envelope shape as TaskService. */
@@ -87,6 +93,8 @@ export interface ProjectGetInput {
   id: ProjectId;
   /** Default `true`. When `false`, `tasks` is omitted from the result. */
   includeTaskTree?: boolean;
+  /** See {@link ProjectListInput.includeLinks}. Applies to the project and any attached tasks. */
+  includeLinks?: boolean;
 }
 
 /** Result of {@link ProjectService.get}. */
@@ -147,9 +155,16 @@ export class ProjectService {
     const cacheKey = this.listCacheKey(filterHash, input.cursor);
     const cacheHit = this.cache.has(cacheKey);
 
-    const { projects, nextCursor } = await this.cache.wrap(cacheKey, async () =>
+    // `_links` is injected post-cache so toggling includeLinks doesn't
+    // fragment the cache.
+    const { projects: bareProjects, nextCursor } = await this.cache.wrap(cacheKey, async () =>
       this.fetchPage(normalized, cursor, limit, filterHash),
     );
+
+    const projects =
+      input.includeLinks === true
+        ? bareProjects.map((p) => ({ ...p, _links: buildProjectLinks(p) }))
+        : bareProjects;
 
     return {
       projects,
@@ -191,19 +206,31 @@ export class ProjectService {
    */
   async get(input: ProjectGetInput): Promise<ProjectGetResult> {
     const includeTaskTree = input.includeTaskTree ?? true;
+    const includeLinks = input.includeLinks ?? false;
     const cacheKey = this.getCacheKey(input.id, includeTaskTree);
     const cacheHit = this.cache.has(cacheKey);
 
+    // Cache bare (link-free) records — `_links` is injected post-cache so
+    // toggling includeLinks doesn't fragment the cache.
     const payload = await this.cache.wrap(cacheKey, async () => {
       const project = await this.adapter.getProject(input.id);
-      const enrichedProject = { ...project, _links: buildProjectLinks(project) };
-      if (!includeTaskTree) return { project: enrichedProject };
+      if (!includeTaskTree) return { project };
       const tasks = await this.adapter.listTasks({ projectId: input.id });
-      const enrichedTasks = tasks.map((t) => ({ ...t, _links: buildTaskLinks(t) }));
-      return { project: enrichedProject, tasks: enrichedTasks };
+      return { project, tasks };
     });
 
-    return { ...payload, cacheHit };
+    const project = includeLinks
+      ? { ...payload.project, _links: buildProjectLinks(payload.project) }
+      : payload.project;
+    const tasks = includeLinks
+      ? payload.tasks?.map((t) => ({ ...t, _links: buildTaskLinks(t) }))
+      : payload.tasks;
+
+    return {
+      project,
+      ...(tasks !== undefined ? { tasks } : {}),
+      cacheHit,
+    };
   }
 
   // -- Internal: page assembly -------------------------------------------
@@ -247,8 +274,9 @@ export class ProjectService {
     const hasMore = afterCursor.length > limit;
     const nextCursor = hasMore ? this.encodeNextCursor(page, filterHash) : null;
 
-    const projects = page.map((p) => ({ ...p, _links: buildProjectLinks(p) }));
-    return { projects, nextCursor };
+    // Bare projects — `_links` is injected by the public `list()` method only
+    // when the caller opts in. Caching link-free results keeps the cache compact.
+    return { projects: page, nextCursor };
   }
 
   // -- Internal: validation ----------------------------------------------

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -36,6 +36,13 @@ export interface SearchInput extends SearchFilter {
   limit?: number;
   /** Opaque cursor from a previous search_query response. */
   cursor?: string;
+  /**
+   * When `true`, returned tasks carry a `_links` HATEOAS block (self, project,
+   * parent, tags). Default `false` — the block is omitted entirely to save
+   * payload size. Get the underlying IDs from `id`, `projectId`, `parentId`,
+   * and `tagIds` on the task directly.
+   */
+  includeLinks?: boolean;
 }
 
 /** Result of {@link SearchService.search}. */
@@ -133,7 +140,11 @@ export class SearchService {
     // Take one extra to detect hasMore
     const page = afterCursor.slice(0, limit + 1);
     const hasMore = page.length > limit;
-    const tasks = page.slice(0, limit).map((t) => ({ ...t, _links: buildTaskLinks(t) }));
+    const bareTasks = page.slice(0, limit);
+    const tasks =
+      input.includeLinks === true
+        ? bareTasks.map((t) => ({ ...t, _links: buildTaskLinks(t) }))
+        : bareTasks;
 
     // Encode next cursor
     const last = tasks.at(-1);

--- a/src/services/taskService.test.ts
+++ b/src/services/taskService.test.ts
@@ -288,6 +288,31 @@ describe("TaskService.list — cache", () => {
     await service.list({ flagged: false, limit: 10 });
     expect(spy).toHaveBeenCalledTimes(2);
   });
+
+  it("toggling includeLinks does not fragment the cache", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createTask({ name: "a", flagged: true });
+    const spy = vi.spyOn(adapter, "listTasks");
+    await service.list({ flagged: true, limit: 10 });
+    await service.list({ flagged: true, limit: 10, includeLinks: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TaskService.list — _links opt-in", () => {
+  it("omits _links by default", async () => {
+    const { service, adapter } = makeHarness();
+    await adapter.createTask({ name: "a", flagged: true });
+    const result = await service.list({ flagged: true, limit: 10 });
+    expect(result.tasks[0]?._links).toBeUndefined();
+  });
+
+  it("includes _links when includeLinks=true", async () => {
+    const { service, adapter } = makeHarness();
+    const id = (await adapter.createTask({ name: "a", flagged: true })) as TaskId;
+    const result = await service.list({ flagged: true, limit: 10, includeLinks: true });
+    expect(result.tasks[0]?._links?.self).toBe(`omnifocus://task/${id}`);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -344,11 +369,42 @@ describe("TaskService.get — happy path", () => {
     expect(result.subtasks).toBeUndefined();
   });
 
-  it("includes _links on the returned task", async () => {
+  it("omits _links by default (includeLinks defaults to false)", async () => {
+    const { service, adapter } = makeHarness();
+    const id = (await adapter.createTask({ name: "NoLinks" })) as TaskId;
+    const result = await service.get({ id });
+    expect(result.task._links).toBeUndefined();
+  });
+
+  it("includes _links when includeLinks=true", async () => {
     const { service, adapter } = makeHarness();
     const id = (await adapter.createTask({ name: "Linked" })) as TaskId;
-    const result = await service.get({ id });
+    const result = await service.get({ id, includeLinks: true });
     expect(result.task._links).toBeDefined();
+    expect(result.task._links?.self).toBe(`omnifocus://task/${id}`);
+  });
+
+  it("explicit includeLinks=false also omits _links", async () => {
+    const { service, adapter } = makeHarness();
+    const id = (await adapter.createTask({ name: "ExplicitOff" })) as TaskId;
+    const result = await service.get({ id, includeLinks: false });
+    expect(result.task._links).toBeUndefined();
+  });
+
+  it("propagates includeLinks to subtask bodies", async () => {
+    const { service, adapter } = makeHarness();
+    const parentId = (await adapter.createTask({ name: "Parent" })) as TaskId;
+    await adapter.createTask({ name: "Child", parentId });
+    const result = await service.get({ id: parentId, includeSubtasks: true, includeLinks: true });
+    expect(result.subtasks?.[0]?._links).toBeDefined();
+  });
+
+  it("subtasks omit _links by default", async () => {
+    const { service, adapter } = makeHarness();
+    const parentId = (await adapter.createTask({ name: "Parent" })) as TaskId;
+    await adapter.createTask({ name: "Child", parentId });
+    const result = await service.get({ id: parentId, includeSubtasks: true });
+    expect(result.subtasks?.[0]?._links).toBeUndefined();
   });
 });
 

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -92,6 +92,13 @@ export interface TaskListInput {
   /** 1..1000; service default is 200 when caller omits and any filter is set. */
   limit?: number;
   cursor?: string;
+  /**
+   * When `true`, returned tasks carry a `_links` HATEOAS block (self, project,
+   * parent, tags). Default `false` — the block is omitted entirely to save
+   * payload size. Get the underlying IDs from `id`, `projectId`, `parentId`,
+   * and `tagIds` on the task directly.
+   */
+  includeLinks?: boolean;
 }
 
 export interface TaskGetInput {
@@ -103,6 +110,8 @@ export interface TaskGetInput {
    * fetch specific subtasks when you need their detail.
    */
   includeSubtasks?: boolean;
+  /** See {@link TaskListInput.includeLinks}. Applies to the returned task and any subtasks. */
+  includeLinks?: boolean;
 }
 
 export interface TaskGetResult {
@@ -183,10 +192,16 @@ export class TaskService {
     const cacheHit = this.cache.has(cacheKey);
 
     // The cached payload is the final page slice — not the adapter's raw list —
-    // so cursor pagination remains stable under cache re-use.
-    const { tasks, nextCursor } = await this.cache.wrap(cacheKey, async () =>
+    // so cursor pagination remains stable under cache re-use. `_links` is
+    // injected post-cache so toggling includeLinks doesn't fragment the cache.
+    const { tasks: bareTasks, nextCursor } = await this.cache.wrap(cacheKey, async () =>
       this.fetchPage(input, normalized, cursor, limit, filterHash),
     );
+
+    const tasks =
+      input.includeLinks === true
+        ? bareTasks.map((t) => ({ ...t, _links: buildTaskLinks(t) }))
+        : bareTasks;
 
     return {
       tasks,
@@ -208,23 +223,37 @@ export class TaskService {
    */
   async get(input: TaskGetInput): Promise<TaskGetResult> {
     const includeSubtasks = input.includeSubtasks ?? false;
+    const includeLinks = input.includeLinks ?? false;
     const cacheKey = `task:${input.id}:${includeSubtasks ? "with-subtasks" : "ids-only"}`;
     const cacheHit = this.cache.has(cacheKey);
 
+    // Cache the bare (link-free) payload — `_links` is injected post-cache so
+    // toggling includeLinks doesn't fragment the cache.
     const payload = await this.cache.wrap(cacheKey, async () => {
       const task = await this.adapter.getTask(input.id);
-      const enrichedTask = { ...task, _links: buildTaskLinks(task) };
       // Always fetch subtask list — needed for IDs even when bodies not requested.
       const subtaskList = await this.adapter.listTasks({ parentId: input.id });
       if (includeSubtasks) {
-        const enrichedSubtasks = subtaskList.map((t) => ({ ...t, _links: buildTaskLinks(t) }));
-        return { task: enrichedTask, subtasks: enrichedSubtasks };
+        return { task, subtasks: subtaskList };
       }
       const subtaskIds = subtaskList.map((t) => t.id);
-      return { task: enrichedTask, subtaskIds, subtaskCount: subtaskIds.length };
+      return { task, subtaskIds, subtaskCount: subtaskIds.length };
     });
 
-    return { ...payload, cacheHit };
+    const task = includeLinks
+      ? { ...payload.task, _links: buildTaskLinks(payload.task) }
+      : payload.task;
+    const subtasks = includeLinks
+      ? payload.subtasks?.map((t) => ({ ...t, _links: buildTaskLinks(t) }))
+      : payload.subtasks;
+
+    return {
+      task,
+      ...(payload.subtaskIds !== undefined ? { subtaskIds: payload.subtaskIds } : {}),
+      ...(payload.subtaskCount !== undefined ? { subtaskCount: payload.subtaskCount } : {}),
+      ...(subtasks !== undefined ? { subtasks } : {}),
+      cacheHit,
+    };
   }
 
   // -- Internal: page assembly -------------------------------------------
@@ -293,8 +322,9 @@ export class TaskService {
     const hasMore = afterCursor.length > limit;
     const nextCursor = hasMore ? this.encodeNextCursor(page, filterHash, getSortValue) : null;
 
-    const tasks = page.map((t) => ({ ...t, _links: buildTaskLinks(t) }));
-    return { tasks, nextCursor };
+    // Bare tasks — `_links` is injected by the public `list()` method only when
+    // the caller opts in. Caching link-free results keeps the cache compact.
+    return { tasks: page, nextCursor };
   }
 
   // -- Internal: validation ----------------------------------------------

--- a/src/tools/project/get.ts
+++ b/src/tools/project/get.ts
@@ -63,6 +63,14 @@ export const projectGetInputSchema = z.object({
         "Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS. " +
         "Note: only the project record is projected — attached tasks keep their full shape.",
     ),
+  includeLinks: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, the project (and each attached task, if includeTaskTree=true) carries a " +
+        "`_links` HATEOAS block. Default false — the block is omitted to save payload size. " +
+        "Use the underlying ID fields (`id`, `folderId`, `projectId`, `parentId`, `tagIds`) directly instead.",
+    ),
 });
 
 export type ProjectGetToolInput = z.infer<typeof projectGetInputSchema>;
@@ -85,6 +93,7 @@ export async function handleProjectGet(input: ProjectGetToolInput, ctx: ProjectG
   const result = await ctx.projectService.get({
     id: input.id,
     ...(input.includeTaskTree !== undefined ? { includeTaskTree: input.includeTaskTree } : {}),
+    ...(input.includeLinks !== undefined ? { includeLinks: input.includeLinks } : {}),
   });
   // Parse decision against the full note before projection.
   const decision = parseDecision(result.project.note);

--- a/src/tools/project/list.ts
+++ b/src/tools/project/list.ts
@@ -104,6 +104,14 @@ export const projectListInputSchema = z.object({
         "Omit for the full project shape. Empty array returns just id. " +
         "Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS.",
     ),
+  includeLinks: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, each project carries a `_links` HATEOAS block (self, folder). " +
+        "Default false — the block is omitted to save payload size. " +
+        "Use the project's `id` and `folderId` fields directly instead.",
+    ),
 });
 
 export type ProjectListToolInput = z.infer<typeof projectListInputSchema>;

--- a/src/tools/search/query.test.ts
+++ b/src/tools/search/query.test.ts
@@ -255,3 +255,45 @@ describe("search_query — pagination", () => {
     expect(warning?.details).toMatchObject({ unknown: ["bogus"] });
   });
 });
+
+// ---------------------------------------------------------------------------
+// _links opt-in (#792)
+// ---------------------------------------------------------------------------
+
+describe("search_query — _links opt-in", () => {
+  it("omits _links from each task by default", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Task" });
+    const result = await handleSearchQuery({ q: "task" }, ctx);
+    const t = result.data.tasks[0] as unknown as Record<string, unknown>;
+    expect(t._links).toBeUndefined();
+  });
+
+  it("includes _links when includeLinks=true", async () => {
+    const { ctx, adapter } = makeCtx();
+    const id = await adapter.createTask({ name: "Task" });
+    const result = await handleSearchQuery({ q: "task", includeLinks: true }, ctx);
+    const t = result.data.tasks[0] as unknown as { _links?: { self?: string } };
+    expect(t._links?.self).toBe(`omnifocus://task/${id}`);
+  });
+
+  it("explicit includeLinks=false also omits _links", async () => {
+    const { ctx, adapter } = makeCtx();
+    await adapter.createTask({ name: "Task" });
+    const result = await handleSearchQuery({ q: "task", includeLinks: false }, ctx);
+    const t = result.data.tasks[0] as unknown as Record<string, unknown>;
+    expect(t._links).toBeUndefined();
+  });
+
+  it("toggling includeLinks does not break cursor pagination (filter hash stable)", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 5; i++) await adapter.createTask({ name: `Task ${i}` });
+    const page1 = await handleSearchQuery({ q: "task", limit: 3 }, ctx);
+    const cursor = page1.pagination?.cursor ?? "";
+    expect(cursor).toBeTruthy();
+    // Switch includeLinks mid-sequence — must still succeed (not part of hash).
+    const page2 = await handleSearchQuery({ q: "task", limit: 3, cursor, includeLinks: true }, ctx);
+    expect(page2.data.tasks).toHaveLength(2);
+    expect((page2.data.tasks[0] as unknown as { _links?: unknown })._links).toBeDefined();
+  });
+});

--- a/src/tools/search/query.ts
+++ b/src/tools/search/query.ts
@@ -94,6 +94,14 @@ export const searchQueryInputSchema = z.object({
         "Unknown names are dropped silently and surface in meta.warnings.WARN_UNKNOWN_FIELDS. " +
         `Allowed: ${TASK_FIELD_NAMES.join(", ")}.`,
     ),
+  includeLinks: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, each task carries a `_links` HATEOAS block (self, project, parent, tags). " +
+        "Default false — the block is omitted to save payload size. " +
+        "Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead.",
+    ),
 });
 
 export type SearchQueryToolInput = z.infer<typeof searchQueryInputSchema>;
@@ -120,6 +128,7 @@ export async function handleSearchQuery(input: SearchQueryToolInput, ctx: Search
     ...(input.completed !== undefined ? { completed: input.completed } : {}),
     ...(input.limit !== undefined ? { limit: input.limit } : {}),
     ...(input.cursor !== undefined ? { cursor: input.cursor } : {}),
+    ...(input.includeLinks !== undefined ? { includeLinks: input.includeLinks } : {}),
   };
 
   const result = await ctx.searchService.search(serviceInput);

--- a/src/tools/task/get.ts
+++ b/src/tools/task/get.ts
@@ -67,6 +67,14 @@ export const taskGetInputSchema = z.object({
         "Omit for the full task shape. Empty array returns just id. " +
         "Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS.",
     ),
+  includeLinks: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, the task (and each subtask, if requested) carries a `_links` HATEOAS block " +
+        "(self, project, parent, tags). Default false — the block is omitted to save payload size. " +
+        "Use `id`, `projectId`, `parentId`, and `tagIds` directly instead.",
+    ),
 });
 
 export type TaskGetToolInput = z.infer<typeof taskGetInputSchema>;

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -178,6 +178,14 @@ export const taskListInputSchema = z.object({
         "Omit for the full task shape. Empty array returns just id. " +
         "Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS.",
     ),
+  includeLinks: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, each task carries a `_links` HATEOAS block (self, project, parent, tags). " +
+        "Default false — the block is omitted to save payload size. " +
+        "Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead.",
+    ),
 });
 
 /** TypeScript input type derived from {@link taskListInputSchema}. */

--- a/src/tools/task/search.ts
+++ b/src/tools/task/search.ts
@@ -110,6 +110,14 @@ export const taskSearchInputShape = {
     .describe(
       "Opaque cursor from a previous task_search response. Must use the same filters — changing filters mid-sequence returns a ValidationError.",
     ),
+  includeLinks: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, each task carries a `_links` HATEOAS block (self, project, parent, tags). " +
+        "Default false — the block is omitted to save payload size. " +
+        "Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead.",
+    ),
 };
 
 /** Full schema with at-least-one-field refinement — use for runtime validation. */
@@ -165,6 +173,7 @@ export async function handleTaskSearch(input: TaskSearchToolInput, ctx: TaskSear
     ...(input.completed !== undefined && { completed: input.completed }),
     ...(input.limit !== undefined && { limit: input.limit }),
     ...(input.cursor !== undefined && { cursor: input.cursor }),
+    ...(input.includeLinks !== undefined && { includeLinks: input.includeLinks }),
   });
   const pagination: Pagination = {
     cursor: result.nextCursor,

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-10",
-  "toolListBytes": 174064,
+  "generatedAt": "2026-05-20",
+  "toolListBytes": 177953,
   "workflows": {
     "inbox-triage": {
       "callCount": 6,
       "totalRequestBytes": 29603,
-      "totalResponseBytes": 38226,
-      "totalRoundTripBytes": 67829,
-      "totalTokens": 60473,
+      "totalResponseBytes": 34466,
+      "totalRoundTripBytes": 64069,
+      "totalTokens": 60506,
       "byTool": {
         "tag_create": {
           "calls": 1,
@@ -27,16 +27,16 @@
         },
         "task_list": {
           "calls": 2,
-          "responseBytes": 26798
+          "responseBytes": 23038
         }
       }
     },
     "project-planning": {
       "callCount": 6,
       "totalRequestBytes": 2609,
-      "totalResponseBytes": 26154,
-      "totalRoundTripBytes": 28763,
-      "totalTokens": 50707,
+      "totalResponseBytes": 20474,
+      "totalRoundTripBytes": 23083,
+      "totalTokens": 50259,
       "byTool": {
         "project_create": {
           "calls": 1,
@@ -44,7 +44,7 @@
         },
         "project_get": {
           "calls": 1,
-          "responseBytes": 10332
+          "responseBytes": 7422
         },
         "tag_create": {
           "calls": 1,
@@ -60,16 +60,16 @@
         },
         "task_list": {
           "calls": 1,
-          "responseBytes": 9638
+          "responseBytes": 6868
         }
       }
     },
     "weekly-review": {
       "callCount": 11,
       "totalRequestBytes": 292,
-      "totalResponseBytes": 19130,
-      "totalRoundTripBytes": 19422,
-      "totalTokens": 48372,
+      "totalResponseBytes": 15410,
+      "totalRoundTripBytes": 15702,
+      "totalTokens": 48414,
       "byTool": {
         "project_mark_reviewed": {
           "calls": 5,
@@ -81,7 +81,7 @@
         },
         "task_list": {
           "calls": 5,
-          "responseBytes": 13210
+          "responseBytes": 9490
         }
       }
     }


### PR DESCRIPTION
## Summary

- Every list/get tool that injected the HATEOAS `_links` block (`task_list`, `task_get`, `project_list`, `project_get`, `search_query`, `task_search`) now omits it by default. Callers opt in per-call with `includeLinks: true`.
- `_links` is injected post-cache so toggling the flag does not fragment the LRU cache; the cursor filter-hash is unchanged so cursors survive mid-sequence flips.
- Token-cost baseline regenerated; measured savings on bench fixtures (in-memory adapter):
  - inbox-triage `task_list`: 26,798 → 23,038 B (−14%)
  - project-planning `task_list`: 9,638 → 6,868 B (−29%)
  - project-planning `project_get`: 10,332 → 7,422 B (−28%)
  - weekly-review `task_list`: 13,210 → 9,490 B (−28%)
- `tools/list` payload grew by ~3.9 KiB to document the new `includeLinks` field on six tools — small price for the per-response savings.

Closes #792.

## Issue

Implements [#792 — perf(tools): make _links opt-in via includeLinks flag, default off](https://github.com/torsday/omnifocus-mcp/issues/792). Part of the [#770](https://github.com/torsday/omnifocus-mcp/issues/770) token-efficiency epic; reverses the default of [#149](https://github.com/torsday/omnifocus-mcp/issues/149) without removing the feature.

## Breaking change?

- [x] No — additive flag. Default behavior changes (`_links` no longer present unless requested), which is a contract change in spirit and will land as a minor bump per the issue's note. Clients that explicitly want `_links` add `includeLinks: true` and recover byte-for-byte parity.

## Test plan

- [x] Unit tests cover default-off, explicit-true, explicit-false, and subtask propagation for `TaskService.get`, `TaskService.list`, `ProjectService.get`, `ProjectService.list`, and the `search_query` tool handler.
- [x] New cache test asserts toggling `includeLinks` does not fragment the cache.
- [x] New pagination test asserts switching `includeLinks` mid-cursor still works (filter hash unchanged).
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean (lint, docs:check, nl-quality, custom-lint, doc-sizes).
- [x] `pnpm test` — 3799 passed / 59 skipped.
- [x] `pnpm bench:tokens` — baseline regenerated, no drift > 5% against the new baseline.
- [x] Self-reviewed via `/review-pr` (deletion sweep + Definition of Done walk).
- [x] No new dependencies.