### PR TITLE
feat(scripts): opt task_search into ts-check (#989 slice 20)

### DIFF
--- a/src/scripts/jxa/_types/sdef-overrides.d.ts
+++ b/src/scripts/jxa/_types/sdef-overrides.d.ts
@@ -300,6 +300,13 @@ interface Application {
 interface Project {
   /** Child collection of direct tasks. Runtime extra — sdef omits the element block. */
   tasks: JxaCollection<Task> & (() => JxaCollection<Task>);
+  /**
+   * Flattened collection of all descendant tasks (recursive). Runtime
+   * extra — the sdef declares `flattened task` only on the document
+   * class, but JXA exposes it on real project specifiers too. Used by
+   * `task_search.js` / `task_list.js` for project-scoped searches.
+   */
+  flattenedTasks: JxaCollection<FlattenedTask> & (() => JxaCollection<FlattenedTask>);
 }
 
 interface Task {

--- a/src/scripts/jxa/task_search.js
+++ b/src/scripts/jxa/task_search.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: search tasks by keyword and/or structured filters.
  *
@@ -63,6 +69,7 @@ function run(argv) {
   } else {
     // No source-narrowing — push pushable predicates into whose() so the
     // long tail of non-matching tasks is never iterated.
+    /** @type {Record<string, unknown>} */
     const predicate = {};
     if (args.flagged !== null && args.flagged !== undefined) {
       predicate.flagged = args.flagged;
@@ -74,9 +81,11 @@ function run(argv) {
     }
     // "any" passes through — no completed predicate.
     if (dueBefore !== null || dueAfter !== null) {
-      predicate.dueDate = {};
-      if (dueBefore !== null) predicate.dueDate._lessThan = dueBefore;
-      if (dueAfter !== null) predicate.dueDate._greaterThan = dueAfter;
+      /** @type {Record<string, unknown>} */
+      const dueDate = {};
+      if (dueBefore !== null) dueDate._lessThan = dueBefore;
+      if (dueAfter !== null) dueDate._greaterThan = dueAfter;
+      predicate.dueDate = dueDate;
     }
     const hasPushable = Object.keys(predicate).length > 0;
     if (hasPushable) {
@@ -130,7 +139,7 @@ function run(argv) {
     // O(filterTags × taskTags) nested scan (#803).
     if (args.tagIds && args.tagIds.length > 0) {
       const taskTagSet = new Set(built.tagIds);
-      const allPresent = args.tagIds.every((tid) => taskTagSet.has(tid));
+      const allPresent = args.tagIds.every(/** @param {string} tid */ (tid) => taskTagSet.has(tid));
       if (!allPresent) continue;
     }
 

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -65,6 +65,7 @@
     "src/scripts/jxa/task_get.js",
     "src/scripts/jxa/task_get_many.js",
     "src/scripts/jxa/task_move.js",
+    "src/scripts/jxa/task_search.js",
     "src/scripts/jxa/task_reorder.js",
     "src/scripts/jxa/task_uncomplete.js",
     "src/scripts/jxa/task_undrop.js",


### PR DESCRIPTION
## Summary

- Adds `// @ts-check` prologue to `src/scripts/jxa/task_search.js` and opts it into `tsconfig.jxa-tscheck.json` — 60 of 61 scripts now ts-checked.
- Nine errors close via three patterns:
  - `Project.flattenedTasks` added to `sdef-overrides.d.ts` — runtime extra; sdef declares `flattened task` only on document class, JXA exposes on projects too. Inherits to FlattenedProject. Mirror of slice 17's `Project.tasks`.
  - `predicate` and inner `dueDate` get `Record<string, unknown>` annotations — the whose() predicate is built incrementally; tsc narrows the literal too tightly otherwise. Inner `dueDate` is hoisted to a local so each annotation scopes to one builder.
  - `args.tagIds.every((tid) => ...)` annotates the `tid` callback param as `string` to close the implicit-any leak from `JSON.parse`-derived `args`.

Closes #989.

## Issue
Slice 20 of the [#989](https://github.com/torsday/omnifocus-mcp/issues/989) `@ts-check` rollout. After merge, reopen — 2 task R/W scripts still pending (`task_list`, `task_duplicate`).

## Breaking change?
- [x] No — type-only additions and a refactor of one builder block (inner `dueDate` hoisted to a local; identical runtime behavior).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3799 passed / 59 skipped
- [x] `pnpm build` — script inlining still parses
- [x] Self-reviewed (diff +21 / -4 lines)