### PR TITLE
chore(tools): document canonical verb vocabulary; add naming lint

### DIFF
--- a/docs/design/tool-vocabulary.md
+++ b/docs/design/tool-vocabulary.md
@@ -1,0 +1,84 @@
+# Tool naming — canonical verb vocabulary (#837)
+
+Tool names follow a `<resource>_<verb>[_<qualifier>]` grammar. A consistent
+verb-per-action lets the agent apply a pattern instead of memorising a different
+verb for each resource, which measurably improves tool-selection accuracy and
+lets descriptions stay terse (pairs with the description audit, #814).
+
+This document is the canonical vocabulary. The
+[`naming.lint.test.ts`](../../src/tools/naming.lint.test.ts) gate enforces it by
+rejecting non-canonical synonyms (`add`, `remove`, `new`, … ) in new tool names.
+
+## Canonical verbs
+
+### Read
+
+| Verb       | Meaning                                              | Examples                                  |
+| ---------- | --------------------------------------------------- | ----------------------------------------- |
+| `get`      | Fetch a single entity by id                         | `task_get`, `project_get`, `tag_get`      |
+| `get_many` | Fetch multiple entities by a list of ids            | `task_get_many`, `project_get_many`       |
+| `list`     | Paginated listing of a collection                   | `task_list`, `folder_list`, `webhook_list`|
+| `search`   | Query by predicate / free text                      | `task_search`, `search_query`             |
+
+### Create / update / delete (CRUD)
+
+| Verb     | Meaning                                  | Examples                              |
+| -------- | ---------------------------------------- | ------------------------------------- |
+| `create` | Make a new entity                        | `task_create`, `project_create`       |
+| `update` | In-place edit of one or more fields      | `task_update`, `tag_update`           |
+| `delete` | Hard removal                             | `task_delete`, `perspective_delete`   |
+
+Use `create` — **never** `add` or `new`. Use `delete` — **never** `remove` or
+`destroy`. Use `update` — **never** `modify`, `edit`, or `rename`.
+
+### Single-aspect mutation
+
+`set_<aspect>` / `clear_<aspect>` mutate one specific facet of an entity, as
+distinct from `update` (a general multi-field patch). Use these when the action
+targets a single named attribute with its own semantics.
+
+- `task_set_alarms` / `task_clear_alarms`
+- `task_set_repetition` / `task_clear_repetition`
+- `task_set_waiting_on` / `task_clear_waiting_on`
+- `tag_set_status`, `tag_set_location`, `tag_set_allows_next_action`
+- `project_set_next_review_date`, `review_set_interval`, `forecast_set_tag`
+- `note_set` / `note_append` / `note_get` (and `_html` variants)
+
+### Lifecycle transitions
+
+| Verb        | Inverse      | Examples                          |
+| ----------- | ------------ | --------------------------------- |
+| `complete`  | `uncomplete` | `task_complete`, `task_uncomplete`|
+| `drop`      | `undrop`     | `task_drop`, `task_undrop`        |
+| `move`      | —            | `task_move`, `folder_move`        |
+
+### Qualifiers (suffixes)
+
+| Suffix       | Meaning                                                       |
+| ------------ | ------------------------------------------------------------ |
+| `_describe`  | Dry-run preview of a write; returns planned changes, no edit |
+| `_dry_run`   | Evaluate-only variant (e.g. `perspective_evaluate_dry_run`)  |
+| `batch_*`    | Bulk variant operating on an array (`task_batch_create`, …)  |
+| `_smart`     | Intent/NL-driven variant (`task_defer_smart`)               |
+
+## Documented exceptions
+
+These deviate from the vocabulary for a justified reason (encoded in the lint's
+`VERB_SYNONYM_EXCEPTIONS`):
+
+- `app_window_new`, `app_window_new_tab` — `new` is correct here: a UI action
+  that opens a new window/tab, not the creation of a persisted domain object.
+- `attachment_add`, `attachment_remove` — **legacy outliers.** They should be
+  `attachment_create` / `attachment_delete` to match the CRUD vocabulary.
+  Renaming is a breaking change requiring a deprecation window (old name aliases
+  to new for one minor, `tool.deprecated` logged, dropped next major), so it is
+  tracked as a separate breaking follow-up rather than done here.
+
+## Non-CRUD action tools
+
+Some tools are imperative actions, not resource CRUD, and name themselves after
+the action directly: `app_launch`, `sync_trigger`, `plugin_invoke`,
+`database_undo`/`database_redo`, `task_reorder`, `task_reclassify`,
+`task_convert_to_project`, `task_duplicate`, `*_mark_reviewed`,
+`import_*` / `export_*`, `run_jxa_script` / `run_omnijs_script`. These are
+intentional and outside the CRUD grammar.

--- a/src/tools/naming.lint.test.ts
+++ b/src/tools/naming.lint.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tool-name verb-consistency lint — CI gate (#837).
+ *
+ * Tool names follow a canonical `<resource>_<verb>[_<qualifier>]` grammar so the
+ * agent can apply a pattern instead of memorising a verb-per-resource. The
+ * canonical verb vocabulary is documented in `docs/design/tool-vocabulary.md`.
+ *
+ * This lint is the *active counter-pressure*: it fails CI when a tool name uses
+ * a non-canonical synonym of an approved verb (e.g. `add` instead of `create`,
+ * `remove` instead of `delete`). It does not try to validate the entire grammar
+ * — that would be brittle across 143 heterogeneous tools — it targets the
+ * specific drift #837 calls out: synonym verbs that mean the same action.
+ *
+ * To fix a violation: rename the tool to use the canonical verb (a breaking
+ * change — plan a deprecation window), or, for a legitimate non-CRUD use of the
+ * word, add a documented entry to {@link VERB_SYNONYM_EXCEPTIONS}.
+ *
+ * @see docs/design/tool-vocabulary.md — the canonical vocabulary
+ * @see src/tools/descriptions.lint.test.ts — sibling lint for descriptions
+ */
+
+import { describe, expect, it } from "vitest";
+import { ALL_TOOL_DESCRIPTIONS } from "./allDescriptions.js";
+
+/**
+ * Non-canonical verb tokens mapped to the canonical verb they should be. A tool
+ * name containing one of these underscore-delimited tokens fails the lint unless
+ * it is listed in {@link VERB_SYNONYM_EXCEPTIONS}.
+ */
+const BANNED_VERB_SYNONYMS: Readonly<Record<string, string>> = {
+  add: "create",
+  remove: "delete",
+  new: "create",
+  destroy: "delete",
+  fetch: "get",
+  modify: "update",
+  edit: "update",
+  rename: "update",
+};
+
+/**
+ * Tool names exempt from a specific banned-token rule, each with a reason.
+ *
+ * Keep this list short and justified. Two kinds of entry:
+ *  - **Legitimate non-CRUD use**: the word isn't acting as a CRUD verb.
+ *  - **Legacy outlier pending rename**: tracked by a breaking follow-up issue;
+ *    remove the entry when the rename lands.
+ */
+const VERB_SYNONYM_EXCEPTIONS: ReadonlyMap<string, string> = new Map([
+  // `new` here means "open a new window/tab" — a UI surface action, not the
+  // creation of a persisted domain object, so `create` would be misleading.
+  ["app_window_new", "UI action: opens a new window (not domain CRUD)"],
+  ["app_window_new_tab", "UI action: opens a new tab (not domain CRUD)"],
+  // Legacy outliers: should be attachment_create / attachment_delete. Rename is
+  // a breaking change tracked in a follow-up (deprecation window required).
+  ["attachment_add", "legacy outlier — rename to attachment_create tracked in follow-up"],
+  ["attachment_remove", "legacy outlier — rename to attachment_delete tracked in follow-up"],
+]);
+
+/** Split a tool name into its underscore-delimited tokens. */
+function tokensOf(toolName: string): string[] {
+  return toolName.split("_");
+}
+
+describe("tool names — verb-consistency lint (#837)", () => {
+  it("no tool name uses a non-canonical verb synonym", () => {
+    const violations: string[] = [];
+
+    for (const name of Object.keys(ALL_TOOL_DESCRIPTIONS)) {
+      if (VERB_SYNONYM_EXCEPTIONS.has(name)) continue;
+      for (const token of tokensOf(name)) {
+        const canonical = BANNED_VERB_SYNONYMS[token];
+        if (canonical !== undefined) {
+          violations.push(`  ${name}: uses "${token}" — canonical verb is "${canonical}"`);
+          break;
+        }
+      }
+    }
+
+    const report =
+      violations.length === 0
+        ? ""
+        : [
+            "Non-canonical verb(s) found in tool names. Use the canonical verb",
+            "(see docs/design/tool-vocabulary.md), or add a justified exception",
+            "to VERB_SYNONYM_EXCEPTIONS in this file:",
+            ...violations,
+          ].join("\n");
+
+    expect(report, report).toBe("");
+  });
+
+  it("every exception still corresponds to a real tool (no stale entries)", () => {
+    const stale = [...VERB_SYNONYM_EXCEPTIONS.keys()].filter(
+      (name) => !(name in ALL_TOOL_DESCRIPTIONS),
+    );
+    expect(stale, `stale VERB_SYNONYM_EXCEPTIONS entries: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  it("registry is non-empty (guard against accidental empty import)", () => {
+    expect(Object.keys(ALL_TOOL_DESCRIPTIONS).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Audit all 143 tool names (#837): naming is near-universally consistent with a `<resource>_<verb>[_<qualifier>]` grammar.
- Document the canonical verb vocabulary in `docs/design/tool-vocabulary.md` (read / CRUD / single-aspect `set_*`/`clear_*` / lifecycle / qualifiers).
- Add `src/tools/naming.lint.test.ts` as active counter-pressure: it rejects non-canonical verb synonyms (`add`/`remove`/`new`/`modify`/…) in new tool names, mirroring the existing `descriptions.lint` gate.

Closes #837.

## Issue
Implements [#837 — chore(tools): audit verb consistency; document canonical vocabulary](https://github.com/torsday/omnifocus-mcp/issues/837).

### Audit outcome
The only genuinely-misleading outliers are `attachment_add` / `attachment_remove` (should be `create` / `delete`). Renaming is **breaking** and needs a deprecation window, so it is exempted in the lint (with a reason) and tracked as a breaking follow-up — **#1051** — rather than done here. `app_window_new` / `app_window_new_tab` are documented as legitimate (UI actions, not domain CRUD).

This delivers AC items 1–3 (inventory, canonical vocabulary, identify renames + enforcement); AC item 4 (execute the renames with a deprecation window) is the breaking follow-up #1051.

## Breaking change?
- [x] No (documentation + new lint only; no tool renamed in this PR)

## Test plan
- [x] `naming.lint.test.ts` passes (enforces the vocabulary; exempts the two documented outliers and verifies no stale exemptions)
- [x] `pnpm typecheck`, `pnpm lint` (incl. doc-size + docs:check) green
- [x] Full suite green in pre-push
- [x] Self-reviewed via /review-pr
- [x] No new dependencies