### PR TITLE
feat(scripts): opt task_duplicate into ts-check (#989 slice 22 — final)

### DIFF
--- a/src/scripts/jxa/task_duplicate.js
+++ b/src/scripts/jxa/task_duplicate.js
@@ -1,3 +1,9 @@
+// @ts-check
+/// <reference path="_types/omnifocus.d.ts" />
+/// <reference path="_types/jxa-globals.d.ts" />
+/// <reference path="_types/jxa-helpers.d.ts" />
+/// <reference path="_types/sdef-overrides.d.ts" />
+
 /**
  * JXA: duplicate a task. Editable fields copy; completed/dropped state reset.
  * When recursive=true, subtask tree is cloned depth-first, preserving order.
@@ -52,6 +58,8 @@ function run(argv) {
       if (cp) {
         let isDocument = false;
         try {
+          // @ts-expect-error — OF 4.x: `.class()` is a runtime call on Project
+          // that throws on real projects (#673); the typed sdef omits it.
           isDocument = cp.class() === "document";
         } catch (_classErr) {
           /* OF 4.x: real projects throw here */
@@ -63,7 +71,9 @@ function run(argv) {
     }
   }
 
+  /** @param {Task} task */
   function copyProps(task) {
+    /** @type {Record<string, unknown>} */
     const props = { name: task.name() };
     try {
       const n = task.note();
@@ -102,6 +112,10 @@ function run(argv) {
     return props;
   }
 
+  /**
+   * @param {Task | Project | Document} container
+   * @param {Record<string, unknown>} props
+   */
   function makeInto(container, props) {
     if (container === doc) {
       // Inbox creation requires `InboxTask + inboxTasks.push` — OmniFocus 4.x
@@ -110,9 +124,19 @@ function run(argv) {
       doc.inboxTasks.push(task);
       return task;
     }
-    return container.make({ new: "task", withProperties: props });
+    // `container === doc` already returned above, but TS doesn't narrow
+    // identity equality with a non-literal singleton; cast to the post-narrow
+    // union so `.make()` (added in slice 19 to Task and Project) resolves.
+    return /** @type {Task | Project} */ (container).make({
+      new: "task",
+      withProperties: props,
+    });
   }
 
+  /**
+   * @param {Task} from
+   * @param {Task} to
+   */
   function copyTags(from, to) {
     try {
       const tags = from.tags();
@@ -133,7 +157,12 @@ function run(argv) {
 
   let descendantCount = 0;
   if (args.recursive) {
+    /**
+     * @param {Task} srcTask
+     * @param {Task} cloneTask
+     */
     function walk(srcTask, cloneTask) {
+      /** @type {any[]} */
       let children = [];
       try {
         children = srcTask.tasks();

--- a/tsconfig.jxa-tscheck.json
+++ b/tsconfig.jxa-tscheck.json
@@ -63,6 +63,7 @@
     "src/scripts/jxa/task_delete.js",
     "src/scripts/jxa/task_drop.js",
     "src/scripts/jxa/task_get.js",
+    "src/scripts/jxa/task_duplicate.js",
     "src/scripts/jxa/task_get_many.js",
     "src/scripts/jxa/task_move.js",
     "src/scripts/jxa/task_list.js",


### PR DESCRIPTION
## Summary

- **61 of 61 scripts opt in.** Script-level rollout for [#989](https://github.com/torsday/omnifocus-mcp/issues/989) complete.
- Fourteen errors in `task_duplicate.js` close via four patterns:
  - `@ts-expect-error` on `cp.class() === "document"` — documented OF 4.x quirk; the typed sdef correctly omits the runtime-only accessor that throws on real projects (#673).
  - `Record<string, unknown>` annotation on `copyProps`'s `props` literal (same pattern as task_create slice 17).
  - JSDoc `@param` annotations on the four nested helpers (`copyProps`, `makeInto`, `copyTags`, `walk`).
  - `makeInto` casts `container` to `Task | Project` at the `.make()` call site — TS doesn't narrow identity equality against a singleton, so the cast resolves to the union for which slice 19 added `make()`. `let children = []` in `walk` gets explicit `any[]` annotation.

Closes #989.

## Issue
Slice 22 of the [#989](https://github.com/torsday/omnifocus-mcp/issues/989) `@ts-check` rollout — the final script.

After merge, only the CI follow-up remains for #989: promote the `jxa-tsc` meta-lint job from informational (`continue-on-error: true`) to required, intentionally gated on a "clean week" per the job's own comment in `.github/workflows/meta-lint.yml`. Reopen #989 scoped to that single remaining task.

## Breaking change?
- [x] No — type-only additions; runtime behavior identical. Build inlining verified.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3799 passed / 59 skipped
- [x] `pnpm build` — script inlining still parses (870 KB)
- [x] Self-reviewed (diff +31 / -1 lines)