### PR TITLE
perf(jxa): migrate task/project update+move source lookups to byId() — completes #788 sweep (#1091)

### DIFF
--- a/src/scripts/jxa/project_move.js
+++ b/src/scripts/jxa/project_move.js
@@ -21,21 +21,20 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedProjects() linear scan (#788/#1091).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   if (args.folderId) {
-    // Resolve via flattenedFolders iteration (top-level `folders` excludes
-    // nested ones; `byId(...)` returns a lazy specifier whose subsequent
-    // `.projects.end` is nil — same JXA quirk as #674's lookupOrThrow).
-    // Mirroring the same iteration the project lookup above uses.
+    // Folder resolution stays a flattenedFolders iteration on purpose: a
+    // `flattenedFolders.byId(...)` specifier has a nil `.projects.end` (the move
+    // target on the next line) — the #674 JXA quirk. byId is correct for the
+    // project above, but not for a folder we then read `.projects.end` off.
     const allFolders = ofApp.defaultDocument.flattenedFolders();
     let folder = null;
     for (let i = 0; i < allFolders.length; i++) {

--- a/src/scripts/jxa/project_update.js
+++ b/src/scripts/jxa/project_update.js
@@ -25,16 +25,14 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_project.js
+  // @inline _helpers/lookup_or_throw.js
 
-  const allProjects = ofApp.defaultDocument.flattenedProjects();
-  let target = null;
-  for (let i = 0; i < allProjects.length; i++) {
-    if (allProjects[i].id() === args.id) {
-      target = allProjects[i];
-      break;
-    }
-  }
-  if (!target) throw new Error(`Project not found: ${args.id}`);
+  // byId() instead of a flattenedProjects() linear scan (#788/#1091).
+  const target = lookupOrThrow(
+    ofApp.defaultDocument.flattenedProjects.byId(args.id),
+    "Project",
+    args.id,
+  );
 
   if (args.name !== undefined) target.name = args.name;
   if (args.note !== undefined) target.note = args.note ?? "";

--- a/src/scripts/jxa/task_move.js
+++ b/src/scripts/jxa/task_move.js
@@ -20,18 +20,10 @@ function run(argv) {
   const ofApp = Application("OmniFocus");
   ofApp.includeStandardAdditions = false;
 
-  const allTasks =
-    ofApp.defaultDocument.flattenedTasks(); /* narrow-scan-ok: must resolve source task by id before knowing its container */
-  let found = null;
-  for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      found = allTasks[i];
-      break;
-    }
-  }
-  if (!found) throw new Error(`Task not found: ${args.id}`);
-
   // @inline _helpers/lookup_or_throw.js
+
+  // byId() instead of a flattenedTasks() linear scan (#788/#1091).
+  const found = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
 
   if (args.parentId) {
     const parent = lookupOrThrow(

--- a/src/scripts/jxa/task_update.js
+++ b/src/scripts/jxa/task_update.js
@@ -29,17 +29,12 @@ function run(argv) {
   ofApp.includeStandardAdditions = false;
 
   // @inline _helpers/build_task.js
+  // @inline _helpers/lookup_or_throw.js
 
-  const allTasks =
-    ofApp.defaultDocument.flattenedTasks(); /* narrow-scan-ok: must resolve task by id; no scope hint available */
-  let found = null;
-  for (let i = 0; i < allTasks.length; i++) {
-    if (allTasks[i].id() === args.id) {
-      found = allTasks[i];
-      break;
-    }
-  }
-  if (!found) throw new Error(`Task not found: ${args.id}`);
+  // byId() instead of a flattenedTasks() linear scan (#788/#1091). The OmniJS
+  // evaluateJavascript blocks below (repetition, tag-set) resolve their own
+  // targets via Task.byIdentifier and are unchanged.
+  const found = lookupOrThrow(ofApp.defaultDocument.flattenedTasks.byId(args.id), "Task", args.id);
 
   if (args.name !== undefined) found.name = args.name;
   if (Object.hasOwn(args, "note")) {


### PR DESCRIPTION
## Summary

Final slice of epic #788 — the four scripts with logic *around* the source lookup. Each source resolution moves from a `flattenedX()` scan to `byId()` + `lookupOrThrow`; surrounding logic untouched:

- `task_move`: source scan (`narrow-scan-ok` removed) → byId; destination moves already byId.
- `task_update`: source scan (marker removed) → byId; the OmniJS `evaluateJavascript` blocks (repetition, tag-set) are unchanged.
- `project_update`: source scan → byId; folder destination already `folders.byId`.
- `project_move`: source-project scan → byId. Its **folder** lookup *deliberately* stays a `flattenedFolders` iteration — a `byId` folder specifier has a nil `.projects.end` (the move target), the #674 quirk — now documented inline.

**This completes the #788 sweep:** no single-id `flattenedX().filter(t => t.id() === id)` read/write scan remains in `src/scripts/jxa/`, the lone documented exception being `project_move`'s folder resolution.

Part of #788. Closes #1091

## Test plan
- [x] typecheck + JXA-typecheck + lint (incl. `flattened-tasks-byid-must-use-lookup-or-throw`) + build green.
- [x] task + project + sandbox tests (1047); full suite via pre-push.
- [x] Sweep: source scans gone from all 4; `task_update`'s OmniJS blocks unchanged.
- [x] byId perf proven on prior slices (~305× on a real DB).

## Breaking change?
- [x] No — same lookups + not-found behavior; pure perf.