### PR TITLE
feat(scripts): opt forecast_get + 3 window scripts into ts-check

### DIFF
--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -122,3 +122,36 @@ interface Document {
   /** Trigger OmniFocus sync with the configured server. Async — returns immediately. */
   synchronize(): void;
 }
+
+// ---------------------------------------------------------------------------
+// Window accessors bubbled up from DocumentWindow
+//
+// The sdef puts `perspectiveName`, `focus`, and `perspective` on
+// `DocumentWindow` (extends Window). Every OF front window is in practice a
+// DocumentWindow, but `windows[0]()` / `frontWindow()` type-resolves to
+// `Window`. Add the accessors to the parent `Window` interface so window-
+// inspection scripts (`window_get_state`, `window_set_focus`,
+// `window_set_perspective`) typecheck without per-script casts.
+// ---------------------------------------------------------------------------
+
+interface Window {
+  /** Name of the active perspective. DocumentWindow accessor bubbled up. */
+  perspectiveName(): string;
+  /**
+   * Project focus — both gettable (`w.focus()` returns the array of
+   * container specifiers) and settable (`w.focus = [...]` replaces it; an
+   * empty array clears the focus). Typed as `any` because the dual
+   * property/method semantics plus mutability through assignment can't
+   * be expressed as a clean intersection in strict mode. Compile-time
+   * compromise; runtime semantics are documented in the sdef.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: see comment — dual property/method, mutable.
+  focus: any;
+  /**
+   * Active perspective specifier — gettable (`w.perspective()`) and
+   * settable (`w.perspective = target`). Same dual-shape constraint as
+   * `focus`.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: see comment — dual property/method, mutable.
+  perspective: any;
+}

--- a/src/scripts/jxa/forecast_get.js
+++ b/src/scripts/jxa/forecast_get.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: get forecast-view tasks grouped by category (overdue, dueToday,
  * deferredToday, flagged).
@@ -67,7 +73,9 @@ function run(argv) {
   const toDate = new Date(to);
 
   // ID → built task, populated lazily so each task is constructed once.
+  /** @type {Record<string, unknown>} */
   const builtById = {};
+  /** @param {Task} task — JXA task specifier */
   function builtFor(task) {
     const id = task.id();
     if (builtById[id] !== undefined) return builtById[id];
@@ -76,6 +84,7 @@ function run(argv) {
     return b;
   }
 
+  /** @param {Record<string, unknown>} predicate — sdef-attribute predicate object */
   function runQuery(predicate) {
     try {
       return ofApp.defaultDocument.flattenedTasks.whose(predicate)();

--- a/src/scripts/jxa/window_get_state.js
+++ b/src/scripts/jxa/window_get_state.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: read the current state of OmniFocus's front window.
  *
@@ -7,7 +13,7 @@
  *                             (empty array when nothing is focused)
  *  or { error: { code: "NO_FRONT_WINDOW", message } } when OF has no front window
  *
- * @see #466
+ * @see GH issue 466
  * @see src/adapter/jxa/JxaTransport.ts — getWindowState() caller
  */
 

--- a/src/scripts/jxa/window_set_focus.js
+++ b/src/scripts/jxa/window_set_focus.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: set or clear the front window's focus container.
  *
@@ -15,7 +21,7 @@
  * Container resolution: tries projects first, then folders. If the same ID
  * matches both (shouldn't happen but defensive), the project wins.
  *
- * @see #466
+ * @see GH issue 466
  * @see src/adapter/jxa/JxaTransport.ts — setWindowFocus() caller
  */
 

--- a/src/scripts/jxa/window_set_perspective.js
+++ b/src/scripts/jxa/window_set_perspective.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: switch the front window to a named perspective.
  *
@@ -8,7 +14,7 @@
  * Built-in perspectives (Inbox, Projects, Tags, Forecast, Flagged, Review, etc.)
  * and custom perspectives both work — JXA `Window.perspective` accepts either.
  *
- * @see #466
+ * @see GH issue 466
  * @see src/adapter/jxa/JxaTransport.ts — setWindowPerspective() caller
  */
 

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -19,6 +19,7 @@
     "src/scripts/jxa/attachment_save_to_path.js",
     "src/scripts/jxa/folder_get.js",
     "src/scripts/jxa/folder_list.js",
+    "src/scripts/jxa/forecast_get.js",
     "src/scripts/jxa/perspective_evaluate.js",
     "src/scripts/jxa/perspective_list.js",
     "src/scripts/jxa/ping.js",
@@ -30,6 +31,9 @@
     "src/scripts/jxa/tag_get.js",
     "src/scripts/jxa/tag_get_many.js",
     "src/scripts/jxa/tag_list.js",
-    "src/scripts/jxa/task_get.js"
+    "src/scripts/jxa/task_get.js",
+    "src/scripts/jxa/window_get_state.js",
+    "src/scripts/jxa/window_set_focus.js",
+    "src/scripts/jxa/window_set_perspective.js"
   ]
 }


### PR DESCRIPTION
## Summary
- Slice 9 of #989. **23 of 61** scripts now under the gate (+4 this slice).
- `forecast_get.js` opts in with two inner-helper JSDoc annotations (`builtById`, `builtFor`, `runQuery`).
- Three window scripts (`window_get_state`, `window_set_focus`, `window_set_perspective`) opt in after:
  - JSDoc `@see #466` → `@see GH issue 466` (the `#NNN` form trips TS1003 as private-class-field syntax).
  - `sdef-overrides.d.ts` extends `Window` with `perspectiveName()`, `focus`, and `perspective` (DocumentWindow accessors bubbled up; `focus`/`perspective` typed as `any` because they're dual property/method shapes mutated via assignment).

Closes #989 (reopened post-merge — 38 of 61 remain).

## Test plan
- [x] `pnpm exec tsc -p tsconfig.jxa-tscheck.json` clean (23 opt-ins)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 3783 passed / 59 skipped