### PR TITLE
fix(lifecycle): kill orphan osascript children on shutdown

### DIFF
--- a/docs/design/concurrency-and-lifecycle.md
+++ b/docs/design/concurrency-and-lifecycle.md
@@ -47,8 +47,36 @@ On first successful JXA call, the adapter caches `{ ofVersion, ofEdition }` via 
   1. Stop accepting new tool calls (MCP server rejects with `ServerShuttingDown`)
   2. Drain in-flight reads (grace window: 5s)
   3. Wait for write queue to drain (grace window: 10s)
-  4. Close logger; flush stderr
-  5. Exit 0
+  4. Run cleanup hooks — kill any `osascript` child still in flight (see below)
+  5. Close logger; flush stderr
+  6. Exit 0
 - Unhandled exception:
   - Log at `fatal`
   - Exit 1 (the client will reconnect on its own; partial state in OF is OF's concern)
+
+Grace windows are configurable via `OMNIFOCUS_READ_GRACE_MS` / `OMNIFOCUS_WRITE_GRACE_MS`.
+The controller is `src/server/shutdown.ts`; signal handlers and hook registration
+are wired in `src/server/mcpServer.ts`.
+
+#### Orphan-process cleanup (#839)
+
+Both script runners spawn `osascript` via `child_process.execFile`. Each child
+holds the OmniFocus database open while it runs, so a child orphaned at exit
+keeps OF locked and the *next* server start can't read or write until the orphan
+finally times out. To prevent that, every spawned child is registered in
+`src/adapter/_shared/childRegistry.ts`; the shutdown controller's
+`osascript-children` cleanup hook runs **after** the drain window and terminates
+any survivor — `SIGTERM` first, then `SIGKILL` after a 2s grace
+(`DEFAULT_CHILD_KILL_GRACE_MS`). A clean drain leaves the registry empty, so the
+hook is a no-op in the common case. The `DatabaseWatcher` Swift child is killed
+separately on `process` `exit` and `stop()`.
+
+#### Audit findings (what is *not* leaked)
+
+- **Idempotency store** (`src/server/idempotencyStore.ts`) and **read cache**
+  (`src/cache/lruCache.ts`) are both purely in-memory (`Map`-backed). There is no
+  on-disk state, so there is nothing to flush and no "half-written" corruption
+  risk on exit — the drain already lets in-flight writes complete before the
+  process ends. No flush step is needed.
+- **Telemetry sink flush** is deferred until the opt-in JSONL sink (#823) exists;
+  when it lands it should register its own cleanup hook via `registerCleanup`.

--- a/src/adapter/_shared/childRegistry.test.ts
+++ b/src/adapter/_shared/childRegistry.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the osascript child-process registry (#839).
+ *
+ * These spawn REAL child processes (short-lived `node` invocations) so the
+ * SIGTERM → SIGKILL escalation is exercised against actual OS process
+ * semantics, not a mock. This is the "send SIGTERM during a long-running call;
+ * confirm clean shutdown, no orphan processes" smoke test from the issue AC,
+ * minus the live-OmniFocus dependency — a long-lived `node` child stands in for
+ * an in-flight `osascript` call.
+ *
+ * @see src/adapter/_shared/childRegistry.ts
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetChildRegistryForTest,
+  activeChildCount,
+  killActiveChildren,
+  trackChild,
+} from "./childRegistry.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Spawn a long-lived child that keeps the event loop alive until killed. */
+function spawnLongLived(): ChildProcess {
+  return spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    stdio: "ignore",
+  });
+}
+
+/**
+ * Spawn a child that traps SIGTERM and refuses to exit, so only SIGKILL can
+ * stop it. Exercises the force-kill escalation path. The child writes `ready`
+ * to stdout *after* the handler is registered so the test can avoid the race
+ * where SIGTERM lands during node's startup (before the handler exists, where
+ * the default terminate behaviour would apply).
+ */
+function spawnSigtermIgnoring(): ChildProcess {
+  return spawn(
+    process.execPath,
+    [
+      "-e",
+      "process.on('SIGTERM', () => {}); process.stdout.write('ready'); setInterval(() => {}, 1000)",
+    ],
+    { stdio: ["ignore", "pipe", "ignore"] },
+  );
+}
+
+/** Resolve once the child has written its first byte of stdout. */
+function waitForReady(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    child.stdout?.once("data", () => resolve());
+  });
+}
+
+/** Resolve once the child has fully exited (so the OS has reaped it). */
+function waitForExit(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+    child.once("exit", () => resolve());
+  });
+}
+
+afterEach(() => {
+  __resetChildRegistryForTest();
+});
+
+// ---------------------------------------------------------------------------
+// Tracking
+// ---------------------------------------------------------------------------
+
+describe("childRegistry — tracking", () => {
+  it("starts empty", () => {
+    expect(activeChildCount()).toBe(0);
+  });
+
+  it("tracks a spawned child and prunes it on natural exit", async () => {
+    const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+    trackChild(child);
+    expect(activeChildCount()).toBe(1);
+
+    await waitForExit(child);
+    // The `exit` listener prunes synchronously; give the microtask a tick.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(activeChildCount()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// killActiveChildren
+// ---------------------------------------------------------------------------
+
+describe("childRegistry — killActiveChildren", () => {
+  it("is a no-op when nothing is in flight", async () => {
+    expect(await killActiveChildren(50)).toBe(0);
+  });
+
+  it("SIGTERMs an in-flight child and drains the registry", async () => {
+    const child = spawnLongLived();
+    trackChild(child);
+    expect(activeChildCount()).toBe(1);
+
+    const killed = await killActiveChildren(2_000);
+    expect(killed).toBe(1);
+
+    await waitForExit(child);
+    expect(activeChildCount()).toBe(0);
+    // Killed by signal, not a self-chosen exit code.
+    expect(child.signalCode).not.toBeNull();
+  });
+
+  it("escalates to SIGKILL for a child that ignores SIGTERM", async () => {
+    const child = spawnSigtermIgnoring();
+    trackChild(child);
+    await waitForReady(child); // ensure the SIGTERM handler is registered first
+
+    // Short grace so the SIGTERM window lapses quickly and SIGKILL fires.
+    const killed = await killActiveChildren(100);
+    expect(killed).toBe(1);
+
+    await waitForExit(child);
+    expect(child.signalCode).toBe("SIGKILL");
+    expect(activeChildCount()).toBe(0);
+  });
+
+  it("terminates multiple in-flight children in one sweep", async () => {
+    const children = [spawnLongLived(), spawnLongLived(), spawnLongLived()];
+    for (const c of children) trackChild(c);
+    expect(activeChildCount()).toBe(3);
+
+    expect(await killActiveChildren(2_000)).toBe(3);
+    await Promise.all(children.map(waitForExit));
+    expect(activeChildCount()).toBe(0);
+  });
+});

--- a/src/adapter/_shared/childRegistry.ts
+++ b/src/adapter/_shared/childRegistry.ts
@@ -1,0 +1,116 @@
+/**
+ * Registry of live `osascript` child processes, for graceful shutdown (#839).
+ *
+ * Both the JXA and OmniJS script runners spawn `osascript` via
+ * `child_process.execFile`. Each spawned child holds the OmniFocus database
+ * open while it runs. If the server exits (SIGINT/SIGTERM) while a child is
+ * mid-flight, that child is orphaned — it keeps running detached and keeps
+ * OmniFocus locked, so the *next* server start can't acquire the database and
+ * read/write scripts fail until the orphan finally times out.
+ *
+ * This module tracks every spawned child and exposes {@link killActiveChildren}
+ * so the shutdown controller can terminate survivors after the in-flight drain
+ * window closes: SIGTERM first, then SIGKILL for any child that ignores it.
+ *
+ * The registry is a process-global singleton (children are a process-global
+ * resource). It self-prunes: each tracked child is removed on `exit` / `error`,
+ * so a clean run leaves the set empty and {@link killActiveChildren} is a no-op.
+ *
+ * @see src/server/shutdown.ts — registers {@link killActiveChildren} as a cleanup
+ * @see ADR-0009 — concurrency pool and queue (what feeds these spawns)
+ */
+
+import type { ChildProcess } from "node:child_process";
+import { logger } from "../../logging/logger.js";
+
+/** Default grace window (ms) between SIGTERM and the SIGKILL escalation. */
+export const DEFAULT_CHILD_KILL_GRACE_MS = 2_000;
+
+/** Poll interval (ms) while waiting for SIGTERM'd children to exit. */
+const KILL_POLL_MS = 25;
+
+/** Live children, keyed by identity. Self-pruned on `exit` / `error`. */
+const activeChildren = new Set<ChildProcess>();
+
+/**
+ * Register a freshly spawned child so the shutdown controller can terminate it
+ * if the process exits before the child finishes. Idempotent per child. The
+ * child is removed automatically when it emits `exit` or `error`, so callers
+ * never need to untrack manually.
+ */
+export function trackChild(child: ChildProcess): void {
+  activeChildren.add(child);
+  const prune = (): void => {
+    activeChildren.delete(child);
+  };
+  child.once("exit", prune);
+  child.once("error", prune);
+}
+
+/** Number of `osascript` children currently in flight. */
+export function activeChildCount(): number {
+  return activeChildren.size;
+}
+
+/**
+ * Terminate all tracked children. Sends SIGTERM to each, waits up to `graceMs`
+ * for them to exit on their own, then SIGKILLs any survivor. Returns the number
+ * of children that were signalled (0 when the registry is already empty, the
+ * normal case after a clean drain).
+ *
+ * Safe to call when nothing is in flight — it returns immediately. `kill()` on
+ * an already-exited child is a harmless no-op and any throw is swallowed so one
+ * dead child can't abort the sweep.
+ *
+ * @param graceMs  ms to wait after SIGTERM before escalating to SIGKILL.
+ */
+export async function killActiveChildren(
+  graceMs: number = DEFAULT_CHILD_KILL_GRACE_MS,
+): Promise<number> {
+  const signalled = [...activeChildren];
+  if (signalled.length === 0) return 0;
+
+  logger.info(
+    { event: "server.shutdown.kill_children", count: signalled.length, graceMs },
+    "terminating in-flight osascript children",
+  );
+
+  for (const child of signalled) {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Already exited between snapshot and kill — harmless.
+    }
+  }
+
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline && activeChildren.size > 0) {
+    await new Promise<void>((resolve) => setTimeout(resolve, KILL_POLL_MS));
+  }
+
+  const survivors = [...activeChildren];
+  for (const child of survivors) {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Race: exited just now. Harmless.
+    }
+  }
+  if (survivors.length > 0) {
+    logger.warn(
+      { event: "server.shutdown.kill_children_force", count: survivors.length },
+      "force-killed osascript children that ignored SIGTERM",
+    );
+  }
+
+  return signalled.length;
+}
+
+/**
+ * Test-only: clear the registry without signalling. Use in `afterEach` so a
+ * child left tracked by one test can't leak into the next. Mirrors the
+ * `__reset*ForTest` convention used elsewhere in the adapter layer.
+ */
+export function __resetChildRegistryForTest(): void {
+  activeChildren.clear();
+}

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -40,6 +40,7 @@ import {
 import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
 import { probeOmniFocusResponsiveness } from "../_shared/busyProbe.js";
+import { trackChild } from "../_shared/childRegistry.js";
 import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
 import { ensureSpawnFloorCalibration, getSpawnFloorMs } from "../_shared/spawnFloor.js";
 import { getJxaCircuit, isCircuitTransient } from "../_shared/transportCircuit.js";
@@ -103,6 +104,9 @@ export const defaultJxaSpawner: ScriptSpawner = (scriptBody, jsonArg, timeoutMs)
         });
       },
     );
