### PR TITLE
fix(forecast): tz-aware start-of-day in resolveAnchorDate (#1036)

### DIFF
--- a/src/tools/forecast/get.test.ts
+++ b/src/tools/forecast/get.test.ts
@@ -11,6 +11,8 @@ import {
   forecastGetInputSchema,
   handleForecastGet,
   localDayKey,
+  resolveAnchorDate,
+  startOfDayInTz,
 } from "./get.js";
 
 const FROM = "2026-04-23T00:00:00.000Z";
@@ -461,5 +463,73 @@ describe("forecast_get — byDate local-day bucketing (#1035)", () => {
     // The instant is 00:30 PDT (or 23:30 PST after the rollback). Either
     // way the local calendar day is 2026-11-01.
     expect(localDayKey("2026-11-01T07:30:00.000Z", "America/Los_Angeles")).toBe("2026-11-01");
+  });
+});
+
+describe("forecast_get — resolveAnchorDate TZ-aware start of day (#1036)", () => {
+  // The bug pre-fix: `resolveAnchorDate` used `d.setHours(0,0,0,0)` which
+  // computes midnight in the host runtime's TZ. If the server runs in UTC
+  // but the user is in PT, "today" anchored from a UTC host produces a
+  // start-of-day at 00:00 UTC — which is 5pm the previous afternoon PT.
+  //
+  // The fix introduces an optional `tz` parameter that wires through to a
+  // TZ-aware `startOfDayInTz`. Tests pin the cross-TZ behavior without
+  // depending on the runner's process TZ.
+
+  it("startOfDayInTz: midnight in PT (DST: PDT) is 7am UTC", () => {
+    expect(startOfDayInTz("2026-05-26", "America/Los_Angeles").toISOString()).toBe(
+      "2026-05-26T07:00:00.000Z",
+    );
+  });
+
+  it("startOfDayInTz: midnight in PT (standard: PST) is 8am UTC", () => {
+    // Pre-DST: Jan 5, 2026 — PT is PST (UTC-8).
+    expect(startOfDayInTz("2026-01-05", "America/Los_Angeles").toISOString()).toBe(
+      "2026-01-05T08:00:00.000Z",
+    );
+  });
+
+  it("startOfDayInTz: midnight in UTC is itself", () => {
+    expect(startOfDayInTz("2026-05-26", "UTC").toISOString()).toBe("2026-05-26T00:00:00.000Z");
+  });
+
+  it("startOfDayInTz: positive-offset TZ (Asia/Tokyo, UTC+9) is the prior day at 15:00 UTC", () => {
+    expect(startOfDayInTz("2026-05-26", "Asia/Tokyo").toISOString()).toBe(
+      "2026-05-25T15:00:00.000Z",
+    );
+  });
+
+  it("startOfDayInTz: spring-forward day still anchors at midnight (gap is at 02:00)", () => {
+    // US DST starts 2026-03-08; clocks jump 02:00 → 03:00. Midnight is
+    // unambiguous (still PST that night = UTC-8).
+    expect(startOfDayInTz("2026-03-08", "America/Los_Angeles").toISOString()).toBe(
+      "2026-03-08T08:00:00.000Z",
+    );
+  });
+
+  it("resolveAnchorDate(iso, tz='America/Los_Angeles') anchors to midnight PT, not host", () => {
+    // Regardless of where the host process is, requesting tz=PT for an
+    // instant during 2026-05-26 PT should produce 2026-05-26T00:00 PT =
+    // 07:00 UTC (PDT). Use an ISO with a PT offset so the anchor's
+    // calendar-day input is clearly the 26th in PT.
+    expect(
+      resolveAnchorDate("2026-05-26T12:00:00-07:00", "America/Los_Angeles").toISOString(),
+    ).toBe("2026-05-26T07:00:00.000Z");
+  });
+
+  it("resolveAnchorDate(iso, tz='UTC') anchors to UTC midnight regardless of host", () => {
+    expect(resolveAnchorDate("2026-05-26T12:00:00Z", "UTC").toISOString()).toBe(
+      "2026-05-26T00:00:00.000Z",
+    );
+  });
+
+  it("resolveAnchorDate without tz preserves host-local behavior (back-compat)", () => {
+    // Without `tz`, the function is unchanged from the pre-#1036 shape.
+    // We can't pin a specific UTC instant without knowing the host TZ —
+    // assert structural property: hour 0 in host TZ.
+    const d = resolveAnchorDate("2026-05-26T12:00:00Z");
+    expect(d.getHours()).toBe(0);
+    expect(d.getMinutes()).toBe(0);
+    expect(d.getSeconds()).toBe(0);
   });
 });

