### PR TITLE
test(chaos): pin slow-first-call recovery for read-only JXA scripts (#887)

### DIFF
--- a/docs/design/testing-and-ci.md
+++ b/docs/design/testing-and-ci.md
@@ -73,6 +73,25 @@ The helper appends `[quarantine]` to the test name so reviewers scanning a CI lo
 2. Run `pnpm test:integration:quarantine` locally and confirm the quarantined test now passes reliably.
 3. Replace `quarantineTest(...)` with plain `test(...)` and drop the explanatory comment. The graduation happens in the same PR as the repair so the test rejoins the gate immediately.
 
+### Cold-start JXA timeout on the first integration read ([#887](https://github.com/torsday/omnifocus-mcp/issues/887))
+
+**Symptom.** The integration suite intermittently fails with a single JXA `Timeout` on the suite's *first* contract read (`createTask + getTask round-trip`), while the other ~47 tests pass. The failing run's total wall-time runs long (e.g. 806s vs the typical ~696s), consistent with the shared `mac-local` runner being under load rather than a logic bug — the triggering PR is often docs-only, with zero mechanism to slow `task_get`.
+
+**Root cause.** Cold-start latency on the first `osascript` spawn of a run, compounded by runner contention: the first JXA call pays OF's settle time and the macOS Automation handshake. On a contended runner that one-time cost can exceed the 30s `OMNIFOCUS_JXA_TIMEOUT_MS`.
+
+**Mitigation (already in place).** `task_get` is a member of `READ_ONLY_JXA_SCRIPTS`, so `runJxaScript` **retries once** on a transient failure — and a hard timeout (`SpawnResult.timedOut`) is classified transient (#816, `src/adapter/jxa/scriptRunner.ts`). A slow first call that times out is retried transparently; the caller sees success unless *both* attempts exceed the timeout. The retry path is regression-pinned by `tests/chaos/transport.chaos.test.ts` → "chaos — slow first call recovery (#887)":
+
+- a timeout-then-success spawner proves `task_get` recovers transparently;
+- a persistent-timeout spawner proves the typed `Timeout` still surfaces (no hang) when the retry can't save it.
+
+**If the flake recurs** despite the retry (i.e. both attempts time out on a badly contended runner), escalate in this order:
+
+1. **Quarantine** the specific test via `quarantineTest` (see above) so the gate stays honest while the runner issue is addressed.
+2. **Cross-ref serialize** the integration job — the `concurrency:` group in `.github/workflows/integration.yml` is `integration-${{ github.ref }}`, which serializes same-ref runs but lets cross-PR runs share the runner. Widening the group to a constant serializes all integration jobs at the cost of throughput.
+3. **Warm-up** — add an explicit cheap read (e.g. `ping`) in the contract harness `beforeAll` so the cold-start cost is paid before any timed test. Deferred for now: the existing `beforeAll` already does a `createFolder` round-trip that warms the transport, and the retry-once covers the residual risk.
+
+Writes deliberately do **not** retry (a non-idempotent create could duplicate) — pinned at `src/adapter/jxa/scriptRunner.test.ts` ("does NOT retry a write-shaped script even when the failure is transient").
+
 ---
 
 ## CI/CD

--- a/tests/chaos/chaosSpawner.ts
+++ b/tests/chaos/chaosSpawner.ts
@@ -25,6 +25,40 @@
 
 import type { ScriptSpawner, SpawnResult } from "../../src/adapter/jxa/scriptRunner.js";
 
+/**
+ * Build a spawner that returns each supplied `SpawnResult` in order, one
+ * per call, then repeats the last entry for any further calls. Models a
+ * transient failure that recovers on retry — e.g. a cold-start timeout on
+ * the first JXA call followed by a fast success (#887).
+ *
+ * @see tests/chaos/transport.chaos.test.ts — "slow first call recovers"
+ */
+export function sequencedSpawner(...results: SpawnResult[]): ScriptSpawner {
+  if (results.length === 0) {
+    throw new Error("sequencedSpawner requires at least one SpawnResult");
+  }
+  let call = 0;
+  return async (): Promise<SpawnResult> => {
+    const idx = Math.min(call, results.length - 1);
+    call += 1;
+    // biome-ignore lint/style/noNonNullAssertion: idx is clamped to a valid index.
+    return results[idx]!;
+  };
+}
+
+/** A `SpawnResult` representing a hard timeout (cold-start / contention). */
+export const TIMEOUT_RESULT: SpawnResult = {
+  stdout: "",
+  stderr: "",
+  exitCode: 1,
+  timedOut: true,
+};
+
+/** Build a success `SpawnResult` carrying the given JSON stdout. */
+export function okResult(stdout: string): SpawnResult {
+  return { stdout, stderr: "", exitCode: 0, timedOut: false };
+}
+
 export type ChaosMode =
   | "of-not-running"
   | "permission-denied"

--- a/tests/chaos/transport.chaos.test.ts
+++ b/tests/chaos/transport.chaos.test.ts
@@ -19,9 +19,11 @@
  * @see src/server/circuitBreaker.ts — circuit breaker
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { __resetTransportCircuitsForTest } from "../../src/adapter/_shared/transportCircuit.js";
 import { JxaTransport } from "../../src/adapter/jxa/JxaTransport.js";
 import { OmniJsTransport } from "../../src/adapter/omnijs/OmniJsTransport.js";
+import type { TaskId } from "../../src/domain/ids.js";
 import {
   CircuitOpen,
   OmniFocusError,
@@ -32,7 +34,13 @@ import {
   TransportUnavailable,
 } from "../../src/errors/index.js";
 import { CircuitBreaker } from "../../src/server/circuitBreaker.js";
-import { type ChaosMode, chaosSpawner } from "./chaosSpawner.js";
+import {
+  type ChaosMode,
+  chaosSpawner,
+  okResult,
+  sequencedSpawner,
+  TIMEOUT_RESULT,
+} from "./chaosSpawner.js";
 
 // ---------------------------------------------------------------------------
 // Expectation table — one row per failure mode.
@@ -195,4 +203,60 @@ describe("chaos — sustained failures open the circuit breaker", () => {
     expect(tasks).toEqual([]);
     expect(breaker.state).toBe("closed");
   });
+});
+
+// ---------------------------------------------------------------------------
+// Slow-first-call recovery (#887)
+//
+// The integration suite intermittently failed with a JXA Timeout on the
+// first `task_get` of a run — cold-start latency or runner contention, not
+// a logic bug (the failing test was always the suite's first contract read).
+// `task_get` is a read-only script, so `runJxaScript` retries once on a
+// transient timeout (#816). These tests pin that the retry transparently
+// recovers a slow first call, and that a *persistent* timeout still
+// surfaces the typed error rather than hanging.
+//
+// The module-level transport circuit is reset before each test so a prior
+// describe's induced failures can't bleed in.
+// ---------------------------------------------------------------------------
+
+describe("chaos — slow first call recovery (#887)", () => {
+  beforeEach(() => {
+    __resetTransportCircuitsForTest();
+  });
+
+  it("read-only task_get recovers when the first call times out then succeeds", async () => {
+    // First spawn: cold-start timeout. Second spawn (the retry): fast success.
+    const spawner = sequencedSpawner(
+      TIMEOUT_RESULT,
+      okResult(JSON.stringify({ task: { id: "task_warm", name: "warmed up" } })),
+    );
+    // delayMs default is 100ms; keep the transport's own timeout tight so a
+    // genuine hang would fail fast rather than stalling the test budget.
+    const transport = new JxaTransport({ spawner, timeoutMs: 100 });
+
+    const task = await transport.getTask("task_warm" as TaskId);
+
+    // The retry swallowed the cold-start timeout — the caller sees success.
+    expect(task.id).toBe("task_warm");
+    expect(task.name).toBe("warmed up");
+  });
+
+  it("a persistent timeout (both attempts) surfaces a typed Timeout, not a hang", async () => {
+    // Every spawn times out — the retry can't save it. The transport must
+    // surface the typed error so the circuit breaker and caller can react.
+    const spawner = sequencedSpawner(TIMEOUT_RESULT);
+    const transport = new JxaTransport({ spawner, timeoutMs: 100 });
+
+    const err = await transport.getTask("task_cold" as TaskId).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Timeout);
+    expect((err as Timeout).code).toBe("OF_TIMEOUT");
+  });
+
+  // The complementary invariant — writes never retry a transient failure —
+  // is pinned at the runner level in
+  // `src/adapter/jxa/scriptRunner.test.ts` ("does NOT retry a write-shaped
+  // script even when the failure is transient"). Not re-asserted here: the
+  // spawn-floor calibration call (#939) fires its own spawn on the first
+  // transport call, so a call-count assertion at this layer is unreliable.
 });


