### PR TITLE
feat(scripts): opt sync_trigger + tag_get_many into ts-check

### DIFF
--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -108,3 +108,17 @@ interface Project {
   /** Review interval expressed as a scalar day count. Runtime convenience. */
   reviewIntervalDays(): number;
 }
+
+// ---------------------------------------------------------------------------
+// Document-level commands
+//
+// The sdef declares `<command name="synchronize">` taking a document specifier
+// as `<direct-parameter>`. The generator only emits `<class>` and `<property>`
+// shapes (not standalone commands), so `doc.synchronize()` shows up as missing.
+// Used by `sync_trigger.js`.
+// ---------------------------------------------------------------------------
+
+interface Document {
+  /** Trigger OmniFocus sync with the configured server. Async — returns immediately. */
+  synchronize(): void;
+}

--- a/src/scripts/jxa/sync_trigger.js
+++ b/src/scripts/jxa/sync_trigger.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: trigger Omni Sync.
  *

--- a/src/scripts/jxa/tag_get_many.js
+++ b/src/scripts/jxa/tag_get_many.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: fetch multiple tags by IDs.
  *
@@ -17,6 +23,7 @@ function run(argv) {
 
   // @inline _helpers/build_tag.js
 
+  /** @type {Record<string, unknown>} */
   const idSet = {};
   for (let i = 0; i < args.ids.length; i++) {
     idSet[args.ids[i]] = null;

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -25,7 +25,9 @@
     "src/scripts/jxa/project_get_many.js",
     "src/scripts/jxa/project_list.js",
     "src/scripts/jxa/review_list_due.js",
+    "src/scripts/jxa/sync_trigger.js",
     "src/scripts/jxa/tag_get.js",
+    "src/scripts/jxa/tag_get_many.js",
     "src/scripts/jxa/tag_list.js",
     "src/scripts/jxa/task_get.js"
   ]


### PR DESCRIPTION
## Summary
- Slice 7 of #989: `sync_trigger` and `tag_get_many` opt in. **18 of 61** scripts now under the gate.
- `sdef-overrides.d.ts`: `Document.synchronize(): void` — runtime extra (sdef declares synchronize as a standalone `<command>` with a document direct-parameter, which the generator doesn't emit as a method).
- `tag_get_many.js`: `@type {Record<string, unknown>}` on `idSet` (same shape as project_get_many in slice 6).

Originally surveyed 5 more scripts (forecast_get, perspective_evaluate, three window scripts); each surfaced distinct issues that warrant separate slices. See commit body.

Closes #989 (reopened post-merge — 43 of 61 remain).

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (18 opt-ins)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 3783 passed / 59 skipped