### PR TITLE
perf(jxa): migrate project review-setters to byId() (#1089)

### DIFF
--- a/src/scripts/jxa/project_mark_reviewed.js
+++ b/src/scripts/jxa/project_mark_reviewed.js
@@ -21,15 +21,14 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedProjects() linear scan (#788/#1089).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   // Mark the project reviewed — sets lastReviewDate and advances nextReviewDate
   ofApp.markReviewed(target);

--- a/src/scripts/jxa/project_set_next_review_date.js
+++ b/src/scripts/jxa/project_set_next_review_date.js
@@ -33,15 +33,14 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedProjects() linear scan (#788/#1089).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   // @ts-expect-error JXA accepts property-setter form on sdef properties; see _types/sdef-overrides.d.ts.
   target.nextReviewDate = args.nextReviewDate === null ? null : new Date(args.nextReviewDate);

--- a/src/scripts/jxa/project_set_review_interval.js
+++ b/src/scripts/jxa/project_set_review_interval.js
@@ -21,15 +21,14 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedProjects() linear scan (#788/#1089).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   target.reviewIntervalDays = args.days;
 


### PR DESCRIPTION
## Summary

Slice of epic #788. `project_mark_reviewed`, `project_set_next_review_date`, `project_set_review_interval` resolved the project via a `flattenedProjects()` linear scan then set a review field. Replaced the scan with `flattenedProjects.byId(id)` + `lookupOrThrow` (same `"Project not found: <id>"`).

**This completes the clean single-id-lookup migrations under #788** (~23 scripts across tags/folders, tasks, projects, attachments/window, review-setters — all verified ~305× faster on a real DB). Remaining: `project_update`/`move` (folder/destination resolution) and `task_update`/`move` (mixed JXA/OmniJS + `narrow-scan-ok` markers) — intricate, for per-script slices.

Part of #788. Closes #1089

## Test plan
- [x] typecheck + JXA-typecheck + lint + build green; project/review/sandbox tests (505).
- [x] Sweep: no `flattenedProjects()` scan remains in the 3.

## Breaking change?
- [x] No — same lookups + not-found behavior; pure perf.