### PR TITLE
feat(scripts): opt task_update into ts-check (#989 slice 18)

### DIFF
--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: update task fields.
  *
@@ -41,9 +47,11 @@ function run(argv) {
   }
   if (args.flagged !== undefined) found.flagged = args.flagged;
   if (Object.hasOwn(args, "deferDate")) {
+    // @ts-expect-error — sdef property setter; JXA accepts assignment, generator emits method signature only.
     found.deferDate = args.deferDate ? new Date(args.deferDate) : null;
   }
   if (Object.hasOwn(args, "dueDate")) {
+    // @ts-expect-error — sdef property setter; JXA accepts assignment, generator emits method signature only.
     found.dueDate = args.dueDate ? new Date(args.dueDate) : null;
   }
   if (Object.hasOwn(args, "estimatedMinutes")) {
@@ -77,6 +85,7 @@ function run(argv) {
         "  t.repetitionRule = null;" +
         "})()";
     } else {
+      /** @type {Record<string, string>} */
       const FREQ_BY_UNIT = {
         minutes: "MINUTELY",
         hours: "HOURLY",
@@ -85,6 +94,7 @@ function run(argv) {
         months: "MONTHLY",
         years: "YEARLY",
       };
+      /** @type {Record<string, string>} */
       const ICAL_DAYS = {
         sunday: "SU",
         monday: "MO",
@@ -94,6 +104,7 @@ function run(argv) {
         friday: "FR",
         saturday: "SA",
       };
+      /** @type {Record<string, string>} */
       const METHOD_BY_NAME = {
         fixed: "Fixed",
         "start-again": "Start",

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -58,6 +58,7 @@
     "src/scripts/jxa/task_batch_update.js",
     "src/scripts/jxa/task_complete.js",
     "src/scripts/jxa/task_create.js",
+    "src/scripts/jxa/task_update.js",
     "src/scripts/jxa/task_delete.js",
     "src/scripts/jxa/task_drop.js",
     "src/scripts/jxa/task_get.js",


### PR DESCRIPTION
## Summary

- Adds `// @ts-check` prologue to `src/scripts/jxa/task_update.js` and opts it into `tsconfig.jxa-tscheck.json` — 58 of 61 scripts now ts-checked.
- Six errors close via two patterns:
  - Two `@ts-expect-error` lines on `found.deferDate = ...` / `found.dueDate = ...` — sdef property-setter assignments the generator emits as method signatures only (per the documented sdef-overrides pattern for setter forms declaration merging can't paper over).
  - `Record<string, string>` JSDoc annotations on `FREQ_BY_UNIT`, `ICAL_DAYS`, `METHOD_BY_NAME` — the maps are keyed on string values resolved from `JSON.parse` (typed `any`), so the literal object type narrows too tightly for index access. Existing guards already handle the now-`string | undefined` return.

Closes #989.

## Issue
Slice 18 of the [#989](https://github.com/torsday/omnifocus-mcp/issues/989) `@ts-check` rollout. After merge, reopen #989 — 3 task R/W scripts still pending (`task_list`, `task_search`, `task_duplicate`, `task_batch_create`), tracked separately by [#1017](https://github.com/torsday/omnifocus-mcp/issues/1017).

## Breaking change?
- [x] No — type-only additions plus prologue. Runtime behavior unchanged; build inlining verified.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3799 passed / 59 skipped
- [x] `pnpm build` — script inlining still parses (868 KB)
- [x] Self-reviewed (diff +12 lines, single concern)