### PR TITLE
feat(scripts): opt project_get + perspective_list into ts-check

### DIFF
--- a/src/scripts/jxa/perspective_list.js
+++ b/src/scripts/jxa/perspective_list.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+
 /**
  * JXA: list all perspectives (built-in + custom).
  *
@@ -27,6 +32,7 @@ function run(_argv) {
     "review",
   ]);
 
+  /** @type {Record<string, string>} */
   const BUILTIN_NAMES = {
     inbox: "Inbox",
     projects: "Projects",

--- a/src/scripts/jxa/project_get.js
+++ b/src/scripts/jxa/project_get.js
@@ -1,3 +1,8 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+
 /**
  * JXA: fetch one project by ID.
  *

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -19,7 +19,9 @@
     "src/scripts/jxa/attachment_save_to_path.js",
     "src/scripts/jxa/folder_get.js",
     "src/scripts/jxa/folder_list.js",
+    "src/scripts/jxa/perspective_list.js",
     "src/scripts/jxa/ping.js",
+    "src/scripts/jxa/project_get.js",
     "src/scripts/jxa/tag_get.js",
     "src/scripts/jxa/tag_list.js",
     "src/scripts/jxa/task_get.js"


### PR DESCRIPTION
## Summary
- Slice 5 of #989: `project_get` and `perspective_list` opt in. **13 of 61** scripts now under the gate.
- `perspective_list.js` needed a single per-script JSDoc (`@type {Record<string, string>}` on the `BUILTIN_NAMES` literal) so strict-mode TS would allow indexing with the looser `string` Set members.
- Three originally-targeted scripts (`project_get_many`, `project_list`, `review_list_due`) deferred to separate slices — each needs a distinct type-system extension (es2022 lib bump, generalized property-vs-method intersection on Document accessors, sdef-overrides addition for `reviewIntervalDays`). Details in commit body.

Closes #989 (reopened post-merge — 48 of 61 remain).

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (13 opt-ins)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 3783 passed / 59 skipped
- [x] No runtime change