+    // Track the child so a SIGINT/SIGTERM mid-flight can terminate it rather
+    // than orphan an osascript process that keeps OmniFocus locked (#839).
+    trackChild(child);
     // Pipe the script body in via stdin so we never write a temp file and never
     // pass user content on argv (where the shell could see it).
     if (child.stdin !== null) {

--- a/src/adapter/omnijs/scriptRunner.ts
+++ b/src/adapter/omnijs/scriptRunner.ts
@@ -51,6 +51,7 @@ import {
 import { logger } from "../../logging/logger.js";
 import { emitTransportCall } from "../../logging/transportCall.js";
 import { probeOmniFocusResponsiveness } from "../_shared/busyProbe.js";
+import { trackChild } from "../_shared/childRegistry.js";
 import { type RetryPolicy, resolveRetryPolicy } from "../_shared/retryPolicy.js";
 import { ensureSpawnFloorCalibration, getSpawnFloorMs } from "../_shared/spawnFloor.js";
 import { getOmniJsCircuit, isCircuitTransient } from "../_shared/transportCircuit.js";
@@ -119,6 +120,9 @@ export const defaultOmniJsSpawner: ScriptSpawner = (wrappedJxaBody, _argsJson, t
         });
       },
     );
+    // Track the child so a SIGINT/SIGTERM mid-flight can terminate it rather
+    // than orphan an osascript process that keeps OmniFocus locked (#839).
+    trackChild(child);
     if (child.stdin !== null) {
       child.stdin.end(wrappedJxaBody, "utf8");
     }

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -31,6 +31,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 // `resolveJsonModule` in tsconfig and tsup's bundler both inline the JSON,
 // so this stays a compile-time constant — no runtime fs read.
 import packageJson from "../../package.json" with { type: "json" };
