### PR TITLE
fix(jxa): close jxa-tsc errors from #899 in perspective_evaluate

### DIFF
--- a/src/scripts/jxa/perspective_evaluate.js
+++ b/src/scripts/jxa/perspective_evaluate.js
@@ -53,7 +53,12 @@ function run(argv) {
     // rejection, fall back to the bare source so the post-loop guard
     // still produces correct results.
     /**
-     * @param {{ whose?: (p: Record<string, unknown>) => () => unknown[] } & (() => unknown[])} source
+     * @param {any} source — a JXA element collection (callable returning the
+     *   array; also exposes `.whose(predicate)` and other element verbs).
+     *   Typed `any` because the OF runtime shape (callable + property
+     *   accessor + whose() method) doesn't model cleanly as a JSDoc
+     *   intersection without forcing every call site through a guard.
+     *   The try/catch fallback below absorbs any shape mismatch.
      * @param {Record<string, unknown>} predicate
      * @returns {unknown[]}
      */
@@ -144,6 +149,7 @@ function run(argv) {
       // any tag's `.tasks()` collection so the old "tagIds.length > 0"
       // post-filter is now structural.
       const tags = ofApp.defaultDocument.flattenedTags();
+      /** @type {Record<string, boolean>} */
       const seen = {};
       for (let g = 0; g < tags.length; g++) {
         const matches = tasksMatching(tags[g].tasks, { completed: false, dropped: false });


### PR DESCRIPTION
## Summary

[PR #1027](https://github.com/torsday/omnifocus-mcp/pull/1027) (#899) landed with three type errors that `jxa-tsc` surfaced post-merge (the job is informational per #989's pending CI promotion, so the merge proceeded — but the regressions are real and would block #989's promotion to required).

- `tasksMatching` source param retyped from a JSDoc intersection to plain `any` — the intersection shape `{ whose?: ... } & (() => unknown[])` made `source.whose` possibly-undefined, breaking the try-branch call. The try/catch fallback already absorbs any shape mismatch; the inline comment documents why `any` is the right pragma here.
- `seen` dedup map (`tags` branch) retyped as `Record<string, boolean>` — was inferred `{}`, breaking the index access.

No runtime behavior change. Sandbox tests still pass unchanged.

Refs #899. Closes #989 followup-blocker (no separate ticket; the jxa-tsc job's promotion to required is gated on a clean week per #989's last sub-task, and a regression like this would block it).