### PR TITLE
fix(omnijs): non-recursive task_duplicate copies repetition rules and attachments (#1068)

### DIFF
--- a/src/scripts/omnijs/task_duplicate.js
+++ b/src/scripts/omnijs/task_duplicate.js
@@ -1,8 +1,10 @@
 /**
- * OmniJS: duplicate a task. Editable fields copy; completed/dropped state
- * reset on every clone. When `recursive: true`, the entire subtree is
- * cloned via `duplicateTasks(...)` (preserves order); otherwise the clone
- * is a single fresh task with copied props (no children).
+ * OmniJS: duplicate a task. All editable fields copy with full fidelity
+ * (name, note, dates, flagged, estimate, sequential, tags, repetition rule,
+ * attachments); completed/dropped state is reset on every clone. Both modes
+ * clone via native `duplicateTasks(...)` (preserves order); when
+ * `recursive: false` the cloned children are deleted afterwards, leaving a
+ * single task that still carries every editable property (#1068).
  *
  * Routes through OmniJS rather than JXA per ADR-0019: JXA's
  * `task.duplicate()` and `container.make({...})` operate on transient
@@ -108,46 +110,38 @@
     }
   }
 
-  let newId;
-  let descendantCount = 0;
-
-  if (args.recursive) {
-    // Subtree clone via OmniJS. `duplicateTasks` returns a TaskArray
-    // whose elements are the new top-level clones (one per input).
-    const result = duplicateTasks([source], position);
-    const clone = result[0];
-    if (!clone) {
-      return JSON.stringify({
-        error: { code: "VALIDATION", message: "duplicateTasks returned no clone" },
-      });
-    }
-    resetSubtree(clone);
-    // descendantCount = total descendants under the clone. On a Task,
-    // `flattenedTasks` returns descendants only (NOT self) — no subtraction.
-    descendantCount = clone.flattenedTasks?.length ?? 0;
-    newId = clone.id.primaryKey;
-  } else {
-    // Non-recursive: build a fresh single task with copied editable props
-    // (no children). Naturally produces an uncompleted clone — no
-    // reset-completion call needed for the root.
-    const clone = new Task(source.name, position);
-    if (source.note) clone.note = source.note;
-    clone.flagged = source.flagged;
-    if (source.deferDate) clone.deferDate = source.deferDate;
-    if (source.dueDate) clone.dueDate = source.dueDate;
-    if (source.estimatedMinutes != null) {
-      clone.estimatedMinutes = source.estimatedMinutes;
-    }
-    clone.sequential = source.sequential;
-    // Tags
-    if (source.tags) {
-      for (const tag of source.tags) {
-        clone.addTag(tag);
-      }
-    }
-    newId = clone.id.primaryKey;
-    descendantCount = 0;
+  // Both modes clone via the native `duplicateTasks`, which copies the source
+  // with full fidelity — name, note, dates, flagged, estimate, sequential,
+  // tags, **repetition rule, and attachments** (#1068) — and returns a
+  // TaskArray of the new top-level clones (one per input). For the
+  // non-recursive case we then drop the cloned children, leaving a single
+  // task that still carries every editable property (the old hand-rolled
+  // `new Task(...)` copy silently lost repetition + attachments).
+  const clone = duplicateTasks([source], position)[0];
+  if (!clone) {
+    return JSON.stringify({
+      error: { code: "VALIDATION", message: "duplicateTasks returned no clone" },
+    });
   }
 
-  return JSON.stringify({ newId, descendantCount });
+  if (!args.recursive) {
+    // Snapshot the children before deleting — mutating the live array mid-loop
+    // would skip elements.
+    const children = clone.children ? clone.children.slice() : [];
+    for (const child of children) {
+      deleteObject(child);
+    }
+  }
+
+  // Reset completion across whatever remains (root always; full subtree when
+  // recursive). `duplicateTasks` preserves the source's completed/dropped
+  // state, but the tool contract is a fresh, active clone.
+  resetSubtree(clone);
+
+  // descendantCount = total descendants under the clone. On a Task,
+  // `flattenedTasks` returns descendants only (NOT self) — no subtraction.
+  // Always 0 in the non-recursive case (children were just removed).
+  const descendantCount = args.recursive ? (clone.flattenedTasks?.length ?? 0) : 0;
+
+  return JSON.stringify({ newId: clone.id.primaryKey, descendantCount });
 })();

--- a/src/tools/task/duplicate.test.ts
+++ b/src/tools/task/duplicate.test.ts
@@ -355,3 +355,26 @@ describe("task_duplicate — cache invalidation", () => {
     expect(projScopeCount).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Repetition fidelity on non-recursive clones (#1068)
+// ---------------------------------------------------------------------------
+//
+// Before #1068 the OmniJS non-recursive branch built the clone with a manual
+// prop copy that omitted the repetition rule (and attachments). It now clones
+// via native `duplicateTasks` + child-delete, so every editable field carries
+// over. Attachments aren't modelled by InMemoryAdapter (or the Task domain
+// object), so attachment fidelity is covered by the live osascript spike cited
+// in the PR; repetition IS modelled, so it's asserted here as the contract guard.
+describe("handleTaskDuplicate — repetition fidelity (#1068)", () => {
+  it("preserves the repetition rule on a non-recursive clone", async () => {
+    const { ctx, adapter } = makeCtx();
+    const src = await adapter.createTask({ name: "Repeating" });
+    const rule = { method: "fixed", unit: "weeks", steps: 1 } as const;
+    await adapter.updateTask(src, { repetition: rule });
+
+    const res = await handleTaskDuplicate({ id: src, recursive: false }, ctx);
+    const clone = await adapter.getTask(res.data.newId);
+    expect(clone.repetition).toEqual(rule);
+  });
+});


### PR DESCRIPTION
## Summary

- The OmniJS `task_duplicate` **non-recursive** branch built the clone with `new Task(...)` + a manual prop copy that silently dropped the source's **repetition rule** and **file attachments**. (The recursive branch already copied them via native `duplicateTasks`.)
- Unify both modes on `duplicateTasks([source], position)` — which copies the source with full fidelity (tags, dates, flagged, estimate, sequential, repetition, attachments) — then, for non-recursive, delete the cloned children (snapshot-before-delete). Net result: a single-task clone that carries every editable property. Completion/dropped reset unchanged. (Net −44/+61, mostly removing the hand-rolled copy.)

## Provenance

Surfaced while closing #799 (the OmniJS duplicate migration, #692, already delivered the 5–20× perf goal); this is the one completeness sliver that remained.

Closes #1068

## Live verification (osascript / `evaluateJavascript` against OmniFocus)

Source = weekly repetition rule + a file attachment + completed + 2 children; duplicated **non-recursive** with the new logic:

| check | result |
|---|---|
| children on clone | **0** ✓ |
| repetition rule | **copied** (`FREQ=WEEKLY`) ✓ |
| attachments | **1 copied** ✓ |
| completed state | **reset → false** ✓ |
| flagged | **preserved → true** ✓ |

(Each spike created self-named scratch projects deleted in a `finally` — net-zero DB change, 0 leftovers.)

## Breaking change?

- [x] No — same `{ newId, descendantCount }` contract; non-recursive still yields a childless, active clone. Only added fidelity (repetition + attachments now carry over).

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test` green (full suite 3986).
- [x] `pnpm build` — confirms the edited OmniJS script still inlines/parses.
- [x] Added a repetition-fidelity unit test (InMemory models repetition). Attachment fidelity is live-only → verified by the osascript spike above.
- [x] Existing duplicate tests (24) green.