### PR TITLE
feat(scripts): opt task_list into ts-check (#989 slice 21)

### DIFF
--- a/src/scripts/jxa/task_list.js
+++ b/src/scripts/jxa/task_list.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: list tasks, optionally filtered.
  *
@@ -81,6 +87,7 @@ function run(argv) {
     // OF's runtime via whose(). Predicates that don't push down (tag /
     // available / blocked / completedSince — all need buildTask's
     // computed values) stay client-side in the loop below.
+    /** @type {Record<string, unknown>} */
     const predicate = {};
     if (args.flagged !== null && args.flagged !== undefined) {
       predicate.flagged = args.flagged;
@@ -89,14 +96,18 @@ function run(argv) {
       predicate.completed = args.completed;
     }
     if (dueBefore !== null || dueAfter !== null) {
-      predicate.dueDate = {};
-      if (dueBefore !== null) predicate.dueDate._lessThan = dueBefore;
-      if (dueAfter !== null) predicate.dueDate._greaterThan = dueAfter;
+      /** @type {Record<string, unknown>} */
+      const dueDate = {};
+      if (dueBefore !== null) dueDate._lessThan = dueBefore;
+      if (dueAfter !== null) dueDate._greaterThan = dueAfter;
+      predicate.dueDate = dueDate;
     }
     if (deferredBefore !== null || deferredAfter !== null) {
-      predicate.deferDate = {};
-      if (deferredBefore !== null) predicate.deferDate._lessThan = deferredBefore;
-      if (deferredAfter !== null) predicate.deferDate._greaterThan = deferredAfter;
+      /** @type {Record<string, unknown>} */
+      const deferDate = {};
+      if (deferredBefore !== null) deferDate._lessThan = deferredBefore;
+      if (deferredAfter !== null) deferDate._greaterThan = deferredAfter;
+      predicate.deferDate = deferDate;
     }
     const hasPushable = Object.keys(predicate).length > 0;
     if (hasPushable) {

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -65,6 +65,7 @@
     "src/scripts/jxa/task_get.js",
     "src/scripts/jxa/task_get_many.js",
     "src/scripts/jxa/task_move.js",
+    "src/scripts/jxa/task_list.js",
     "src/scripts/jxa/task_search.js",
     "src/scripts/jxa/task_reorder.js",
     "src/scripts/jxa/task_uncomplete.js",


### PR DESCRIPTION
## Summary

- Adds `// @ts-check` prologue to `src/scripts/jxa/task_list.js` and opts it into `tsconfig.jxa-tscheck.json`.
- Nine errors close via the same predicate pattern slice 20 established for `task_search`: `predicate` annotated `Record<string, unknown>`, with the inner `dueDate` / `deferDate` builders hoisted to locals so each annotation scopes to one map.
- No new sdef-overrides needed — slice 20's `Project.flattenedTasks` addition already covered the missing collection on FlattenedProject.

Closes #989.

## Issue
Slice 21 of the [#989](https://github.com/torsday/omnifocus-mcp/issues/989) `@ts-check` rollout. After merge, reopen — 1 task R/W script still pending (`task_duplicate`).

## Breaking change?
- [x] No — type-only additions and a refactor of two builder blocks (inner date predicates hoisted to locals; identical runtime behavior).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3799 passed / 59 skipped
- [x] `pnpm build` — script inlining still parses
- [x] Self-reviewed (diff +18 / -6 lines)