### PR TITLE
feat(scripts): generalize element-accessor type + 3 more opt-ins

### DIFF
--- a/scripts/generate-jxa-types.ts
+++ b/scripts/generate-jxa-types.ts
@@ -285,18 +285,27 @@ function emitClass(cls: ClassDef, knownClasses: Set<string>): string {
     lines.push(`  ${tsAccessor(p.name)}(): ${tsType};`);
   }
 
-  // Elements: child collections. Type is the *element-of* class wrapped in
-  // `JxaCollection<T>` so the JXA element-query API (`byId`, `whose`, `at`)
-  // is exposed to `// @ts-check` consumers — see the JxaCollection comment
-  // at the top of this file. A plain `T[]` would lose those methods even
-  // though they exist at runtime.
+  // Elements: child collections. Emitted as a property-or-callable
+  // intersection — `name: JxaCollection<T> & (() => JxaCollection<T>)` —
+  // because JXA exposes element collections in both forms at runtime:
+  //
+  //   doc.folders()              // evaluates to a snapshot array
+  //   doc.folders.byId(id)       // queries the live element specifier
+  //   doc.folders.push(folder)   // mutates the underlying collection
+  //
+  // Without the intersection, property-access call sites (`doc.folders.byId`)
+  // trip `TS2339: Property 'byId' does not exist on type '() => JxaCollection<Folder>'`.
+  // Both forms are correct at runtime; the type system now accepts both.
+  // Same pattern as `defaultDocument` (jxa-globals.d.ts) and
+  // `fileAttachments` (sdef-overrides.d.ts) — generalized here so every
+  // element accessor inherits it.
   for (const e of cls.elements) {
     const tsType = mapTypeToTs(e.type, knownClasses);
-    // Plural — JXA convention: `flattenedTasks()`, `tags()`, etc.
+    // Plural — JXA convention: `flattenedTasks`, `tags`, etc.
     // The sdef element name is singular; pluralization is mechanical.
     const plural = pluralizeAccessor(e.type);
     lines.push(`  /** child collection of '${e.type}' */`);
-    lines.push(`  ${plural}(): JxaCollection<${tsType}>;`);
+    lines.push(`  ${plural}: JxaCollection<${tsType}> & (() => JxaCollection<${tsType}>);`);
   }
 
   lines.push(`}`);

--- a/src/scripts/jxa/_types/omnifocus.d.ts
+++ b/src/scripts/jxa/_types/omnifocus.d.ts
@@ -34,13 +34,13 @@ interface Application {
   /** [read-only] The names of all available perspectives in the default document. */
   perspectiveNames(): unknown;
   /** child collection of 'document' */
-  documents(): JxaCollection<Document>;
+  documents: JxaCollection<Document> & (() => JxaCollection<Document>);
   /** child collection of 'window' */
-  windows(): JxaCollection<Window>;
+  windows: JxaCollection<Window> & (() => JxaCollection<Window>);
   /** child collection of 'perspective' */
-  perspectives(): JxaCollection<Perspective>;
+  perspectives: JxaCollection<Perspective> & (() => JxaCollection<Perspective>);
   /** child collection of 'preference' */
-  preferences(): JxaCollection<Preference>;
+  preferences: JxaCollection<Preference> & (() => JxaCollection<Preference>);
 }
 
 /** OmniFocus 'document' class (sdef code: docu). */
