### PR TITLE
chore(observability): audit token-cost bench coverage; add end-of-day workflow (#831)

### DIFF
--- a/docs/benchmarks/coverage-matrix.md
+++ b/docs/benchmarks/coverage-matrix.md
@@ -1,0 +1,78 @@
+# Token-cost benchmark coverage matrix
+
+> Living inventory of which tool categories the `pnpm bench:tokens` suite
+> exercises. The bench gates PRs on response-bytes drift (≥ 5%, per
+> [#822](https://github.com/torsday/omnifocus-mcp/issues/822)); its
+> usefulness as a gate depends on whether the workflows actually touch
+> the categories where regressions can hide.
+>
+> Filed under [#831](https://github.com/torsday/omnifocus-mcp/issues/831).
+> Source workflows: `tests/benchmark/token-cost/workflows/`.
+
+## Categories
+
+The audit groups tools by *bytes shape* — what determines a response's
+byte size, and therefore what kind of regression a workflow can detect.
+
+| Category               | Bytes driver                                                                                  | Representative tools                                              |
+|------------------------|-----------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| **Read by id**         | Fixed shape; one envelope per call                                                            | `task_get`, `project_get`, `task_get_many` (small N)              |
+| **List filtered**      | N matched × per-row payload + filter overhead                                                 | `task_list`, `project_list`, `folder_list`, `tag_list`            |
+| **List paginated**     | `limit` × per-row payload + cursor codec                                                      | `task_list { limit, cursor }`, `task_get_many` (large N pages)    |
+| **Search**             | N matched × per-row payload + whose() pushdown shape                                          | `task_search`, `task_find_similar`                                |
+| **Forecast**           | Day rollups × tasks-by-date dedup overhead                                                    | `forecast_get`, `forecast_pack`                                   |
+| **Perspective**        | Per-perspective filter cost + result-set bytes                                                | `perspective_evaluate`, `perspective_list`                        |
+| **Batch mutation**     | Per-item success/failure × array length                                                       | `task_batch_create`, `task_batch_assign`, `task_batch_complete`   |
+| **Single mutation**    | Fixed envelope; ID + status                                                                   | `tag_create`, `project_create`, `task_update`                     |
+| **Review-cycle**       | Project list + per-project task list per ritual                                               | `review_list_due`, `project_mark_reviewed`                        |
+
+## Coverage by workflow
+
+`✓` = at least one call against this category in the workflow's bench
+calls. `—` = no calls in that workflow against this category. Categories
+that no workflow exercises are listed in the gap section below.
+
+| Category            | inbox-triage | project-planning | weekly-review | end-of-day-review |
+|---------------------|:------------:|:----------------:|:-------------:|:-----------------:|
+| Read by id          | —            | ✓ (`project_get`) | —             | —                 |
+| List filtered       | ✓ (`task_list`) | ✓ (`task_list`) | ✓ (`task_list`) | —              |
+| List paginated      | —            | —                | —             | —                 |
+| Search              | —            | —                | —             | ✓ (`task_search`) |
+| Forecast            | —            | —                | —             | ✓ (`forecast_get`)|
+| Perspective         | —            | —                | —             | ✓ (`perspective_evaluate`) |
+| Batch mutation      | ✓ (`task_batch_*`) | ✓ (`task_batch_*`) | —        | —                 |
+| Single mutation     | ✓ (`tag_create`) | ✓ (`*_create`) | —             | —                 |
+| Review-cycle        | —            | —                | ✓ (`review_*`) | —                 |
+
+## Status as of this audit
+
+The PR closing [#831](https://github.com/torsday/omnifocus-mcp/issues/831)
+adds an `end-of-day-review` workflow that covers **search**, **forecast**,
+and **perspective** in one coherent narrative — three previously
+uncovered categories close at once.
+
+Two gaps remain, both tracked as follow-ups:
+
+- **List paginated** ([#1029](https://github.com/torsday/omnifocus-mcp/issues/1029))
+  — the existing `task_list` calls don't exercise `limit` + `cursor`,
+  so the bench gate is blind to pagination-shape regressions.
+- **5k+ task fixture smoke** ([#1030](https://github.com/torsday/omnifocus-mcp/issues/1030))
+  — depends on the `OMNIFOCUS_E2E_USE_MEMORY` adapter plus a
+  fixture-seeding harness; pulled out of #831 so this PR stays
+  reviewable.
+
+## How a new workflow earns its place
+
+A workflow belongs in the bench when:
+
+1. It exercises at least one category the existing workflows don't, or
+2. It exercises a known-hot path (e.g. cache-fragmenting params, large
+   pagination windows) where regressions have shipped historically.
+
+Workflows that overlap existing coverage without a distinct shape add
+test cost without adding gate sensitivity — keep the suite tight.
+
+Each new workflow file lives under
+`tests/benchmark/token-cost/workflows/<name>.ts` and is registered in
+`tests/benchmark/token-cost/cli.ts`. Snapshot reset via
+`pnpm bench:tokens --update`; CI re-runs against the committed baseline.

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -2,6 +2,27 @@
   "generatedAt": "2026-05-26",
   "toolListBytes": 177953,
   "workflows": {
+    "end-of-day-review": {
+      "callCount": 3,
+      "totalRequestBytes": 154,
+      "totalResponseBytes": 30076,
+      "totalRoundTripBytes": 30230,
+      "totalTokens": 52046,
+      "byTool": {
+        "forecast_get": {
+          "calls": 1,
+          "responseBytes": 10180
+        },
+        "perspective_evaluate": {
+          "calls": 1,
+          "responseBytes": 7548
+        },
+        "task_search": {
+          "calls": 1,
+          "responseBytes": 12348
+        }
+      }
+    },
     "inbox-triage": {
       "callCount": 6,
       "totalRequestBytes": 29603,

--- a/tests/benchmark/token-cost/cli.ts
+++ b/tests/benchmark/token-cost/cli.ts
@@ -17,6 +17,7 @@ import {
   writeSnapshot,
 } from "./snapshot.js";
 import { estimateTokens } from "./tokenizer.js";
+import { runEndOfDayReview } from "./workflows/endOfDayReview.js";
 import { runInboxTriage } from "./workflows/inboxTriage.js";
 import { runProjectPlanning } from "./workflows/projectPlanning.js";
 import { runWeeklyReview } from "./workflows/weeklyReview.js";
@@ -40,6 +41,7 @@ async function main(): Promise<void> {
     ["inbox-triage", runInboxTriage] as const,
     ["weekly-review", runWeeklyReview] as const,
     ["project-planning", runProjectPlanning] as const,
+    ["end-of-day-review", runEndOfDayReview] as const,
   ]) {
     const bench = await runner(createBenchContext());
     const result = bench.result(toolListBytes);

--- a/tests/benchmark/token-cost/workflows/endOfDayReview.ts
+++ b/tests/benchmark/token-cost/workflows/endOfDayReview.ts
@@ -1,0 +1,105 @@
+/**
+ * Fixture workflow — end-of-day review (#831).
+ *
+ * Closes three coverage gaps in one coherent narrative:
+ *
+ *   - **search** — `task_search` looking for stuck items by keyword;
+ *   - **forecast** — `forecast_get` over today + the next two days;
+ *   - **perspective** — `perspective_evaluate` of the `flagged` built-in.
+ *
+ * Coverage matrix lives in `docs/benchmarks/coverage-matrix.md`; this
+ * workflow is the canonical example of a multi-category bench fixture.
+ * One narrative, three tools — keeps the bench's per-workflow byte
+ * budget meaningful for downstream tracking instead of fragmenting
+ * each missing category into its own micro-fixture.
+ *
+ * Database shape: 4 projects × 5 tasks (= 20 tasks), with a flagged
+ * subset and a small handful of due-today dates. Sized to surface
+ * representative response bytes without dwarfing the existing
+ * fixtures' totals.
+ */
+
+import { handleForecastGet } from "../../../../src/tools/forecast/get.js";
+import { handlePerspectiveEvaluate } from "../../../../src/tools/perspective/evaluate.js";
+import { handleTaskSearch } from "../../../../src/tools/task/search.js";
+import { Bench, type BenchToolContext } from "../runBench.js";
+
+const TASK_NOTE =
+  "Captured earlier in the week. Pending decision; revisit before end of day. " +
+  "Stakeholders to ping: alex, jamie. Background context links omitted.";
+
+async function seedEndOfDayDatabase(ctx: BenchToolContext): Promise<void> {
+  const today = new Date();
+  // Anchor "due today" exactly at noon local to avoid timezone edge cases
+  // while still landing inside the day.
+  const noon = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 12).toISOString();
+
+  for (let p = 0; p < 4; p += 1) {
+    const projectId = await ctx.adapter.createProject({
+      name: `End-of-day project ${String(p + 1).padStart(2, "0")}`,
+      note: "Routine work, no special status.",
+    });
+    for (let t = 0; t < 5; t += 1) {
+      const flagged = t % 2 === 0;
+      const dueToday = t === 0;
+      if (dueToday) {
+        await ctx.adapter.createTask({
+          name: `stuck thread ${String(t + 1)} on project ${String(p + 1)}`,
+          projectId,
+          note: TASK_NOTE,
+          flagged,
+          dueDate: noon,
+        });
+      } else {
+        await ctx.adapter.createTask({
+          name: `stuck thread ${String(t + 1)} on project ${String(p + 1)}`,
+          projectId,
+          note: TASK_NOTE,
+          flagged,
+        });
+      }
+    }
+  }
+}
+
+export async function runEndOfDayReview(ctx: BenchToolContext): Promise<Bench> {
+  const bench = new Bench("end-of-day-review");
+
+  await seedEndOfDayDatabase(ctx);
+
+  // 1) Search — "what's stuck?". Keyword + scope covers the canonical
+  //    interactive use of task_search.
+  const searchInput = { q: "stuck", scope: "all" as const, completed: "exclude" as const };
+  await bench.call("task_search", searchInput, () =>
+    handleTaskSearch(searchInput, { searchService: ctx.searchService, makeMeta: ctx.makeMeta }),
+  );
+
+  // 2) Forecast — today + next two days. Three-day window is the
+  //    representative interactive shape ("what's on my plate this
+  //    week?") rather than the unbounded one.
+  const forecastInput = {
+    days: 3,
+    includeOverdue: true,
+    includeDeferred: false,
+    includeFlagged: true,
+  };
+  await bench.call("forecast_get", forecastInput, () =>
+    handleForecastGet(forecastInput, {
+      forecastService: ctx.forecastService,
+      makeMeta: ctx.makeMeta,
+    }),
+  );
+
+  // 3) Perspective — the `flagged` built-in. Exercises the whose()
+  //    pushdown path (#789 / #894) that perspective_evaluate gained
+  //    and that #899 source-narrowed further.
+  const perspectiveInput = { perspectiveId: "flagged" as const };
+  await bench.call("perspective_evaluate", perspectiveInput, () =>
+    handlePerspectiveEvaluate(perspectiveInput, {
+      perspectiveService: ctx.perspectiveService,
+      makeMeta: ctx.makeMeta,
+    }),
+  );
+
+  return bench;
+}


### PR DESCRIPTION
## Summary

- New workflow `tests/benchmark/token-cost/workflows/endOfDayReview.ts` exercising **search**, **forecast**, and **perspective** in one coherent narrative — three previously uncovered categories close at once.
- New living doc `docs/benchmarks/coverage-matrix.md` inventories which tool categories each workflow exercises, lists the remaining gaps with their follow-up issues, and documents the "earn its place" rule for adding new workflows.
- Baseline regenerated; CI re-runs against it.

`end-of-day-review` totals: 29.4 KiB response (task_search 12.1 KiB, forecast_get 9.9 KiB, perspective_evaluate 7.4 KiB) — representative per-tool deltas without dwarfing the existing fixtures.

Closes #831.

## Issue
Implements [#831](https://github.com/torsday/omnifocus-mcp/issues/831). Two AC items pulled out into follow-ups so this PR stays reviewable:

- **#1029** — list-paginated workflow (`task_list { limit, cursor }`)
- **#1030** — 5k-task-fixture smoke harness (depends on `OMNIFOCUS_E2E_USE_MEMORY` + a seeding helper)

The audit-and-coverage-doc portion of #831 is fully landed here; per the issue's "If audit reveals a structural doc gap (not just drift), file a separate `type: docs` issue rather than expanding scope here" guidance, the structural gaps got their own tickets.

## Breaking change?
- [x] No — additive: one new workflow, one new doc, baseline regenerated. Existing 3 workflows unchanged.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (lint, docs:check, nl-quality, custom-lint, doc-sizes, migrations-doc gate)
- [x] `pnpm test` — 3807 passed
- [x] `pnpm bench:tokens` — new workflow runs; re-run vs updated baseline shows no drift
- [x] `pnpm build` — script inlining still parses
- [x] Self-reviewed (diff +206 / 0 lines)