### PR TITLE
feat(scripts): opt 3 attachment scripts into ts-check

### DIFF
--- a/src/scripts/jxa/_types/jxa-globals.d.ts
+++ b/src/scripts/jxa/_types/jxa-globals.d.ts
@@ -41,17 +41,32 @@ declare function Application(name: string): Application & {
    * means callers may still write `ofApp.defaultDocument()` if they prefer.
    */
   defaultDocument: Document;
-  /** Standard JXA constructor proxy — used to instantiate Tag/Folder/Project/Task by name. */
-  Tag: new (props: {
-    name: string;
-    [key: string]: unknown;
-  }) => unknown;
-  Folder: new (props: { name: string; [key: string]: unknown }) => unknown;
-  Project: new (props: { name: string; status?: unknown; [key: string]: unknown }) => unknown;
-  InboxTask: new (props: { name: string; [key: string]: unknown }) => unknown;
-  Task: new (props: { name: string; [key: string]: unknown }) => unknown;
+  /**
+   * Standard JXA constructor proxies — instantiate by class name. JXA
+   * accepts both `ofApp.Tag(props)` and `new ofApp.Tag(props)`; every
+   * script in this repo uses the bare-call form (see `tag_create.js`,
+   * `folder_create.js`, `project_create.js`, `task_create.js`).
+   * Modeled as call-signature-only so both forms typecheck without
+   * forcing the `new` keyword.
+   */
+  Tag: (props: { name: string; [key: string]: unknown }) => unknown;
+  Folder: (props: { name: string; [key: string]: unknown }) => unknown;
+  Project: (props: { name: string; status?: unknown; [key: string]: unknown }) => unknown;
+  InboxTask: (props: { name: string; [key: string]: unknown }) => unknown;
+  Task: (props: { name: string; [key: string]: unknown }) => unknown;
+  /**
+   * FileAttachment constructor proxy — used by `attachment_add.js` to
+   * build an attachment from a local file (`ofApp.FileAttachment({ file: Path(...) })`)
+   * before pushing it onto an owner's `fileAttachments` collection.
+   */
+  FileAttachment: (props: { file: unknown; [key: string]: unknown }) => FileAttachment;
   /** Send-event wrapper used by some OF commands. */
   add: (item: unknown, options: { to: unknown }) => void;
+  /**
+   * Standard JXA `delete` verb — removes a specifier from its container.
+   * Used by `attachment_remove.js` (`ofApp.delete(attachment)`).
+   */
+  delete: (item: unknown) => void;
   /** Evaluate an OmniJS expression inside the OmniFocus host (#960 / #962). */
   evaluateJavascript: (source: string) => string;
   /**

--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -41,14 +41,20 @@
 // `attachment_add.js`, `attachment_save_to_path.js`, `attachment_remove.js`.
 // ---------------------------------------------------------------------------
 
+// `fileAttachments` is both callable (`.fileAttachments()` evaluates to a
+// snapshot — `attachment_list.js`) and property-accessible
+// (`.fileAttachments.push(att)` mutates the live element collection —
+// `attachment_add.js`). The intersection lets both forms typecheck; same
+// pattern as `defaultDocument` in `jxa-globals.d.ts`.
+
 interface Task {
   /** Runtime convenience over `note.fileAttachments` — see file header. */
-  fileAttachments(): JxaCollection<FileAttachment>;
+  fileAttachments: JxaCollection<FileAttachment> & (() => JxaCollection<FileAttachment>);
 }
 
 interface Project {
   /** Runtime convenience over `note.fileAttachments` — see file header. */
-  fileAttachments(): JxaCollection<FileAttachment>;
+  fileAttachments: JxaCollection<FileAttachment> & (() => JxaCollection<FileAttachment>);
 }
 
 // ---------------------------------------------------------------------------
@@ -76,4 +82,15 @@ interface Attachment {
   fileSize(): number | null;
   /** `true` when the attachment is an alias rather than embedded. May throw. */
   linked(): boolean;
+}
+
+interface FileAttachment {
+  /**
+   * The JXA Path object for the attachment's underlying file. Used by
+   * `attachment_save_to_path.js` to source a binary-safe copy via
+   * NSFileManager. The returned Path-like exposes `.toString()` →
+   * POSIX path; typed conservatively as `{ toString(): string }` so
+   * the only operation consumers can perform is the supported one.
+   */
+  file(): { toString(): string };
 }

--- a/src/scripts/jxa/attachment_add.js
+++ b/src/scripts/jxa/attachment_add.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: add an attachment to a task or project from a local file path.
  *

--- a/src/scripts/jxa/attachment_remove.js
+++ b/src/scripts/jxa/attachment_remove.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: remove an attachment by ID from a task or project.
  *

--- a/src/scripts/jxa/attachment_save_to_path.js
+++ b/src/scripts/jxa/attachment_save_to_path.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: copy an attachment's content to a local file path.
  *

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -13,7 +13,10 @@
   },
   "include": [
     "src/scripts/jxa/app_launch.js",
+    "src/scripts/jxa/attachment_add.js",
     "src/scripts/jxa/attachment_list.js",
+    "src/scripts/jxa/attachment_remove.js",
+    "src/scripts/jxa/attachment_save_to_path.js",
     "src/scripts/jxa/ping.js",
     "src/scripts/jxa/task_get.js"
   ]


### PR DESCRIPTION
## Summary
- Slice 3 of #989 rollout: `attachment_add`, `attachment_remove`, `attachment_save_to_path` opt in alongside `attachment_list` from #1001. **7 of 61** JXA scripts now under the gate.
- `jxa-globals.d.ts` grows by `delete(item)`, `FileAttachment(props)`; the existing five constructor proxies flip from `new (...) => unknown` to bare-callable to match every existing call site.
- `sdef-overrides.d.ts` grows by `FileAttachment.file()`; `Task.fileAttachments` / `Project.fileAttachments` flip to a `JxaCollection<T> & (() => JxaCollection<T>)` intersection so both call forms (snapshot evaluation, push-mutation) typecheck.

Closes #989 (will be **reopened post-merge** — 54 scripts remain; same documented multi-slice workflow as PRs #996, #997, #998).

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (7 opt-ins)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, 16 warnings unchanged)
- [x] `pnpm test` 3783 passed / 59 skipped
- [x] No runtime change (compile-time only)