### PR TITLE
fix(repetition): read OF 4.x recurrence and use DeferUntilDate for start-again

### DIFF
--- a/src/adapter/jxa/sandbox/fixtures.ts
+++ b/src/adapter/jxa/sandbox/fixtures.ts
@@ -234,6 +234,22 @@ export function fakeTask(
   return task;
 }
 
+/**
+ * Build a fake JXA RepetitionRule specifier as OmniFocus 4.x actually exposes
+ * it (#1071): `recurrence` and `repetitionMethod` are STRING PROPERTIES, not
+ * the `method()` / `unit()` / `steps()` methods the old buildRepetition wrongly
+ * called. Pass the return value as a task's `repetitionRule` override:
+ *
+ *   fakeTask({ repetitionRule: () => fakeRepetitionRule(
+ *     "FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH", "due after completion") })
+ *
+ * `repetitionMethod` accepts the three OF 4.x human labels:
+ *   "fixed repetition" | "start after completion" | "due after completion".
+ */
+export function fakeRepetitionRule(recurrence: string, repetitionMethod: string) {
+  return { recurrence, repetitionMethod };
+}
+
 export interface FakeProjectOverrides {
   id?: () => string;
   name?: () => string;

--- a/src/adapter/jxa/sandbox/index.test.ts
+++ b/src/adapter/jxa/sandbox/index.test.ts
@@ -80,6 +80,7 @@ import {
   fakeFolder,
   fakePerspective,
   fakeProject,
+  fakeRepetitionRule,
   fakeTag,
   fakeTask,
   fakeWindow,
@@ -744,6 +745,104 @@ describe("JXA sandbox — task_get", () => {
       { tasks: [t] },
     );
     expect(result.task.projectId).toBeNull();
+  });
+
+  // #1071: buildRepetition must parse the OF 4.x `recurrence` RRULE +
+  // `repetitionMethod` string. The old code called rr.method()/unit()/steps()
+  // (undefined on OF 4.x) and the swallowing try/catch returned null for EVERY
+  // repetition read. These cases exercise the parse via the real inlined
+  // build_task.js, mirroring the live osascript round-trip.
+  it("reads a daily fixed repetition rule — regression #1071", () => {
+    const t = fakeTask({
+      id: () => "task_rep",
+      repetitionRule: () => fakeRepetitionRule("FREQ=DAILY;INTERVAL=1", "fixed repetition"),
+    });
+    const result = runJxaScriptInSandbox<{ task: { repetition: unknown } }>(
+      taskGetScript,
+      { id: "task_rep" },
+      { tasks: [t] },
+    );
+    expect(result.task.repetition).toEqual({ method: "fixed", unit: "days", steps: 1 });
+  });
+
+  it("maps 'due after completion' to due-again with interval — regression #1071", () => {
+    const t = fakeTask({
+      id: () => "task_rep",
+      repetitionRule: () => fakeRepetitionRule("FREQ=DAILY;INTERVAL=3", "due after completion"),
+    });
+    const result = runJxaScriptInSandbox<{ task: { repetition: unknown } }>(
+      taskGetScript,
+      { id: "task_rep" },
+      { tasks: [t] },
+    );
+    expect(result.task.repetition).toEqual({ method: "due-again", unit: "days", steps: 3 });
+  });
+
+  it("maps 'start after completion' to start-again with weekday list — regression #1071", () => {
+    const t = fakeTask({
+      id: () => "task_rep",
+      repetitionRule: () =>
+        fakeRepetitionRule("FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH", "start after completion"),
+    });
+    const result = runJxaScriptInSandbox<{ task: { repetition: unknown } }>(
+      taskGetScript,
+      { id: "task_rep" },
+      { tasks: [t] },
+    );
+    expect(result.task.repetition).toEqual({
+      method: "start-again",
+      unit: "weeks",
+      steps: 2,
+      weekdays: ["tuesday", "thursday"],
+    });
+  });
+
+  it("parses a monthly day-of-month anchor — regression #1071", () => {
+    const t = fakeTask({
+      id: () => "task_rep",
+      repetitionRule: () =>
+        fakeRepetitionRule("FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15", "fixed repetition"),
+    });
+    const result = runJxaScriptInSandbox<{ task: { repetition: unknown } }>(
+      taskGetScript,
+      { id: "task_rep" },
+      { tasks: [t] },
+    );
+    expect(result.task.repetition).toEqual({
+      method: "fixed",
+      unit: "months",
+      steps: 1,
+      monthlyAnchor: { day: 15 },
+    });
+  });
+
+  it("parses a monthly positional weekday anchor (last Friday) — regression #1071", () => {
+    const t = fakeTask({
+      id: () => "task_rep",
+      repetitionRule: () =>
+        fakeRepetitionRule("FREQ=MONTHLY;INTERVAL=1;BYDAY=-1FR", "due after completion"),
+    });
+    const result = runJxaScriptInSandbox<{ task: { repetition: unknown } }>(
+      taskGetScript,
+      { id: "task_rep" },
+      { tasks: [t] },
+    );
+    expect(result.task.repetition).toEqual({
+      method: "due-again",
+      unit: "months",
+      steps: 1,
+      monthlyAnchor: { weekday: "friday", position: "last" },
+    });
+  });
+
+  it("returns null repetition when no rule is set — regression #1071", () => {
+    const t = fakeTask({ id: () => "task_norep" });
+    const result = runJxaScriptInSandbox<{ task: { repetition: unknown } }>(
+      taskGetScript,
+      { id: "task_norep" },
+      { tasks: [t] },
+    );
+    expect(result.task.repetition).toBeNull();
   });
 });
 

