### PR TITLE
perf(jxa): migrate tag + folder by-id lookups to flattenedX.byId() (#1081)

### DIFF
--- a/src/adapter/jxa/sandbox/index.ts
+++ b/src/adapter/jxa/sandbox/index.ts
@@ -317,6 +317,26 @@ function buildFakeDocument(doc: SandboxDocument) {
     },
   });
 
+  // `flattenedFolders` exposes both the callable (full list) and `.byId(id)`,
+  // mirroring flattenedTasks/flattenedProjects/flattenedTags — folder_delete.js
+  // and other scripts resolve a known folder id via byId (#788/#1081). A missing
+  // id resolves to a -1728 specifier whose `.id()` throws, which lookupOrThrow
+  // maps to "Folder not found: <id>".
+  const flattenedFolders = Object.assign(() => folders, {
+    byId: (id: string) => {
+      const hit = (folders as Array<{ id?: () => string }>).find(
+        (f) => typeof f.id === "function" && f.id() === id,
+      );
+      if (hit) return hit;
+      const msg = "Can't get object. (-1728)";
+      return {
+        id: () => {
+          throw new ScriptError(msg, { details: { stderr: msg } });
+        },
+      };
+    },
+  });
+
   // Top-level project collection. project_create.js pushes new projects
   // here OR into a folder's `.projects`. project_update / project_move use
   // `target.move({ to: ... .projects.end })`; the `.end` accessor is a