@@ -78,33 +78,33 @@ interface Document {
   /** [read-only] The names of all available perspectives in this document. */
   perspectiveNames(): unknown;
   /** child collection of 'setting' */
-  settings(): JxaCollection<Setting>;
+  settings: JxaCollection<Setting> & (() => JxaCollection<Setting>);
   /** child collection of 'document window' */
-  documentWindows(): JxaCollection<DocumentWindow>;
+  documentWindows: JxaCollection<DocumentWindow> & (() => JxaCollection<DocumentWindow>);
   /** child collection of 'section' */
-  sections(): JxaCollection<Section>;
+  sections: JxaCollection<Section> & (() => JxaCollection<Section>);
   /** child collection of 'folder' */
-  folders(): JxaCollection<Folder>;
+  folders: JxaCollection<Folder> & (() => JxaCollection<Folder>);
   /** child collection of 'project' */
-  projects(): JxaCollection<Project>;
+  projects: JxaCollection<Project> & (() => JxaCollection<Project>);
   /** child collection of 'tag' */
-  tags(): JxaCollection<Tag>;
+  tags: JxaCollection<Tag> & (() => JxaCollection<Tag>);
   /** child collection of 'deprecated context' */
-  deprecatedContexts(): JxaCollection<DeprecatedContext>;
+  deprecatedContexts: JxaCollection<DeprecatedContext> & (() => JxaCollection<DeprecatedContext>);
   /** child collection of 'inbox task' */
-  inboxTasks(): JxaCollection<InboxTask>;
+  inboxTasks: JxaCollection<InboxTask> & (() => JxaCollection<InboxTask>);
   /** child collection of 'task' */
-  tasks(): JxaCollection<Task>;
+  tasks: JxaCollection<Task> & (() => JxaCollection<Task>);
   /** child collection of 'flattened task' */
-  flattenedTasks(): JxaCollection<FlattenedTask>;
+  flattenedTasks: JxaCollection<FlattenedTask> & (() => JxaCollection<FlattenedTask>);
   /** child collection of 'flattened project' */
-  flattenedProjects(): JxaCollection<FlattenedProject>;
+  flattenedProjects: JxaCollection<FlattenedProject> & (() => JxaCollection<FlattenedProject>);
   /** child collection of 'flattened folder' */
-  flattenedFolders(): JxaCollection<FlattenedFolder>;
+  flattenedFolders: JxaCollection<FlattenedFolder> & (() => JxaCollection<FlattenedFolder>);
   /** child collection of 'flattened tag' */
-  flattenedTags(): JxaCollection<FlattenedTag>;
+  flattenedTags: JxaCollection<FlattenedTag> & (() => JxaCollection<FlattenedTag>);
   /** child collection of 'perspective' */
-  perspectives(): JxaCollection<Perspective>;
+  perspectives: JxaCollection<Perspective> & (() => JxaCollection<Perspective>);
 }
 
 /** OmniFocus 'window' class (sdef code: cwin). */
@@ -156,15 +156,15 @@ interface QuickEntryTree extends Tree {
   /** [read-only] Whether the quick entry panel is currently visible. */
   visible(): boolean;
   /** child collection of 'folder' */
-  folders(): JxaCollection<Folder>;
+  folders: JxaCollection<Folder> & (() => JxaCollection<Folder>);
   /** child collection of 'project' */
-  projects(): JxaCollection<Project>;
+  projects: JxaCollection<Project> & (() => JxaCollection<Project>);
   /** child collection of 'tag' */
-  tags(): JxaCollection<Tag>;
+  tags: JxaCollection<Tag> & (() => JxaCollection<Tag>);
   /** child collection of 'deprecated context' */
-  deprecatedContexts(): JxaCollection<DeprecatedContext>;
+  deprecatedContexts: JxaCollection<DeprecatedContext> & (() => JxaCollection<DeprecatedContext>);
   /** child collection of 'inbox task' */
-  inboxTasks(): JxaCollection<InboxTask>;
+  inboxTasks: JxaCollection<InboxTask> & (() => JxaCollection<InboxTask>);
 }
 
 /** OmniFocus 'setting' class (sdef code: FCos). */