--- a/src/scripts/jxa/_helpers/build_task.js
+++ b/src/scripts/jxa/_helpers/build_task.js
@@ -222,15 +222,104 @@ function buildTask(task, options) {
   };
 }
 
+// OmniFocus 4.x note (#1071): the JXA RepetitionRule specifier does NOT expose
+// `method()` / `unit()` / `steps()` — those are undefined and throw
+// "rr.method is not a function". The previous body called them and the
+// try/catch swallowed the throw, so EVERY repetition read returned null even
+// when a rule was set (the write was fixed separately in #938). The members
+// that actually exist on OF 4.x are two string properties:
+//   - `rr.recurrence`        — the RFC 5545 RRULE, e.g. "FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH"
+//   - `rr.repetitionMethod`  — a human-readable method name (see METHOD_BY_LABEL)
+// So we parse the RRULE back into the canonical domain shape. This is the
+// inverse of the FREQ_BY_UNIT / ICAL_DAYS / method maps in task_update.js;
+// keep the two in sync.
 function buildRepetition(task) {
   try {
     const rr = task.repetitionRule();
     if (!rr) return null;
-    return {
-      method: rr.method(),
-      unit: rr.unit(),
-      steps: rr.steps(),
+
+    // recurrence is the canonical signal; without it there is no rule to report.
+    const recurrence = rr.recurrence;
+    if (!recurrence || typeof recurrence !== "string") return null;
+
+    // Parse the RRULE "KEY=VALUE;KEY=VALUE" into a lookup.
+    const parts = {};
+    const segments = recurrence.split(";");
+    for (let i = 0; i < segments.length; i++) {
+      const eq = segments[i].indexOf("=");
+      if (eq > 0) parts[segments[i].slice(0, eq)] = segments[i].slice(eq + 1);
+    }
+
+    const UNIT_BY_FREQ = {
+      MINUTELY: "minutes",
+      HOURLY: "hours",
+      DAILY: "days",
+      WEEKLY: "weeks",
+      MONTHLY: "months",
+      YEARLY: "years",
     };
+    const unit = UNIT_BY_FREQ[parts.FREQ];
+    if (!unit) return null; // unknown/absent FREQ — can't represent it faithfully
+
+    const steps = parts.INTERVAL ? parseInt(parts.INTERVAL, 10) : 1;
+
+    // repetitionMethod is a human string on OF 4.x — map it back to the enum.
+    // "fixed repetition" -> fixed; "due after completion" -> due-again;
+    // "start after completion" -> start-again. Default to fixed if unrecognized.
+    const METHOD_BY_LABEL = {
+      "fixed repetition": "fixed",
+      "due after completion": "due-again",
+      "start after completion": "start-again",
+    };
+    let method = "fixed";
+    try {
+      const label = rr.repetitionMethod;
+      if (label && METHOD_BY_LABEL[label]) method = METHOD_BY_LABEL[label];
+    } catch (_methodErr) {
+      /* repetitionMethod absent — keep the fixed default */
+    }
+
+    const result = { method: method, unit: unit, steps: steps };
+
+    // Weekly weekday list: BYDAY=MO,WE,FR (plain day codes, no position prefix).
+    const WEEKDAY_BY_ICAL = {
+      SU: "sunday",
+      MO: "monday",
+      TU: "tuesday",
+      WE: "wednesday",
+      TH: "thursday",
+      FR: "friday",
+      SA: "saturday",
+    };
+    if (unit === "weeks" && parts.BYDAY) {
+      const codes = parts.BYDAY.split(",");
+      const weekdays = [];
+      for (let i = 0; i < codes.length; i++) {
+        const name = WEEKDAY_BY_ICAL[codes[i]];
+        if (name) weekdays.push(name);
+      }
+      if (weekdays.length > 0) result.weekdays = weekdays;
+    }
+
+    // Monthly anchor: either BYMONTHDAY=15 (day) or BYDAY=2TU / BYDAY=-1FR (position).
+    if (unit === "months") {
+      if (parts.BYMONTHDAY) {
+        const day = parseInt(parts.BYMONTHDAY, 10);
+        if (!Number.isNaN(day)) result.monthlyAnchor = { day: day };
+      } else if (parts.BYDAY) {
+        // Positional form: optional leading signed integer then the 2-letter day.
+        const m = parts.BYDAY.match(/^(-?\d+)([A-Z]{2})$/);
+        if (m) {
+          const pos = parseInt(m[1], 10);
+          const weekday = WEEKDAY_BY_ICAL[m[2]];
+          if (weekday) {
+            result.monthlyAnchor = { weekday: weekday, position: pos === -1 ? "last" : pos };
+          }
+        }
+      }
+    }
+
+    return result;
   } catch (_e) {
     return null;
   }

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -104,10 +104,16 @@ function run(argv) {
         friday: "FR",
         saturday: "SA",
       };
+      // #1071: OF 4.x `Task.RepetitionMethod` has only None / Fixed /
+      // DeferUntilDate / DueDate — there is no `Start` member. A prior mapping
+      // of start-again to a `Start` member resolved to undefined, so
+      // `new Task.RepetitionRule(rule, undefined)` silently persisted
+      // start-again rules as Fixed. The correct member for "start again after
+      // completion" (sdef enumerator FRmS) is DeferUntilDate.
       /** @type {Record<string, string>} */
       const METHOD_BY_NAME = {
         fixed: "Fixed",
-        "start-again": "Start",
+        "start-again": "DeferUntilDate",
         "due-again": "DueDate",
       };
       const freq = FREQ_BY_UNIT[rule.unit];

--- a/src/tools/task/clearRepetition.ts
+++ b/src/tools/task/clearRepetition.ts
@@ -15,6 +15,7 @@ import { type InvalidatingCache, invalidateTaskMutation } from "../../cache/inva
 import { TaskId } from "../../domain/ids.js";
 import { summaryTaskClearRepetition } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { ScriptError } from "../../errors/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description
@@ -62,6 +63,13 @@ export async function handleTaskClearRepetition(
 ) {
   await ctx.adapter.updateTask(input.id, { repetition: null });
   const task = await ctx.adapter.getTask(input.id);
+  // Round-trip verification (#1071): never report a successful clear on a
+  // no-op. If the re-read still shows a rule, the clear did not land.
+  if (task.repetition !== null) {
+    throw new ScriptError(
+      `Repetition rule did not clear for task ${input.id}: a follow-up read still returned a rule. This indicates a transport-level no-op (see #938, #1071).`,
+    );
+  }
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }

--- a/src/tools/task/repetition.test.ts
+++ b/src/tools/task/repetition.test.ts
@@ -279,3 +279,50 @@ describe("task_set_repetition / task_clear_repetition — cache invalidation", (
     expect(scopes).toEqual([`task:${id}`, "forecast:*", "perspective:*", "search:*"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Read-back gate (#1071) — never report success on a silent transport no-op
+// ---------------------------------------------------------------------------
+
+describe("task_set_repetition / task_clear_repetition — read-back gate (#1071)", () => {
+  const taskId = "task_000001" as import("../../domain/ids.js").TaskId;
+  const makeMeta = (): ResponseMeta => ({
+    correlationId: "test-cid",
+    durationMs: 1,
+    cacheHit: false,
+    transport: "memory",
+    ofVersion: "test",
+  });
+
+  it("set throws when the rule does not persist (write silently no-ops)", async () => {
+    // Stub adapter: updateTask is a no-op and the re-read shows no rule — the
+    // exact #938/#1071 failure mode the gate must catch instead of lying.
+    const adapter = {
+      updateTask: async () => {},
+      getTask: async () => ({ id: taskId, name: "No-op", projectId: null, repetition: null }),
+    } as unknown as InMemoryAdapter;
+
+    await expect(
+      handleTaskSetRepetition(
+        { id: taskId, rule: { method: "fixed", unit: "days", steps: 1 } },
+        { adapter, makeMeta },
+      ),
+    ).rejects.toThrow(/did not persist/);
+  });
+
+  it("clear throws when the rule does not clear (clear silently no-ops)", async () => {
+    const adapter = {
+      updateTask: async () => {},
+      getTask: async () => ({
+        id: taskId,
+        name: "No-op",
+        projectId: null,
+        repetition: { method: "fixed", unit: "days", steps: 1 },
+      }),
+    } as unknown as InMemoryAdapter;
+
+    await expect(handleTaskClearRepetition({ id: taskId }, { adapter, makeMeta })).rejects.toThrow(
+      /did not clear/,
+    );
+  });
+});

--- a/src/tools/task/setRepetition.ts
+++ b/src/tools/task/setRepetition.ts
@@ -22,6 +22,7 @@ import { TaskId } from "../../domain/ids.js";
 import { RepetitionRuleSchema } from "../../domain/task.js";
 import { summaryTaskSetRepetition } from "../../domain/writeSummary.js";
 import { ok, type ResponseMeta, toolResponse } from "../../envelope/index.js";
+import { ScriptError } from "../../errors/index.js";
 
 // ---------------------------------------------------------------------------
 // Tool description
@@ -77,6 +78,15 @@ export async function handleTaskSetRepetition(
 ) {
   await ctx.adapter.updateTask(input.id, { repetition: input.rule });
   const task = await ctx.adapter.getTask(input.id);
+  // Round-trip verification (#1071): the JXA repetition write can silently
+  // no-op (it did across #938 and again via the broken read-back / wrong enum
+  // member). Never report success on a no-op — if the re-read shows no rule,
+  // the write did not land. "The round-trip is the only proof."
+  if (task.repetition === null) {
+    throw new ScriptError(
+      `Repetition rule did not persist for task ${input.id}: the write reported success but a follow-up read returned no rule. This indicates a transport-level no-op (see #938, #1071).`,
+    );
+  }
   if (ctx.cache !== undefined) {
     invalidateTaskMutation(ctx.cache, { taskId: input.id, projectId: task.projectId });
   }

--- a/tests/benchmark/token-cost/README.md
+++ b/tests/benchmark/token-cost/README.md
@@ -9,6 +9,14 @@ workflow without regressing the others.
 The suite is hermetic: it drives `InMemoryAdapter` directly, does not
 touch JXA, and does not require OmniFocus to be running.
 
+> **Known issue ([#1075](https://github.com/torsday/omnifocus-mcp/issues/1075)):**
+> despite being deterministic, `toolListBytes` currently computes ~30% larger
+> on the `mac-local` CI runner than on any local checkout (247910 vs 189728 at
+> the time of writing), so the `token-cost bench` gate can red-flag PRs that
+> never touched the tool surface. Until #1075 is resolved the check is
+> advisory; an unrelated PR caught by the divergence may carry the
+> `bench: regression-allowed` label with a justification in its description.
+
 ## What it measures
 
 For each fixture workflow the suite records:


### PR DESCRIPTION
## What

Fixes two independent OmniFocus 4.x repetition transport defects and adds a read-back gate so the tools can't report success on a silent no-op.

### Bug 1 — read path (the filed issue)
`buildRepetition()` (`build_task.js`) read the rule via `rr.method()` / `rr.unit()` / `rr.steps()`, which are **undefined** on the OF 4.x JXA RepetitionRule specifier — every call threw and the swallowing `try/catch` returned `null`, so **every** repetition read (`task_get`, `task_list`, `task_get_many`, `task_search`, `forecast_get`, `perspective_evaluate`, and the echo in set/clear) reported `repetition: null` even when a rule was set. The real members are the string properties `rr.recurrence` (RFC 5545 RRULE) and `rr.repetitionMethod`. Rewrote `buildRepetition` to parse the RRULE into the canonical domain shape. Fixed once in the shared `@inline` helper, so all consumers are repaired together.

### Bug 2 — write path (found while implementing)
`task_update.js` mapped `start-again` → `Task.RepetitionMethod.Start`, but OF 4.x has **no `Start` member** (only `None` / `Fixed` / `DeferUntilDate` / `DueDate`), so the constructor received `undefined` and silently persisted `start-again` rules as `fixed`. The correct member (sdef enumerator `FRmS`, "start after completion") is `DeferUntilDate`. The original report's repro used `fixed` / `due-again`, which map correctly, so it never tripped this.

### Read-back gate
`setRepetition` / `clearRepetition` now re-read after the write and throw a `ScriptError` if the rule didn't land (non-null after set, null after clear) instead of returning a success envelope on a no-op — the "round-trip is the only proof" principle from #938.

## Verified method mapping (live OmniFocus, bidirectional)
| domain | write enum | read-back `rr.repetitionMethod` |
|---|---|---|
| `fixed` | `Fixed` | `"fixed repetition"` |
| `start-again` | `DeferUntilDate` | `"start after completion"` |
| `due-again` | `DueDate` | `"due after completion"` |

## Testing
- **Live OmniFocus round-trip: 7/7** rule shapes (all three methods, weekly weekdays, monthly day + positional anchors, hourly).
- New `fakeRepetitionRule` sandbox fixture (models the OF 4.x string-property shape) + 6 read-path regression tests and 2 handler read-back gate tests, closing the coverage gap that let #938's incomplete fix and this defect ship undetected.
- Full suite green on the pre-push hook (3994 passed); `tsc` + `biome` clean; build carries both fixes.

## Note for release
#938's write fix (`1b12f59`) is on `main` but in no released tag (latest `v1.5.3`). This read-path fix + a release are both needed before repetition round-trips for end users.

Closes #1071


---

### `bench: regression-allowed` — justification

The `token-cost bench` failure on this PR is **not caused by this change** and is **not a real regression**. This PR's diff is 7 files (`build_task.js`, `task_update.js`, sandbox `fixtures.ts`/`index.test.ts`, `setRepetition.ts`/`clearRepetition.ts`/`repetition.test.ts`) — none touch tool descriptions, input schemas, or the response envelope, so it cannot change `toolListBytes`.

The bench reports `toolListBytes 189728 → 247910 (+30.7%)`, but that value reproduces **only on the CI runner**: every local configuration (node 24.3.0 and CI's 24.15.0, lockfile-frozen deps, zod 4.4.3) computes exactly **189728** — a zero-drift match to the committed baseline. This is a CI-environment divergence in the gate itself, tracked in **#1075**. Labeling this PR `bench: regression-allowed` per the workflow's documented escape hatch so the advisory check doesn't block an unrelated, verified fix. The gate itself is fixed under #1075.
