### PR TITLE
fix(scripts): raise validate-deps issue fetch limit to 2000

### DIFF
--- a/scripts/validate-deps.sh
+++ b/scripts/validate-deps.sh
@@ -34,7 +34,7 @@ trap 'rm -f "$TABLE"' EXIT
 
 echo "==> Fetching all issues (open + closed) from $REPO" >&2
 # TSV: number \t state \t space-separated-blockers
-gh issue list --repo "$REPO" --state all --limit 500 \
+gh issue list --repo "$REPO" --state all --limit 2000 \
   --json number,state,body \
   --jq '.[] | [
     (.number|tostring),


### PR DESCRIPTION
## Summary
- `validate-deps.sh` used `--limit 500` which missed early issues (#1–#8) in a repo with 1000+ issues
- These early closed issues are referenced as blockers by other closed issues, causing false orphan reports
- Fix: raise limit to 2000 (current issue count is ~1037)

Closes #1018.

## Issue
Implements [#1018 — [audit] Dependency-graph drift](https://github.com/torsday/omnifocus-mcp/issues/1018).

## Breaking change?
- [x] No

## Test plan
- [x] `bash scripts/validate-deps.sh` now reports clean: parsed 517 issues, no orphans/stale/cycles
- [x] Self-reviewed via /review-pr
- [x] No new dependencies