### PR TITLE
perf(jxa): migrate attachment + window_set_focus by-id lookups to byId() (#1087)

### DIFF
--- a/src/scripts/jxa/attachment_add.js
+++ b/src/scripts/jxa/attachment_add.js
@@ -22,20 +22,16 @@ function run(argv) {
   ofApp.includeStandardAdditions = true;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   function findOwner() {
+    // byId() instead of flattenedX() linear scans (#788/#1087); lookupOrThrow
+    // throws the same "<Kind> not found: <id>" on a missing id.
     if (args.taskId) {
-      const tasks = doc.flattenedTasks();
-      for (let i = 0; i < tasks.length; i++) {
-        if (tasks[i].id() === args.taskId) return tasks[i];
-      }
-      throw new Error(`Task not found: ${args.taskId}`);
+      return lookupOrThrow(doc.flattenedTasks.byId(args.taskId), "Task", args.taskId);
     }
     if (args.projectId) {
-      const projects = doc.flattenedProjects();
-      for (let i = 0; i < projects.length; i++) {
-        if (projects[i].id() === args.projectId) return projects[i];
-      }
-      throw new Error(`Project not found: ${args.projectId}`);
+      return lookupOrThrow(doc.flattenedProjects.byId(args.projectId), "Project", args.projectId);
     }
     throw new Error("One of taskId or projectId is required");
   }

--- a/src/scripts/jxa/attachment_list.js
+++ b/src/scripts/jxa/attachment_list.js
@@ -23,20 +23,16 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   function findOwner() {
+    // byId() instead of flattenedX() linear scans (#788/#1087); lookupOrThrow
+    // throws the same "<Kind> not found: <id>" on a missing id.
     if (args.taskId) {
-      const tasks = doc.flattenedTasks();
-      for (let i = 0; i < tasks.length; i++) {
-        if (tasks[i].id() === args.taskId) return tasks[i];
-      }
-      throw new Error(`Task not found: ${args.taskId}`);
+      return lookupOrThrow(doc.flattenedTasks.byId(args.taskId), "Task", args.taskId);
     }
     if (args.projectId) {
-      const projects = doc.flattenedProjects();
-      for (let i = 0; i < projects.length; i++) {
-        if (projects[i].id() === args.projectId) return projects[i];
-      }
-      throw new Error(`Project not found: ${args.projectId}`);
+      return lookupOrThrow(doc.flattenedProjects.byId(args.projectId), "Project", args.projectId);
     }
     throw new Error("One of taskId or projectId is required");
   }

--- a/src/scripts/jxa/attachment_remove.js
+++ b/src/scripts/jxa/attachment_remove.js
@@ -22,20 +22,16 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   function findOwner() {
+    // byId() instead of flattenedX() linear scans (#788/#1087); lookupOrThrow
+    // throws the same "<Kind> not found: <id>" on a missing id.
     if (args.taskId) {
-      const tasks = doc.flattenedTasks();
-      for (let i = 0; i < tasks.length; i++) {
-        if (tasks[i].id() === args.taskId) return tasks[i];
-      }
-      throw new Error(`Task not found: ${args.taskId}`);
+      return lookupOrThrow(doc.flattenedTasks.byId(args.taskId), "Task", args.taskId);
     }
     if (args.projectId) {
-      const projects = doc.flattenedProjects();
-      for (let i = 0; i < projects.length; i++) {
-        if (projects[i].id() === args.projectId) return projects[i];
-      }
-      throw new Error(`Project not found: ${args.projectId}`);
+      return lookupOrThrow(doc.flattenedProjects.byId(args.projectId), "Project", args.projectId);
     }
     throw new Error("One of taskId or projectId is required");
   }

--- a/src/scripts/jxa/attachment_save_to_path.js
+++ b/src/scripts/jxa/attachment_save_to_path.js
@@ -27,20 +27,16 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
   const doc = ofApp.defaultDocument;
 
+  // @inline _helpers/lookup_or_throw.js
+
   function findOwner() {
+    // byId() instead of flattenedX() linear scans (#788/#1087); lookupOrThrow
+    // throws the same "<Kind> not found: <id>" on a missing id.
     if (args.taskId) {
-      const tasks = doc.flattenedTasks();
-      for (let i = 0; i < tasks.length; i++) {
-        if (tasks[i].id() === args.taskId) return tasks[i];
-      }
-      throw new Error(`Task not found: ${args.taskId}`);
+      return lookupOrThrow(doc.flattenedTasks.byId(args.taskId), "Task", args.taskId);
     }
     if (args.projectId) {
-      const projects = doc.flattenedProjects();
-      for (let i = 0; i < projects.length; i++) {
-        if (projects[i].id() === args.projectId) return projects[i];
-      }
-      throw new Error(`Project not found: ${args.projectId}`);
+      return lookupOrThrow(doc.flattenedProjects.byId(args.projectId), "Project", args.projectId);
     }
     throw new Error("One of taskId or projectId is required");
   }

--- a/src/scripts/jxa/window_set_focus.js
+++ b/src/scripts/jxa/window_set_focus.js
@@ -49,23 +49,31 @@ function run(argv) {
 
   // Resolve to a project or folder.
   const doc = ofApp.defaultDocument;
+
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of flattenedX() linear scans (#788/#1087). The container may
+  // be a project OR a folder, so try project first and fall back to folder
+  // before reporting NOT_FOUND.
   let target = null;
-
-  const projects = doc.flattenedProjects();
-  for (let i = 0; i < projects.length; i++) {
-    if (projects[i].id() === args.containerId) {
-      target = projects[i];
-      break;
-    }
+  try {
+    target = lookupOrThrow(
+      doc.flattenedProjects.byId(args.containerId),
+      "Project",
+      args.containerId,
+    );
+  } catch (_e) {
+    /* not a project — try folder next */
   }
-
   if (!target) {
-    const folders = doc.flattenedFolders();
-    for (let i = 0; i < folders.length; i++) {
-      if (folders[i].id() === args.containerId) {
-        target = folders[i];
-        break;
-      }
+    try {
+      target = lookupOrThrow(
+        doc.flattenedFolders.byId(args.containerId),
+        "Folder",
+        args.containerId,
+      );
+    } catch (_e) {
+      /* not a folder either — NOT_FOUND below */
     }
   }
 


### PR DESCRIPTION
## Summary

Slice of epic #788 — Attachments + Window group:

- `attachment_list`/`add`/`remove`/`save_to_path`: each `findOwner()` resolved a task-or-project via `flattenedX()` scans and threw `"<Kind> not found"`; replaced with `lookupOrThrow(doc.flattenedX.byId(id), …)` (same message).
- `window_set_focus`: container may be a project OR folder — replaced the two scans with `byId` + try/catch, trying project then folder before the same `NOT_FOUND` "Container not found (project or folder)" envelope.

Part of #788. Closes #1087

## Test plan
- [x] typecheck + JXA-typecheck + lint + build green; attachment + sandbox tests (259); full suite via pre-push.
- [x] Sweep: no `flattenedX()` scans remain in the 5.
- [x] byId perf proven on prior slices (~305× on a real DB).

## Breaking change?
- [x] No — same lookups + not-found behavior; pure perf.