### PR TITLE
perf(jxa): migrate task get/get_many/complete/uncomplete/delete to byId() (#1083)

### DIFF
--- a/src/scripts/jxa/task_complete.js
+++ b/src/scripts/jxa/task_complete.js
@@ -20,15 +20,11 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allTasks = ofApp.defaultDocument.flattenedTasks();
-  let found = null;
-  for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      found = allTasks[i];
-      break;
-    }
-  }
-  if (!found) throw new Error(`Task not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedTasks() linear scan (#788/#1083); byId resolves
+  // completed tasks fine (verified), so no scan fallback is needed.
+  const found = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
 
   ofApp.markComplete(found);
 

--- a/src/scripts/jxa/task_delete.js
+++ b/src/scripts/jxa/task_delete.js
@@ -20,15 +20,10 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allTasks = ofApp.defaultDocument.flattenedTasks();
-  let found = null;
-  for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      found = allTasks[i];
-      break;
-    }
-  }
-  if (!found) throw new Error(`Task not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedTasks() linear scan (#788/#1083).
+  const found = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
 
   found.delete();
 

--- a/src/scripts/jxa/task_get.js
+++ b/src/scripts/jxa/task_get.js
@@ -38,14 +38,10 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_task.js
+  // @inline _helpers/lookup_or_throw.js
 
-  const allTasks = ofApp.defaultDocument.flattenedTasks();
-  for (let i = 0; i < allTasks.length; i++) {
-    const t = allTasks[i];
-    if (t.id() === args.id) {
-      return JSON.stringify({ task: buildTask(t) });
-    }
-  }
-
-  throw new Error(`Task not found: ${args.id}`);
+  // byId() instead of a flattenedTasks() linear scan (#788/#1083). lookupOrThrow
+  // throws the same "Task not found: <id>" on a missing id.
+  const t = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
+  return JSON.stringify({ task: buildTask(t) });
 }

--- a/src/scripts/jxa/task_get_many.js
+++ b/src/scripts/jxa/task_get_many.js
@@ -22,24 +22,23 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_task.js
+  // @inline _helpers/lookup_or_throw.js
 
-  /** @type {Record<string, unknown>} */
-  const idSet = {};
-  for (let i = 0; i < args.ids.length; i++) {
-    idSet[args.ids[i]] = null;
-  }
+  const doc = ofApp.defaultDocument;
 
-  const allTasks = ofApp.defaultDocument.flattenedTasks();
-  for (let i = 0; i < allTasks.length; i++) {
-    const tid = allTasks[i].id();
-    if (Object.hasOwn(idSet, tid)) {
-      idSet[tid] = buildTask(allTasks[i]);
-    }
-  }
-
+  // byId() per requested id instead of one full flattenedTasks() linear scan
+  // (#788/#1083). lookupOrThrow forces resolution and throws on a missing id
+  // (-1728); we catch that and emit `null`, preserving the (Task | null)[]
+  // contract (get_many never throws on a miss).
   const results = [];
   for (let i = 0; i < args.ids.length; i++) {
-    results.push(idSet[args.ids[i]]);
+    let task = null;
+    try {
+      task = buildTask(lookupOrThrow(doc.flattenedTasks.byId(args.ids[i]), "Task", args.ids[i]));
+    } catch (_e) {
+      task = null;
+    }
+    results.push(task);
   }
 
   return JSON.stringify({ tasks: results });

--- a/src/scripts/jxa/task_uncomplete.js
+++ b/src/scripts/jxa/task_uncomplete.js
@@ -20,15 +20,10 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allTasks = ofApp.defaultDocument.flattenedTasks();
-  let found = null;
-  for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      found = allTasks[i];
-      break;
-    }
-  }
-  if (!found) throw new Error(`Task not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedTasks() linear scan (#788/#1083).
+  const found = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
 
   ofApp.markIncomplete(found);
 


### PR DESCRIPTION
## Summary

Slice of epic #788. Five hot-path Task scripts resolved a known id via a `flattenedTasks()` linear scan (O(n) Apple Events; ~5s on a large DB to find one). Migrate to `flattenedTasks.byId(id)` + `lookupOrThrow`:

- `task_get`, `task_complete`, `task_uncomplete`, `task_delete` → `lookupOrThrow` (throws the **same** `"Task not found: <id>"`).
- `task_get_many` → `lookupOrThrow` wrapped in try/catch → `null` on miss, preserving the `(Task | null)[]` contract (and satisfying the `flattened-tasks-byid-must-use-lookup-or-throw` custom rule).

Part of #788. Closes #1083

## Verified the #788 fallback caveat is unnecessary

#788 said complete/uncomplete/delete should "fall back to scan for already-completed/dropped targets." Spiked it live: `flattenedTasks.byId()` resolves a **completed** task fine (`byId_completed: true`, same as the scan). So no fallback is needed — a straight `byId` migration is correct. (`task_update`/`task_move` carry `narrow-scan-ok` comments → deferred to a separate slice for per-script review.)

## Breaking change?

- [x] No — same lookups, same not-found errors; pure perf.

## Test plan

- [x] `pnpm typecheck` + JXA `tsc -p tsconfig.jxa-tscheck.json` + `pnpm lint` (incl. custom rules) + `pnpm build` green.
- [x] Sandbox + task unit tests green (824); full suite 3998 passed (the `extractFromImage` attachment tests need a home-scoped `TMPDIR`, unrelated).
- [x] Sweep: no `flattenedTasks().filter(... .id() === id)` remains in the 5 scripts.
- [x] byId perf proven on the prior slice (#1081): ~305× on a real DB.