### PR TITLE
test(perf): add tests/benchmark/latency harness (#941)

### DIFF
--- a/.github/workflows/latency-bench.yml
+++ b/.github/workflows/latency-bench.yml
@@ -1,0 +1,78 @@
+name: Latency benchmark
+
+# Per-PR latency scorecard (#941). Runs the latency benchmark suite against
+# the checked-in baseline; fails on ≥ 15% drift in any tracked field.
+#
+# **Non-required** until baseline stability is established. See
+# `tests/benchmark/latency/README.md` § "CI promotion path" for the
+# promotion criteria. Until then this job exits 0 on drift so PRs are not
+# blocked — the drift is recorded in the job summary for reviewer visibility.
+#
+# Unlike token-cost-bench, there is no `bench: regression-allowed` label
+# gate yet: the job is not required, so allowlisting individual PRs has no
+# meaning at this stage. Re-introduce the gate when promoting to required.
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/benchmark/latency/**"
+      - "tests/benchmark/token-cost/workflows/**"
+      - ".github/workflows/latency-bench.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  push:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: latency-bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 20
+    name: latency bench
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run latency benchmark
+        id: bench
+        run: |
+          set +e
+          pnpm test:bench:latency
+          status=$?
+          set -e
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      # Non-required — always exit 0, even on drift. Drift goes to the
+      # job summary so reviewers can eyeball it. Flip this to a hard
+      # fail once the baseline has stabilized; see README § promotion path.
+      - name: Apply non-required gate
+        env:
+          STATUS: ${{ steps.bench.outputs.status }}
+        run: |
+          {
+            echo "## Latency benchmark"
+            echo ""
+            if [ "$STATUS" = "0" ]; then
+              echo "✅ No drift beyond the 15% threshold."
+            else
+              echo "🟡 **Drift detected.** Bench is non-required; PR is not blocked. The drift breakdown is in the step log above."
+              echo ""
+              echo "If this PR is meant to change latency (e.g. #882-class work), re-baseline via \`pnpm bench:latency --update\` and include the diff."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "test:e2e": "OMNIFOCUS_E2E=1 vitest run tests/e2e",
     "test:bench:tokens": "OMNIFOCUS_BENCH=1 vitest run tests/benchmark/token-cost",
     "bench:tokens": "tsx tests/benchmark/token-cost/cli.ts",
+    "test:bench:latency": "OMNIFOCUS_LATENCY_BENCH=1 vitest run tests/benchmark/latency --testTimeout=600000",
+    "bench:latency": "tsx tests/benchmark/latency/cli.ts",
     "mutation": "stryker run",
     "prepublishOnly": "pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run build",
     "prepare": "simple-git-hooks"

--- a/tests/benchmark/latency/README.md
+++ b/tests/benchmark/latency/README.md
@@ -1,0 +1,133 @@
+# Latency benchmark suite (#941)
+
+A measurement-only suite that records the **wall-clock latency** an MCP
+client would observe per call when running canonical workflows
+against a real OmniFocus database. Sister to
+[`tests/benchmark/token-cost/`](../token-cost/README.md): same workflows,
+same baseline-and-drift discipline, different metric.
+
+This is the perf scorecard for [#882](https://github.com/torsday/omnifocus-mcp/issues/882)-class
+structural changes (e.g. persistent `osascript` REPL) — a PR that
+claims "40% lower call latency" lands a measurable diff against this
+baseline, or the claim has no proof.
+
+## What it measures
+
+Workflows execute through the **real** transport chain
+(`JxaTransport` + `OmniJsTransport` routed by `TransportRouter`). Each
+workflow runs in its own Node worker process so the first call to
+each script genuinely pays the spawn-dominated cold cost — running
+multiple workflows in one process would warm the runtime after the
+first and bias every subsequent cold reading downward.
+
+Per workflow, per script (e.g. `task_list`, `project_create`):
+
+| Field | What it captures |
+| --- | --- |
+| `count` | Total invocations of this script in the workflow run. |
+| `p50Ms` / `p95Ms` / `maxMs` | Wall-clock percentiles across **all** calls (cold + warm). |
+| `coldP95Ms` | The first call to this script in the worker's process (spawn-dominated). |
+| `warmP95Ms` | p95 of every call **after** the first. `null` when the script ran exactly once. |
+| `spawnPctOfTotal` | `sum(spawnFloorMs * count) / sum(durationMs)` — how much of the workflow's wall time the calibrated osascript spawn floor explains. |
+
+Wall-clock comes from `performance.now()` deltas in
+`src/logging/transportCall.ts`; the spawn floor comes from the #939
+calibration that already runs at boot.
+
+## Fixture workflows
+
+Reused **verbatim** from token-cost (the workflows are transport-
+agnostic; only the harness differs):
+
+- `inbox-triage`
+- `weekly-review`
+- `project-planning`
+- `end-of-day-review`
+
+`large-pagination` is intentionally excluded — it asserts exact page-
+count invariants against its own 120-task seed that would either fail
+or pollute the user's OF database when driven through real JXA.
+
+## Side effects — read this before running
+
+Unlike token-cost (hermetic `InMemoryAdapter`), the latency bench
+drives **real** OmniFocus. Every workflow creates real entities (tags,
+tasks, projects). The harness does **not** clean up after itself in
+this initial cut (follow-up issue: automatic cleanup). For local
+runs, expect debris with names like `Triage candidate NN — capture
+from inbox`, `Q3 Migration — strategy phase`, the `@actionable` tag,
+etc. CI uses the `mac-local` runner against a dedicated OmniFocus
+profile, so debris stays out of anyone's working database.
+
+## Running
+
+```bash
+# Drive each workflow through real JXA, compare against the checked-in baseline.
+pnpm bench:latency
+
+# Re-baseline (writes __snapshots__/baseline.json).
+pnpm bench:latency --update
+
+# CI-style via vitest, gated on OMNIFOCUS_LATENCY_BENCH=1.
+pnpm test:bench:latency
+```
+
+The vitest entry is gated on `OMNIFOCUS_LATENCY_BENCH=1` so it stays
+out of the default `pnpm test` matrix. Total wall-time is several
+minutes per workflow at current `JxaTransport` cost; once #882 lands,
+expect a measurable drop in `coldP95Ms`.
+
+## Drift policy
+
+Baseline at [`__snapshots__/baseline.json`](./__snapshots__/baseline.json)
+is the contract. Each run rebuilds the rollup and compares.
+
+- **Drift `< 15%`** in any tracked field → passes silently. Wider band
+  than token-cost's 5% because wall-clock measurements on the
+  `mac-local` runner are noisier than byte counts.
+- **Drift `≥ 15%`** in either direction → fails the run, prints the
+  diff. Symmetric thresholds catch both regressions and improvements
+  that forgot to re-baseline.
+
+`coldP95Ms` is intentionally **not** gated. Single-iteration cold runs
+are too noisy to assert on; revisit once the multi-iteration follow-up
+lands.
+
+### How optimization PRs use this suite
+
+A PR under #882 should:
+
+1. Implement the optimization.
+2. Run `pnpm bench:latency` locally on a `mac-local`-equivalent box.
+3. Run `pnpm bench:latency --update` to rewrite the baseline.
+4. Include the baseline diff in the PR — the JSON change is the
+   documentation that the optimization landed.
+5. Confirm a ≥30% drop in at least one workflow's `coldP95Ms` (per
+   #882's structural claim) without regressing other workflows by ≥15%.
+
+A PR that should **not** affect latency but trips drift is a real
+regression and must be investigated before merge.
+
+## CI promotion path
+
+The benchmark currently runs as a **non-required** check at
+[`.github/workflows/latency-bench.yml`](../../../.github/workflows/latency-bench.yml).
+
+Promote to required once:
+
+1. The baseline has held for one week of unrelated PR traffic without
+   spurious failures.
+2. Re-baselining cadence under #882-class work stabilizes.
+
+Promotion is a one-line edit to the repo's branch protection settings;
+no code change here.
+
+## Adding a new fixture
+
+1. Add the workflow under `tests/benchmark/token-cost/workflows/<name>.ts`
+   (transport-agnostic, so both harnesses can drive it).
+2. Wire it into both `tests/benchmark/token-cost/run.test.ts` /
+   `cli.ts` **and** `tests/benchmark/latency/workflows.ts`.
+3. Run `pnpm bench:latency --update` to extend the latency baseline,
+   and `pnpm bench:tokens --update` for the token baseline.
+4. Document the new fixture in this README and in token-cost's.

--- a/tests/benchmark/latency/__snapshots__/baseline.json
+++ b/tests/benchmark/latency/__snapshots__/baseline.json
@@ -1,0 +1,4 @@
+{
+  "generatedAt": "1970-01-01",
+  "workflows": {}
+}

--- a/tests/benchmark/latency/aggregate.test.ts
+++ b/tests/benchmark/latency/aggregate.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import { aggregateWorkflow } from "./aggregate.js";
+import type { ScriptCallEvent } from "./types.js";
+
+function ev(
+  scriptName: string | undefined,
+  durationMs: number,
+  sequence: number,
+  spawnFloorMs?: number,
+): ScriptCallEvent {
+  return {
+    transport: "jxa",
+    scriptName,
+    durationMs,
+    outcome: "ok",
+    sequence,
+    ...(spawnFloorMs !== undefined ? { spawnFloorMs } : {}),
+  };
+}
+
+describe("aggregateWorkflow", () => {
+  test("empty events produce an empty workflow rollup", () => {
+    const r = aggregateWorkflow("wf", []);
+    expect(r.callCount).toBe(0);
+    expect(r.byScript).toEqual({});
+    expect(r.totalDurationMs).toBe(0);
+    expect(r.spawnPctOfTotal).toBe(0);
+  });
+
+  test("first call to each script is cold; rest are warm", () => {
+    const r = aggregateWorkflow("wf", [
+      ev("task_list", 500, 0), // cold
+      ev("task_list", 50, 1), // warm
+      ev("task_list", 60, 2), // warm
+      ev("project_get", 700, 3), // cold (first of its kind)
+    ]);
+    expect(r.byScript.task_list).toBeDefined();
+    expect(r.byScript.task_list?.count).toBe(3);
+    expect(r.byScript.task_list?.coldP95Ms).toBe(500);
+    expect(r.byScript.task_list?.warmP95Ms).toBe(60);
+    expect(r.byScript.project_get).toBeDefined();
+    expect(r.byScript.project_get?.count).toBe(1);
+    expect(r.byScript.project_get?.coldP95Ms).toBe(700);
+    expect(r.byScript.project_get?.warmP95Ms).toBeNull();
+  });
+
+  test("warmP95 is null when a script is called exactly once", () => {
+    const r = aggregateWorkflow("wf", [ev("ping", 12, 0)]);
+    expect(r.byScript.ping?.warmP95Ms).toBeNull();
+    expect(r.byScript.ping?.coldP95Ms).toBe(12);
+  });
+
+  test("p50/p95/max are computed across all calls of a script", () => {
+    const r = aggregateWorkflow("wf", [
+      ev("foo", 10, 0),
+      ev("foo", 20, 1),
+      ev("foo", 30, 2),
+      ev("foo", 40, 3),
+      ev("foo", 50, 4),
+    ]);
+    const s = r.byScript.foo;
+    expect(s?.count).toBe(5);
+    expect(s?.maxMs).toBe(50);
+    // nearest-rank: p50 → ceil(0.5*5) = 3rd → 30; p95 → ceil(0.95*5) = 5th → 50
+    expect(s?.p50Ms).toBe(30);
+    expect(s?.p95Ms).toBe(50);
+  });
+
+  test("unannotated calls land in __unknown__ (still aggregated, never dropped)", () => {
+    const r = aggregateWorkflow("wf", [ev(undefined, 1, 0), ev(undefined, 2, 1)]);
+    expect(r.byScript.__unknown__?.count).toBe(2);
+  });
+
+  test("sequence numbers — not array order — decide cold", () => {
+    // Events arrive out-of-order; aggregator should still pick sequence 0 as cold.
+    const r = aggregateWorkflow("wf", [
+      ev("task_list", 50, 1), // warm
+      ev("task_list", 500, 0), // cold (lower sequence)
+      ev("task_list", 60, 2), // warm
+    ]);
+    expect(r.byScript.task_list?.coldP95Ms).toBe(500);
+  });
+
+  test("spawnPctOfTotal reports 0 when no spawnFloor samples are available", () => {
+    const r = aggregateWorkflow("wf", [ev("task_list", 100, 0), ev("task_list", 50, 1)]);
+    expect(r.spawnPctOfTotal).toBe(0);
+  });
+
+  test("spawnPctOfTotal reflects calibrated spawn floor when present", () => {
+    const r = aggregateWorkflow("wf", [
+      ev("task_list", 200, 0, 80), // spawn floor 80ms, total 200ms
+      ev("task_list", 100, 1, 80),
+    ]);
+    // 2 samples × 80ms spawn floor = 160ms; total 300ms; share = 53.3%.
+    expect(r.spawnPctOfTotal).toBeCloseTo(53.3, 0);
+  });
+});

--- a/tests/benchmark/latency/aggregate.ts
+++ b/tests/benchmark/latency/aggregate.ts
@@ -1,0 +1,105 @@
+/**
+ * Aggregation — turn raw {@link ScriptCallEvent} streams into per-workflow
+ * latency rollups (#941).
+ *
+ * Cold-vs-warm split rule:
+ *   For each `scriptName` within a workflow run, the *first* observed
+ *   event is cold (it pays the osascript spawn floor); everything after
+ *   is warm. Unannotated calls (`scriptName === undefined`) aggregate
+ *   under the `__unknown__` key — they should not exist for production
+ *   call sites, but the bucket prevents data loss if a new code path
+ *   forgets to pass `scriptName`.
+ *
+ * Single-iteration caveat:
+ *   With one worker process per workflow (current design), `coldP95` is
+ *   a single-sample percentile — it equals the one cold call's wall-
+ *   clock. The shape is forward-compatible with multi-iteration runs
+ *   (just feed N iterations of events into one aggregator); the
+ *   follow-up issue for multi-iteration nets that.
+ */
+
+import { max, percentile } from "./percentiles.js";
+import type { ScriptCallEvent, ScriptLatency, WorkflowLatency } from "./types.js";
+
+const UNKNOWN_SCRIPT_KEY = "__unknown__";
+
+interface Buckets {
+  all: number[];
+  cold: number[];
+  warm: number[];
+}
+
+/** Build a per-workflow rollup from the worker's raw event stream. */
+export function aggregateWorkflow(
+  workflow: string,
+  events: readonly ScriptCallEvent[],
+): WorkflowLatency {
+  const byScript: Record<string, Buckets> = {};
+  const seen = new Set<string>();
+  let totalDurationMs = 0;
+  let totalSpawnFloorMs = 0;
+  let spawnSamples = 0;
+
+  // Sort by sequence to make cold detection deterministic — the recorder
+  // assigns sequence numbers in the order events arrive at the listener,
+  // so the first observed scriptName is cold.
+  const ordered = [...events].sort((a, b) => a.sequence - b.sequence);
+  for (const e of ordered) {
+    const key = e.scriptName ?? UNKNOWN_SCRIPT_KEY;
+    let bucket = byScript[key];
+    if (bucket === undefined) {
+      bucket = { all: [], cold: [], warm: [] };
+      byScript[key] = bucket;
+    }
+    bucket.all.push(e.durationMs);
+    if (seen.has(key)) {
+      bucket.warm.push(e.durationMs);
+    } else {
+      bucket.cold.push(e.durationMs);
+      seen.add(key);
+    }
+    totalDurationMs += e.durationMs;
+    if (e.spawnFloorMs !== undefined) {
+      totalSpawnFloorMs += e.spawnFloorMs;
+      spawnSamples += 1;
+    }
+  }
+
+  const byScriptOut: Record<string, ScriptLatency> = {};
+  for (const key of Object.keys(byScript).sort()) {
+    const b = byScript[key]!;
+    byScriptOut[key] = {
+      count: b.all.length,
+      p50Ms: round(percentile(b.all, 0.5)),
+      p95Ms: round(percentile(b.all, 0.95)),
+      maxMs: round(max(b.all)),
+      coldP95Ms: round(percentile(b.cold, 0.95)),
+      // `null` when no warm samples — preserves the distinction from "0ms warm".
+      warmP95Ms: b.warm.length === 0 ? null : round(percentile(b.warm, 0.95)),
+    };
+  }
+
+  // Spawn share: average spawnFloor (over samples that had it) × call count
+  // ÷ total duration. Falls back to 0 if calibration never reported (the
+  // README documents how to read that).
+  const spawnShare =
+    spawnSamples === 0 || totalDurationMs === 0
+      ? 0
+      : (totalSpawnFloorMs / spawnSamples) * spawnSamples;
+  const spawnPctOfTotal =
+    totalDurationMs === 0 ? 0 : round((spawnShare / totalDurationMs) * 100, 1);
+
+  return {
+    workflow,
+    totalDurationMs: round(totalDurationMs),
+    spawnPctOfTotal,
+    callCount: ordered.length,
+    byScript: byScriptOut,
+  };
+}
+
+/** Round to the nearest 0.1ms by default — keeps snapshots stable across runs while preserving useful detail. */
+function round(n: number, digits = 1): number {
+  const factor = 10 ** digits;
+  return Math.round(n * factor) / factor;
+}

--- a/tests/benchmark/latency/cli.ts
+++ b/tests/benchmark/latency/cli.ts
@@ -1,0 +1,117 @@
+/**
+ * CLI entry — `pnpm bench:latency` (#941).
+ *
+ * Runs every workflow (each in its own worker process), prints a
+ * markdown table per workflow plus an overall summary, then either
+ * compares against the checked-in baseline (default) or rewrites it
+ * (`--update`). Exits non-zero on drift ≥ `DRIFT_FAIL_PCT`.
+ *
+ * **Requires** OmniFocus to be running locally — the workers spawn
+ * `osascript` against the user's database. See the suite's README for
+ * the cleanup caveat.
+ */
+
+import { runAllWorkflows } from "./runBench.js";
+import {
+  buildSnapshot,
+  DRIFT_FAIL_PCT,
+  diffSnapshots,
+  formatDrift,
+  readSnapshot,
+  SNAPSHOT_PATH,
+  writeSnapshot,
+} from "./snapshot.js";
+import type { WorkflowLatency } from "./types.js";
+
+function pad(label: string, w: number): string {
+  return label.length >= w ? label : `${label}${" ".repeat(w - label.length)}`;
+}
+
+function fmtMs(n: number): string {
+  if (n < 10) return n.toFixed(1);
+  return n.toFixed(0);
+}
+
+function printWorkflow(wf: WorkflowLatency): void {
+  // biome-ignore lint/suspicious/noConsole: intentional CLI output
+  console.log(`\n# ${wf.workflow}`);
+  // biome-ignore lint/suspicious/noConsole: intentional CLI output
+  console.log(
+    `  calls: ${wf.callCount}  total: ${fmtMs(wf.totalDurationMs)} ms  ` +
+      `spawn share: ${wf.spawnPctOfTotal.toFixed(1)}%`,
+  );
+  // biome-ignore lint/suspicious/noConsole: intentional CLI output
+  console.log(
+    `  | ${pad("script", 26)} | ${pad("count", 5)} | ${pad("p50", 7)} | ${pad("p95", 7)} | ${pad("max", 7)} | ${pad("cold p95", 9)} | ${pad("warm p95", 9)} |`,
+  );
+  // biome-ignore lint/suspicious/noConsole: intentional CLI output
+  console.log(
+    `  | ${"-".repeat(26)} | ${"-".repeat(5)} | ${"-".repeat(7)} | ${"-".repeat(7)} | ${"-".repeat(7)} | ${"-".repeat(9)} | ${"-".repeat(9)} |`,
+  );
+  for (const script of Object.keys(wf.byScript).sort()) {
+    const s = wf.byScript[script]!;
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.log(
+      `  | ${pad(script, 26)} | ${pad(String(s.count), 5)} | ` +
+        `${pad(`${fmtMs(s.p50Ms)} ms`, 7)} | ` +
+        `${pad(`${fmtMs(s.p95Ms)} ms`, 7)} | ` +
+        `${pad(`${fmtMs(s.maxMs)} ms`, 7)} | ` +
+        `${pad(`${fmtMs(s.coldP95Ms)} ms`, 9)} | ` +
+        `${pad(s.warmP95Ms === null ? "—" : `${fmtMs(s.warmP95Ms)} ms`, 9)} |`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const update = process.argv.includes("--update");
+
+  const spawns = await runAllWorkflows();
+  const results = spawns.map((s) => s.result);
+
+  // Surface any worker-side errors before drift compare — a workflow that
+  // bombed mid-run produces unreliable numbers; fail loudly.
+  const failed = spawns.filter((s) => s.raw.error !== undefined);
+  if (failed.length > 0) {
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.error("\nworker errors:");
+    for (const f of failed) {
+      // biome-ignore lint/suspicious/noConsole: intentional CLI output
+      console.error(`  ${f.raw.workflow}: ${f.raw.error}`);
+    }
+    process.exit(1);
+  }
+
+  for (const r of results) printWorkflow(r);
+
+  const current = buildSnapshot(results);
+
+  if (update) {
+    writeSnapshot(current);
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.log(`\nbaseline updated: ${SNAPSHOT_PATH}`);
+    return;
+  }
+
+  const baseline = readSnapshot();
+  if (baseline === undefined) {
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.error(
+      `\nno baseline snapshot at ${SNAPSHOT_PATH} — run \`pnpm bench:latency --update\` to create one`,
+    );
+    process.exit(1);
+  }
+  const drift = diffSnapshots(baseline, current);
+  if (drift.length > 0) {
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.error(`\ndrift ≥ ${DRIFT_FAIL_PCT}%:\n${formatDrift(drift)}`);
+    process.exit(1);
+  }
+  // biome-ignore lint/suspicious/noConsole: intentional CLI output
+  console.log(`\nno drift ≥ ${DRIFT_FAIL_PCT}% — baseline holds`);
+}
+
+main().catch((err) => {
+  // biome-ignore lint/suspicious/noConsole: intentional CLI error
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/benchmark/latency/context.ts
+++ b/tests/benchmark/latency/context.ts
@@ -1,0 +1,96 @@
+/**
+ * Build a {@link BenchToolContext} backed by the *real* `JxaTransport`
+ * + `OmniJsTransport` chain — what the latency bench measures (#941).
+ *
+ * Mirrors `composition.composeAdapter` + `composition.composeServices`,
+ * but skips `startServer`'s stdio / signal-handler / watcher setup so the
+ * harness stays in-process without booting a real MCP server.
+ *
+ * The workflow definitions live under `tests/benchmark/token-cost/workflows/`
+ * and are transport-agnostic; they accept any context shape matching
+ * {@link BenchToolContext}. Reusing them directly is the whole point of
+ * the AC's "import the workflows" clause.
+ *
+ * **Side effects:** unlike the token-cost harness (`InMemoryAdapter`,
+ * no IO), this context drives real OmniFocus via `osascript`. Workflows
+ * create real entities. See `README.md` for the cleanup caveat.
+ */
+
+import { JxaTransport } from "../../../src/adapter/jxa/JxaTransport.js";
+import type { OmniFocusAdapter } from "../../../src/adapter/OmniFocusAdapter.js";
+import { OmniJsTransport } from "../../../src/adapter/omnijs/OmniJsTransport.js";
+import { TransportRouter } from "../../../src/adapter/router.js";
+import { OmniFocusLruCache } from "../../../src/cache/lruCache.js";
+import { parseConfig } from "../../../src/config/env.js";
+import type { ResponseMeta } from "../../../src/envelope/index.js";
+import { generateCorrelationId, getCorrelationId } from "../../../src/logging/correlation.js";
+import { AttachmentService } from "../../../src/services/attachmentService.js";
+import { ExportService } from "../../../src/services/exportService.js";
+import { FolderService } from "../../../src/services/folderService.js";
+import { ForecastService } from "../../../src/services/forecastService.js";
+import { PerspectiveService } from "../../../src/services/perspectiveService.js";
+import { PluginService } from "../../../src/services/pluginService.js";
+import { ProjectService } from "../../../src/services/projectService.js";
+import { ReviewService } from "../../../src/services/reviewService.js";
+import { SearchService } from "../../../src/services/searchService.js";
+import { TagService } from "../../../src/services/tagService.js";
+import { TaskService } from "../../../src/services/taskService.js";
+import type { BenchToolContext } from "../token-cost/runBench.js";
+
+function makeMeta(partial: Partial<ResponseMeta> = {}): ResponseMeta {
+  return {
+    correlationId: getCorrelationId() ?? generateCorrelationId(),
+    durationMs: 0,
+    cacheHit: false,
+    transport: "jxa",
+    ofVersion: "unknown",
+    ...partial,
+  };
+}
+
+/**
+ * Build a real adapter (JXA + OmniJS routed via {@link TransportRouter}).
+ *
+ * Reads `OMNIFOCUS_JXA_TIMEOUT_MS` / `OMNIFOCUS_OMNIJS_TIMEOUT_MS` from
+ * env via the canonical {@link parseConfig}, matching production wiring.
+ */
+function buildRealAdapter(): OmniFocusAdapter {
+  const config = parseConfig();
+  const jxa = new JxaTransport({ timeoutMs: config.OMNIFOCUS_JXA_TIMEOUT_MS });
+  const omnijs = new OmniJsTransport({ timeoutMs: config.OMNIFOCUS_OMNIJS_TIMEOUT_MS });
+  return TransportRouter.fromTransports(jxa, omnijs);
+}
+
+/**
+ * Build a {@link BenchToolContext} ready to drive any token-cost workflow
+ * through the real transport chain. Each call returns fresh instances so
+ * worker processes never share state.
+ */
+export function createLatencyBenchContext(): BenchToolContext {
+  const adapter = buildRealAdapter();
+  const config = parseConfig();
+  const cache = new OmniFocusLruCache({
+    capacity: config.OMNIFOCUS_CACHE_CAPACITY,
+    ttlMs: config.OMNIFOCUS_CACHE_TTL_MS,
+  });
+  return {
+    adapter,
+    cache,
+    taskService: new TaskService({ adapter, cache }),
+    projectService: new ProjectService({ adapter, cache }),
+    tagService: new TagService({ adapter, cache }),
+    folderService: new FolderService({ adapter, cache }),
+    attachmentService: new AttachmentService({
+      adapter,
+      allowedPaths: config.OMNIFOCUS_ATTACHMENT_PATHS,
+      maxAttachmentMb: config.OMNIFOCUS_MAX_ATTACHMENT_MB,
+    }),
+    exportService: new ExportService({ adapter }),
+    forecastService: new ForecastService({ adapter, cache }),
+    perspectiveService: new PerspectiveService({ adapter }),
+    pluginService: new PluginService({ adapter }),
+    reviewService: new ReviewService({ adapter, cache }),
+    searchService: new SearchService({ adapter }),
+    makeMeta,
+  };
+}

--- a/tests/benchmark/latency/percentiles.test.ts
+++ b/tests/benchmark/latency/percentiles.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { max, percentile } from "./percentiles.js";
+
+describe("percentile", () => {
+  test("empty input returns 0 (callers can rely on this without guarding)", () => {
+    expect(percentile([], 0.5)).toBe(0);
+    expect(percentile([], 0.95)).toBe(0);
+  });
+
+  test("single sample returns that sample at any p", () => {
+    expect(percentile([42], 0.5)).toBe(42);
+    expect(percentile([42], 0.95)).toBe(42);
+  });
+
+  test("p50 of [1..10] lands on the 5th element (nearest-rank)", () => {
+    expect(percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.5)).toBe(5);
+  });
+
+  test("p95 of [1..20] lands on the 19th element", () => {
+    const xs = Array.from({ length: 20 }, (_, i) => i + 1);
+    expect(percentile(xs, 0.95)).toBe(19);
+  });
+
+  test("input is not mutated", () => {
+    const xs = [3, 1, 2];
+    percentile(xs, 0.5);
+    expect(xs).toEqual([3, 1, 2]);
+  });
+});
+
+describe("max", () => {
+  test("empty input returns 0", () => {
+    expect(max([])).toBe(0);
+  });
+
+  test("returns the largest sample", () => {
+    expect(max([1, 5, 3, 2])).toBe(5);
+    expect(max([42])).toBe(42);
+  });
+});

--- a/tests/benchmark/latency/percentiles.ts
+++ b/tests/benchmark/latency/percentiles.ts
@@ -1,0 +1,30 @@
+/**
+ * Percentile helpers for the latency benchmark (#941).
+ *
+ * Uses the nearest-rank method on a copy of the input — small N (typical
+ * workflow has tens-to-hundreds of samples), so the cost of allocating a
+ * fresh sorted array per call is negligible and keeps the inputs immutable.
+ */
+
+/**
+ * Nearest-rank percentile. `p` is in [0, 1]. Returns `0` for an empty input
+ * so callers don't have to guard at every site.
+ */
+export function percentile(samples: readonly number[], p: number): number {
+  if (samples.length === 0) return 0;
+  const sorted = [...samples].sort((a, b) => a - b);
+  if (samples.length === 1) return sorted[0]!;
+  // Nearest-rank: ceil(p * N), clamped to [1, N], then 0-indexed.
+  const rank = Math.max(1, Math.min(sorted.length, Math.ceil(p * sorted.length)));
+  return sorted[rank - 1]!;
+}
+
+export function max(samples: readonly number[]): number {
+  if (samples.length === 0) return 0;
+  let m = samples[0]!;
+  for (let i = 1; i < samples.length; i += 1) {
+    const v = samples[i]!;
+    if (v > m) m = v;
+  }
+  return m;
+}

--- a/tests/benchmark/latency/recorder.test.ts
+++ b/tests/benchmark/latency/recorder.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Recorder unit tests — synthesize `transport.call` events through the
+ * public `emitTransportCall` API rather than spinning up real
+ * `osascript`. The aggregator and emit layer are exercised together by
+ * `aggregate.test.ts`; this file owns the listener-subscription contract.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  __resetTransportCallListeners,
+  emitTransportCall,
+} from "../../../src/logging/transportCall.js";
+import { Recorder } from "./recorder.js";
+
+afterEach(() => {
+  __resetTransportCallListeners();
+});
+
+describe("Recorder", () => {
+  test("captures every emitted event with monotonically-increasing sequence", () => {
+    const r = new Recorder();
+    r.start();
+    emitTransportCall("jxa", "task_list", { x: 1 }, 100, "ok", 80);
+    emitTransportCall("jxa", "task_get", { id: "a" }, 50, "ok", 80);
+    emitTransportCall("omnijs", "task_move", { id: "a" }, 30, "ok");
+    r.stop();
+
+    const events = r.events;
+    expect(events).toHaveLength(3);
+    expect(events.map((e) => e.scriptName)).toEqual(["task_list", "task_get", "task_move"]);
+    expect(events.map((e) => e.sequence)).toEqual([0, 1, 2]);
+    expect(events[0]?.spawnFloorMs).toBe(80);
+    expect(events[2]?.spawnFloorMs).toBeUndefined(); // omitted when not provided
+  });
+
+  test("stop() unsubscribes — no further events captured", () => {
+    const r = new Recorder();
+    r.start();
+    emitTransportCall("jxa", "a", {}, 10, "ok");
+    r.stop();
+    emitTransportCall("jxa", "b", {}, 20, "ok");
+    expect(r.events.map((e) => e.scriptName)).toEqual(["a"]);
+  });
+
+  test("start() / stop() are idempotent", () => {
+    const r = new Recorder();
+    r.start();
+    r.start(); // no-op
+    emitTransportCall("jxa", "x", {}, 1, "ok");
+    r.stop();
+    r.stop(); // no-op
+    expect(r.events).toHaveLength(1);
+  });
+
+  test("events getter returns a copy (mutating the result doesn't poison the recorder)", () => {
+    const r = new Recorder();
+    r.start();
+    emitTransportCall("jxa", "x", {}, 1, "ok");
+    const snapshot = r.events;
+    snapshot.length = 0;
+    expect(r.events).toHaveLength(1);
+  });
+});

--- a/tests/benchmark/latency/recorder.ts
+++ b/tests/benchmark/latency/recorder.ts
@@ -1,0 +1,54 @@
+/**
+ * Recorder — collects `transport.call` events emitted by the script
+ * runners (#941).
+ *
+ * Subscribes via {@link onTransportCall} (the same observer hook used by
+ * the latency-stats aggregator in production) so we capture every osascript
+ * spawn and OmniJS invocation without modifying the spawners themselves.
+ * The recorder is workflow-scoped: instantiate one per worker process,
+ * `start()` before the workflow runs, `stop()` after, and read `events`.
+ */
+
+import { onTransportCall, type TransportCallEvent } from "../../../src/logging/transportCall.js";
+import type { ScriptCallEvent } from "./types.js";
+
+export class Recorder {
+  private readonly _events: ScriptCallEvent[] = [];
+  private dispose: (() => void) | undefined;
+  private nextSeq = 0;
+
+  /** Begin recording. Idempotent — calling twice is a no-op. */
+  start(): void {
+    if (this.dispose !== undefined) return;
+    this.dispose = onTransportCall((event: TransportCallEvent) => {
+      const e: ScriptCallEvent = {
+        transport: event.transport,
+        scriptName: event.scriptName,
+        durationMs: event.durationMs,
+        outcome: event.outcome,
+        sequence: this.nextSeq,
+        ...(event.spawnFloorMs !== undefined ? { spawnFloorMs: event.spawnFloorMs } : {}),
+      };
+      this._events.push(e);
+      this.nextSeq += 1;
+    });
+  }
+
+  /** Stop recording. Idempotent. */
+  stop(): void {
+    if (this.dispose === undefined) return;
+    this.dispose();
+    this.dispose = undefined;
+  }
+
+  /** Snapshot the events recorded so far. The returned array is a copy. */
+  get events(): ScriptCallEvent[] {
+    return [...this._events];
+  }
+
+  /** Drop all recorded events without unsubscribing. Test helper. */
+  reset(): void {
+    this._events.length = 0;
+    this.nextSeq = 0;
+  }
+}

--- a/tests/benchmark/latency/run.test.ts
+++ b/tests/benchmark/latency/run.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Vitest entry for the latency benchmark suite (#941).
+ *
+ * Gated on `OMNIFOCUS_LATENCY_BENCH=1` so it stays out of the default
+ * test matrix — workers spawn real `osascript` and require OmniFocus
+ * to be running. The CI workflow at
+ * `.github/workflows/latency-bench.yml` is the canonical caller.
+ *
+ * Unit tests for the harness itself live in `*.test.ts` siblings of
+ * each module (aggregate.test.ts, snapshot.test.ts, percentiles.test.ts)
+ * and run on every push — those don't need OmniFocus.
+ */
+
+import { describe, expect, test } from "vitest";
+import { runAllWorkflows } from "./runBench.js";
+import { buildSnapshot, diffSnapshots, formatDrift, readSnapshot } from "./snapshot.js";
+
+const ENABLED = process.env.OMNIFOCUS_LATENCY_BENCH === "1";
+
+if (!ENABLED) {
+  describe("latency benchmark", () => {
+    test.skip("skipped — set OMNIFOCUS_LATENCY_BENCH=1 to run", () => {});
+  });
+} else {
+  describe("latency benchmark", () => {
+    test(
+      "workflows match baseline within tolerance",
+      async () => {
+        const spawns = await runAllWorkflows();
+        const errs = spawns
+          .filter((s) => s.raw.error !== undefined)
+          .map((s) => `${s.raw.workflow}: ${s.raw.error}`);
+        if (errs.length > 0) {
+          throw new Error(`worker errors:\n${errs.join("\n")}`);
+        }
+        const current = buildSnapshot(spawns.map((s) => s.result));
+        const baseline = readSnapshot();
+        if (baseline === undefined) {
+          throw new Error(
+            "no baseline snapshot — run `pnpm bench:latency --update` to generate one",
+          );
+        }
+        const drift = diffSnapshots(baseline, current);
+        expect(drift, `drift detected:\n${formatDrift(drift)}`).toEqual([]);
+      },
+      // Wall-clock benches against real OmniFocus take minutes.
+      10 * 60 * 1000,
+    );
+  });
+}

--- a/tests/benchmark/latency/runBench.test.ts
+++ b/tests/benchmark/latency/runBench.test.ts
@@ -1,0 +1,69 @@
+/**
+ * runBench parent-side tests — exercises {@link runAllWorkflows} with an
+ * injected {@link WorkerLauncher} so we never spawn a real worker (no
+ * `tsx`, no OmniFocus, no `osascript`).
+ */
+
+import { describe, expect, test } from "vitest";
+import { runAllWorkflows, type WorkerLauncher } from "./runBench.js";
+import type { ScriptCallEvent, WorkerOutput } from "./types.js";
+import { workflowNames } from "./workflows.js";
+
+function evt(seq: number, scriptName: string, durationMs: number): ScriptCallEvent {
+  return { transport: "jxa", scriptName, durationMs, outcome: "ok", sequence: seq };
+}
+
+describe("runAllWorkflows", () => {
+  test("spawns one worker per registered workflow and aggregates each", async () => {
+    const launches: string[] = [];
+    const launcher: WorkerLauncher = (workflow): Promise<WorkerOutput> => {
+      launches.push(workflow);
+      return Promise.resolve({
+        workflow,
+        workflowDurationMs: 100,
+        events: [
+          evt(0, "task_list", 500), // cold
+          evt(1, "task_list", 50), // warm
+        ],
+      });
+    };
+
+    const out = await runAllWorkflows(launcher);
+
+    expect(launches).toEqual([...workflowNames()]);
+    expect(out).toHaveLength(workflowNames().length);
+    for (const spawn of out) {
+      expect(spawn.result.callCount).toBe(2);
+      expect(spawn.result.byScript.task_list?.coldP95Ms).toBe(500);
+      expect(spawn.result.byScript.task_list?.warmP95Ms).toBe(50);
+    }
+  });
+
+  test("propagates worker-side errors through `raw.error`", async () => {
+    const launcher: WorkerLauncher = (workflow) =>
+      Promise.resolve({
+        workflow,
+        workflowDurationMs: 0,
+        events: [],
+        error: "OmniFocusNotRunning: app isn't running",
+      });
+    const out = await runAllWorkflows(launcher);
+    expect(out[0]?.raw.error).toMatch(/OmniFocusNotRunning/);
+    // Aggregation still produces a (zeroed) rollup so callers see a stable shape.
+    expect(out[0]?.result.callCount).toBe(0);
+  });
+
+  test("runs workflows sequentially — no overlapping launcher invocations", async () => {
+    let inflight = 0;
+    let maxInflight = 0;
+    const launcher: WorkerLauncher = async (workflow) => {
+      inflight += 1;
+      maxInflight = Math.max(maxInflight, inflight);
+      await new Promise((r) => setTimeout(r, 5));
+      inflight -= 1;
+      return { workflow, workflowDurationMs: 5, events: [] };
+    };
+    await runAllWorkflows(launcher);
+    expect(maxInflight).toBe(1);
+  });
+});

--- a/tests/benchmark/latency/runBench.ts
+++ b/tests/benchmark/latency/runBench.ts
@@ -1,0 +1,81 @@
+/**
+ * Parent orchestration — spawn one worker per workflow, parse each
+ * worker's JSON output, and aggregate (#941).
+ *
+ * Splits cleanly from the worker so the parent has zero adapter/JXA
+ * imports — that keeps the spawn cost on the worker side, and means
+ * the parent can be unit-tested by injecting a fake spawn function.
+ */
+
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { aggregateWorkflow } from "./aggregate.js";
+import type { WorkerOutput, WorkflowLatency } from "./types.js";
+import { WORKFLOWS } from "./workflows.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WORKER_PATH = resolve(HERE, "worker.ts");
+
+export interface WorkerSpawn {
+  /** Pre-aggregation worker payload (raw events + workflow timing). */
+  raw: WorkerOutput;
+  /** Aggregated rollup, computed from `raw.events`. */
+  result: WorkflowLatency;
+}
+
+/**
+ * Shape of the function that actually launches a worker. The default
+ * implementation spawns a `tsx` subprocess; tests inject a fake that
+ * returns canned output without touching `osascript`.
+ */
+export type WorkerLauncher = (workflow: string) => Promise<WorkerOutput>;
+
+/** Production launcher: `tsx <worker.ts> --workflow <name>`. */
+export const defaultWorkerLauncher: WorkerLauncher = (workflow) =>
+  new Promise<WorkerOutput>((resolveOut, rejectOut) => {
+    const child = spawn("node", ["--import", "tsx", WORKER_PATH, "--workflow", workflow], {
+      // Inherit env so the worker sees the user's OMNIFOCUS_* config.
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c));
+    child.stderr.on("data", (c: Buffer) => stderrChunks.push(c));
+    child.on("error", (err) => rejectOut(err));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        const stderrStr = Buffer.concat(stderrChunks).toString("utf8");
+        rejectOut(new Error(`worker '${workflow}' exited ${code}: ${stderrStr}`));
+        return;
+      }
+      const stdoutStr = Buffer.concat(stdoutChunks).toString("utf8");
+      try {
+        resolveOut(JSON.parse(stdoutStr) as WorkerOutput);
+      } catch (err) {
+        rejectOut(
+          new Error(
+            `worker '${workflow}' produced invalid JSON: ${(err as Error).message}\n${stdoutStr.slice(0, 400)}`,
+          ),
+        );
+      }
+    });
+  });
+
+/**
+ * Run every registered workflow in its own worker process and
+ * aggregate the results. Workflows run sequentially (not in parallel)
+ * so they don't fight over the single osascript instance / OmniFocus
+ * write lock.
+ */
+export async function runAllWorkflows(
+  launcher: WorkerLauncher = defaultWorkerLauncher,
+): Promise<WorkerSpawn[]> {
+  const out: WorkerSpawn[] = [];
+  for (const [workflow] of WORKFLOWS) {
+    const raw = await launcher(workflow);
+    out.push({ raw, result: aggregateWorkflow(workflow, raw.events) });
+  }
+  return out;
+}

--- a/tests/benchmark/latency/snapshot.test.ts
+++ b/tests/benchmark/latency/snapshot.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "vitest";
+import { buildSnapshot, DRIFT_FAIL_PCT, diffSnapshots, formatDrift } from "./snapshot.js";
+import type { WorkflowLatency } from "./types.js";
+
+function wf(
+  workflow: string,
+  totalDurationMs: number,
+  callCount: number,
+  byScript: WorkflowLatency["byScript"] = {},
+  spawnPctOfTotal = 0,
+): WorkflowLatency {
+  return { workflow, totalDurationMs, callCount, byScript, spawnPctOfTotal };
+}
+
+describe("buildSnapshot", () => {
+  test("sorts workflows alphabetically for stable diffs", () => {
+    const snap = buildSnapshot([wf("z-last", 10, 1), wf("a-first", 20, 2)]);
+    expect(Object.keys(snap.workflows)).toEqual(["a-first", "z-last"]);
+  });
+
+  test("generatedAt is an ISO date (YYYY-MM-DD)", () => {
+    const snap = buildSnapshot([wf("a", 1, 1)]);
+    expect(snap.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("diffSnapshots", () => {
+  const baseline = buildSnapshot([
+    wf("inbox-triage", 1000, 10, {
+      task_list: {
+        count: 5,
+        p50Ms: 100,
+        p95Ms: 200,
+        maxMs: 250,
+        coldP95Ms: 250,
+        warmP95Ms: 110,
+      },
+    }),
+  ]);
+
+  test("identical snapshots report no drift", () => {
+    const same = buildSnapshot([
+      wf("inbox-triage", 1000, 10, {
+        task_list: {
+          count: 5,
+          p50Ms: 100,
+          p95Ms: 200,
+          maxMs: 250,
+          coldP95Ms: 250,
+          warmP95Ms: 110,
+        },
+      }),
+    ]);
+    expect(diffSnapshots(baseline, same)).toEqual([]);
+  });
+
+  test("noise under threshold passes silently", () => {
+    const noisy = buildSnapshot([
+      wf("inbox-triage", 1080, 10, {
+        task_list: {
+          count: 5,
+          p50Ms: 105,
+          p95Ms: 210, // +5% — under 15% gate
+          maxMs: 255,
+          coldP95Ms: 255,
+          warmP95Ms: 115,
+        },
+      }),
+    ]);
+    expect(diffSnapshots(baseline, noisy)).toEqual([]);
+  });
+
+  test("regression beyond threshold is flagged", () => {
+    const regressed = buildSnapshot([
+      wf("inbox-triage", 1500, 10, {
+        task_list: {
+          count: 5,
+          p50Ms: 100,
+          p95Ms: 300, // +50% — over 15% gate
+          maxMs: 350,
+          coldP95Ms: 350,
+          warmP95Ms: 150,
+        },
+      }),
+    ]);
+    const findings = diffSnapshots(baseline, regressed);
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings.some((f) => f.path.includes("task_list.p95Ms"))).toBe(true);
+    expect(findings.some((f) => f.path.includes("totalDurationMs"))).toBe(true);
+  });
+
+  test("symmetric: improvements beyond threshold also fail (forces re-baseline)", () => {
+    const improved = buildSnapshot([
+      wf("inbox-triage", 500, 10, {
+        task_list: {
+          count: 5,
+          p50Ms: 50,
+          p95Ms: 100, // -50%
+          maxMs: 125,
+          coldP95Ms: 125,
+          warmP95Ms: 55,
+        },
+      }),
+    ]);
+    const findings = diffSnapshots(baseline, improved);
+    expect(findings.length).toBeGreaterThan(0);
+  });
+
+  test("new workflow is flagged so reviewer notices the baseline gap", () => {
+    const added = buildSnapshot([
+      wf("inbox-triage", 1000, 10, {
+        task_list: {
+          count: 5,
+          p50Ms: 100,
+          p95Ms: 200,
+          maxMs: 250,
+          coldP95Ms: 250,
+          warmP95Ms: 110,
+        },
+      }),
+      wf("weekly-review", 800, 8),
+    ]);
+    const findings = diffSnapshots(baseline, added);
+    expect(findings.some((f) => f.path.includes("weekly-review (new workflow)"))).toBe(true);
+  });
+
+  test("coldP95 is intentionally not gated — too noisy at single-iteration", () => {
+    const coldDrift = buildSnapshot([
+      wf("inbox-triage", 1000, 10, {
+        task_list: {
+          count: 5,
+          p50Ms: 100,
+          p95Ms: 200,
+          maxMs: 250,
+          coldP95Ms: 800, // 3x baseline cold — but the gate ignores cold
+          warmP95Ms: 110,
+        },
+      }),
+    ]);
+    const findings = diffSnapshots(baseline, coldDrift);
+    expect(findings.some((f) => f.path.includes("coldP95"))).toBe(false);
+  });
+});
+
+describe("formatDrift", () => {
+  test("empty findings produce the no-drift message at the configured threshold", () => {
+    expect(formatDrift([])).toBe(`no drift ≥ ${DRIFT_FAIL_PCT}%`);
+  });
+
+  test("formats each finding with sign on the percentage", () => {
+    const out = formatDrift([
+      { path: "wf.script.p95Ms", baseline: 100, current: 150, driftPct: 50 },
+      { path: "wf.script.warmP95Ms", baseline: 100, current: 70, driftPct: -30 },
+    ]);
+    expect(out).toContain("+50.0%");
+    expect(out).toContain("-30.0%");
+  });
+});

--- a/tests/benchmark/latency/snapshot.ts
+++ b/tests/benchmark/latency/snapshot.ts
@@ -1,0 +1,117 @@
+/**
+ * Snapshot read/write/diff for the latency benchmark (#941).
+ *
+ * Mirrors `tests/benchmark/token-cost/snapshot.ts` but tracks wall-clock
+ * fields. The drift policy is the same in *shape* — symmetric percentage
+ * threshold — but **looser in size**: wall-clock measurements on the
+ * mac-local runner are noisier than byte counts (`DRIFT_FAIL_PCT`
+ * defaults to 15 here vs 5 in token-cost; revisit once we have baseline
+ * stability data per the README's CI promotion path).
+ *
+ * Re-baseline by running `pnpm bench:latency --update`. The PR diff is
+ * the documentation that an optimization landed.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { WorkflowLatency } from "./types.js";
+
+/**
+ * Drift tolerance — looser than token-cost's 5% because wall-clock has
+ * real run-to-run variance on a mac-local runner. If stability holds
+ * for one week of unrelated PR traffic, consider tightening to 10%.
+ */
+export const DRIFT_FAIL_PCT = 15;
+
+const SNAPSHOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "__snapshots__");
+const BASELINE_PATH = resolve(SNAPSHOT_DIR, "baseline.json");
+
+export interface SnapshotPayload {
+  /** Advisory — ISO date the snapshot was last regenerated. */
+  generatedAt: string;
+  workflows: Record<string, WorkflowLatency>;
+}
+
+export function buildSnapshot(results: readonly WorkflowLatency[]): SnapshotPayload {
+  const workflows: Record<string, WorkflowLatency> = {};
+  for (const r of [...results].sort((a, b) => a.workflow.localeCompare(b.workflow))) {
+    workflows[r.workflow] = r;
+  }
+  return { generatedAt: new Date().toISOString().slice(0, 10), workflows };
+}
+
+export function readSnapshot(): SnapshotPayload | undefined {
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as SnapshotPayload;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+export function writeSnapshot(payload: SnapshotPayload): void {
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+export interface DriftFinding {
+  path: string;
+  baseline: number;
+  current: number;
+  driftPct: number;
+}
+
+export function diffSnapshots(baseline: SnapshotPayload, current: SnapshotPayload): DriftFinding[] {
+  const findings: DriftFinding[] = [];
+  const wfNames = new Set([...Object.keys(baseline.workflows), ...Object.keys(current.workflows)]);
+  for (const wf of [...wfNames].sort()) {
+    const b = baseline.workflows[wf];
+    const c = current.workflows[wf];
+    if (!b) {
+      findings.push({ path: `${wf} (new workflow)`, baseline: 0, current: 1, driftPct: 100 });
+      continue;
+    }
+    if (!c) {
+      findings.push({ path: `${wf} (removed workflow)`, baseline: 1, current: 0, driftPct: 100 });
+      continue;
+    }
+    pushIfDrifted(findings, `${wf}.totalDurationMs`, b.totalDurationMs, c.totalDurationMs);
+    pushIfDrifted(findings, `${wf}.callCount`, b.callCount, c.callCount);
+
+    // Per-script drift — gate on p95 (overall) and warmP95 since they
+    // dominate steady-state user perception. coldP95 is intentionally
+    // *not* gated here: single-iteration cold runs are too noisy to
+    // assert on; revisit once multi-iteration lands.
+    const scriptNames = new Set([...Object.keys(b.byScript), ...Object.keys(c.byScript)]);
+    for (const s of [...scriptNames].sort()) {
+      const bs = b.byScript[s];
+      const cs = c.byScript[s];
+      if (!bs || !cs) continue; // script appeared/disappeared — likely a workflow edit, not drift
+      pushIfDrifted(findings, `${wf}.${s}.p95Ms`, bs.p95Ms, cs.p95Ms);
+      if (bs.warmP95Ms !== null && cs.warmP95Ms !== null) {
+        pushIfDrifted(findings, `${wf}.${s}.warmP95Ms`, bs.warmP95Ms, cs.warmP95Ms);
+      }
+    }
+  }
+  return findings;
+}
+
+function pushIfDrifted(out: DriftFinding[], path: string, baseline: number, current: number): void {
+  if (baseline === 0 && current === 0) return;
+  const driftPct = baseline === 0 ? 100 : ((current - baseline) / baseline) * 100;
+  if (Math.abs(driftPct) >= DRIFT_FAIL_PCT) {
+    out.push({ path, baseline, current, driftPct });
+  }
+}
+
+export function formatDrift(findings: readonly DriftFinding[]): string {
+  if (findings.length === 0) return `no drift ≥ ${DRIFT_FAIL_PCT}%`;
+  return findings
+    .map((f) => {
+      const sign = f.driftPct >= 0 ? "+" : "";
+      return `  ${f.path}: ${f.baseline} → ${f.current} (${sign}${f.driftPct.toFixed(1)}%)`;
+    })
+    .join("\n");
+}
+
+export const SNAPSHOT_PATH = BASELINE_PATH;

--- a/tests/benchmark/latency/types.ts
+++ b/tests/benchmark/latency/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared types for the latency benchmark harness (#941).
+ *
+ * The harness records one event per `runJxaScript` / `runOmniJsScript`
+ * invocation (via {@link onTransportCall}) and aggregates them into a
+ * per-workflow per-script latency picture. Sister to
+ * `tests/benchmark/token-cost/` — same audience, same baseline policy,
+ * but measuring wall-clock instead of wire bytes.
+ *
+ * @see tests/benchmark/latency/README.md — measurement contract, baseline policy
+ */
+
+/** One raw measurement, captured by {@link Recorder} via `onTransportCall`. */
+export interface ScriptCallEvent {
+  /** Which transport produced the call (mirrors the log field). */
+  transport: "jxa" | "omnijs";
+  /** Script name (e.g. `task_list`, `project_create`). Undefined for unannotated calls. */
+  scriptName: string | undefined;
+  /** Total wall-clock for the call: spawn + script execution + transport overhead. */
+  durationMs: number;
+  /** Calibrated osascript spawn floor at the time of the call. Absent until calibration completes. */
+  spawnFloorMs?: number;
+  outcome: "ok" | "error";
+  /** Order of arrival within the workflow run — stable for cold/warm split. */
+  sequence: number;
+}
+
+/** Aggregated picture for one (workflow, script) pair. */
+export interface ScriptLatency {
+  /** Total calls observed in the workflow. */
+  count: number;
+  /** Wall-clock p50 across all calls. */
+  p50Ms: number;
+  /** Wall-clock p95 across all calls. */
+  p95Ms: number;
+  /** Wall-clock max across all calls. */
+  maxMs: number;
+  /**
+   * p95 of cold calls — the *first* invocation of this script in the
+   * workflow's process. With one iteration per workflow, this is a
+   * single value (cold p95 == cold max == the cold call's wall-clock).
+   * Repeating the workflow N times across worker processes turns this
+   * into a true p95; deferred until the multi-iteration follow-up.
+   */
+  coldP95Ms: number;
+  /**
+   * p95 of warm calls — every invocation *after* the first. `null` when
+   * the workflow calls this script exactly once (no warm samples).
+   */
+  warmP95Ms: number | null;
+}
+
+/** Per-workflow rollup. */
+export interface WorkflowLatency {
+  /** Workflow name (e.g. `inbox-triage`, matches the token-cost workflow id). */
+  workflow: string;
+  /** Sum of every call's `durationMs` (jxa + omnijs combined). */
+  totalDurationMs: number;
+  /**
+   * `sum(spawnFloorMs * count) / sum(durationMs)`. When no spawnFloor is
+   * available (calibration didn't complete), reports `0` — operators
+   * should read that as "spawn share unknown for this run", not "spawn
+   * is 0% of cost".
+   */
+  spawnPctOfTotal: number;
+  /** Total call count across all scripts. */
+  callCount: number;
+  /** Per-script measurements, keyed by `scriptName`. Unannotated calls aggregate under `__unknown__`. */
+  byScript: Record<string, ScriptLatency>;
+}
+
+/** What a worker process emits to stdout. Always a JSON-encoded `WorkerOutput`. */
+export interface WorkerOutput {
+  workflow: string;
+  /** Wall-clock cost of the workflow body inside the worker. */
+  workflowDurationMs: number;
+  /** Raw events — the parent aggregates. */
+  events: ScriptCallEvent[];
+  /** Workflow setup or teardown errors propagated as a string for the parent to log. */
+  error?: string;
+}

--- a/tests/benchmark/latency/worker.ts
+++ b/tests/benchmark/latency/worker.ts
@@ -1,0 +1,71 @@
+/**
+ * Worker entry — runs a single workflow in its own Node process and
+ * emits the recorded events as JSON to stdout (#941).
+ *
+ * Per-workflow process isolation is the whole reason for the worker
+ * split: it gives each workflow a freshly-spawned osascript runtime,
+ * so the "first call to that script" timing genuinely captures the
+ * spawn-dominated cold case. Running multiple workflows in the same
+ * process would warm the runtime after the first workflow and bias
+ * every subsequent workflow's cold numbers downward.
+ *
+ * Invocation contract:
+ *   node ... worker.js --workflow <name>
+ * Output contract (always exit 0 unless argv is invalid; workflow
+ * errors propagate via `error` in the JSON payload):
+ *   {"workflow": "...", "workflowDurationMs": N, "events": [...], "error"?: "..."}
+ */
+
+import { performance } from "node:perf_hooks";
+import { createLatencyBenchContext } from "./context.js";
+import { Recorder } from "./recorder.js";
+import type { WorkerOutput } from "./types.js";
+import { lookupWorkflow } from "./workflows.js";
+
+function parseArgs(argv: readonly string[]): { workflow: string } {
+  const idx = argv.indexOf("--workflow");
+  if (idx < 0 || idx === argv.length - 1) {
+    throw new Error("worker: --workflow <name> is required");
+  }
+  return { workflow: argv[idx + 1]! };
+}
+
+async function main(): Promise<void> {
+  const { workflow } = parseArgs(process.argv.slice(2));
+  const runner = lookupWorkflow(workflow);
+  if (runner === undefined) {
+    throw new Error(`worker: unknown workflow '${workflow}'`);
+  }
+
+  const recorder = new Recorder();
+  recorder.start();
+
+  const t0 = performance.now();
+  let error: string | undefined;
+  try {
+    const ctx = createLatencyBenchContext();
+    await runner(ctx);
+  } catch (err) {
+    // Preserve typed errors as plain strings — the parent only logs them.
+    error = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+  } finally {
+    recorder.stop();
+  }
+  const workflowDurationMs = performance.now() - t0;
+
+  const output: WorkerOutput = {
+    workflow,
+    workflowDurationMs,
+    events: recorder.events,
+    ...(error !== undefined ? { error } : {}),
+  };
+  process.stdout.write(JSON.stringify(output));
+}
+
+main().catch((err) => {
+  // Pre-flight failures (bad argv, missing workflow) are real config errors —
+  // exit non-zero so the parent surfaces them rather than silently aggregating
+  // an empty result.
+  process.stderr.write(`${err instanceof Error ? err.stack : String(err)}\n`);
+  process.exit(1);
+});

--- a/tests/benchmark/latency/workflows.ts
+++ b/tests/benchmark/latency/workflows.ts
@@ -1,0 +1,42 @@
+/**
+ * Workflow registry — single source of truth for which fixture
+ * workflows the latency bench measures (#941).
+ *
+ * Reuses the token-cost workflow definitions directly. The same
+ * canonical user journeys (inbox triage, weekly review, project
+ * planning, end-of-day review) get measured for both wire bytes
+ * (token-cost, hermetic) and wall-clock (latency, real JXA).
+ *
+ * `largePagination` is intentionally **excluded** here: it asserts
+ * exact page-count invariants against its own 120-task seed; running
+ * it against a real OmniFocus database (with whatever the user has)
+ * would either fail the invariant or pollute their data. File a
+ * follow-up if pagination latency turns out to be a separate concern
+ * worth its own fixture.
+ */
+
+import type { Bench, BenchToolContext } from "../token-cost/runBench.js";
+import { runEndOfDayReview } from "../token-cost/workflows/endOfDayReview.js";
+import { runInboxTriage } from "../token-cost/workflows/inboxTriage.js";
+import { runProjectPlanning } from "../token-cost/workflows/projectPlanning.js";
+import { runWeeklyReview } from "../token-cost/workflows/weeklyReview.js";
+
+export type WorkflowRunner = (ctx: BenchToolContext) => Promise<Bench>;
+
+/** Tuple form so callers iterate in a stable, declaration order. */
+export const WORKFLOWS: ReadonlyArray<readonly [string, WorkflowRunner]> = [
+  ["inbox-triage", runInboxTriage],
+  ["weekly-review", runWeeklyReview],
+  ["project-planning", runProjectPlanning],
+  ["end-of-day-review", runEndOfDayReview],
+] as const;
+
+/** Lookup helper used by the worker (`--workflow <name>`). */
+export function lookupWorkflow(name: string): WorkflowRunner | undefined {
+  return WORKFLOWS.find(([id]) => id === name)?.[1];
+}
+
+/** Names only — used by the parent CLI when planning which workers to spawn. */
+export function workflowNames(): readonly string[] {
+  return WORKFLOWS.map(([id]) => id);
+}

--- a/tests/benchmark/token-cost/runBench.ts
+++ b/tests/benchmark/token-cost/runBench.ts
@@ -25,6 +25,7 @@
  */
 
 import { InMemoryAdapter } from "../../../src/adapter/inMemory/InMemoryAdapter.js";
+import type { OmniFocusAdapter } from "../../../src/adapter/OmniFocusAdapter.js";
 import { OmniFocusLruCache } from "../../../src/cache/lruCache.js";
 import type { ResponseMeta } from "../../../src/envelope/index.js";
 import { isError, type ToolEnvelope, toolResponse } from "../../../src/envelope/index.js";
@@ -74,7 +75,14 @@ export interface WorkflowResult {
  * specific shape each call needs.
  */
 export interface BenchToolContext {
-  adapter: InMemoryAdapter;
+  /**
+   * The adapter the workflow drives. Token-cost uses {@link InMemoryAdapter};
+   * the latency harness (#941) passes a real {@link TransportRouter} backed
+   * by `JxaTransport` + `OmniJsTransport`. Widened to `OmniFocusAdapter` so
+   * workflow definitions can be imported by both harnesses (transport-
+   * agnostic per the harness contract).
+   */
+  adapter: OmniFocusAdapter;
   cache: OmniFocusLruCache;
   taskService: TaskService;
   projectService: ProjectService;


### PR DESCRIPTION
## Summary

- Adds `tests/benchmark/latency/` as a sister harness to the existing `tests/benchmark/token-cost/`. Drives the same canonical workflows (inbox-triage, weekly-review, project-planning, end-of-day-review) through the **real** `JxaTransport` + `OmniJsTransport` chain and records per-script wall-clock with a cold-vs-warm split.
- Becomes the perf scorecard for [#882](https://github.com/torsday/omnifocus-mcp/issues/882)-class structural changes — a PR that claims "lower call latency" lands a measurable diff against this baseline, or the claim is unprovable.
- Widens `BenchToolContext.adapter` from `InMemoryAdapter` to `OmniFocusAdapter` so the workflow definitions are reusable verbatim (transport-agnostic per the AC). Token-cost still passes — `InMemoryAdapter` satisfies the wider type.

Closes #941.

## Design notes

- **Per-workflow process isolation.** One Node worker child per workflow so the first call to each script genuinely pays the spawn-dominated cold cost. Running every workflow in one process would warm the runtime after the first and bias every subsequent cold reading downward.
- **Wall-clock at the spawner level.** Subscribes to the existing `onTransportCall` observer hook (the same one the production latency aggregator uses). No spawner-shape changes; the recorder is a workflow-scoped listener that captures every `transport.call` event.
- **Drift gate at ±15%.** Looser than token-cost's 5% because wall-clock measurements on `mac-local` are noisier than byte counts. `coldP95` is intentionally **not** gated — single-iteration cold runs are too noisy to assert on; revisit once multi-iteration lands.
- **CI workflow is non-required.** Drift goes to the job summary; PRs are not blocked. Promotion path documented in the README.

## Issue

Implements [#941](https://github.com/torsday/omnifocus-mcp/issues/941). Both decision/data dependencies (#939, #940) are already closed, so this work is genuinely unblocked.

## Known limitations (deferred to follow-ups)

- **No automatic cleanup.** Workflows create real OmniFocus entities under the user's database. Documented as a caveat in the README; the `mac-local` runner uses a dedicated OF profile. Will file a follow-up for tag-prefixed cleanup.
- **Single iteration per workflow.** `coldP95Ms` is a single-sample percentile. Forward-compatible with multi-iteration (just feed N iterations into the existing aggregator).
- `large-pagination` is excluded from the latency harness — it asserts exact page-count invariants against its own 120-task seed that would either fail or pollute the user's OF database.

## Breaking change?

- [x] No — purely additive (new directory, new scripts, new CI workflow). The one widening edit to `BenchToolContext.adapter` is lossless.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (24 pre-existing `noNonNullAssertion` warnings, none new in shape — matches the established convention in `tests/benchmark/token-cost/snapshot.ts` etc.)
- [x] `pnpm test` — 3869 passed, 60 skipped (the new harness contributes 32 unit tests covering Recorder, aggregator, percentiles, snapshot diff, and runBench launcher injection)
- [x] Token-cost suite still passes after the type widening (`OMNIFOCUS_BENCH=1 pnpm test:bench:tokens`)
- [ ] End-to-end run on `mac-local` against a real OmniFocus database — deferred to the first CI run. The initial `__snapshots__/baseline.json` is empty; the first successful run will populate it via `pnpm bench:latency --update`.