### PR TITLE
test(bench): add large-pagination workflow to token-cost suite (#1029)

### DIFF
--- a/docs/benchmarks/coverage-matrix.md
+++ b/docs/benchmarks/coverage-matrix.md
@@ -32,34 +32,35 @@ byte size, and therefore what kind of regression a workflow can detect.
 calls. `—` = no calls in that workflow against this category. Categories
 that no workflow exercises are listed in the gap section below.
 
-| Category            | inbox-triage | project-planning | weekly-review | end-of-day-review |
-|---------------------|:------------:|:----------------:|:-------------:|:-----------------:|
-| Read by id          | —            | ✓ (`project_get`) | —             | —                 |
-| List filtered       | ✓ (`task_list`) | ✓ (`task_list`) | ✓ (`task_list`) | —              |
-| List paginated      | —            | —                | —             | —                 |
-| Search              | —            | —                | —             | ✓ (`task_search`) |
-| Forecast            | —            | —                | —             | ✓ (`forecast_get`)|
-| Perspective         | —            | —                | —             | ✓ (`perspective_evaluate`) |
-| Batch mutation      | ✓ (`task_batch_*`) | ✓ (`task_batch_*`) | —        | —                 |
-| Single mutation     | ✓ (`tag_create`) | ✓ (`*_create`) | —             | —                 |
-| Review-cycle        | —            | —                | ✓ (`review_*`) | —                 |
+| Category            | inbox-triage | project-planning | weekly-review | end-of-day-review | large-pagination |
+|---------------------|:------------:|:----------------:|:-------------:|:-----------------:|:----------------:|
+| Read by id          | —            | ✓ (`project_get`) | —             | —                 | —                |
+| List filtered       | ✓ (`task_list`) | ✓ (`task_list`) | ✓ (`task_list`) | —              | —                |
+| List paginated      | —            | —                | —             | —                 | ✓ (`task_list`, 3 pages) |
+| Search              | —            | —                | —             | ✓ (`task_search`) | —                |
+| Forecast            | —            | —                | —             | ✓ (`forecast_get`)| —                |
+| Perspective         | —            | —                | —             | ✓ (`perspective_evaluate`) | —       |
+| Batch mutation      | ✓ (`task_batch_*`) | ✓ (`task_batch_*`) | —        | —                 | —                |
+| Single mutation     | ✓ (`tag_create`) | ✓ (`*_create`) | —             | —                 | —                |
+| Review-cycle        | —            | —                | ✓ (`review_*`) | —                 | —                |
 
 ## Status as of this audit
 
-The PR closing [#831](https://github.com/torsday/omnifocus-mcp/issues/831)
-adds an `end-of-day-review` workflow that covers **search**, **forecast**,
-and **perspective** in one coherent narrative — three previously
-uncovered categories close at once.
+After [#831](https://github.com/torsday/omnifocus-mcp/issues/831) and
+[#1029](https://github.com/torsday/omnifocus-mcp/issues/1029), the
+five categorical gaps the audit identified — search, forecast,
+perspective, list-paginated, and the originally-undocumented
+list-paginated cursor walk — are all covered:
 
-Two gaps remain, both tracked as follow-ups:
+- `end-of-day-review` covers **search**, **forecast**, **perspective**.
+- `large-pagination` covers **list paginated** (3-page walk via
+  `task_list { limit: 50, cursor }` against a 120-task fixture).
 
-- **List paginated** ([#1029](https://github.com/torsday/omnifocus-mcp/issues/1029))
-  — the existing `task_list` calls don't exercise `limit` + `cursor`,
-  so the bench gate is blind to pagination-shape regressions.
+One AC item remains tracked as a follow-up:
+
 - **5k+ task fixture smoke** ([#1030](https://github.com/torsday/omnifocus-mcp/issues/1030))
   — depends on the `OMNIFOCUS_E2E_USE_MEMORY` adapter plus a
-  fixture-seeding harness; pulled out of #831 so this PR stays
-  reviewable.
+  fixture-seeding harness.
 
 ## How a new workflow earns its place
 

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -52,6 +52,19 @@
         }
       }
     },
+    "large-pagination": {
+      "callCount": 3,
+      "totalRequestBytes": 324,
+      "totalResponseBytes": 31794,
+      "totalRoundTripBytes": 32118,
+      "totalTokens": 52518,
+      "byTool": {
+        "task_list": {
+          "calls": 3,
+          "responseBytes": 31794
+        }
+      }
+    },
     "project-planning": {
       "callCount": 6,
       "totalRequestBytes": 2609,

--- a/tests/benchmark/token-cost/cli.ts
+++ b/tests/benchmark/token-cost/cli.ts
@@ -19,6 +19,7 @@ import {
 import { estimateTokens } from "./tokenizer.js";
 import { runEndOfDayReview } from "./workflows/endOfDayReview.js";
 import { runInboxTriage } from "./workflows/inboxTriage.js";
+import { runLargePagination } from "./workflows/largePagination.js";
 import { runProjectPlanning } from "./workflows/projectPlanning.js";
 import { runWeeklyReview } from "./workflows/weeklyReview.js";
 
@@ -42,6 +43,7 @@ async function main(): Promise<void> {
     ["weekly-review", runWeeklyReview] as const,
     ["project-planning", runProjectPlanning] as const,
     ["end-of-day-review", runEndOfDayReview] as const,
+    ["large-pagination", runLargePagination] as const,
   ]) {
     const bench = await runner(createBenchContext());
     const result = bench.result(toolListBytes);

--- a/tests/benchmark/token-cost/workflows/largePagination.ts
+++ b/tests/benchmark/token-cost/workflows/largePagination.ts
@@ -1,0 +1,69 @@
+/**
+ * Fixture workflow — large-list pagination (#1029).
+ *
+ * Closes the last categorical gap from #831's coverage audit: cursor-driven
+ * paging. Seeds 120 tasks under one project, then walks `task_list` at
+ * `{ limit: 50 }` until `meta.pagination.hasMore` is false — three pages
+ * (50 + 50 + 20) in this fixture.
+ *
+ * The gate-sensitive shapes this workflow surfaces:
+ *
+ *   - cursor codec bytes per page (opaque token in `meta.pagination.cursor`),
+ *   - per-row payload at a representative limit (50),
+ *   - the small trailing page that exercises the `hasMore: false` envelope.
+ *
+ * Coverage matrix lives in `docs/benchmarks/coverage-matrix.md`.
+ */
+
+import { handleTaskList } from "../../../../src/tools/task/list.js";
+import { Bench, type BenchToolContext } from "../runBench.js";
+
+const TASK_NOTE =
+  "Routine action; revisit owner & deadline at end-of-week. " +
+  "Background captured in adjacent thread.";
+
+async function seedLargePaginationDatabase(ctx: BenchToolContext): Promise<void> {
+  const projectId = await ctx.adapter.createProject({
+    name: "Large-pagination fixture",
+    note: "120 tasks for the bench's cursor-paging shape.",
+  });
+  // 120 tasks → 3 pages at limit 50 (sizes 50, 50, 20). Keep per-task note
+  // size modest so the per-page payload stays in the same order of magnitude
+  // as the existing fixtures and the snapshot is comparable.
+  for (let t = 0; t < 120; t += 1) {
+    await ctx.adapter.createTask({
+      name: `paged item ${String(t + 1).padStart(3, "0")}`,
+      projectId,
+      note: TASK_NOTE,
+    });
+  }
+}
+
+export async function runLargePagination(ctx: BenchToolContext): Promise<Bench> {
+  const bench = new Bench("large-pagination");
+
+  await seedLargePaginationDatabase(ctx);
+
+  let cursor: string | undefined;
+  let page = 0;
+  // Cap the loop defensively — three pages are expected; 6 means we drifted.
+  for (page = 1; page <= 6; page += 1) {
+    const input: { limit: number; cursor?: string } = { limit: 50 };
+    if (cursor !== undefined) input.cursor = cursor;
+    const env = await bench.call("task_list", input, () =>
+      handleTaskList(input, { taskService: ctx.taskService, makeMeta: ctx.makeMeta }),
+    );
+    if (!("data" in env)) {
+      throw new Error(`task_list page ${page} did not succeed`);
+    }
+    const next = env.pagination?.cursor ?? null;
+    const hasMore = env.pagination?.hasMore ?? false;
+    if (!hasMore || next === null) break;
+    cursor = next;
+  }
+  if (page > 3) {
+    throw new Error(`large-pagination walked ${page} pages; expected 3 — fixture drifted`);
+  }
+
+  return bench;
+}


### PR DESCRIPTION
## Summary

- New workflow `tests/benchmark/token-cost/workflows/largePagination.ts` seeds 120 tasks and walks `task_list { limit: 50, cursor }` until `pagination.hasMore` is false (3 pages: 50 + 50 + 20).
- Registered in `cli.ts`; baseline regenerated.
- `docs/benchmarks/coverage-matrix.md` updated to mark the list-paginated row covered; the remaining-gap list trims to a single follow-up (#1030, 5k-fixture smoke).

Measured: 3 calls, 31.0 KiB total response across 3 pages. Gate sensitivity comes from cursor-codec byte size, per-row payload at the limit, and the trailing-page envelope (`hasMore: false`). The loop aborts loudly if drift produces ≠ 3 pages — catches cursor-codec regressions instead of letting the snapshot absorb them silently.

Closes #1029.

## Issue
Implements [#1029](https://github.com/torsday/omnifocus-mcp/issues/1029), filed during [PR #1031](https://github.com/torsday/omnifocus-mcp/pull/1031) (#831 audit) as the last categorical gap.

## Breaking change?
- [x] No — additive: one new workflow, baseline regenerated, matrix doc updated.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3807 passed
- [x] `pnpm bench:tokens` — new workflow runs and walks 3 pages; re-run against the updated baseline shows no drift
- [x] `pnpm build` — script inlining still parses
- [x] Self-reviewed (diff +106 / -21 lines, +1 new file)