@@ -387,7 +407,7 @@ function buildFakeDocument(doc: SandboxDocument) {
     flattenedTasks,
     flattenedProjects,
     projects: docProjects,
-    flattenedFolders: () => folders,
+    flattenedFolders,
     folders: docFolders,
     inboxTasks: docInboxTasks,
     // Some scripts access inbox tasks through `doc.inbox.tasks()` instead

--- a/src/scripts/jxa/folder_delete.js
+++ b/src/scripts/jxa/folder_delete.js
@@ -21,15 +21,14 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allFolders = ofApp.defaultDocument.flattenedFolders();
-  let target = null;
-  for (let i = 0; i < allFolders.length; i++) {
-    if (allFolders[i].id() === args.id) {
-      target = allFolders[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Folder not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedFolders() linear scan (#788/#1081).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedFolders.byId(args.id),
+    "Folder",
+    args.id,
+  );
 
   const projectCount = target.projects ? target.projects().length : 0;
   const subfolderCount = target.folders ? target.folders().length : 0;

--- a/src/scripts/jxa/tag_delete.js
+++ b/src/scripts/jxa/tag_delete.js
@@ -21,15 +21,10 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allTags = ofApp.defaultDocument.flattenedTags();
-  let target = null;
-  for (let i = 0; i < allTags.length; i++) {
-    if (allTags[i].id() === args.id) {
-      target = allTags[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Tag not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedTags() linear scan (#788/#1081).
+  const target = lookupOrThrow(ofApp.defaultDocument.flattenedTags.byId(args.id), "Tag", args.id);
 
   ofApp.delete(target);
 

--- a/src/scripts/jxa/tag_get.js
+++ b/src/scripts/jxa/tag_get.js
@@ -21,15 +21,13 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_tag.js
+  // @inline _helpers/lookup_or_throw.js
 
   const doc = ofApp.defaultDocument;
   const docId = doc.id();
-  const allTags = doc.flattenedTags();
-  for (let i = 0; i < allTags.length; i++) {
-    if (allTags[i].id() === args.id) {
-      return JSON.stringify({ tag: buildTag(allTags[i], docId) });
-    }
-  }
-
-  throw new Error(`Tag not found: ${args.id}`);
+  // byId() instead of a flattenedTags() linear scan (#788/#1081): O(1) bridge
+  // lookup vs O(n) Apple Events. lookupOrThrow forces resolution and throws the
+  // same "Tag not found: <id>" on a missing id.
+  const tag = lookupOrThrow(doc.flattenedTags.byId(args.id), "Tag", args.id);
+  return JSON.stringify({ tag: buildTag(tag, docId) });
 }

--- a/src/scripts/jxa/tag_get_many.js
+++ b/src/scripts/jxa/tag_get_many.js
@@ -23,25 +23,24 @@ function run(argv) {
 
   // @inline _helpers/build_tag.js
 
-  /** @type {Record<string, unknown>} */
-  const idSet = {};
-  for (let i = 0; i < args.ids.length; i++) {
-    idSet[args.ids[i]] = null;
-  }
-
   const doc = ofApp.defaultDocument;
   const docId = doc.id();
-  const allTags = doc.flattenedTags();
-  for (let i = 0; i < allTags.length; i++) {
-    const tid = allTags[i].id();
-    if (Object.hasOwn(idSet, tid)) {
-      idSet[tid] = buildTag(allTags[i], docId);
-    }
-  }
 
+  // byId() per requested id instead of one full flattenedTags() linear scan
+  // (#788/#1081). Each byId() is an O(1) bridge lookup; a missing id resolves
+  // to a -1728 specifier whose `.id()` throws — caught here as `null`, which
+  // preserves the (Tag | null)[] contract (get_many never throws on a miss).
   const results = [];
   for (let i = 0; i < args.ids.length; i++) {
-    results.push(idSet[args.ids[i]]);
+    let tag = null;
+    try {
+      const spec = doc.flattenedTags.byId(args.ids[i]);
+      spec.id(); // force resolution; throws on a non-existent id
+      tag = buildTag(spec, docId);
+    } catch (_e) {
+      tag = null;
+    }
+    results.push(tag);
   }
 
   return JSON.stringify({ tags: results });

--- a/src/scripts/jxa/tag_update.js
+++ b/src/scripts/jxa/tag_update.js
@@ -22,18 +22,12 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_tag.js
+  // @inline _helpers/lookup_or_throw.js
 
   const doc = ofApp.defaultDocument;
   const docId = doc.id();
-  const allTags = doc.flattenedTags();
-  let target = null;
-  for (let i = 0; i < allTags.length; i++) {
-    if (allTags[i].id() === args.id) {
-      target = allTags[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Tag not found: ${args.id}`);
+  // byId() instead of a flattenedTags() linear scan (#788/#1081).
+  const target = lookupOrThrow(doc.flattenedTags.byId(args.id), "Tag", args.id);
 
   if (args.name !== undefined) target.name = args.name;
   if (args.status !== undefined) {


### PR DESCRIPTION
## Summary

Slice of epic #788. Five JXA scripts resolved a known id with a `flattenedX().filter`/for-scan — O(n) Apple Events per call (~5s on a 308-tag DB just to find one). Replaced with `byId(id)` + `lookupOrThrow` (the #687 pattern, mirroring `task_drop.js`):

- `tag_get`, `tag_update`, `tag_delete`, `folder_delete` → `lookupOrThrow(doc.flattenedX.byId(id), "<Kind>", id)` — throws the **same** `"<Kind> not found: <id>"`, so the not-found contract is unchanged.
- `tag_get_many` → `byId` per requested id with try/catch → `null` on miss, preserving the `(Tag | null)[]` contract (get_many never throws on a missing id).

Part of #788. Closes #1081

## Sandbox fidelity fix

`flattenedFolders` in the sandbox only exposed the callable, not `.byId` (unlike tasks/projects/tags). Added it — a missing id resolves to a `-1728` specifier whose `.id()` throws. This unblocks the `folder_delete` sandbox tests **and** closes the gap that would otherwise let a by-scan↔by-id divergence hide.

## Live verification (OmniFocus 4.x, 308-tag DB)

| check | result |
|---|---|
| `byId(existing)` | resolves ✓ |
| `byId(missing).id()` | throws → mapped to "not found" ✓ |
| 20× lookup: **scan** vs **byId** | **103118 ms → 338 ms (~305×)** ✓ (#788 target ≥10×) |

Scratch tag cleaned up (0 leftovers).

## Breaking change?

- [x] No — same lookups, same not-found errors; pure perf + sandbox-fidelity.

## Test plan

- [x] `pnpm typecheck` + JXA `tsc -p tsconfig.jxa-tscheck.json` + `pnpm build` (inlining of `@inline _helpers/lookup_or_throw.js`) green.
- [x] Sandbox + tag/folder unit tests green (355); full suite 3998 passed.
- [x] Sweep: no `flattenedX().filter(... .id() === id)` remains in the 5 scripts.