### PR TITLE
feat(scripts): opt task_batch_create into ts-check (#989 slice 19)

### DIFF
--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -230,6 +230,15 @@ interface Task {
   markIncomplete(): void;
   /** Mark this task dropped — element-verb form. */
   markDropped(): void;
+  /**
+   * Standard JXA `make` element verb — constructs a child element of the
+   * given class with the given properties. Used by `task_batch_create.js`
+   * to create subtasks (`parent.make({ new: "task", withProperties })`).
+   * Return type is `any` because the resulting class depends on the `new:`
+   * arg — typing it tighter would force a cast at every call site.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: return class depends on `new:` arg — see comment.
+  make(opts: { new: string; withProperties: Record<string, unknown> }): any;
 }
 
 interface Project {
@@ -239,6 +248,12 @@ interface Project {
   move(opts: { to: unknown; positioned?: string }): void;
   /** HTML representation of the note. Runtime extra. */
   noteHtml(): string | null;
+  /**
+   * Standard JXA `make` element verb — same shape as `Task.make`. Used by
+   * `task_batch_create.js` to create top-level tasks under a project.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: return class depends on `new:` arg — see Task.make.
+  make(opts: { new: string; withProperties: Record<string, unknown> }): any;
 }
 
 interface Folder {

--- a/src/scripts/jxa/task_batch_create.js
+++ b/src/scripts/jxa/task_batch_create.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: batch-create tasks in a single round-trip.
  *
@@ -79,7 +85,7 @@ function run(argv) {
 
       succeeded.push({ index: i, value: newTask.id() });
     } catch (e) {
-      const msg = e?.message || String(e);
+      const msg = e instanceof Error ? e.message : String(e);
       const m = msg.match(/^(OF_[A-Z_]+):/);
       const errorCode = m ? m[1] : "OF_UNKNOWN";
       failed.push({ index: i, errorCode: errorCode, message: msg });

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -55,6 +55,7 @@
     "src/scripts/jxa/task_batch_drop.js",
     "src/scripts/jxa/task_batch_uncomplete.js",
     "src/scripts/jxa/task_batch_undrop.js",
+    "src/scripts/jxa/task_batch_create.js",
     "src/scripts/jxa/task_batch_update.js",
     "src/scripts/jxa/task_complete.js",
     "src/scripts/jxa/task_create.js",


### PR DESCRIPTION
## Summary

- Adds `// @ts-check` prologue to `src/scripts/jxa/task_batch_create.js` and opts it into `tsconfig.jxa-tscheck.json` — 59 of 61 scripts now ts-checked.
- Three errors close via two patterns:
  - `Task.make()` / `Project.make()` land in `sdef-overrides.d.ts` as standard JXA element verbs, alongside existing `delete()` / `move()`. Return type `any` — created class depends on the `new:` arg.
  - `e?.message || String(e)` narrows to `e instanceof Error ? e.message : String(e)` — strict-mode catch variables are `unknown`.

Closes #989.

## Issue
Slice 19 of the [#989](https://github.com/torsday/omnifocus-mcp/issues/989) `@ts-check` rollout. After merge, reopen #989 — 3 task R/W scripts still pending (`task_list`, `task_search`, `task_duplicate`).

## Breaking change?
- [x] No — type-only additions plus prologue + a strict-mode-correct catch narrowing. Runtime behavior identical.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3799 passed / 59 skipped
- [x] `pnpm build` — script inlining still parses
- [x] Self-reviewed (diff +23 / -1 lines)