--- a/src/tools/forecast/get.ts
+++ b/src/tools/forecast/get.ts
@@ -150,10 +150,51 @@ export interface ForecastGetContext {
 }
 
 /**
+ * Compute the UTC instant of midnight on `ymd` (YYYY-MM-DD) in `tz`.
+ *
+ * Strategy: take midnight-UTC of `ymd`, ask `Intl.DateTimeFormat` what
+ * the tz's offset is at that instant, and subtract it. DST-safe because
+ * midnight in any IANA TZ is unambiguous (the spring-forward gap is
+ * at 02:00, never at 00:00).
+ *
+ * @internal
+ */
+export function startOfDayInTz(ymd: string, tz: string): Date {
+  const midnightUtc = new Date(`${ymd}T00:00:00.000Z`);
+  const offsetFmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    timeZoneName: "longOffset",
+  });
+  const offsetPart = offsetFmt.formatToParts(midnightUtc).find((p) => p.type === "timeZoneName");
+  const offsetValue = offsetPart?.value ?? "GMT";
+  // "GMT" (UTC), "GMT-07:00", or "GMT+05:30" — parse the optional ±HH:MM tail.
+  const match = /^GMT(?:([+-])(\d{2}):(\d{2}))?$/.exec(offsetValue);
+  if (!match) {
+    // Defensive: unknown format → no shift (host fallback).
+    return midnightUtc;
+  }
+  if (match[1] === undefined) return midnightUtc; // Plain "GMT"
+  const sign = match[1] === "+" ? 1 : -1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3]);
+  const offsetMs = sign * (hours * 60 + minutes) * 60 * 1000;
+  return new Date(midnightUtc.getTime() - offsetMs);
+}
+
+/**
  * Resolve a date string (ISO-8601 or relative shortcut) to a JS Date at
  * the start of that local calendar day.
+ *
+ * `tz` overrides the host's TZ for the start-of-day computation — used by
+ * tests that pin the cross-TZ behavior without depending on the runner's
+ * process TZ. Production callers pass no `tz` and the function uses the
+ * host's TZ via `setHours` (= the user's Mac TZ per `docs/dates.md`'s
+ * contract). See #1036 for the audit + tests that exercise the
+ * server-in-UTC + user-in-PT scenario.
+ *
+ * @internal — exported for the `tz` parameter test path.
  */
-function resolveAnchorDate(dateStr: string): Date {
+export function resolveAnchorDate(dateStr: string, tz?: string): Date {
   let iso: string;
   if (isRelativeDateShortcut(dateStr)) {
     iso = resolveRelativeDate(dateStr);
@@ -166,6 +207,18 @@ function resolveAnchorDate(dateStr: string): Date {
         details: { field: "date", value: dateStr },
       },
     );
+  }
+  if (tz !== undefined) {
+    // Get the Y-M-D in tz, then construct the UTC instant of midnight-in-tz
+    // of that day. This is DST-safe (midnight is never inside a DST gap).
+    const ymdFmt = new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    const ymd = ymdFmt.format(new Date(iso));
+    return startOfDayInTz(ymd, tz);
   }
   const d = new Date(iso);
   d.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary

`resolveAnchorDate` used `setHours(0,0,0,0)`, which is host-TZ-dependent. Server-in-UTC + user-in-PT produced an anchor at UTC midnight — which is 5pm PT the prior afternoon, so "today" was off by a day from the user's perspective.

Fix:

- New helper `startOfDayInTz(ymd, tz)` returns the UTC instant of midnight on the given calendar day in the given TZ. Uses `Intl.DateTimeFormat`'s `longOffset` to fetch the TZ's offset at the date's UTC midnight (DST-safe — midnight is never inside the spring-forward gap).
- `resolveAnchorDate(dateStr, tz?)` accepts an optional `tz`. With `tz`, anchors via the new helper. Without `tz`, behavior is unchanged (host-local) — back-compat preserved.

Production callers pass no `tz` (host == user's Mac per `docs/dates.md`). The new `tz` parameter exists for tests, which pin the cross-TZ behavior without process-TZ manipulation.

Closes #1036.

## Issue
Implements [#1036](https://github.com/torsday/omnifocus-mcp/issues/1036), surfaced by the [#833](https://github.com/torsday/omnifocus-mcp/issues/833) audit. Sibling [#1035](https://github.com/torsday/omnifocus-mcp/issues/1035) landed; [#1037](https://github.com/torsday/omnifocus-mcp/issues/1037) (full DST + cross-TZ test matrix at the handler level) remains as the closing follow-up of the audit chain.

## Breaking change?
- [x] No — existing callers (no `tz` argument) get unchanged behavior.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3820 passed (8 new)
- [x] `pnpm build` clean
- [x] Self-reviewed (diff +124 / -1 lines)