### PR DESCRIPTION
## Summary

The integration suite intermittently failed with a JXA `Timeout` on the suite's first contract read — cold-start latency + runner contention, not a logic bug. `task_get` is read-only, so `runJxaScript` already retries once on a transient timeout (#816). The gap was test coverage of that recovery path + documentation.

- **`tests/chaos/chaosSpawner.ts`** — `sequencedSpawner(...results)` helper + `TIMEOUT_RESULT` / `okResult(stdout)` builders. Models a transient failure that recovers on retry.
- **`tests/chaos/transport.chaos.test.ts`** — new "slow first call recovery (#887)" describe:
  - timeout-then-success → `task_get` recovers transparently;
  - persistent timeout → typed `Timeout` still surfaces (no hang).
  Resets the module transport circuit per test for isolation.
- **`docs/design/testing-and-ci.md`** — "Cold-start JXA timeout on the first integration read" section: symptom, root cause, the existing retry-once mitigation, and the escalation order (quarantine → cross-ref serialize → `beforeAll` warm-up) if it recurs.

Closes #887.

## Issue
Implements [#887](https://github.com/torsday/omnifocus-mcp/issues/887).

**On the AC's "reproduce" + "decide on a fix" items:** live-runner reproduction isn't feasible in an automated cycle. The diagnosis (the issue's own forensics + confirming `task_get`'s read-only retry membership) points at cold-start/contention on the first read; the fix is the existing retry-once path, now regression-pinned by the new chaos tests, with a documented escalation playbook for recurrence. The chaos-test and documentation AC items are fully delivered. If a maintainer wants the proactive `beforeAll` warm-up landed too, that's a small follow-up — noted in the doc's escalation list.

## Breaking change?
- [x] No — test + doc only.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 3871 passed (2 new chaos cases)
- [x] `pnpm build` clean
- [x] Self-reviewed (diff +119 / -2)