### PR TITLE
fix(bench): align run.test.ts workflow list with cli.ts

### DIFF
--- a/tests/benchmark/token-cost/run.test.ts
+++ b/tests/benchmark/token-cost/run.test.ts
@@ -15,7 +15,9 @@
 import { describe, expect, test } from "vitest";
 import { createBenchContext, measureToolsListOnce, type WorkflowResult } from "./runBench.js";
 import { buildSnapshot, diffSnapshots, formatDrift, readSnapshot } from "./snapshot.js";
+import { runEndOfDayReview } from "./workflows/endOfDayReview.js";
 import { runInboxTriage } from "./workflows/inboxTriage.js";
+import { runLargePagination } from "./workflows/largePagination.js";
 import { runProjectPlanning } from "./workflows/projectPlanning.js";
 import { runWeeklyReview } from "./workflows/weeklyReview.js";
 
@@ -31,7 +33,19 @@ if (!ENABLED) {
       const toolListBytes = measureToolsListOnce();
       const results: WorkflowResult[] = [];
 
-      for (const runner of [runInboxTriage, runWeeklyReview, runProjectPlanning]) {
+      // Keep this list in lockstep with `cli.ts`. Drift between the two has
+      // burned us twice (#1031 / #1032 follow-ups): the vitest gate reads
+      // the shared baseline but only built a subset of the workflows, so
+      // the diff reported newer workflows as "removed (driftPct 100)". A
+      // bench-coverage matrix entry that isn't in this list is silently
+      // missing from CI gate enforcement.
+      for (const runner of [
+        runInboxTriage,
+        runWeeklyReview,
+        runProjectPlanning,
+        runEndOfDayReview,
+        runLargePagination,
+      ]) {
         const bench = await runner(createBenchContext());
         results.push(bench.result(toolListBytes));
       }


### PR DESCRIPTION
## Summary

The vitest bench gate at `tests/benchmark/token-cost/run.test.ts` keeps its own workflow-runner list independent of `cli.ts`. Adding `end-of-day-review` (#1031) and `large-pagination` (#1032) updated `cli.ts` and the baseline snapshot but the test file kept iterating only the original three. Result: baseline (5 workflows) vs current (3 workflows) diff reported the two recent additions as "removed workflow, driftPct 100", and `token-cost bench` has been failing on main since #1031 landed.

The PRs merged anyway because `token-cost bench` isn't branch-protection-required — but the failure was real and would have started biting at the next release.

Fix: add the two missing imports + iterate them. Inline comment documents the drift mode so the lockstep between `cli.ts` and `run.test.ts` is explicit for the next person.

Closes #1034.

## Breaking change?
- [x] No.

## Test plan
- [x] `OMNIFOCUS_BENCH=1 pnpm test tests/benchmark/token-cost/run.test.ts` — was failing on main, now passes
- [x] `pnpm typecheck` clean
- [x] Self-reviewed (diff +14 / -1 lines)