### PR TITLE
fix(strings): code-point-safe truncation across display sites

### DIFF
--- a/docs/design/i18n.md
+++ b/docs/design/i18n.md
@@ -6,3 +6,55 @@
 - **No translation of error messages** in v1 — English only. i18n hooks exist in the error class (each error has a `code`; messages are English strings mapped from code) so future i18n is additive.
 - **Date formatting** uses ISO-8601, which is locale-independent.
 - **User-visible text in task content** is never interpreted by the server — passed through verbatim.
+
+## Unicode-safety audit (#834)
+
+Task / project / tag names and notes routinely contain emoji, CJK, RTL scripts,
+and combining diacritics. This is the audit of every place the server slices,
+sorts, compares, or hashes those strings.
+
+### Truncation — code-point-safe
+
+JavaScript `.length` / `.slice()` count UTF-16 code *units*, so slicing at an
+arbitrary offset can cut a surrogate pair in half and emit a lone surrogate
+(`�` on the wire). All truncation goes through the code-point-safe helpers in
+[`src/domain/text.ts`](../../src/domain/text.ts) (`truncateCodePoints`,
+`truncateWithEllipsis`), which slice on code-point boundaries via `Array.from`:
+
+- `humanReadableSummary` capping (`src/domain/writeSummary.ts`)
+- `*_describe` note previews (`src/tools/{task,project}/{create,update}Describe.ts`)
+- transport error / stdout excerpts (`src/adapter/{jxa,omnijs}/scriptRunner.ts`)
+- the note-preview contract (`src/tools/task/notePreview.ts`, pre-existing #775/#786)
+
+**Scope:** code-point safety (never a lone surrogate) is the contract, *not*
+grapheme-cluster preservation. A ZWJ emoji sequence (e.g. a family glyph joined
+by U+200D) may break into its component code points at the boundary; the result
+is still well-formed Unicode. Grapheme-aware truncation would need
+`Intl.Segmenter` and is deferred until a concrete need surfaces.
+
+### Sorting — locale-aware where it matters
+
+Name-ordered output uses `String.prototype.localeCompare` (e.g. forecast tags,
+agenda, project health), which is Unicode-aware and handles accents sensibly.
+Comparisons over ISO-8601 dates and IDs use raw `<`/`>` — safe because those
+values are ASCII by construction.
+
+### Search / matching — simple case-fold (documented)
+
+Name matching (`findByName`, `waitingOn`, template lookups, the in-memory search
+double) folds case with `String.prototype.toLowerCase()`, which is
+locale-*independent*. This is intentional: locale-sensitive folding
+(`toLocaleLowerCase`) would make matching depend on the server's locale and
+introduce the Turkish dotless-i (`I`/`ı`) and German `ß` surprises. Predictable,
+locale-independent folding is the contract. Combining-accent equivalence is
+*not* normalized before matching — a name in NFC won't match the same name typed
+in NFD. In practice OmniFocus stores names in a single normalization form, so
+this is a theoretical edge; if it ever bites, normalize both sides with
+`.normalize("NFC")` at the match site.
+
+### Hashing — deterministic over UTF-8
+
+Cursor filter hashes and idempotency / cache keys hash `stableStringify(...)`
+output (JSON, UTF-8) and emit hex digests, which are ASCII — safe to `.slice()`.
+Hash inputs are not NFC-normalized, so the NFC-vs-NFD caveat above applies to
+hash identity as well; same rationale, same deferral.

--- a/src/adapter/jxa/scriptRunner.ts
+++ b/src/adapter/jxa/scriptRunner.ts
@@ -26,6 +26,7 @@
 
 import { execFile } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
+import { truncateWithEllipsis } from "../../domain/text.js";
 import {
   ConflictError,
   NotFound,
@@ -353,7 +354,7 @@ async function runJxaScriptInner<T>(
       details: {
         transport: "jxa",
         exitCode: result.exitCode,
-        stderr: truncate(result.stderr, 1024),
+        stderr: truncateWithEllipsis(result.stderr, 1024),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -383,7 +384,7 @@ async function runJxaScriptInner<T>(
       cause,
       details: {
         transport: "jxa",
-        stdoutPreview: truncate(trimmed, 200),
+        stdoutPreview: truncateWithEllipsis(trimmed, 200),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -414,7 +415,7 @@ function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
     return new OmniFocusNotRunning({
       details: {
         transport: "jxa",
-        stderr: truncate(stderr, 512),
+        stderr: truncateWithEllipsis(stderr, 512),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -431,7 +432,7 @@ function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
     return new PermissionDenied({
       details: {
         transport: "jxa",
-        stderr: truncate(stderr, 512),
+        stderr: truncateWithEllipsis(stderr, 512),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -459,7 +460,7 @@ function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
     return new NotFound(stderr, {
       details: {
         transport: "jxa",
-        stderr: truncate(stderr, 512),
+        stderr: truncateWithEllipsis(stderr, 512),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -474,7 +475,7 @@ function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
     return new ValidationError(stderr, {
       details: {
         transport: "jxa",
-        stderr: truncate(stderr, 512),
+        stderr: truncateWithEllipsis(stderr, 512),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -485,16 +486,11 @@ function classifyJxaStderr(stderr: string, scriptName?: string): Error | null {
     return new ConflictError(stderr, {
       details: {
         transport: "jxa",
-        stderr: truncate(stderr, 512),
+        stderr: truncateWithEllipsis(stderr, 512),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
   }
 
   return null;
-}
-
-/** Cap a string to `n` chars so it never balloons an error payload. */
-function truncate(s: string, n: number): string {
-  return s.length <= n ? s : `${s.slice(0, n)}…`;
 }

--- a/src/adapter/omnijs/scriptRunner.ts
+++ b/src/adapter/omnijs/scriptRunner.ts
@@ -40,6 +40,7 @@
 
 import { execFile } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
+import { truncateWithEllipsis } from "../../domain/text.js";
 import {
   OFBusy,
   OmniFocusNotRunning,
@@ -336,7 +337,7 @@ async function runOmniJsScriptInner<T>(
       details: {
         transport: "omnijs",
         exitCode: result.exitCode,
-        stderr: truncate(result.stderr, 1024),
+        stderr: truncateWithEllipsis(result.stderr, 1024),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -368,7 +369,7 @@ async function runOmniJsScriptInner<T>(
       cause,
       details: {
         transport: "omnijs",
-        stdoutPreview: truncate(trimmed, 200),
+        stdoutPreview: truncateWithEllipsis(trimmed, 200),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -425,7 +426,7 @@ function classifyOmniJsStderr(stderr: string, scriptName?: string): Error | null
     return new OmniFocusNotRunning({
       details: {
         transport: "omnijs",
-        stderr: truncate(stderr, 512),
+        stderr: truncateWithEllipsis(stderr, 512),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
@@ -440,16 +441,11 @@ function classifyOmniJsStderr(stderr: string, scriptName?: string): Error | null
     return new PermissionDenied({
       details: {
         transport: "omnijs",
-        stderr: truncate(stderr, 512),
+        stderr: truncateWithEllipsis(stderr, 512),
         ...(scriptName !== undefined ? { scriptName } : {}),
       },
     });
   }
 
   return null;
-}
-
-/** Cap a string to `n` chars so it never balloons an error payload. */
-function truncate(s: string, n: number): string {
-  return s.length <= n ? s : `${s.slice(0, n)}…`;
 }

--- a/src/domain/text.test.ts
+++ b/src/domain/text.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for Unicode-safe string helpers (#834).
+ *
+ * The core invariant under test: truncation never splits a UTF-16 surrogate
+ * pair, so the result is always valid Unicode (no lone surrogate / `�`). The
+ * fixtures cover the categories the audit called out: emoji (astral plane),
+ * ZWJ sequences, CJK, and combining accents.
+ *
+ * @see src/domain/text.ts
+ */
+
+import { describe, expect, it } from "vitest";
+import { codePointLength, ELLIPSIS, truncateCodePoints, truncateWithEllipsis } from "./text.js";
+
+// Fixtures (written as \u escapes so the source file stays ASCII on disk —
+// raw multi-plane chars + a ZWJ make git treat the file as binary).
+const FOX = "\u{1F98A}"; // fox — single astral code point, 2 UTF-16 units
+const CJK = "\u4E2D\u6587"; // CJK "Chinese"
+const CAFE_NFC = "caf\u00E9"; // cafe with precomposed e-acute (NFC)
+const FAMILY = "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}"; // family ZWJ sequence
+
+/** A string has no lone surrogate iff re-encoding round-trips losslessly. */
+function isWellFormed(s: string): boolean {
+  // String#isWellFormed (ES2024) is available on Node 20+; fall back to a
+  // regex for lone surrogates if absent.
+  if (typeof (s as { isWellFormed?: () => boolean }).isWellFormed === "function") {
+    return (s as unknown as { isWellFormed(): boolean }).isWellFormed();
+  }
+  return !/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(s);
+}
+
+describe("codePointLength", () => {
+  it("counts code points, not UTF-16 code units", () => {
+    expect(FOX.length).toBe(2); // sanity: UTF-16 units
+    expect(codePointLength(FOX)).toBe(1);
+    expect(codePointLength(CJK)).toBe(2);
+    expect(codePointLength("ascii")).toBe(5);
+    expect(codePointLength("")).toBe(0);
+  });
+});
+
+describe("truncateCodePoints", () => {
+  it("returns the input unchanged when within budget", () => {
+    expect(truncateCodePoints(CJK, 5)).toBe(CJK);
+    expect(truncateCodePoints("ascii", 5)).toBe("ascii");
+  });
+
+  it("never splits a surrogate pair at the boundary", () => {
+    // "🦊🦊🦊" is 6 UTF-16 units / 3 code points. A naive .slice(0, 3) would
+    // cut the second fox in half. We cut on code points instead.
+    const foxes = FOX.repeat(3);
+    const out = truncateCodePoints(foxes, 2);
+    expect(codePointLength(out)).toBe(2);
+    expect(out).toBe(FOX.repeat(2));
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("handles max <= 0 as empty", () => {
+    expect(truncateCodePoints("anything", 0)).toBe("");
+    expect(truncateCodePoints("anything", -3)).toBe("");
+  });
+
+  it("keeps a multibyte char whole at exactly the boundary", () => {
+    const mixed = `ab${FOX}cd`; // a b 🦊 c d — 5 code points
+    expect(truncateCodePoints(mixed, 3)).toBe(`ab${FOX}`);
+    expect(isWellFormed(truncateCodePoints(mixed, 3))).toBe(true);
+  });
+});
+
+describe("truncateWithEllipsis", () => {
+  it("returns the input unchanged when within budget", () => {
+    expect(truncateWithEllipsis("short", 10)).toBe("short");
+    expect(truncateWithEllipsis(CAFE_NFC, 10)).toBe(CAFE_NFC);
+  });
+
+  it("appends an ellipsis and stays within the code-point budget", () => {
+    const out = truncateWithEllipsis("a".repeat(150), 140);
+    expect(codePointLength(out)).toBe(140);
+    expect(out.endsWith(ELLIPSIS)).toBe(true);
+  });
+
+  it("never splits a surrogate pair, even with the ellipsis reservation", () => {
+    const foxes = FOX.repeat(10); // 10 code points
+    const out = truncateWithEllipsis(foxes, 4); // 3 foxes + …
+    expect(out).toBe(`${FOX.repeat(3)}${ELLIPSIS}`);
+    expect(codePointLength(out)).toBe(4);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("cuts a ZWJ emoji sequence without producing a lone surrogate", () => {
+    // Code-point safety is the contract — the family glyph may break into its
+    // component people, but the result must still be well-formed Unicode.
+    const out = truncateWithEllipsis(`${FAMILY}${FAMILY}`, 4);
+    expect(isWellFormed(out)).toBe(true);
+    expect(codePointLength(out)).toBe(4);
+  });
+});

--- a/src/domain/text.ts
+++ b/src/domain/text.ts
@@ -1,0 +1,63 @@
+/**
+ * Unicode-safe string helpers (#834).
+ *
+ * JavaScript's `String.prototype.length` and `.slice()` operate on UTF-16 code
+ * *units*, not Unicode code *points*. Slicing at an arbitrary code-unit offset
+ * can cut a surrogate pair in half — a 4-byte emoji (👨, 🦊, …) or any
+ * astral-plane character (many CJK extensions) becomes a lone surrogate, which
+ * serializes as the replacement character `�` or invalid UTF-8 on the wire.
+ *
+ * These helpers slice on code-point boundaries via `Array.from`, so a multibyte
+ * character at the cut point is kept whole or dropped whole — never split.
+ *
+ * Scope note: code-point safety is the contract here, *not* grapheme-cluster
+ * preservation. A ZWJ emoji sequence (e.g. 👨‍👩‍👧, a family glyph made of
+ * several code points joined by U+200D) may still be cut between its component
+ * code points at the boundary. Preventing that would require `Intl.Segmenter`
+ * and a grapheme-aware budget; the wire-safety bug these helpers fix is the
+ * surrogate split, which `Array.from` resolves. See `docs/design/i18n.md`.
+ *
+ * @see src/tools/task/notePreview.ts — the note-preview contract uses the same
+ *   `Array.from` code-point slicing for its dedicated `notePreview` window.
+ */
+
+/** Ellipsis appended by {@link truncateWithEllipsis} (one code point, U+2026). */
+export const ELLIPSIS = "…";
+
+/**
+ * Count the Unicode code points in `s` (not UTF-16 code units).
+ *
+ * `"🦊".length` is 2 (a surrogate pair); `codePointLength("🦊")` is 1.
+ */
+export function codePointLength(s: string): number {
+  // Array.from iterates by code point, honouring surrogate pairs.
+  return Array.from(s).length;
+}
+
+/**
+ * Return the first `max` code points of `s`, never splitting a surrogate pair.
+ * No ellipsis is appended — use this when the caller wants a raw prefix (e.g. a
+ * fixed-width preview column). `max <= 0` returns the empty string.
+ */
+export function truncateCodePoints(s: string, max: number): string {
+  if (max <= 0) return "";
+  const cps = Array.from(s);
+  if (cps.length <= max) return s;
+  return cps.slice(0, max).join("");
+}
+
+/**
+ * Truncate `s` to at most `max` code points *including* a trailing ellipsis.
+ * Strings already within budget are returned unchanged; longer strings are cut
+ * to `max - 1` code points plus `…`, so the result is never longer than `max`
+ * code points and never splits a surrogate pair.
+ *
+ * `max < 1` is treated as 1 (just the ellipsis) to keep the result non-empty
+ * for any over-budget input.
+ */
+export function truncateWithEllipsis(s: string, max: number): string {
+  const cps = Array.from(s);
+  if (cps.length <= max) return s;
+  const budget = Math.max(max - 1, 0);
+  return cps.slice(0, budget).join("") + ELLIPSIS;
+}

--- a/src/domain/writeSummary.ts
+++ b/src/domain/writeSummary.ts
@@ -8,6 +8,8 @@
  * - No model calls — purely template-driven
  */
 
+import { truncateWithEllipsis } from "./text.js";
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -16,8 +18,12 @@ function q(name: string): string {
   return `'${name}'`;
 }
 
+/**
+ * Cap a summary at 140 code points (per ADR-0015 §3), code-point-safe so a
+ * multibyte name at the boundary isn't split into a lone surrogate (#834).
+ */
 function cap(s: string): string {
-  return s.length > 140 ? `${s.slice(0, 137)}…` : s;
+  return truncateWithEllipsis(s, 140);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/project/createDescribe.ts
+++ b/src/tools/project/createDescribe.ts
@@ -6,6 +6,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { truncateCodePoints } from "../../domain/text.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { formatDate, resolveFolderName, resolveTagName } from "../describe/prose.js";
 import type { ChangeRecord } from "../describe/types.js";
@@ -63,7 +64,7 @@ export async function handleProjectCreateDescribe(
     parts.push(`tagged ${tagNames.map((n) => `'${n}'`).join(", ")}`);
   }
   if (input.note !== undefined) {
-    changes.push({ field: "note", newValue: input.note.slice(0, 50) });
+    changes.push({ field: "note", newValue: truncateCodePoints(input.note, 50) });
   }
 
   const description = `Would create project ${parts.join(", ")}.`;

--- a/src/tools/project/updateDescribe.ts
+++ b/src/tools/project/updateDescribe.ts
@@ -6,6 +6,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { truncateCodePoints } from "../../domain/text.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { formatDate, resolveTagName } from "../describe/prose.js";
 import type { ChangeRecord } from "../describe/types.js";
@@ -81,7 +82,7 @@ export async function handleProjectUpdateDescribe(
     if (input.note !== undefined) {
       changes.push({
         field: "note",
-        newValue: input.note === null ? null : input.note.slice(0, 50),
+        newValue: input.note === null ? null : truncateCodePoints(input.note, 50),
       });
       parts.push(input.note === null ? "clear note" : "update note");
     }

--- a/src/tools/task/createDescribe.ts
+++ b/src/tools/task/createDescribe.ts
@@ -6,6 +6,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { truncateCodePoints } from "../../domain/text.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import {
   formatDate,
@@ -72,7 +73,7 @@ export async function handleTaskCreateDescribe(
     parts.push(`tagged ${tagNames.map((n) => `'${n}'`).join(", ")}`);
   }
   if (input.note !== undefined) {
-    changes.push({ field: "note", newValue: input.note.slice(0, 50) });
+    changes.push({ field: "note", newValue: truncateCodePoints(input.note, 50) });
   }
 
   const description = `Would create task ${parts.join(", ")}.`;

--- a/src/tools/task/updateDescribe.ts
+++ b/src/tools/task/updateDescribe.ts
@@ -6,6 +6,7 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OmniFocusAdapter } from "../../adapter/OmniFocusAdapter.js";
+import { truncateCodePoints } from "../../domain/text.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
 import { formatDate, resolveTagName } from "../describe/prose.js";
 import type { ChangeRecord } from "../describe/types.js";
@@ -103,7 +104,7 @@ export async function handleTaskUpdateDescribe(
     if (input.note !== undefined) {
       changes.push({
         field: "note",
-        newValue: input.note === null ? null : input.note.slice(0, 50),
+        newValue: input.note === null ? null : truncateCodePoints(input.note, 50),
       });
       parts.push(input.note === null ? "clear note" : "update note");
     }


### PR DESCRIPTION
## Summary
- Add a shared code-point-safe truncation helper (`src/domain/text.ts`: `truncateCodePoints`, `truncateWithEllipsis`, `codePointLength`) and route every display truncation through it, so an emoji/CJK char at a boundary is never split into a lone surrogate.
- Fixed sites: `humanReadableSummary` capping (`domain/writeSummary.ts`), the four `*_describe` note previews, and the transport error/stdout excerpts — the latter consolidating two duplicate local `truncate()` helpers in the JXA/OmniJS script runners.
- Documented the full audit (sort/search/hash) in `docs/design/i18n.md`.

Closes #834.

## Issue
Implements [#834 — chore(strings): non-ascii safety audit across truncation, sort, hash, and search](https://github.com/torsday/omnifocus-mcp/issues/834). See `docs/design/i18n.md` for the audit writeup.

### Audit findings
- **Truncation** — the only real bugs: UTF-16 `.slice()` on multibyte-capable strings. Fixed (above). Note-preview (`notePreview.ts`) was already code-point-safe from #775/#786.
- **Sort** — already uses locale-aware `localeCompare`; other comparisons are over ISO dates / IDs (ASCII). No change.
- **Search / matching** — `toLowerCase()` (locale-*independent*) is intentional; documented (avoids Turkish-i / German-ß surprises).
- **Hash** — deterministic over UTF-8, hex digests are ASCII. No change.
- NFC-vs-NFD equivalence in matching/hashing noted as a deferred theoretical edge (OF stores one normalization form).

## Breaking change?
- [x] No

## Test plan
- [x] `src/domain/text.test.ts` — emoji (astral), ZWJ family sequence, CJK, combining-accent, surrogate-boundary fixtures; asserts results stay well-formed Unicode (`isWellFormed`) and within the code-point budget
- [x] Existing `writeSummary` / scriptRunner / describe suites green
- [x] Full suite green locally (pre-push)
- [x] Self-reviewed via /review-pr; net-negative on the duplicated truncate logic
- [x] No new dependencies