### PR TITLE
feat(envelope): add maxOutputBytes cap with truncation envelope (#776)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4537,6 +4537,7 @@ List tasks in OmniFocus with optional filters (project, tag, inbox, flagged, com
 | `verbose` | boolean | No | When true, return the full unelided task shape (every field present, even at defaults). Default: false — fields equal to their documented default (flagged: false, completed: false, tagIds: [], note: null, dueDate: null, etc.) are omitted from the wire payload. An omitted field means the default applies. See docs/token-cost.md for the full defaults table. |
 | `fields` | string[] | No | Restrict each returned task to this list of top-level fields (id is always returned). Omit for the full task shape. Empty array returns just id. Unknown names surface in meta.warnings.WARN_UNKNOWN_FIELDS. |
 | `includeLinks` | boolean | No | When true, each task carries a `_links` HATEOAS block (self, project, parent, tags). Default false — the block is omitted to save payload size. Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead. |
+| `maxOutputBytes` | number | No | Cap the serialized byte size of the returned tasks[] array. When the response would exceed this, the server returns as many whole tasks as fit, sets meta.truncatedAtCap=true with meta.bytesReturned and meta.itemsReturned, and returns a pagination cursor that resumes at the first dropped task. Omit for no cap. Values above the server's hard ceiling (~1 MiB) are clamped. A single task larger than the cap is still returned whole so pagination always advances. |
 
 ### Example call
 

--- a/src/envelope/CLAUDE.md
+++ b/src/envelope/CLAUDE.md
@@ -9,7 +9,7 @@ Tool-response envelope contracts. The success-path of every read tool flows thro
 1. **Project** (planned, [#773](https://github.com/torsday/omnifocus-mcp/issues/773)) — keep only the fields the caller asked for via `fields[]`. Done first because the next steps shouldn't waste work on fields about to be dropped.
 2. **Elide** (`elideDefaults.ts` + `defaultsRegistry.ts`) — drop fields equal to their documented default per `docs/token-cost.md`. Tools accept `verbose: true` to bypass.
 3. **Truncate** (`src/tools/task/notePreview.ts`, [#775](https://github.com/torsday/omnifocus-mcp/issues/775)) — replace long `note` with `notePreview` + `noteTruncated` + `noteLength`. `notePreviewChars: -1` opts out.
-4. **Cap** (planned, [#776](https://github.com/torsday/omnifocus-mcp/issues/776)) — hard wire-byte ceiling with truncation envelope. Last so it sees the post-elide post-truncate size.
+4. **Cap** (`cap.ts`, [#776](https://github.com/torsday/omnifocus-mcp/issues/776)) — `applyByteCap` enforces an optional `maxOutputBytes` wire-byte ceiling, trimming whole items and re-anchoring the continuation cursor at the last kept one. Last so it sees the post-elide post-truncate size. Wired into `task_list` as the reference; remaining heavy-read tools tracked as a follow-up. Each tool supplies a `cursorFor` callback that resumes at the first dropped item (see `taskService.cursorForListItem`).
 
 If you add a new transformation, decide which step in the pipeline it belongs to before writing it. Two transformations in the same step should commute; if they don't, they're separate steps.
 

--- a/src/envelope/cap.test.ts
+++ b/src/envelope/cap.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the wire-byte cap (#776) — the final stage of the response
+ * envelope pipeline. Covers the no-op path, mid-result truncation, the
+ * forward-progress guarantee, hard-ceiling clamping, and the env parse rule.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyByteCap,
+  type ByteCapOptions,
+  DEFAULT_HARD_CEILING_BYTES,
+  resolveHardCeilingBytes,
+} from "./cap.js";
+
+// Each `{ id: "a" }` serializes to `{"id":"a"}` = 10 bytes; the array adds 2 for
+// the `[]` framing and 1 comma between items.
+const item = (id: string) => ({ id });
+const cursorFor = (i: number) => `cursor@${i}`;
+
+function cap<T>(items: readonly T[], opts: Partial<ByteCapOptions> = {}) {
+  return applyByteCap(items, { cursorFor, ...opts });
+}
+
+describe("applyByteCap — no-op paths", () => {
+  it("returns an empty array unchanged", () => {
+    const r = cap([]);
+    expect(r).toMatchObject({
+      truncatedAtCap: false,
+      bytesReturned: 2,
+      itemsReturned: 0,
+      cursor: null,
+    });
+    expect(r.items).toEqual([]);
+  });
+
+  it("does not cap when maxOutputBytes is undefined", () => {
+    const items = [item("a"), item("b"), item("c")];
+    const r = cap(items);
+    expect(r.truncatedAtCap).toBe(false);
+    expect(r.items).toBe(items); // same reference — no slice
+    expect(r.itemsReturned).toBe(3);
+    expect(r.cursor).toBeNull();
+  });
+
+  it("does not cap when the array fits under maxOutputBytes", () => {
+    const items = [item("a"), item("b")];
+    // 2 framing + 10 + 1 comma + 10 = 23 bytes
+    const r = cap(items, { maxOutputBytes: 100 });
+    expect(r.truncatedAtCap).toBe(false);
+    expect(r.bytesReturned).toBe(23);
+    expect(r.itemsReturned).toBe(2);
+    expect(r.cursor).toBeNull();
+  });
+});
+
+describe("applyByteCap — truncation", () => {
+  it("trims mid-result and re-anchors the cursor at the last kept item", () => {
+    const items = [item("a"), item("b"), item("c")];
+    // cap 22: item0 → 2+10=12; item1 → 12+1+10=23 > 22 → stop at 1 kept
+    const r = cap(items, { maxOutputBytes: 22 });
+    expect(r.truncatedAtCap).toBe(true);
+    expect(r.itemsReturned).toBe(1);
+    expect(r.bytesReturned).toBe(12);
+    expect(r.items).toEqual([item("a")]);
+    expect(r.cursor).toBe("cursor@0");
+  });
+
+  it("keeps exactly the items that fit (boundary equal to cap)", () => {
+    const items = [item("a"), item("b"), item("c")];
+    // cap 23: keeps 2 (12 then 23), item2 would be 34 > 23
+    const r = cap(items, { maxOutputBytes: 23 });
+    expect(r.itemsReturned).toBe(2);
+    expect(r.bytesReturned).toBe(23);
+    expect(r.cursor).toBe("cursor@1");
+  });
+
+  it("only calls cursorFor when truncation actually occurs", () => {
+    const spy = vi.fn(cursorFor);
+    cap([item("a")], { maxOutputBytes: 1000, cursorFor: spy });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyByteCap — forward-progress guarantee", () => {
+  it("returns a single oversized item rather than an empty page when more follow", () => {
+    const items = [item("aaaaaaaaaa"), item("b")];
+    // first item alone exceeds a tiny cap, but is kept so pagination advances
+    const r = cap(items, { maxOutputBytes: 5 });
+    expect(r.itemsReturned).toBe(1);
+    expect(r.truncatedAtCap).toBe(true);
+    expect(r.cursor).toBe("cursor@0");
+  });
+
+  it("does not mark truncated when a lone oversized item is the whole array", () => {
+    const r = cap([item("aaaaaaaaaa")], { maxOutputBytes: 5 });
+    expect(r.itemsReturned).toBe(1);
+    expect(r.truncatedAtCap).toBe(false);
+    expect(r.cursor).toBeNull();
+  });
+});
+
+describe("applyByteCap — hard ceiling", () => {
+  it("clamps a pathological maxOutputBytes to the hard ceiling", () => {
+    const items = [item("a"), item("b"), item("c")];
+    const r = cap(items, { maxOutputBytes: Number.MAX_SAFE_INTEGER, hardCeilingBytes: 12 });
+    expect(r.truncatedAtCap).toBe(true);
+    expect(r.itemsReturned).toBe(1); // ceiling 12 → only first item fits
+  });
+});
+
+describe("resolveHardCeilingBytes", () => {
+  it("defaults when the env var is absent", () => {
+    expect(resolveHardCeilingBytes(undefined)).toBe(DEFAULT_HARD_CEILING_BYTES);
+  });
+
+  it("accepts a positive integer", () => {
+    expect(resolveHardCeilingBytes("2048")).toBe(2048);
+  });
+
+  it.each(["0", "-5", "abc", "1.5", ""])("falls back to the default for %j", (raw) => {
+    expect(resolveHardCeilingBytes(raw)).toBe(DEFAULT_HARD_CEILING_BYTES);
+  });
+});

--- a/src/envelope/cap.ts
+++ b/src/envelope/cap.ts
@@ -1,0 +1,128 @@
+/**
+ * Wire-byte cap — the final stage of the response envelope pipeline
+ * (`project → elide → truncate → cap`; see `src/envelope/CLAUDE.md`).
+ *
+ * Even after projection, default-elision, and note-truncation, a heavy read can
+ * still return a surprising payload — e.g. `task_list` over a database with
+ * thousands of tasks. `applyByteCap` lets a caller pre-commit to an upper bound
+ * on the serialized size of the result array: items are appended until the next
+ * one would push the wire size past the cap, then the response is finalized with
+ * a continuation cursor so the caller resumes exactly where the page was cut.
+ *
+ * Because the cap runs last, it measures the *actual* post-transform wire size
+ * of each item, not the pre-trim size (#776).
+ *
+ * Invariants:
+ * - **Unset cap is a no-op.** `maxOutputBytes: undefined` ⇒ effective cap is
+ *   `Infinity` ⇒ every item is returned and `truncatedAtCap` is false. Existing
+ *   behavior is unchanged for callers that don't opt in.
+ * - **Hard ceiling clamps the caller.** Even `maxOutputBytes: MAX_SAFE_INTEGER`
+ *   is clamped to the server ceiling so a pathological input can't defeat the cap.
+ * - **Forward progress is guaranteed.** At least one item is always returned, so
+ *   a single item larger than the cap is emitted whole (with `truncatedAtCap`
+ *   true and a cursor) rather than yielding an empty, non-advancing page.
+ *
+ * @see src/envelope/CLAUDE.md — pipeline composition order
+ * @see docs/adr/0013-tool-response-envelope.md — response envelope contract
+ */
+
+// ---------------------------------------------------------------------------
+// Hard ceiling
+// ---------------------------------------------------------------------------
+
+/** Absolute server-side ceiling on the effective cap, regardless of caller input. */
+export const DEFAULT_HARD_CEILING_BYTES = 1024 * 1024; // 1 MiB
+
+/**
+ * Resolve the hard-ceiling override from a raw env string. Invalid, non-positive,
+ * or absent values fall back to {@link DEFAULT_HARD_CEILING_BYTES}. Exported for
+ * unit coverage of the parse rule.
+ */
+export function resolveHardCeilingBytes(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_HARD_CEILING_BYTES;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : DEFAULT_HARD_CEILING_BYTES;
+}
+
+/**
+ * Env-resolved hard ceiling, read once at module load — matches the
+ * `OMNIFOCUS_LEGACY_TEXT_CONTENT` precedent in `src/envelope/index.ts`. The env
+ * var does not re-read between calls; tests override per-call via
+ * {@link ByteCapOptions.hardCeilingBytes}.
+ */
+const HARD_CEILING_BYTES = resolveHardCeilingBytes(process.env.OMNIFOCUS_MAX_OUTPUT_BYTES_CEILING);
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Outcome of {@link applyByteCap}. */
+export interface ByteCapResult<T> {
+  /** The retained prefix of the input array (the same array reference when not truncated). */
+  items: T[];
+  /** True when at least one item was dropped to satisfy the cap. */
+  truncatedAtCap: boolean;
+  /** Serialized byte size of the returned array (`[]` framing + items + commas). */
+  bytesReturned: number;
+  /** Number of items in {@link items}. */
+  itemsReturned: number;
+  /** Continuation cursor anchored at the last kept item; `null` when not truncated. */
+  cursor: string | null;
+}
+
+/** Options for {@link applyByteCap}. */
+export interface ByteCapOptions {
+  /** Caller's requested cap in bytes; `undefined` ⇒ no cap (only framing measured). */
+  maxOutputBytes?: number;
+  /**
+   * Build a continuation cursor anchored at the item at `lastKeptIndex`. Only
+   * called when the response is actually truncated. The cursor must resume at
+   * the first dropped item — i.e. it is anchored at `items[lastKeptIndex]`.
+   */
+  cursorFor: (lastKeptIndex: number) => string;
+  /** Override the hard ceiling (testing). Defaults to the env-resolved ceiling. */
+  hardCeilingBytes?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a wire-byte cap to a list-response array.
+ *
+ * @param items - the fully-transformed (projected/elided/truncated) wire items
+ * @param opts - cap value, cursor builder, optional ceiling override
+ * @returns the retained prefix plus the truncation signal, byte/item counts,
+ *   and a re-anchored continuation cursor when truncation occurred
+ */
+export function applyByteCap<T>(items: readonly T[], opts: ByteCapOptions): ByteCapResult<T> {
+  const ceiling = opts.hardCeilingBytes ?? HARD_CEILING_BYTES;
+  const cap =
+    opts.maxOutputBytes === undefined
+      ? Number.POSITIVE_INFINITY
+      : Math.min(opts.maxOutputBytes, ceiling);
+
+  // Array framing: `[` + `]`. Each item adds its JSON bytes plus a leading comma
+  // for every item after the first.
+  let bytes = 2;
+  let kept = 0;
+  for (let i = 0; i < items.length; i++) {
+    const itemBytes = Buffer.byteLength(JSON.stringify(items[i]) ?? "null", "utf8");
+    const sep = i === 0 ? 0 : 1; // comma separator
+    const next = bytes + sep + itemBytes;
+    // Never drop the first item — guarantees forward progress past an oversized row.
+    if (i > 0 && next > cap) break;
+    bytes = next;
+    kept = i + 1;
+  }
+
+  const truncatedAtCap = kept < items.length;
+  return {
+    items: truncatedAtCap ? items.slice(0, kept) : (items as T[]),
+    truncatedAtCap,
+    bytesReturned: bytes,
+    itemsReturned: kept,
+    cursor: truncatedAtCap ? opts.cursorFor(kept - 1) : null,
+  };
+}

--- a/src/envelope/index.ts
+++ b/src/envelope/index.ts
@@ -95,6 +95,20 @@ export function warnResultTruncated(limit: number): Warning {
   };
 }
 
+/**
+ * Build a `WARN_RESULT_TRUNCATED` warning when a `maxOutputBytes` cap trims a
+ * list response (#776). Reuses the existing code — `WARN_RESULT_TRUNCATED`
+ * covers a hard size *or* count ceiling — with byte-oriented detail.
+ */
+export function warnResultTruncatedBytes(bytesReturned: number, itemsReturned: number): Warning {
+  return {
+    code: "WARN_RESULT_TRUNCATED",
+    message: `Response was truncated at the maxOutputBytes cap; returned ${itemsReturned} item(s) (${bytesReturned} bytes).`,
+    suggestion: "Fetch the next page with the returned pagination cursor, or raise maxOutputBytes.",
+    details: { bytesReturned, itemsReturned },
+  };
+}
+
 /** Build a `WARN_SYNC_PENDING` warning on mutation responses. */
 export function warnSyncPending(): Warning {
   return {
@@ -171,6 +185,22 @@ export interface ResponseMeta {
    * Each entry has a stable `code` agents can switch on — see `Warning`.
    */
   warnings?: Warning[];
+  /**
+   * True when a `maxOutputBytes` cap trimmed this list response before its
+   * natural page boundary (#776). When set, `pagination.cursor` resumes at the
+   * first dropped item. Absent on uncapped responses.
+   */
+  truncatedAtCap?: boolean;
+  /**
+   * Serialized wire size (bytes) of the returned data array, present only when a
+   * `maxOutputBytes` cap was applied (paired with `truncatedAtCap`). Absent otherwise.
+   */
+  bytesReturned?: number;
+  /**
+   * Number of items returned after a `maxOutputBytes` cap was applied (paired
+   * with `truncatedAtCap`). Absent otherwise.
+   */
+  itemsReturned?: number;
   /**
    * Current rate-limit window state for this tool. Absent on cached responses
    * (no rate check was performed). Present on live calls and on RateLimited errors

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -212,6 +212,26 @@ export class TaskService {
   }
 
   /**
+   * Build a continuation cursor anchored at `task`, as though it were the last
+   * item of a page produced for `input`.
+   *
+   * The response byte-cap (#776) uses this to resume at the last *kept* task
+   * when the wire-size cap trims a page before its natural boundary: reusing
+   * `list()`'s exact normalization guarantees the filter-hash and sort value
+   * match what the next `list({ cursor })` call expects. Keep this in lockstep
+   * with {@link encodeNextCursor} — both anchor on the same `taskSortValue`.
+   */
+  cursorForListItem(task: Task, input: TaskListInput): string {
+    const normalized = this.normalize(input);
+    const filterHash = hashFilter(normalized as unknown as Record<string, unknown>);
+    return encodeCursor({
+      lastId: task.id,
+      lastSortValue: taskSortValue(task, normalized.sortBy),
+      filterHash,
+    });
+  }
+
+  /**
    * Fetch a single task by ID.
    *
    * Optionally attaches the task's flat subtask list (all tasks with `parentId === id`).
@@ -283,18 +303,7 @@ export class TaskService {
 
     // Stable sort: (sortValue, id ASC). Null values sort last regardless of direction.
     const { sortBy, sortDirection } = normalized;
-    const getSortValue = (t: Task): string | null => {
-      switch (sortBy) {
-        case "dueDate":
-          return t.dueDate ?? null;
-        case "modifiedAt":
-          return t.modifiedAt;
-        case "name":
-          return t.name;
-        default:
-          return t.createdAt;
-      }
-    };
+    const getSortValue = (t: Task): string | null => taskSortValue(t, sortBy);
 
     const sorted = [...afterUpdatedSince].sort((a, b) => {
       const av = getSortValue(a);
@@ -485,6 +494,27 @@ export class TaskService {
       lastSortValue: getSortValue(last),
       filterHash,
     });
+  }
+}
+
+/**
+ * Sort-field accessor shared by page assembly ({@link TaskService.fetchPage})
+ * and cursor construction ({@link TaskService.cursorForListItem},
+ * {@link TaskService.encodeNextCursor}). They MUST stay in lockstep — a
+ * divergence here silently breaks pagination by emitting a cursor whose
+ * `lastSortValue` doesn't match how the next page is sorted (the #760 / #802
+ * class of bug). Null sort values sort last regardless of direction.
+ */
+function taskSortValue(t: Task, sortBy: TaskSortBy): string | null {
+  switch (sortBy) {
+    case "dueDate":
+      return t.dueDate ?? null;
+    case "modifiedAt":
+      return t.modifiedAt;
+    case "name":
+      return t.name;
+    default:
+      return t.createdAt;
   }
 }
 

--- a/src/tools/task/list.test.ts
+++ b/src/tools/task/list.test.ts
@@ -378,3 +378,82 @@ describe("handleTaskList — field projection", () => {
     expect(task.completed).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// maxOutputBytes cap (#776)
+// ---------------------------------------------------------------------------
+
+describe("handleTaskList — maxOutputBytes cap (#776)", () => {
+  it("does not add cap meta when maxOutputBytes is omitted", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 3; i++) await adapter.createTask({ name: `t${i}`, flagged: true });
+
+    const result = await handleTaskList({ flagged: true }, ctx);
+    expect(result.data.tasks).toHaveLength(3);
+    expect(result.meta).not.toHaveProperty("truncatedAtCap");
+    expect(result.meta).not.toHaveProperty("bytesReturned");
+  });
+
+  it("trims the page to the cap and signals truncation in meta + warnings", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 6; i++) await adapter.createTask({ name: `task-${i}`, flagged: true });
+
+    // Measure the uncapped wire size, then cap to roughly a third to force a trim.
+    const full = await handleTaskList({ flagged: true, limit: 50 }, ctx);
+    const fullBytes = Buffer.byteLength(JSON.stringify(full.data.tasks), "utf8");
+    const cap = Math.floor(fullBytes / 3);
+
+    const result = await handleTaskList({ flagged: true, limit: 50, maxOutputBytes: cap }, ctx);
+
+    expect(result.data.tasks.length).toBeGreaterThan(0);
+    expect(result.data.tasks.length).toBeLessThan(6);
+    expect(result.meta.truncatedAtCap).toBe(true);
+    expect(result.meta.itemsReturned).toBe(result.data.tasks.length);
+    // Reported bytes match the actual serialized array and stay within the cap
+    // (more than one task fits, so the forward-progress override doesn't apply).
+    expect(result.meta.bytesReturned).toBe(
+      Buffer.byteLength(JSON.stringify(result.data.tasks), "utf8"),
+    );
+    expect(result.meta.bytesReturned).toBeLessThanOrEqual(cap);
+    expect(result.pagination).toMatchObject({ hasMore: true });
+    expect(result.pagination?.cursor).toEqual(expect.any(String));
+    expect(result.meta.warnings?.some((w) => w.code === "WARN_RESULT_TRUNCATED")).toBe(true);
+  });
+
+  it("resumes correctly from the re-anchored cursor with no gaps or overlaps", async () => {
+    const { ctx, adapter } = makeCtx();
+    const created: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      created.push(await adapter.createTask({ name: `task-${i}`, flagged: true }));
+    }
+
+    const full = await handleTaskList({ flagged: true, limit: 50 }, ctx);
+    const cap = Math.floor(Buffer.byteLength(JSON.stringify(full.data.tasks), "utf8") / 3);
+
+    // Walk every page using the cap-issued cursor; collect ids in order.
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let guard = 0; guard < 20; guard++) {
+      const page = await handleTaskList(
+        { flagged: true, limit: 50, maxOutputBytes: cap, ...(cursor ? { cursor } : {}) },
+        ctx,
+      );
+      for (const t of page.data.tasks) seen.push((t as { id: string }).id);
+      if (!page.pagination?.hasMore) break;
+      cursor = page.pagination.cursor ?? undefined;
+    }
+
+    // Every created task appears exactly once, in creation (createdAt asc) order.
+    expect(seen).toEqual(created);
+    expect(new Set(seen).size).toBe(created.length);
+  });
+
+  it("does not truncate when the cap comfortably exceeds the payload", async () => {
+    const { ctx, adapter } = makeCtx();
+    for (let i = 0; i < 3; i++) await adapter.createTask({ name: `t${i}`, flagged: true });
+
+    const result = await handleTaskList({ flagged: true, maxOutputBytes: 1_000_000 }, ctx);
+    expect(result.data.tasks).toHaveLength(3);
+    expect(result.meta).not.toHaveProperty("truncatedAtCap");
+  });
+});

--- a/src/tools/task/list.ts
+++ b/src/tools/task/list.ts
@@ -22,7 +22,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { flexDateString } from "../../domain/dates.js";
 import { ProjectId, TagId, TaskId } from "../../domain/ids.js";
-import { TASK_FIELD_NAMES, TASK_FIELD_NAMES_SET } from "../../domain/task.js";
+import { TASK_FIELD_NAMES, TASK_FIELD_NAMES_SET, type Task } from "../../domain/task.js";
+import { applyByteCap } from "../../envelope/cap.js";
 import { TASK_DEFAULTS } from "../../envelope/defaultsRegistry.js";
 import { elideDefaults } from "../../envelope/elideDefaults.js";
 import {
@@ -30,6 +31,8 @@ import {
   type Pagination,
   type ResponseMeta,
   toolResponse,
+  type Warning,
+  warnResultTruncatedBytes,
   warnUnknownFields,
 } from "../../envelope/index.js";
 import { applyProjection, validateFields } from "../../envelope/projection.js";
@@ -186,6 +189,18 @@ export const taskListInputSchema = z.object({
         "Default false — the block is omitted to save payload size. " +
         "Use the task's `id`, `projectId`, `parentId`, and `tagIds` fields directly instead.",
     ),
+  maxOutputBytes: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      "Cap the serialized byte size of the returned tasks[] array. When the response would exceed this, " +
+        "the server returns as many whole tasks as fit, sets meta.truncatedAtCap=true with " +
+        "meta.bytesReturned and meta.itemsReturned, and returns a pagination cursor that resumes at the " +
+        "first dropped task. Omit for no cap. Values above the server's hard ceiling (~1 MiB) are clamped. " +
+        "A single task larger than the cap is still returned whole so pagination always advances.",
+    ),
 });
 
 /** TypeScript input type derived from {@link taskListInputSchema}. */
@@ -207,38 +222,58 @@ export interface ToolContext {
  * can invoke it without constructing an McpServer.
  */
 export async function handleTaskList(input: TaskListToolInput, ctx: ToolContext) {
-  const { notePreviewChars: rawPreviewChars, verbose, fields, ...rest } = input;
+  const { notePreviewChars: rawPreviewChars, verbose, fields, maxOutputBytes, ...rest } = input;
   const serviceInput = rest as TaskListInput;
   const result = await ctx.taskService.list(serviceInput);
-  const pagination: Pagination = {
-    cursor: result.nextCursor,
-    hasMore: result.hasMore,
-  };
   const previewChars = rawPreviewChars ?? DEFAULT_NOTE_PREVIEW_CHARS;
 
   const projection =
     fields !== undefined ? validateFields(fields, TASK_FIELD_NAMES_SET) : undefined;
   const projectFields = projection?.valid;
-  const warnings =
+  const fieldWarnings =
     projection !== undefined && projection.unknown.length > 0
       ? [warnUnknownFields([...projection.unknown], TASK_FIELD_NAMES)]
-      : undefined;
+      : [];
 
   // When fields[] is specified the caller is being explicit — skip elide-defaults
   // so requested fields are never silently dropped. verbose=true also bypasses
   // elide-defaults. Default (no fields, no verbose) applies elide-defaults.
   const applyElide = verbose !== true && projectFields === undefined;
-  const tasks = result.tasks.map((t) => {
+  const wireTasks = result.tasks.map((t) => {
     const projected = applyProjection(t, projectFields);
     const previewed = applyNotePreview(projected, previewChars);
     return applyElide ? elideDefaults(previewed, TASK_DEFAULTS) : previewed;
   });
 
+  // Cap stage (#776) — runs last so it measures the true post-elide/post-preview
+  // wire size. Re-anchor the continuation cursor at the last *kept* task so a
+  // trimmed page resumes exactly where it was cut (not at the full page's end).
+  const cap = applyByteCap(wireTasks, {
+    ...(maxOutputBytes !== undefined ? { maxOutputBytes } : {}),
+    cursorFor: (lastKeptIndex) =>
+      ctx.taskService.cursorForListItem(result.tasks[lastKeptIndex] as Task, serviceInput),
+  });
+
+  const pagination: Pagination = cap.truncatedAtCap
+    ? { cursor: cap.cursor, hasMore: true }
+    : { cursor: result.nextCursor, hasMore: result.hasMore };
+
+  const warnings: Warning[] = cap.truncatedAtCap
+    ? [...fieldWarnings, warnResultTruncatedBytes(cap.bytesReturned, cap.itemsReturned)]
+    : fieldWarnings;
+
   const meta = ctx.makeMeta({
     cacheHit: result.cacheHit,
-    ...(warnings !== undefined ? { warnings } : {}),
+    ...(warnings.length > 0 ? { warnings } : {}),
+    ...(cap.truncatedAtCap
+      ? {
+          truncatedAtCap: true,
+          bytesReturned: cap.bytesReturned,
+          itemsReturned: cap.itemsReturned,
+        }
+      : {}),
   });
-  return ok({ tasks }, meta, pagination);
+  return ok({ tasks: cap.items }, meta, pagination);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implements the reserved final stage of the envelope pipeline (`project → elide → truncate → **cap**`): `applyByteCap` enforces an optional per-call `maxOutputBytes` ceiling on the serialized size of a list response, trimming whole items and re-anchoring the continuation cursor at the last kept one so the next page resumes exactly where the cut occurred.
- On truncation, finalizes with `meta.truncatedAtCap` / `meta.bytesReturned` / `meta.itemsReturned`, a `WARN_RESULT_TRUNCATED` warning, and a resumable `pagination.cursor`.
- Invariants: unset cap is a **no-op** (behavior unchanged); a configurable hard ceiling (1 MiB, `OMNIFOCUS_MAX_OUTPUT_BYTES_CEILING`) clamps pathological input; at least one item is always returned so pagination never stalls.
- Wired into **`task_list`** as the reference implementation. Correct cursor re-anchoring required a reusable `TaskService.cursorForListItem`; the sort-value accessor is factored into a shared `taskSortValue` to keep cursor construction and page assembly in lockstep (guards the #760/#802 pagination-bug class).

## Design link

Implements [#776 — feat(tools): maxOutputBytes cap on heavy reads with truncation envelope](https://github.com/torsday/omnifocus-mcp/issues/776). Pipeline contract: `src/envelope/CLAUDE.md`; envelope contract: [ADR-0013](../docs/adr/0013-tool-response-envelope.md).

Closes #776

## Scope / follow-up

This ships the **mechanism + `task_list` reference** as a coherent, fully-tested slice. Deferred to a follow-up issue (to keep the diff reviewable and each service's cursor re-anchoring correct):

- Wiring the remaining heavy-read tools (`search_query`, `task_get_many`, `project_list`/`get`/`get_many`, `tag_list`/`get`/`get_many`, `forecast_get`, `perspective_evaluate`) — each needs its service's `cursorForListItem` analog.
- The #771 token-cost benchmark workload that exercises the cap.

## Breaking change?

- [x] No — additive only (optional `maxOutputBytes` input; optional `truncatedAtCap`/`bytesReturned`/`itemsReturned` meta fields; reuses the existing `WARN_RESULT_TRUNCATED` code). Minor per [ADR-0011](../docs/adr/0011-versioning-and-stability.md).

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` green (full suite passed in the pre-push hook).
- [x] Unit: `src/envelope/cap.test.ts` — no-op paths, mid-result truncation, forward-progress guarantee (oversized-row), hard-ceiling clamp, env parse rule.
- [x] Integration: `src/tools/task/list.test.ts` — cap omitted (no meta), cap hit (meta + warning + bytes ≤ cap), **cursor resumes with no gaps/overlaps across pages**, cap comfortably exceeds payload (no truncation).
- [x] Response envelope + `Warning` taxonomy used; no generic `Error`.
- [x] Tool description follows the what / when-not / returns / side-effects shape; `docs/tools.md` regenerated.

## Notes

- The hard ceiling is read once at module load via `process.env` in `src/envelope/cap.ts`, matching the existing `OMNIFOCUS_LEGACY_TEXT_CONTENT` precedent in the envelope layer (keeps the low-level envelope module self-contained rather than threading `Config` through every handler). Overridable per-call in tests.