### PR TITLE
perf(jxa): migrate project get/get_many/complete/drop/delete to byId() (#1085)

### DIFF
--- a/src/scripts/jxa/project_complete.js
+++ b/src/scripts/jxa/project_complete.js
@@ -21,15 +21,14 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedProjects() linear scan (#788/#1085).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   ofApp.markComplete(target);
 

--- a/src/scripts/jxa/project_delete.js
+++ b/src/scripts/jxa/project_delete.js
@@ -21,15 +21,14 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedProjects() linear scan (#788/#1085).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   ofApp.delete(target);
 

--- a/src/scripts/jxa/project_drop.js
+++ b/src/scripts/jxa/project_drop.js
@@ -21,15 +21,14 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedProjects() linear scan (#788/#1085).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   // @ts-expect-error JXA accepts property-setter form on sdef properties; see _types/sdef-overrides.d.ts.
   target.status = "dropped";

--- a/src/scripts/jxa/project_get.js
+++ b/src/scripts/jxa/project_get.js
@@ -21,13 +21,13 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_project.js
+  // @inline _helpers/lookup_or_throw.js
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      return JSON.stringify({ project: buildProject(allProjects[i]) });
-    }
-  }
-
-  throw new Error(`Project not found: ${args.id}`);
+  // byId() instead of a flattenedProjects() linear scan (#788/#1085).
+  const proj = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
+  return JSON.stringify({ project: buildProject(proj) });
 }

--- a/src/scripts/jxa/project_get_many.js
+++ b/src/scripts/jxa/project_get_many.js
@@ -22,24 +22,24 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_project.js
+  // @inline _helpers/lookup_or_throw.js
 
-  /** @type {Record<string, unknown>} */
-  const idSet = {};
-  for (let i = 0; i < args.ids.length; i++) {
-    idSet[args.ids[i]] = null;
-  }
+  const doc = ofApp.defaultDocument;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  for (let i = 0; i < allProjects.length; i++) {
-    const pid = allProjects[i].id();
-    if (Object.hasOwn(idSet, pid)) {
-      idSet[pid] = buildProject(allProjects[i]);
-    }
-  }
-
+  // byId() per requested id instead of one full flattenedProjects() linear scan
+  // (#788/#1085). lookupOrThrow forces resolution and throws on a missing id;
+  // we catch that and emit `null`, preserving the (Project | null)[] contract.
   const results = [];
   for (let i = 0; i < args.ids.length; i++) {
-    results.push(idSet[args.ids[i]]);
+    let project = null;
+    try {
+      project = buildProject(
+        lookupOrThrow(doc.flattenedProjects.byId(args.ids[i]), "Project", args.ids[i]),
+      );
+    } catch (_e) {
+      project = null;
+    }
+    results.push(project);
   }
 
   return JSON.stringify({ projects: results });


### PR DESCRIPTION
## Summary

Slice of epic #788. Five simple single-id Project scripts resolved the project via a `flattenedProjects()` linear scan (O(n) Apple Events). Migrate to `flattenedProjects.byId(id)` + `lookupOrThrow`:

- `project_get`, `project_complete`, `project_drop`, `project_delete` → `lookupOrThrow` (same `"Project not found: <id>"`).
- `project_get_many` → `lookupOrThrow` in try/catch → `null` on miss (preserves `(Project | null)[]`).

`project_update`/`project_move`/review-setters resolve a project plus (in some cases) a destination folder/parent — deferred to a separate slice.

Part of #788. Closes #1085

## Breaking change?
- [x] No — same lookups, same not-found errors; pure perf.

## Test plan
- [x] `pnpm typecheck` + JXA `tsc -p tsconfig.jxa-tscheck.json` + `pnpm lint` (custom rules) + `pnpm build` green.
- [x] Project + sandbox tests green (460); full suite via pre-push hook.
- [x] Sweep: no `flattenedProjects()` scan remains in the 5.
- [x] byId perf proven on the prior slices (~305× on a real DB).