### PR TITLE
fix(project): project_create with reviewIntervalDays is atomic and honors the interval (#1073)

### DIFF
--- a/src/scripts/omnijs/project_create.js
+++ b/src/scripts/omnijs/project_create.js
@@ -61,40 +61,65 @@
   // a real persistent id.primaryKey.
   const proj = new Project(args.name, position);
 
-  // Set props post-construction. OmniJS exposes them as plain assignments.
-  if (args.note != null) proj.note = args.note;
-  if (args.deferDate != null) proj.deferDate = new Date(args.deferDate);
-  if (args.dueDate != null) proj.dueDate = new Date(args.dueDate);
-  if (args.estimatedMinutes != null) proj.estimatedMinutes = args.estimatedMinutes;
-  if (args.flagged != null) proj.flagged = args.flagged;
-  if (args.status != null) {
-    // Map the wire-stable status enum to the OmniJS Project.Status constants.
-    // Wire: "active" | "on-hold" | "done" | "dropped"
-    const statusMap = {
-      active: Project.Status.Active,
-      "on-hold": Project.Status.OnHold,
-      done: Project.Status.Done,
-      dropped: Project.Status.Dropped,
-    };
-    const target = statusMap[args.status];
-    if (target !== undefined) proj.status = target;
-  }
-  if (args.completionCriterion != null) {
-    if (args.completionCriterion === "sequential") proj.sequential = true;
-    else if (args.completionCriterion === "singleActions") {
-      // singleActions: containsSingletonActions=true means project completes
-      // when all its singleton actions complete (or via the singleton flag).
-      proj.containsSingletonActions = true;
+  // Apply editable properties post-construction. Wrap in try/catch so a bad
+  // value can't leave a half-created project: on any failure we delete the
+  // just-constructed project and return an error envelope — creation is
+  // atomic (#1073).
+  try {
+    if (args.note != null) proj.note = args.note;
+    if (args.deferDate != null) proj.deferDate = new Date(args.deferDate);
+    if (args.dueDate != null) proj.dueDate = new Date(args.dueDate);
+    if (args.estimatedMinutes != null) proj.estimatedMinutes = args.estimatedMinutes;
+    if (args.flagged != null) proj.flagged = args.flagged;
+    if (args.status != null) {
+      // Map the wire-stable status enum to the OmniJS Project.Status constants.
+      // Wire: "active" | "on-hold" | "done" | "dropped"
+      const statusMap = {
+        active: Project.Status.Active,
+        "on-hold": Project.Status.OnHold,
+        done: Project.Status.Done,
+        dropped: Project.Status.Dropped,
+      };
+      const target = statusMap[args.status];
+      if (target !== undefined) proj.status = target;
     }
-    // "parallel" is the default — sequential=false, containsSingletonActions=false.
-  }
-  if (args.reviewIntervalDays != null) {
-    // OmniJS Project.reviewInterval takes a `Project.ReviewInterval` value
-    // constructed via `{ steps, unit }`. Days is the canonical unit here.
-    proj.reviewInterval = { steps: args.reviewIntervalDays, unit: "day" };
-  }
-  if (args.nextReviewDate != null) {
-    proj.nextReviewDate = new Date(args.nextReviewDate);
+    if (args.completionCriterion != null) {
+      if (args.completionCriterion === "sequential") proj.sequential = true;
+      else if (args.completionCriterion === "singleActions") {
+        // singleActions: containsSingletonActions=true means project completes
+        // when all its singleton actions complete (or via the singleton flag).
+        proj.containsSingletonActions = true;
+      }
+      // "parallel" is the default — sequential=false, containsSingletonActions=false.
+    }
+    if (args.reviewIntervalDays != null) {
+      // `Project.reviewInterval` requires a value of type `Project.ReviewInterval`
+      // — a plain `{ steps, unit }` object is rejected, and OmniJS has no
+      // `reviewIntervalDays` scalar (assigning it is a silent no-op). Mutate the
+      // project's existing ReviewInterval and reassign it; in-place mutation
+      // alone does not persist (verified live, #1073). nextReviewDate then
+      // recomputes as lastReviewDate + N days.
+      const ri = proj.reviewInterval;
+      ri.steps = args.reviewIntervalDays;
+      ri.unit = "days";
+      proj.reviewInterval = ri;
+    }
+    if (args.nextReviewDate != null) {
+      proj.nextReviewDate = new Date(args.nextReviewDate);
+    }
+  } catch (assignErr) {
+    // Roll back so the failed create leaves nothing behind.
+    try {
+      deleteObject(proj);
+    } catch (_e) {
+      /* best-effort rollback; report the original failure below */
+    }
+    return JSON.stringify({
+      error: {
+        code: "VALIDATION",
+        message: `project_create: failed to apply properties (project rolled back): ${String(assignErr)}`,
+      },
+    });
   }
 
   // Build the response Project — mirrors src/scripts/jxa/project_create.js's

--- a/src/tools/project/create.test.ts
+++ b/src/tools/project/create.test.ts
@@ -173,6 +173,20 @@ describe("project_create — handler", () => {
     expect(project.flagged).toBe(true);
   });
 
+  // #1073: reviewIntervalDays must plumb through create (handler → adapter →
+  // response). The OmniJS-specific behavior — the assignment is atomic and the
+  // interval is honored (nextReviewDate = lastReviewDate + N days) — is verified
+  // live against OmniFocus 4.x in the PR; the OmniJS `Project.reviewInterval`
+  // setter rejects a plain `{ steps, unit }` object and has no scalar fallback.
+  it("plumbs reviewIntervalDays through to the created project (#1073)", async () => {
+    const { ctx, adapter } = makeCtx();
+    const envelope = assertOk(
+      await handleProjectCreate({ name: "Reviewed", reviewIntervalDays: 30 }, ctx),
+    );
+    const project = await adapter.getProject(envelope.data.id);
+    expect(project.reviewIntervalDays).toBe(30);
+  });
+
   it("creates without optional fields (minimal path)", async () => {
     const { ctx } = makeCtx();
     const envelope = assertOk(await handleProjectCreate({ name: "Minimal" }, ctx));


### PR DESCRIPTION
## Summary

Two compounding defects in the OmniJS `project_create` path:

1. **Non-atomic "errors AND creates."** `new Project()` persists first, then props were assigned with no guard — a throwing assignment exited the script unframed (exit 1) while the project already existed, risking duplicates on retry.
2. **Wrong `reviewInterval` API.** `proj.reviewInterval = { steps, unit: "day" }` throws — the OmniJS setter requires a `Project.ReviewInterval` value, not a plain object; and there's no `reviewIntervalDays` scalar (assigning it is a silent no-op, so `nextReviewDate` fell back to the ~9-week default).

**Fix:**
- Read the project's existing `reviewInterval`, mutate `steps`/`unit`, **reassign** (in-place mutation alone doesn't persist). `nextReviewDate` recomputes as `lastReviewDate + N days`.
- Wrap all post-construction assignments in try/catch; on any failure, `deleteObject(proj)` + return `{ error: { code: "VALIDATION", … } }` (mapped to `ValidationError` by `OmniJsTransport`) — **atomic**, no half-created project, properly framed error.

Closes #1073

## Live verification (osascript / OmniFocus 4.x)

| check | result |
|---|---|
| `reviewIntervalDays: 30` → interval | `{steps:30, unit:"days"}` ✓ |
| `nextReviewDate` vs `lastReviewDate` | **+30 days exactly** ✓ |
| forced throwing assignment | caught → `deleteObject` → project **gone** (rolled back) ✓ |

I also spiked the API to ground the fix: a plain `{steps,unit}` object is rejected (`requires a value of type Project.ReviewInterval`); `reviewIntervalDays` doesn't exist in OmniJS; `new Project.ReviewInterval(...)` isn't a constructor — read-mutate-reassign of the existing value is the working path.

## Note (not in scope)
The issue flagged `meta.ofVersion: "unknown"` across the session — a separate detection gap, not touched here.

## Breaking change?

- [x] No — bug fix; `project_create` now honors `reviewIntervalDays` and never half-creates.

## Test plan

- [x] Handler regression test: `reviewIntervalDays` plumbs through create (InMemory).
- [x] Live: interval honored + atomic rollback (above).
- [x] `pnpm typecheck && pnpm lint && pnpm build` green; full suite green except a **pre-existing flake** in `persistentScriptRunner.test.ts` (JXA crash-recovery, unrelated to this OmniJS change — passes 9/9 in isolation).