@@ -180,7 +180,7 @@ interface Setting {
 /** OmniFocus 'focus sections' class (sdef code: FCFS). */
 interface FocusSections {
   /** child collection of 'item' */
-  items(): JxaCollection<unknown>;
+  items: JxaCollection<unknown> & (() => JxaCollection<unknown>);
 }
 
 /** OmniFocus 'section' class (sdef code: FCSX). */
@@ -212,15 +212,15 @@ interface Folder extends Section {
   /** [read-only] The containing document or quick entry tree of the object. */
   containingDocument(): Document;
   /** child collection of 'section' */
-  sections(): JxaCollection<Section>;
+  sections: JxaCollection<Section> & (() => JxaCollection<Section>);
   /** child collection of 'folder' */
-  folders(): JxaCollection<Folder>;
+  folders: JxaCollection<Folder> & (() => JxaCollection<Folder>);
   /** child collection of 'project' */
-  projects(): JxaCollection<Project>;
+  projects: JxaCollection<Project> & (() => JxaCollection<Project>);
   /** child collection of 'flattened project' */
-  flattenedProjects(): JxaCollection<FlattenedProject>;
+  flattenedProjects: JxaCollection<FlattenedProject> & (() => JxaCollection<FlattenedProject>);
   /** child collection of 'flattened folder' */
-  flattenedFolders(): JxaCollection<FlattenedFolder>;
+  flattenedFolders: JxaCollection<FlattenedFolder> & (() => JxaCollection<FlattenedFolder>);
 }
 
 /** OmniFocus 'tag' class (sdef code: FCtg). */
@@ -248,17 +248,17 @@ interface Tag {
   /** The physical location associated with the tag. */
   location(): unknown;
   /** child collection of 'tag' */
-  tags(): JxaCollection<Tag>;
+  tags: JxaCollection<Tag> & (() => JxaCollection<Tag>);
   /** child collection of 'deprecated context' */
-  deprecatedContexts(): JxaCollection<DeprecatedContext>;
+  deprecatedContexts: JxaCollection<DeprecatedContext> & (() => JxaCollection<DeprecatedContext>);
   /** child collection of 'flattened tag' */
-  flattenedTags(): JxaCollection<FlattenedTag>;
+  flattenedTags: JxaCollection<FlattenedTag> & (() => JxaCollection<FlattenedTag>);
   /** child collection of 'task' */
-  tasks(): JxaCollection<Task>;
+  tasks: JxaCollection<Task> & (() => JxaCollection<Task>);
   /** child collection of 'available task' */
-  availableTasks(): JxaCollection<AvailableTask>;
+  availableTasks: JxaCollection<AvailableTask> & (() => JxaCollection<AvailableTask>);
   /** child collection of 'remaining task' */
-  remainingTasks(): JxaCollection<RemainingTask>;
+  remainingTasks: JxaCollection<RemainingTask> & (() => JxaCollection<RemainingTask>);
 }
 
 /** OmniFocus 'deprecated context' class (sdef code: FCct). */
@@ -436,17 +436,17 @@ interface Task {
   /** A simple textual archive of a task that can be used to create, update and distributed tasks. Please see the documentation for more information. */
   transportText(): string;
   /** child collection of 'tag' */
-  tags(): JxaCollection<Tag>;
+  tags: JxaCollection<Tag> & (() => JxaCollection<Tag>);
   /** child collection of 'task' */
-  tasks(): JxaCollection<Task>;
+  tasks: JxaCollection<Task> & (() => JxaCollection<Task>);
   /** child collection of 'flattened task' */
-  flattenedTasks(): JxaCollection<FlattenedTask>;
+  flattenedTasks: JxaCollection<FlattenedTask> & (() => JxaCollection<FlattenedTask>);
 }
 
 /** OmniFocus 'forecast sidebar tree' class (sdef code: FCFt). */
 interface ForecastSidebarTree extends SidebarTree {
   /** child collection of 'forecast day' */
-  forecastDays(): JxaCollection<ForecastDay>;
+  forecastDays: JxaCollection<ForecastDay> & (() => JxaCollection<ForecastDay>);
 }
 
 /** OmniFocus 'forecast day' class (sdef code: FCdy). */
@@ -566,19 +566,19 @@ interface Tree {
   /** A list of the types that can be used when reading nodes from the pasteboard (i.e., pasteing). */
   readablePasteboardTypes(): unknown;
   /** child collection of 'tree' */
-  trees(): JxaCollection<Tree>;
+  trees: JxaCollection<Tree> & (() => JxaCollection<Tree>);
   /** child collection of 'descendant tree' */
-  descendantTrees(): JxaCollection<DescendantTree>;
+  descendantTrees: JxaCollection<DescendantTree> & (() => JxaCollection<DescendantTree>);
   /** child collection of 'ancestor tree' */
-  ancestorTrees(): JxaCollection<AncestorTree>;
+  ancestorTrees: JxaCollection<AncestorTree> & (() => JxaCollection<AncestorTree>);
   /** child collection of 'leaf' */
-  leafs(): JxaCollection<Leaf>;
+  leafs: JxaCollection<Leaf> & (() => JxaCollection<Leaf>);
   /** child collection of 'preceding sibling' */
-  precedingSiblings(): JxaCollection<PrecedingSibling>;
+  precedingSiblings: JxaCollection<PrecedingSibling> & (() => JxaCollection<PrecedingSibling>);
   /** child collection of 'following sibling' */
-  followingSiblings(): JxaCollection<FollowingSibling>;
+  followingSiblings: JxaCollection<FollowingSibling> & (() => JxaCollection<FollowingSibling>);
   /** child collection of 'selected tree' */
-  selectedTrees(): JxaCollection<SelectedTree>;
+  selectedTrees: JxaCollection<SelectedTree> & (() => JxaCollection<SelectedTree>);
 }
 
 /** OmniFocus 'descendant tree' class (sdef code: OTds). */
@@ -612,9 +612,9 @@ interface Style {
   /** The name of the font of the style. */
   font(): string;
   /** child collection of 'named style' */
-  namedStyles(): JxaCollection<NamedStyle>;
+  namedStyles: JxaCollection<NamedStyle> & (() => JxaCollection<NamedStyle>);
   /** child collection of 'attribute' */
-  attributes(): JxaCollection<Attribute>;
+  attributes: JxaCollection<Attribute> & (() => JxaCollection<Attribute>);
 }
 
 /** OmniFocus 'attribute' class (sdef code: OSsa). */
@@ -660,17 +660,17 @@ interface RichText {
   /** Alignment of the text. */
   alignment(): unknown;
   /** child collection of 'character' */
-  characters(): JxaCollection<Character>;
+  characters: JxaCollection<Character> & (() => JxaCollection<Character>);
   /** child collection of 'paragraph' */
-  paragraphs(): JxaCollection<Paragraph>;
+  paragraphs: JxaCollection<Paragraph> & (() => JxaCollection<Paragraph>);
   /** child collection of 'word' */
-  words(): JxaCollection<Word>;
+  words: JxaCollection<Word> & (() => JxaCollection<Word>);
   /** child collection of 'attribute run' */
-  attributeRuns(): JxaCollection<AttributeRun>;
+  attributeRuns: JxaCollection<AttributeRun> & (() => JxaCollection<AttributeRun>);
   /** child collection of 'attachment' */
-  attachments(): JxaCollection<Attachment>;
+  attachments: JxaCollection<Attachment> & (() => JxaCollection<Attachment>);
   /** child collection of 'file attachment' */
-  fileAttachments(): JxaCollection<FileAttachment>;
+  fileAttachments: JxaCollection<FileAttachment> & (() => JxaCollection<FileAttachment>);
 }
 
 /** OmniFocus 'character' class (sdef code: cha ). */

--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -94,3 +94,17 @@ interface FileAttachment {
    */
   file(): { toString(): string };
 }
+
+// ---------------------------------------------------------------------------
+// Review-cycle runtime extras
+//
+// The sdef declares `<property name="review interval" type="repetition interval">`,
+// emitted as `Project.reviewInterval(): RepetitionInterval`. At runtime OF
+// also exposes `reviewIntervalDays()` as a scalar-day convenience — used by
+// `review_list_due.js`.
+// ---------------------------------------------------------------------------
+
+interface Project {
+  /** Review interval expressed as a scalar day count. Runtime convenience. */
+  reviewIntervalDays(): number;
+}

--- a/src/scripts/jxa/project_get_many.js
+++ b/src/scripts/jxa/project_get_many.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: fetch multiple projects by IDs.
  *
@@ -17,6 +23,7 @@ function run(argv) {
 
   // @inline _helpers/build_project.js
 
+  /** @type {Record<string, unknown>} */
   const idSet = {};
   for (let i = 0; i < args.ids.length; i++) {
     idSet[args.ids[i]] = null;

--- a/src/scripts/jxa/project_list.js
+++ b/src/scripts/jxa/project_list.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: list projects, optionally filtered by folderId or status.
  *

--- a/src/scripts/jxa/review_list_due.js
+++ b/src/scripts/jxa/review_list_due.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: list projects due for review (nextReviewDate <= today, or null).
  *

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -4,11 +4,11 @@
     "allowJs": true,
     "checkJs": true,
     "strict": true,
-    "target": "es2020",
+    "target": "es2022",
     "moduleResolution": "bundler",
     "module": "esnext",
     "skipLibCheck": true,
-    "lib": ["es2020"],
+    "lib": ["es2022"],
     "types": []
   },
   "include": [
@@ -22,6 +22,9 @@
     "src/scripts/jxa/perspective_list.js",
     "src/scripts/jxa/ping.js",
     "src/scripts/jxa/project_get.js",
+    "src/scripts/jxa/project_get_many.js",
+    "src/scripts/jxa/project_list.js",
+    "src/scripts/jxa/review_list_due.js",
     "src/scripts/jxa/tag_get.js",
     "src/scripts/jxa/tag_list.js",
     "src/scripts/jxa/task_get.js"


### PR DESCRIPTION
## Summary
- Slice 6 of #989 rollout. **16 of 61** scripts now under the gate.
- **Generator** change: every element accessor emits as `name: JxaCollection<T> & (() => JxaCollection<T>)` so JXA's property-or-method runtime semantics typecheck uniformly. Generalizes the pattern that was already in place for `defaultDocument` and `fileAttachments`.
- **lib bump**: `tsconfig.jxa-tscheck.json` raised es2020 → es2022. JavaScriptCore on macOS 15+ supports the es2022 surface; the gate was lagging behind runtime.
- **sdef-overrides**: `Project.reviewIntervalDays(): number` runtime extra.
- Three deferred scripts now opt in: `project_get_many` (needed all three), `project_list` (generator change), `review_list_due` (override).
- Pre-existing opt-ins (13) typecheck unchanged.

Closes #989 (reopened post-merge — 45 of 61 remain).

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (16 opt-ins)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 3783 passed / 59 skipped
- [x] `tests/scripts/generate-jxa-types.test.ts` 11/11
- [x] No runtime change (compile-time only)