### PR TITLE
fix(forecast): bucket byDate keys by local day, not UTC day (#1035)

### DIFF
--- a/src/tools/forecast/get.test.ts
+++ b/src/tools/forecast/get.test.ts
@@ -6,7 +6,12 @@ import { describe, expect, it } from "vitest";
 import { InMemoryAdapter } from "../../adapter/inMemory/InMemoryAdapter.js";
 import type { ResponseMeta } from "../../envelope/index.js";
 import { ForecastService } from "../../services/forecastService.js";
-import { FORECAST_GET_DESCRIPTION, forecastGetInputSchema, handleForecastGet } from "./get.js";
+import {
+  FORECAST_GET_DESCRIPTION,
+  forecastGetInputSchema,
+  handleForecastGet,
+  localDayKey,
+} from "./get.js";
 
 const FROM = "2026-04-23T00:00:00.000Z";
 const TO = "2026-04-23T23:59:59.999Z";
@@ -419,5 +424,42 @@ describe("forecast_get — pagination", () => {
     // biome-ignore lint/style/noNonNullAssertion: days>1 guarantees byDate present
     const byDateIds = envelope.data.byDate!.flatMap((b) => b.taskIds);
     expect(byDateIds.every((id) => pageIds.has(id))).toBe(true);
+  });
+});
+
+describe("forecast_get — byDate local-day bucketing (#1035)", () => {
+  // The bug pre-fix: `dueDate.slice(0, 10)` returned the UTC day, so a
+  // task due 11pm PT (= 06:00 UTC the next day) bucketed into the
+  // following calendar day from the user's perspective. localDayKey
+  // now formats via Intl with an explicit TZ, so tests can pin the
+  // expected bucket without depending on the host runner's TZ.
+
+  it("11pm PT (06:00 UTC next day) buckets into the PT calendar day", () => {
+    // 2026-05-27T06:00:00Z is 2026-05-26T23:00:00-07:00.
+    const iso = "2026-05-27T06:00:00.000Z";
+    expect(localDayKey(iso, "America/Los_Angeles")).toBe("2026-05-26");
+  });
+
+  it("same instant buckets into the UTC calendar day under tz=UTC", () => {
+    const iso = "2026-05-27T06:00:00.000Z";
+    expect(localDayKey(iso, "UTC")).toBe("2026-05-27");
+  });
+
+  it("midnight UTC buckets into the prior day under PT", () => {
+    // 2026-05-27T00:00:00Z is 2026-05-26T17:00:00-07:00.
+    const iso = "2026-05-27T00:00:00.000Z";
+    expect(localDayKey(iso, "America/Los_Angeles")).toBe("2026-05-26");
+  });
+
+  it("emits YYYY-MM-DD with zero-padded month and day", () => {
+    // 2026-01-05 in UTC at noon.
+    expect(localDayKey("2026-01-05T12:00:00.000Z", "UTC")).toBe("2026-01-05");
+  });
+
+  it("crossing DST (US fall-back) still produces a stable local day", () => {
+    // 2026-11-01T07:30:00Z. US DST ends Nov 1, 02:00 local → 01:00 PST.
+    // The instant is 00:30 PDT (or 23:30 PST after the rollback). Either
+    // way the local calendar day is 2026-11-01.
+    expect(localDayKey("2026-11-01T07:30:00.000Z", "America/Los_Angeles")).toBe("2026-11-01");
   });
 });

--- a/src/tools/forecast/get.ts
+++ b/src/tools/forecast/get.ts
@@ -228,7 +228,39 @@ function resolveRange(input: ForecastGetToolInput): { from: string; to: string; 
 }
 
 /**
- * Group tasks by the calendar day (YYYY-MM-DD) of their `dueDate`.
+ * Day-key extractor for `groupByDate`. Returns the local-time calendar
+ * day for the given ISO instant, in the requested timezone (or the host's
+ * default — which is the user's Mac TZ since the server runs locally per
+ * `docs/dates.md`).
+ *
+ * Slicing the UTC ISO string (the prior implementation) drifted the
+ * bucket by one day whenever the user's wall-clock was a different day
+ * from UTC — e.g. a task due 11pm PT renders as `T06:00:00Z` the next
+ * day in UTC, so the old code bucketed it into the wrong calendar day
+ * from the user's perspective. See #1035 and `docs/dates.md` for the
+ * full TZ contract.
+ *
+ * Exported (not exported from the module index) for tests; production
+ * callers use it indirectly via `groupByDate`.
+ *
+ * @internal
+ */
+export function localDayKey(iso: string, tz?: string): string {
+  // `en-CA` yields `YYYY-MM-DD` from numeric/2-digit options — the format
+  // we already commit to on the wire (and that `task.dueDate.slice(0, 10)`
+  // implicitly produced).
+  const opts: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  };
+  if (tz !== undefined) opts.timeZone = tz;
+  return new Intl.DateTimeFormat("en-CA", opts).format(new Date(iso));
+}
+
+/**
+ * Group tasks by the calendar day (YYYY-MM-DD) of their `dueDate`,
+ * keyed by the host-local interpretation of each instant (#1035).
  * Returns task IDs only — full Task objects already appear in the top-level
  * `dueToday` / `overdue` arrays, so repeating them here would duplicate bytes.
  * Tasks without a dueDate are omitted from the grouping.
@@ -237,7 +269,7 @@ function groupByDate(tasks: Task[]): { date: string; taskIds: string[] }[] {
   const map = new Map<string, string[]>();
   for (const task of tasks) {
     if (!task.dueDate) continue;
-    const day = task.dueDate.slice(0, 10); // "YYYY-MM-DD"
+    const day = localDayKey(task.dueDate);
     const bucket = map.get(day) ?? [];
     bucket.push(task.id);
     map.set(day, bucket);


### PR DESCRIPTION
## Summary

`groupByDate` derived its calendar-day key via `dueDate.slice(0, 10)` — which is the **UTC** day because JXA emits `toISOString()`. For users west of UTC, a task due 11pm local (e.g. 11pm PT = `06:00 UTC` next morning) bucketed into the wrong calendar day on the wire.

Fix:

- New helper `localDayKey(iso, tz?)` formats via `Intl.DateTimeFormat("en-CA", ...)` which yields `YYYY-MM-DD`. Default TZ is the host's (= the user's Mac per `docs/dates.md`'s contract); an optional `tz` argument exists for tests.
- `groupByDate` calls the helper instead of slicing.
- Five new tests pin the cross-midnight cases (11pm PT, midnight UTC, UTC parity), the format invariant, and a DST fall-back date.

Closes #1035.

## Issue
Implements [#1035](https://github.com/torsday/omnifocus-mcp/issues/1035), surfaced by the [#833](https://github.com/torsday/omnifocus-mcp/issues/833) TZ audit. Sibling [#1036](https://github.com/torsday/omnifocus-mcp/issues/1036) (resolveAnchorDate) is the natural next.

## Breaking change?
- [x] No — `byDate[].date` keys change for users west of UTC whose tasks cross midnight, but the wire shape and the field's semantic (a calendar day from the user's perspective) are unchanged. Clients that already dereferenced these keys against the top-level task arrays continue to work; clients that hard-coded UTC-day expectations were already wrong.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3812 passed (5 new)
- [x] `pnpm build` clean
- [x] Self-reviewed (diff +77 / -3 lines)