### PR TITLE
feat(scripts): opt task_create into ts-check (#989 slice 17)

### DIFF
--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -258,3 +258,42 @@ interface Application {
   /** Mark a specifier incomplete — undoes markComplete. JXA verb. */
   markIncomplete(item: unknown): void;
 }
+
+// ---------------------------------------------------------------------------
+// task_create runtime extras
+//
+// `Project.tasks` is a child collection accessible at runtime
+// (`proj.tasks.push(newTask)`), but the sdef declares the project class
+// without any `<element>` block — so the generator emits Project with no
+// `tasks` member. Adding it here also benefits FlattenedProject (which
+// extends Project) so `flattenedProjects.byId(id).tasks.push(...)` checks.
+//
+// `Task.addTag(tag)` is the standard JXA `add` verb targeting the sdef's
+// `<element type="tag">` on the task class. The generator only emits class
+// shapes, not standalone commands, so the verb shows up as missing.
+//
+// `Task.containsSingletonActions` is a runtime extra (the sdef declares
+// "singleton action holder" / "completed by children" / "sequential" but
+// no `containsSingletonActions`). It is both readable as a method
+// (`task.containsSingletonActions()` in `_helpers/build_task.js`) and
+// settable as a property (`newTask.containsSingletonActions = true` in
+// `task_create.js` / `task_update.js`). Typed as `any` per the existing
+// `Tag.status` pattern — there's no generator-emitted member to collide
+// with, so declaration merging is sufficient.
+// ---------------------------------------------------------------------------
+
+interface Project {
+  /** Child collection of direct tasks. Runtime extra — sdef omits the element block. */
+  tasks: JxaCollection<Task> & (() => JxaCollection<Task>);
+}
+
+interface Task {
+  /** Attach a tag to this task. JXA `add` verb against the sdef tag element. */
+  addTag(tag: unknown): void;
+  /**
+   * "Completed when children are completed" flag — readable as a method
+   * and settable as a property. Runtime extra; not in the sdef Task class.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: dual method/property surface — see comment above.
+  containsSingletonActions: any;
+}

--- a/src/scripts/jxa/task_create.js
+++ b/src/scripts/jxa/task_create.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: create a new task.
  *

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -57,6 +57,7 @@
     "src/scripts/jxa/task_batch_undrop.js",
     "src/scripts/jxa/task_batch_update.js",
     "src/scripts/jxa/task_complete.js",
+    "src/scripts/jxa/task_create.js",
     "src/scripts/jxa/task_delete.js",
     "src/scripts/jxa/task_drop.js",
     "src/scripts/jxa/task_get.js",


### PR DESCRIPTION
## Summary

- Adds `// @ts-check` prologue to `src/scripts/jxa/task_create.js` and opts it into `tsconfig.jxa-tscheck.json` — 57 of 61 scripts now ts-checked.
- Three runtime extras land in `_types/sdef-overrides.d.ts` to cover task_create's call sites:
  - `Project.tasks` — child collection runtime-accessible (`proj.tasks.push(newTask)`) but missing from the sdef project class. Adding on Project propagates to `FlattenedProject extends Project`.
  - `Task.addTag(tag)` — standard JXA `add` verb against the sdef's `<element type="tag">`. Generator emits class shapes, not standalone commands.
  - `Task.containsSingletonActions` — readable as a method (`build_task.js`) and settable as a property (`task_create.js`). Typed `any` per the existing `Tag.status` pattern.

Closes #989.

## Issue
Slice 17 of the [#989](https://github.com/torsday/omnifocus-mcp/issues/989) `@ts-check` rollout (parent [#854](https://github.com/torsday/omnifocus-mcp/issues/854)). After merge, reopen #989 — 4 task R/W scripts still pending (`task_update`, `task_list`, `task_search`, `task_duplicate`, `task_batch_create`), tracked separately by [#1017](https://github.com/torsday/omnifocus-mcp/issues/1017).

## Breaking change?
- [x] No — type-only additions plus a prologue. Runtime behavior unchanged; build inlining verified (`pnpm build` clean).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (lint, docs:check, nl-quality, custom-lint, doc-sizes)
- [x] `pnpm test` — 3799 passed / 59 skipped
- [x] `pnpm build` — script inlining still parses (868 KB)
- [x] Self-reviewed (diff +46 lines, single concern)