+import { killActiveChildren } from "../adapter/_shared/childRegistry.js";
 import { configureRetryPolicy } from "../adapter/_shared/retryPolicy.js";
 import { getSpawnFloorMs } from "../adapter/_shared/spawnFloor.js";
 import { configureTransportCircuits } from "../adapter/_shared/transportCircuit.js";
@@ -367,6 +368,11 @@ export async function startServer(): Promise<void> {
   shutdownController.registerQueue(readPool);
   shutdownController.registerQueue(jxaWriteQueue);
   shutdownController.registerQueue(omniJsQueue);
+  // After the queues drain, kill any osascript child still in flight so it
+  // can't outlive the server and keep OmniFocus locked across a restart (#839).
+  shutdownController.registerCleanup("osascript-children", async () => {
+    await killActiveChildren();
+  });
   const adapter = wrapWithConcurrency(router, { readPool, jxaWriteQueue, omniJsQueue });
   const services = composeServices(adapter, config);
 

--- a/src/server/shutdown.test.ts
+++ b/src/server/shutdown.test.ts
@@ -159,3 +159,64 @@ describe("ShutdownController.registerQueue", () => {
     // No assertion needed beyond "doesn't throw"; coverage verifies the branch.
   });
 });
+
+// ---------------------------------------------------------------------------
+// registerCleanup (#839)
+// ---------------------------------------------------------------------------
+
+describe("ShutdownController.registerCleanup", () => {
+  it("runs cleanup hooks before exit", async () => {
+    const ctrl = makeController();
+    const ran: string[] = [];
+    ctrl.registerCleanup("a", () => {
+      ran.push("a");
+    });
+    ctrl.registerCleanup("b", async () => {
+      ran.push("b");
+    });
+    const exitFn = vi.fn();
+    await ctrl.initiate("test", exitFn);
+    expect(ran).toEqual(["a", "b"]); // sequential, in registration order
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it("runs cleanups only after queues have drained", async () => {
+    const ctrl = new ShutdownController({ readGraceMs: 300, writeGraceMs: 300 });
+    const queue = makeQueue("read-pool", 1);
+    ctrl.registerQueue(queue);
+    let pendingWhenCleanupRan = -1;
+    ctrl.registerCleanup("snapshot", () => {
+      pendingWhenCleanupRan = queue.pendingCount();
+    });
+    setTimeout(() => queue.setPending(0), 50);
+    const exitFn = vi.fn();
+    await ctrl.initiate("test", exitFn);
+    expect(pendingWhenCleanupRan).toBe(0); // drain completed first
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+
+  it("continues and still exits when a cleanup hook throws", async () => {
+    const ctrl = makeController();
+    const ran: string[] = [];
+    ctrl.registerCleanup("boom", () => {
+      throw new Error("cleanup failed");
+    });
+    ctrl.registerCleanup("after", () => {
+      ran.push("after");
+    });
+    const exitFn = vi.fn();
+    await ctrl.initiate("test", exitFn);
+    expect(ran).toEqual(["after"]); // later hook still ran
+    expect(exitFn).toHaveBeenCalledWith(0); // and we still exit cleanly
+  });
+
+  it("swallows a rejected async cleanup hook", async () => {
+    const ctrl = makeController();
+    ctrl.registerCleanup("reject", async () => {
+      throw new Error("async cleanup failed");
+    });
+    const exitFn = vi.fn();
+    await expect(ctrl.initiate("test", exitFn)).resolves.toBeUndefined();
+    expect(exitFn).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/server/shutdown.ts
+++ b/src/server/shutdown.ts
@@ -74,9 +74,16 @@ export interface ShutdownControllerOptions {
  * - `registerQueue(q)` — registers a drainable transport queue
  * - `initiate(reason)` — starts the full drain + exit sequence
  */
+/** A named teardown step run after queues drain, before the logger flush. */
+interface CleanupHook {
+  readonly name: string;
+  readonly fn: () => void | Promise<void>;
+}
+
 export class ShutdownController {
   private _shuttingDown = false;
   private readonly _queues: DrainableQueue[] = [];
+  private readonly _cleanups: CleanupHook[] = [];
   private readonly _readGraceMs: number;
   private readonly _writeGraceMs: number;
 
@@ -114,14 +121,26 @@ export class ShutdownController {
   }
 
   /**
+   * Register a teardown step run after queues have drained but before the
+   * logger flush and exit. Use for resources the drain doesn't cover — e.g.
+   * killing spawned `osascript` children that would otherwise be orphaned and
+   * keep OmniFocus locked (#839). Hooks run sequentially in registration order;
+   * a throwing hook is logged and does not block the rest of the sequence.
+   */
+  registerCleanup(name: string, fn: () => void | Promise<void>): void {
+    this._cleanups.push({ name, fn });
+  }
+
+  /**
    * Begin the graceful shutdown sequence. Idempotent — subsequent calls
    * return immediately without re-running the sequence.
    *
    * Sequence:
    *   1. Set `isShuttingDown = true`
    *   2. Drain all registered queues within their grace window
-   *   3. Flush pino logger
-   *   4. `process.exit(0)`
+   *   3. Run registered cleanup hooks (e.g. kill orphan osascript children)
+   *   4. Flush pino logger
+   *   5. `process.exit(0)`
    *
    * @param reason  Human-readable trigger source (e.g. "SIGINT", "SIGTERM").
    * @param exitFn  Injectable exit function; defaults to `process.exit`. Use
@@ -145,6 +164,11 @@ export class ShutdownController {
     // In M0 there are no queues; this resolves immediately.
     const totalGraceMs = this._readGraceMs + this._writeGraceMs;
     await this._drainAll(totalGraceMs);
+
+    // Run teardown hooks (e.g. kill orphan osascript children) after the
+    // graceful drain — anything still in flight past the grace window gets
+    // force-terminated here rather than leaked.
+    await this._runCleanups();
 
     // Flush the pino logger — pino uses a synchronous write to stderr, so
     // `flush()` ensures the last log line is written before exit.
@@ -180,6 +204,24 @@ export class ShutdownController {
         { event: "server.shutdown.drain_timeout", queue: q.name, pending: q.pendingCount() },
         "queue did not drain within grace window; forcing shutdown",
       );
+    }
+  }
+
+  /**
+   * Run registered cleanup hooks sequentially. A hook that throws (or rejects)
+   * is logged and skipped — one failing teardown step must not strand the
+   * others or prevent exit.
+   */
+  private async _runCleanups(): Promise<void> {
+    for (const { name, fn } of this._cleanups) {
+      try {
+        await fn();
+      } catch (err) {
+        logger.warn(
+          { event: "server.shutdown.cleanup_error", cleanup: name, err },
+          "shutdown cleanup hook failed; continuing",
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Track every spawned `osascript` child (JXA + OmniJS runners) in a shared registry (`src/adapter/_shared/childRegistry.ts`) and terminate any survivor at shutdown — `SIGTERM`, then `SIGKILL` after a 2s grace.
- Add a generic `registerCleanup()` teardown step to `ShutdownController`, run after the queue drain and before the logger flush; a throwing hook is logged and skipped so it can't strand the rest of the sequence.
- Document the shutdown audit in `docs/design/concurrency-and-lifecycle.md`.

Closes #839.

## Issue
Implements [#839 — chore(lifecycle): audit graceful shutdown on sigterm and sigint; drain in-flight ops cleanly](https://github.com/torsday/omnifocus-mcp/issues/839).

The pre-existing `ShutdownController` already handled the SIGINT/SIGTERM signal handlers, the read/write drain grace windows, `ServerShuttingDown` for new calls, and exit-0. The one real gap was orphaned `osascript` children, which hold the OmniFocus database locked across a restart — this PR closes it.

### Audit findings (no code needed)
- **Idempotency store + read cache are in-memory** (`Map`-backed). No on-disk state ⇒ nothing to flush, no half-write corruption risk on exit; the drain already lets in-flight writes finish. AC's "flush before exit" item is N/A and documented as such.
- **Telemetry-sink flush** deferred until the opt-in JSONL sink (#823) exists; it should register its own cleanup hook when it lands.

## Breaking change?
- [x] No

## Test plan
- [x] `childRegistry.test.ts` — spawns real child processes; covers tracking, natural-exit pruning, SIGTERM termination, SIGKILL escalation for a SIGTERM-ignoring child, and multi-child sweeps (the issue's "SIGTERM during a long-running call" smoke test, minus the live-OF dependency)
- [x] `shutdown.test.ts` — cleanup hooks run after drain, in order, and survive a throwing/rejecting hook
- [x] Existing JXA/OmniJS scriptRunner suites green (60 tests); full suite green locally (3887 passed)
- [x] Self-reviewed via /review-pr
- [x] No new dependencies