### PR TITLE
perf(jxa): source-narrow perspective_evaluate projects+tags branches (#899)

### DIFF
--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -3043,6 +3043,128 @@ describe("JXA sandbox — perspective_evaluate", () => {
     expect(result.tasks.map((t) => t.id)).toEqual(["task_active"]);
   });
 
+  // -------------------------------------------------------------------------
+  // Source-narrowed projects/tags branches (#899)
+  //
+  // `projects` iterates `flattenedProjects()` then each project's flattened
+  // tasks — inbox tasks (which live on `doc.inboxTasks`, not on any
+  // project's collection) are never iterated. `tags` iterates
+  // `flattenedTags()` then each tag's `.tasks()` — untagged tasks are
+  // never iterated, and a task in multiple tags is deduped by id.
+  // -------------------------------------------------------------------------
+
+  it("'projects' returns tasks under projects; inbox tasks are never iterated", () => {
+    let inboxNameCalls = 0;
+    const inboxTask = fakeTask({
+      id: () => "task_inbox",
+      name: () => {
+        inboxNameCalls++;
+        return "inbox-task";
+      },
+    });
+    const projectTask = fakeTask({
+      id: () => "task_in_project",
+      completed: () => false,
+      dropped: () => false,
+    });
+    const proj = fakeProject({
+      id: () => "proj_a",
+      flattenedTasks: () => [projectTask],
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "projects" },
+      { projects: [proj], inboxTasks: [inboxTask] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_in_project"]);
+    // Inbox task is never reached by the projects branch — buildTask never
+    // read its name. This is the structural source-narrowing guarantee.
+    expect(inboxNameCalls).toBe(0);
+  });
+
+  it("'projects' excludes completed/dropped tasks via the post-loop guard", () => {
+    const active = fakeTask({ id: () => "active", completed: () => false, dropped: () => false });
+    const completed = fakeTask({
+      id: () => "completed",
+      completed: () => true,
+      dropped: () => false,
+    });
+    const dropped = fakeTask({
+      id: () => "dropped",
+      completed: () => false,
+      dropped: () => true,
+    });
+    const proj = fakeProject({
+      id: () => "proj_a",
+      flattenedTasks: () => [active, completed, dropped],
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "projects" },
+      { projects: [proj] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["active"]);
+  });
+
+  it("'tags' returns tasks under tags; untagged tasks are never iterated", () => {
+    let untaggedNameCalls = 0;
+    const untagged = fakeTask({
+      id: () => "task_untagged",
+      name: () => {
+        untaggedNameCalls++;
+        return "untagged";
+      },
+    });
+    const taggedTask = fakeTask({
+      id: () => "task_tagged",
+      completed: () => false,
+      dropped: () => false,
+    });
+    const tag = fakeTag({
+      id: () => "tag_a",
+      tasks: () => [taggedTask],
+    });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "tags" },
+      { tags: [tag], tasks: [untagged] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_tagged"]);
+    expect(untaggedNameCalls).toBe(0);
+  });
+
+  it("'tags' dedupes a task that appears under multiple tags", () => {
+    const shared = fakeTask({
+      id: () => "task_shared",
+      completed: () => false,
+      dropped: () => false,
+    });
+    const work = fakeTag({ id: () => "tag_work", tasks: () => [shared] });
+    const home = fakeTag({ id: () => "tag_home", tasks: () => [shared] });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "tags" },
+      { tags: [work, home] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["task_shared"]);
+  });
+
+  it("'tags' excludes completed/dropped tasks via the post-loop guard", () => {
+    const active = fakeTask({ id: () => "active", completed: () => false, dropped: () => false });
+    const completed = fakeTask({
+      id: () => "completed",
+      completed: () => true,
+      dropped: () => false,
+    });
+    const tag = fakeTag({ id: () => "tag_a", tasks: () => [active, completed] });
+    const result = runJxaScriptInSandbox<{ tasks: { id: string }[] }>(
+      perspectiveEvaluateScript,
+      { perspectiveId: "tags" },
+      { tags: [tag] },
+    );
+    expect(result.tasks.map((t) => t.id)).toEqual(["active"]);
+  });
+
   it("'forecast' pushes dueDate <= endOfDay into whose() — future tasks aren't iterated", () => {
     let futureNameCalls = 0;
     const future = fakeTask({

--- a/src/scripts/jxa/perspective_evaluate.js
+++ b/src/scripts/jxa/perspective_evaluate.js
@@ -15,13 +15,16 @@
  * `forecast_get.js` 25× speedup pattern. Try/catch fallback to the
  * full-scan keeps results correct on whose() rejection.
  *
- * The `projects` and `tags` branches still scan `flattenedTasks()` because
- * their predicates ("has a containingProject" / "has at least one tag")
- * don't translate to whose() — OF's whose() rejects `_isnt: null`
- * (documented in `forecast_get.js`'s comment block) and there's no clean
- * cardinality predicate. Source-collection rethink (e.g. iterating
- * `flattenedProjects()` per project, or `flattenedTags().tasks()` per
- * tag) is tracked separately — see #894's follow-up.
+ * The `projects` and `tags` branches use a **source-collection** rethink
+ * (#899) — `containingProject !== null` and `tagCount > 0` aren't
+ * expressible in OF's `whose()` (rejects `_isnt: null` and has no clean
+ * cardinality predicate), but the same semantics fall out of iterating
+ * `flattenedProjects()` (every task in a project has a containing
+ * project by definition) and `flattenedTags()` (every task in a tag's
+ * `.tasks()` collection has at least one tag). Inbox tasks and untagged
+ * tasks are therefore never iterated. Both branches still apply a
+ * post-loop guard for completed/dropped as a safety net mirroring the
+ * `changes_since` / `task_list` slices.
  *
  * @see src/adapter/jxa/JxaTransport.ts — caller
  * @see src/domain/task.ts — Task domain type
@@ -44,15 +47,25 @@ function run(argv) {
 
     // @inline _helpers/build_task.js
 
-    // whose() pushdown helper — try the predicate, fall back to a full
-    // scan on rejection so the post-loop guard still produces correct
-    // results.
-    /** @param {Record<string, unknown>} predicate — sdef-attribute predicate object */
-    function tasksMatching(predicate) {
+    // whose() pushdown helper — apply the predicate to the given source
+    // collection (`ofApp.defaultDocument.flattenedTasks`, a project's
+    // `flattenedTasks`, a tag's `tasks`, etc.). Try whose() first; on
+    // rejection, fall back to the bare source so the post-loop guard
+    // still produces correct results.
+    /**
+     * @param {{ whose?: (p: Record<string, unknown>) => () => unknown[] } & (() => unknown[])} source
+     * @param {Record<string, unknown>} predicate
+     * @returns {unknown[]}
+     */
+    function tasksMatching(source, predicate) {
       try {
-        return ofApp.defaultDocument.flattenedTasks.whose(predicate)();
+        return source.whose(predicate)();
       } catch (_e) {
-        return ofApp.flattenedTasks();
+        try {
+          return source();
+        } catch (_e2) {
+          return [];
+        }
       }
     }
 
@@ -67,7 +80,11 @@ function run(argv) {
     } else if (perspectiveId === "flagged") {
       // Flagged: flagged tasks that are not completed/dropped — pushed into
       // whose() so the long tail of unflagged tasks is never iterated.
-      const matches = tasksMatching({ flagged: true, completed: false, dropped: false });
+      const matches = tasksMatching(ofApp.defaultDocument.flattenedTasks, {
+        flagged: true,
+        completed: false,
+        dropped: false,
+      });
       for (let i = 0; i < matches.length; i++) {
         const t = matches[i];
         const built = buildTask(t);
@@ -82,7 +99,7 @@ function run(argv) {
       // The dueDate predicate naturally excludes tasks with no dueDate.
       const now = new Date();
       const endOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
-      const matches = tasksMatching({
+      const matches = tasksMatching(ofApp.defaultDocument.flattenedTasks, {
         completed: false,
         dropped: false,
         dueDate: { _lessThanEquals: endOfDay },
@@ -98,27 +115,43 @@ function run(argv) {
         }
       }
     } else if (perspectiveId === "projects") {
-      // Projects: top-level tasks of active projects (not completed/dropped).
-      // No clean whose() predicate — `containingProject` is not nullable
-      // through OF's whose() (rejects _isnt: null). Stays a full scan;
-      // see #894's follow-up for source-collection rethink.
-      const allTasks = ofApp.flattenedTasks();
-      for (let i = 0; i < allTasks.length; i++) {
-        const t = allTasks[i];
-        const built = buildTask(t);
-        if (built.projectId !== null && !built.completed && !built.dropped) {
-          result.push(built);
+      // Projects: tasks under any project, not completed/dropped (#899).
+      // Source-narrow to `flattenedProjects()` then iterate each project's
+      // `flattenedTasks` with whose() pushdown. Inbox tasks live on
+      // `doc.inboxTasks` (never on any project's flattenedTasks) so they
+      // are naturally excluded from this branch — the old full-scan
+      // filtered them via `built.projectId !== null`, the new path
+      // achieves the same semantics by source choice. Post-loop guard
+      // keeps `completed`/`dropped` correct when whose() falls back.
+      const projects = ofApp.defaultDocument.flattenedProjects();
+      for (let p = 0; p < projects.length; p++) {
+        const matches = tasksMatching(projects[p].flattenedTasks, {
+          completed: false,
+          dropped: false,
+        });
+        for (let i = 0; i < matches.length; i++) {
+          const built = buildTask(matches[i]);
+          if (!built.completed && !built.dropped) {
+            result.push(built);
+          }
         }
       }
     } else if (perspectiveId === "tags") {
-      // Tags: tasks that have at least one tag and are not completed/dropped.
-      // Same constraint as `projects` — no clean cardinality predicate via
-      // whose(). Stays a full scan; see #894's follow-up.
-      const allTasks = ofApp.flattenedTasks();
-      for (let i = 0; i < allTasks.length; i++) {
-        const t = allTasks[i];
-        const built = buildTask(t);
-        if (built.tagIds.length > 0 && !built.completed && !built.dropped) {
+      // Tags: tasks with ≥ 1 tag, not completed/dropped (#899). Source-narrow
+      // to `flattenedTags()`, then per-tag iterate `tag.tasks` with whose()
+      // pushdown. A task with N tags appears in N tag collections — dedupe
+      // by id via a Set before emitting. Untagged tasks never appear in
+      // any tag's `.tasks()` collection so the old "tagIds.length > 0"
+      // post-filter is now structural.
+      const tags = ofApp.defaultDocument.flattenedTags();
+      const seen = {};
+      for (let g = 0; g < tags.length; g++) {
+        const matches = tasksMatching(tags[g].tasks, { completed: false, dropped: false });
+        for (let i = 0; i < matches.length; i++) {
+          const built = buildTask(matches[i]);
+          if (built.completed || built.dropped) continue;
+          if (seen[built.id]) continue;
+          seen[built.id] = true;
           result.push(built);
         }
       }


### PR DESCRIPTION
## Summary

- **`projects` branch** — iterate `flattenedProjects()`, then each project's `flattenedTasks.whose({ completed: false, dropped: false })()`. Inbox tasks (which live on `doc.inboxTasks`) are never iterated; the old `built.projectId !== null` post-filter becomes structural.
- **`tags` branch** — iterate `flattenedTags()`, then each tag's `tasks.whose({ completed: false, dropped: false })()`. An in-script id Set dedupes tasks that appear in multiple tags. Untagged tasks are never iterated.
- The whose() helper grows a `source` parameter so the same try/catch fallback shape covers all branches. `flagged` and `forecast` continue to pass `ofApp.defaultDocument.flattenedTasks` explicitly.
- Post-loop guards on `completed`/`dropped` kept intact as a safety net (mirrors the `changes_since` / `task_list` slice pattern).

Closes #899.

## Issue
Implements [#899](https://github.com/torsday/omnifocus-mcp/issues/899). Composes with [#789](https://github.com/torsday/omnifocus-mcp/issues/789) (parent perf-pushdown audit) and [#894](https://github.com/torsday/omnifocus-mcp/issues/894) (slice 3a — flagged + forecast pushdown).

Removes the last two full-DB `flattenedTasks()` scans inside `perspective_evaluate` — both branches now bound their cost by structure (projects × per-project tasks; tags × per-tag tasks) instead of by the long tail of all tasks.

## Breaking change?
- [x] No — outputs unchanged; sandbox tests cover both old and new invariants.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3807 passed (added 5 sandbox tests covering the new source-narrowing invariants)
- [x] `pnpm build` — script inlining still parses
- [x] Self-reviewed (diff +189 / −34 lines)

### New sandbox tests pin
- Inbox tasks aren't iterated by the `projects` branch (name-counter assertion at zero).
- Untagged tasks aren't iterated by the `tags` branch (same shape).
- Multi-tag tasks dedupe to a single result.
- Completed/dropped tasks excluded by the post-loop guard in both branches.