### PR TITLE
feat(scripts): opt folder/tag readers into ts-check

### DIFF
--- a/src/scripts/jxa/_types/jxa-helpers.d.ts
+++ b/src/scripts/jxa/_types/jxa-helpers.d.ts
@@ -25,13 +25,15 @@
 // Ambient (script-mode) — no `export`. Adding one would make the file
 // a module and the declarations would disappear from consumer scope.
 //
-// Signatures are conservatively typed: inputs are the JXA specifiers
-// the helpers actually receive (`unknown` keeps the call site honest),
-// and returns are documented as the projected domain shape but typed
-// as `object` so consumers can JSON.stringify the result without
-// claiming a specific Task / Folder / etc. shape (the projection logic
-// inside each helper is the source of truth for the shape, not this
-// file).
+// Signatures: inputs are the JXA specifiers the helpers actually receive
+// (`unknown` keeps the call site honest). Returns are typed as `any` —
+// each helper produces a domain-shaped projection (Task / Folder / Project
+// / Tag) and consumers routinely read fields off the result (e.g.
+// `built.parentId` in folder_list.js). Modeling the full projection shape
+// here would duplicate the domain types and force every shape tweak to
+// land in two places; the helper's `.js` source remains the single source
+// of truth for the shape, and `any` lets consumers compile without
+// per-script `@type` JSDoc declarations. Trade-off documented inline.
 //
 // @see src/scripts/jxa/_helpers/*.js — runtime sources
 
@@ -41,26 +43,30 @@
  *
  * @see src/scripts/jxa/_helpers/build_task.js
  */
-declare function buildTask(task: unknown, options?: { effectiveAvailability?: boolean }): object;
+// biome-ignore lint/suspicious/noExplicitAny: helper return is the projected domain shape — see file header.
+declare function buildTask(task: unknown, options?: { effectiveAvailability?: boolean }): any;
 
 /**
  * Build the repetition sub-object of a Task (rrule + anchor +
  * scheduleType). Spliced alongside `buildTask` via
  * `// @inline _helpers/build_task.js`.
  */
-declare function buildRepetition(task: unknown): object | null;
+// biome-ignore lint/suspicious/noExplicitAny: see file header.
+declare function buildRepetition(task: unknown): any | null;
 
 /**
  * Build the canonical projected Folder shape from a JXA folder specifier.
  * Spliced via `// @inline _helpers/build_folder.js`.
  */
-declare function buildFolder(folder: unknown, options?: object): object;
+// biome-ignore lint/suspicious/noExplicitAny: see file header.
+declare function buildFolder(folder: unknown, options?: object): any;
 
 /**
  * Build the canonical projected Project shape from a JXA project specifier.
  * Spliced via `// @inline _helpers/build_project.js`.
  */
-declare function buildProject(proj: unknown): object;
+// biome-ignore lint/suspicious/noExplicitAny: see file header.
+declare function buildProject(proj: unknown): any;
 
 /**
  * Build the canonical projected Tag shape from a JXA tag specifier.
@@ -68,7 +74,8 @@ declare function buildProject(proj: unknown): object;
  * top-level tags (container is the document) from nested tags.
  * Spliced via `// @inline _helpers/build_tag.js`.
  */
-declare function buildTag(tag: unknown, docId: string): object;
+// biome-ignore lint/suspicious/noExplicitAny: see file header.
+declare function buildTag(tag: unknown, docId: string): any;
 
 /**
  * Force a JXA `byId(...)` lookup and throw a structured

--- a/src/scripts/jxa/folder_get.js
+++ b/src/scripts/jxa/folder_get.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+
 /**
  * JXA: fetch one folder by ID.
  *
@@ -21,6 +26,7 @@ function run(argv) {
   // sub-folder parentage correctly under the OF 4.8.8 `folder.parent()` bug
   // (#515). Same scan that locates the target folder.
   const allFolders = ofApp.defaultDocument.flattenedFolders();
+  /** @type {Record<string, string>} */
   const parentMap = {};
   for (let i = 0; i < allFolders.length; i++) {
     try {

--- a/src/scripts/jxa/folder_list.js
+++ b/src/scripts/jxa/folder_list.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+
 /**
  * JXA: list all folders, optionally filtered by parentId.
  *
@@ -22,6 +27,7 @@ function run(argv) {
   // folder's .folders() children instead — that API works correctly. Pass
   // the map into buildFolder via options.parentMap.
   const allFolders = ofApp.defaultDocument.flattenedFolders();
+  /** @type {Record<string, string>} */
   const parentMap = {};
   for (let i = 0; i < allFolders.length; i++) {
     try {

--- a/src/scripts/jxa/tag_get.js
+++ b/src/scripts/jxa/tag_get.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+
 /**
  * JXA: fetch one tag by ID.
  *

--- a/src/scripts/jxa/tag_list.js
+++ b/src/scripts/jxa/tag_list.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+
 /**
  * JXA: list all tags, optionally filtered by parentId or status.
  *

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -17,7 +17,11 @@
     "src/scripts/jxa/attachment_list.js",
     "src/scripts/jxa/attachment_remove.js",
     "src/scripts/jxa/attachment_save_to_path.js",
+    "src/scripts/jxa/folder_get.js",
+    "src/scripts/jxa/folder_list.js",
     "src/scripts/jxa/ping.js",
+    "src/scripts/jxa/tag_get.js",
+    "src/scripts/jxa/tag_list.js",
     "src/scripts/jxa/task_get.js"
   ]
 }


### PR DESCRIPTION
## Summary
- Slice 4 of #989 rollout: `folder_get`, `folder_list`, `tag_get`, `tag_list` opt into the gate. **11 of 61** scripts now under static typing.
- `_types/jxa-helpers.d.ts` builder return types widened from `object` to `any` (with `biome-ignore` per declaration). Each builder produces a domain-shaped projection; consumers read fields off the result. The helper's `.js` stays the single source of truth — modeling the projection shape in the `.d.ts` would duplicate domain types.
- `folder_get.js` / `folder_list.js`: `const parentMap = {}` carries `@type {Record<string, string>}` so strict-mode TS doesn't fire `TS7053` on index-assign.

Closes #989 (reopened post-merge — 50 scripts remain; same multi-slice workflow as #1003, #998, #997, #996).

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (11 opt-ins)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors, 16 warnings unchanged)
- [x] `pnpm test` 3783 passed / 59 skipped
- [x] No runtime change (compile-time only)