### PR TITLE
fix(bench): make the token-cost gate environment-robust

### DIFF
--- a/tests/benchmark/token-cost/README.md
+++ b/tests/benchmark/token-cost/README.md
@@ -9,13 +9,17 @@ workflow without regressing the others.
 The suite is hermetic: it drives `InMemoryAdapter` directly, does not
 touch JXA, and does not require OmniFocus to be running.
 
-> **Known issue ([#1075](https://github.com/torsday/omnifocus-mcp/issues/1075)):**
-> despite being deterministic, `toolListBytes` currently computes ~30% larger
-> on the `mac-local` CI runner than on any local checkout (247910 vs 189728 at
-> the time of writing), so the `token-cost bench` gate can red-flag PRs that
-> never touched the tool surface. Until #1075 is resolved the check is
-> advisory; an unrelated PR caught by the divergence may carry the
-> `bench: regression-allowed` label with a justification in its description.
+> **Gate scope ([#1075](https://github.com/torsday/omnifocus-mcp/issues/1075)):**
+> `toolListBytes` computes ~30% larger on the `mac-local` CI runner than on a
+> clean checkout (247910 vs 189728), same code/zod — a `z.toJSONSchema`
+> environment difference. To stop that env noise from red-flagging unrelated
+> PRs, **`toolListBytes` is no longer gated**: the drift gate now compares only
+> the environment-independent per-workflow round-trip bytes (`totalTokens`
+> excludes `toolListBytes`). `toolListBytes` is still reported, advisorily, with
+> the resolved node + zod versions so a future divergence is self-diagnosing.
+> Tool-description size — what actually drives tool-list token cost — stays
+> gated deterministically by the 350-token/tool budget in
+> `src/tools/descriptions.lint.test.ts`.
 
 ## What it measures
 
@@ -23,11 +27,11 @@ For each fixture workflow the suite records:
 
 | Field | What it captures |
 | --- | --- |
-| `toolListBytes` | UTF-8 length of the simulated `tools/list` payload (every tool's `{name, description, inputSchema}`). Workflow-independent. |
+| `toolListBytes` | UTF-8 length of the simulated `tools/list` payload (every tool's `{name, description, inputSchema}`). Workflow-independent. **Advisory only — not gated** (environment-sensitive, #1075). |
 | `totalRequestBytes` | Sum of UTF-8 lengths of every JSON-stringified tool input the workflow sends. |
 | `totalResponseBytes` | Sum of UTF-8 lengths of every `toolResponse(envelope)` the workflow receives. Captures both `content[0].text` and `structuredContent` — what the wire delivers. |
 | `totalRoundTripBytes` | `totalRequestBytes + totalResponseBytes`. |
-| `totalTokens` | `(toolListBytes + totalRoundTripBytes) / TOKEN_DIVISOR`, rounded. |
+| `totalTokens` | `totalRoundTripBytes / TOKEN_DIVISOR`, rounded — the workflow's own round-trip cost. Excludes `toolListBytes` (seen once per session, not per workflow; and env-sensitive, #1075). |
 | `byTool[<name>]` | Per-tool aggregate `{ calls, responseBytes }` — surfaces hotspots so an optimization PR can scope its change. |
 
 ### Why measure at the handler boundary, not the JSON-RPC wire?

--- a/tests/benchmark/token-cost/__snapshots__/baseline.json
+++ b/tests/benchmark/token-cost/__snapshots__/baseline.json
@@ -1,13 +1,17 @@
 {
   "generatedAt": "2026-06-04",
-  "toolListBytes": 248991,
+  "versions": {
+    "node": "24.3.0",
+    "zod": "4.4.3"
+  },
+  "toolListBytes": 249357,
   "workflows": {
     "cap-truncation": {
       "callCount": 3,
       "totalRequestBytes": 135,
       "totalResponseBytes": 22543,
       "totalRoundTripBytes": 22678,
-      "totalTokens": 67917,
+      "totalTokens": 5670,
       "byTool": {
         "forecast_get": {
           "calls": 1,
@@ -24,7 +28,7 @@
       "totalRequestBytes": 5681,
       "totalResponseBytes": 9659,
       "totalRoundTripBytes": 15340,
-      "totalTokens": 66083,
+      "totalTokens": 3835,
       "byTool": {
         "task_batch_create": {
           "calls": 2,
@@ -45,7 +49,7 @@
       "totalRequestBytes": 154,
       "totalResponseBytes": 30076,
       "totalRoundTripBytes": 30230,
-      "totalTokens": 69805,
+      "totalTokens": 7558,
       "byTool": {
         "forecast_get": {
           "calls": 1,
@@ -66,7 +70,7 @@
       "totalRequestBytes": 29603,
       "totalResponseBytes": 16778,
       "totalRoundTripBytes": 46381,
-      "totalTokens": 73843,
+      "totalTokens": 11595,
       "byTool": {
         "tag_create": {
           "calls": 1,
@@ -95,7 +99,7 @@
       "totalRequestBytes": 324,
       "totalResponseBytes": 31794,
       "totalRoundTripBytes": 32118,
-      "totalTokens": 70277,
+      "totalTokens": 8030,
       "byTool": {
         "task_list": {
           "calls": 3,
@@ -108,7 +112,7 @@
       "totalRequestBytes": 2609,
       "totalResponseBytes": 9998,
       "totalRoundTripBytes": 12607,
-      "totalTokens": 65400,
+      "totalTokens": 3152,
       "byTool": {
         "project_create": {
           "calls": 1,
@@ -141,7 +145,7 @@
       "totalRequestBytes": 10623,
       "totalResponseBytes": 23527,
       "totalRoundTripBytes": 34150,
-      "totalTokens": 70785,
+      "totalTokens": 8538,
       "byTool": {
         "changes_since": {
           "calls": 2,
@@ -162,7 +166,7 @@
       "totalRequestBytes": 292,
       "totalResponseBytes": 7860,
       "totalRoundTripBytes": 8152,
-      "totalTokens": 64286,
+      "totalTokens": 2038,
       "byTool": {
         "project_mark_reviewed": {
           "calls": 5,

--- a/tests/benchmark/token-cost/cli.ts
+++ b/tests/benchmark/token-cost/cli.ts
@@ -24,7 +24,9 @@ import {
   diffSnapshots,
   formatDrift,
   readSnapshot,
+  resolveVersions,
   SNAPSHOT_PATH,
+  toolListBytesDrift,
   writeSnapshot,
 } from "./snapshot.js";
 import { estimateTokens } from "./tokenizer.js";
@@ -108,9 +110,11 @@ async function main(): Promise<void> {
     }
   }
 
+  const versions = resolveVersions();
   // biome-ignore lint/suspicious/noConsole: intentional CLI output
   console.log(
-    `\ntools/list payload: ${fmtBytes(toolListBytes)} (~${estimateTokens(toolListBytes)} tokens)`,
+    `\ntools/list payload: ${fmtBytes(toolListBytes)} (~${estimateTokens(toolListBytes)} tokens) ` +
+      `[advisory, env-sensitive — node ${versions.node}, zod ${versions.zod}; #1075]`,
   );
 
   if (smoke5k) {
@@ -141,6 +145,16 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
+  // Advisory: surface toolListBytes drift without failing the gate (#1075).
+  const advisory = toolListBytesDrift(baseline, current);
+  if (advisory !== null) {
+    // biome-ignore lint/suspicious/noConsole: intentional CLI output
+    console.log(
+      `\nadvisory (not gated): ${formatDrift([advisory])}\n` +
+        `  toolListBytes is environment-sensitive (#1075); description size is gated by the 350-token/tool budget lint.`,
+    );
+  }
+
   const drift = diffSnapshots(baseline, current);
   if (drift.length > 0) {
     // biome-ignore lint/suspicious/noConsole: intentional CLI output

--- a/tests/benchmark/token-cost/runBench.ts
+++ b/tests/benchmark/token-cost/runBench.ts
@@ -212,7 +212,15 @@ export class Bench {
       totalRequestBytes: totalRequest,
       totalResponseBytes: totalResponse,
       totalRoundTripBytes: totalRoundTrip,
-      totalTokens: estimateTokens(toolListBytes + totalRoundTrip),
+      // #1075: `totalTokens` is the workflow's OWN round-trip cost only. It
+      // deliberately excludes `toolListBytes` — the LLM sees tools/list once
+      // per session, not per workflow, and `toolListBytes` is environment-
+      // sensitive (its `z.toJSONSchema` byte count differs ~30% on the
+      // self-hosted runner). Folding it in made one env-only inflation drift
+      // every workflow's gated total at once. It's now reported separately
+      // and advisory (see snapshot.ts); description size stays gated
+      // deterministically by the 350-token/tool budget in descriptions.lint.
+      totalTokens: estimateTokens(totalRoundTrip),
       byTool,
     };
   }

--- a/tests/benchmark/token-cost/snapshot.test.ts
+++ b/tests/benchmark/token-cost/snapshot.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the token-cost snapshot gate (#1075).
+ *
+ * The point of #1075: `toolListBytes` is environment-sensitive and must NOT
+ * fail the gate, while real per-workflow response-size regressions still must.
+ * Runs in the normal suite (unlike run.test.ts, which is OMNIFOCUS_BENCH-gated).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  diffSnapshots,
+  resolveVersions,
+  type SnapshotPayload,
+  toolListBytesDrift,
+} from "./snapshot.js";
+
+function snap(over: Partial<SnapshotPayload> = {}): SnapshotPayload {
+  return {
+    generatedAt: "2026-06-04",
+    toolListBytes: 100_000,
+    workflows: {
+      "inbox-triage": {
+        callCount: 3,
+        totalRequestBytes: 100,
+        totalResponseBytes: 5000,
+        totalRoundTripBytes: 5100,
+        totalTokens: 1275,
+        byTool: {},
+      },
+    },
+    ...over,
+  };
+}
+
+describe("diffSnapshots — toolListBytes is not gated (#1075)", () => {
+  it("does not fail on a large toolListBytes-only difference", () => {
+    const baseline = snap({ toolListBytes: 189_728 });
+    const current = snap({ toolListBytes: 247_910 }); // +30.7%, the runner inflation
+    expect(diffSnapshots(baseline, current)).toEqual([]);
+  });
+
+  it("still fails on a real per-workflow response-size regression", () => {
+    const baseline = snap();
+    const current = snap({
+      workflows: {
+        "inbox-triage": {
+          callCount: 3,
+          totalRequestBytes: 100,
+          totalResponseBytes: 7000, // +40%
+          totalRoundTripBytes: 7100,
+          totalTokens: 1775,
+          byTool: {},
+        },
+      },
+    });
+    const drift = diffSnapshots(baseline, current);
+    expect(drift.map((d) => d.path)).toContain("inbox-triage.totalResponseBytes");
+  });
+});
+
+describe("toolListBytesDrift — advisory", () => {
+  it("reports drift without it being in the gated set", () => {
+    const baseline = snap({ toolListBytes: 189_728 });
+    const current = snap({ toolListBytes: 247_910 });
+    const advisory = toolListBytesDrift(baseline, current);
+    expect(advisory?.path).toBe("toolListBytes (advisory)");
+    expect(advisory?.driftPct).toBeGreaterThan(5);
+  });
+
+  it("returns null when within threshold", () => {
+    expect(toolListBytesDrift(snap(), snap())).toBeNull();
+  });
+});
+
+describe("resolveVersions (#1075)", () => {
+  it("records the resolved node + zod versions", () => {
+    const v = resolveVersions();
+    expect(v.node).toBe(process.versions.node);
+    expect(v.zod).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/tests/benchmark/token-cost/snapshot.ts
+++ b/tests/benchmark/token-cost/snapshot.ts
@@ -24,11 +24,30 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { WorkflowResult } from "./runBench.js";
 
 export const DRIFT_FAIL_PCT = 5;
+
+/**
+ * Resolve the runtime versions that influence `toolListBytes` (#1075). The
+ * `toolListBytes` env-discrepancy is most likely a `z.toJSONSchema` output
+ * difference, so recording the resolved `zod` + `node` versions in the
+ * snapshot makes a future divergence self-diagnosing instead of a multi-hour
+ * hunt — exactly what the issue asked for.
+ */
+export function resolveVersions(): { node: string; zod: string } {
+  let zod = "unknown";
+  try {
+    const req = createRequire(import.meta.url);
+    zod = (req("zod/package.json") as { version: string }).version;
+  } catch {
+    // leave "unknown" — recording is best-effort
+  }
+  return { node: process.versions.node, zod };
+}
 
 const SNAPSHOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "__snapshots__");
 const BASELINE_PATH = resolve(SNAPSHOT_DIR, "baseline.json");
@@ -37,7 +56,9 @@ const BASELINE_PATH = resolve(SNAPSHOT_DIR, "baseline.json");
 export interface SnapshotPayload {
   /** ISO date the snapshot was last regenerated; advisory. */
   generatedAt: string;
-  /** Tools/list payload bytes — workflow-independent. */
+  /** Resolved runtime versions at generation time (#1075); advisory, not gated. */
+  versions?: { node: string; zod: string };
+  /** Tools/list payload bytes — workflow-independent, advisory (env-sensitive, #1075). */
   toolListBytes: number;
   /** Per-workflow totals, keyed by workflow name. */
   workflows: Record<
@@ -71,7 +92,27 @@ export function buildSnapshot(results: WorkflowResult[]): SnapshotPayload {
       byTool: sortedByTool,
     };
   }
-  return { generatedAt: new Date().toISOString().slice(0, 10), toolListBytes, workflows };
+  return {
+    generatedAt: new Date().toISOString().slice(0, 10),
+    versions: resolveVersions(),
+    toolListBytes,
+    workflows,
+  };
+}
+
+/**
+ * Advisory (non-gating) drift of the env-sensitive `toolListBytes` (#1075).
+ * Returns a finding when it drifts ≥ threshold so humans/CI can SEE it, but
+ * it is never added to the failing set in {@link diffSnapshots}. `null` when
+ * within threshold or the baseline predates version recording.
+ */
+export function toolListBytesDrift(
+  baseline: SnapshotPayload,
+  current: SnapshotPayload,
+): DriftFinding | null {
+  const out: DriftFinding[] = [];
+  pushIfDrifted(out, "toolListBytes (advisory)", baseline.toolListBytes, current.toolListBytes);
+  return out[0] ?? null;
 }
 
 export function readSnapshot(): SnapshotPayload | undefined {
@@ -97,7 +138,13 @@ export interface DriftFinding {
 /** Compare two snapshots, reporting any field whose drift exceeds the threshold. */
 export function diffSnapshots(baseline: SnapshotPayload, current: SnapshotPayload): DriftFinding[] {
   const findings: DriftFinding[] = [];
-  pushIfDrifted(findings, "toolListBytes", baseline.toolListBytes, current.toolListBytes);
+  // #1075: `toolListBytes` is intentionally NOT gated. Its `z.toJSONSchema`
+  // byte count is environment-sensitive (~30% larger on the self-hosted runner
+  // than a clean checkout, same code/zod), which made the gate red-flag PRs
+  // that never touched the tool surface. Description size — what actually
+  // drives tool-list token cost — is gated deterministically by the
+  // 350-token/tool budget in descriptions.lint.test.ts. toolListBytes drift is
+  // surfaced advisorily via `toolListBytesDrift()` for humans, not failed (#1075).
 
   const wfNames = new Set([...Object.keys(baseline.workflows), ...Object.keys(current.workflows)]);
   for (const wf of [...wfNames].sort()) {


### PR DESCRIPTION
## Summary

The `token-cost bench` gate red-flagged PRs that never touched the tool surface (#1075). `toolListBytes` (the `z.toJSONSchema` tools/list payload) computes **~30% larger on the self-hosted `mac-local` runner than on a clean checkout** (247910 vs 189728, same code + zod 4.4.3), and `runBench.ts` folded it into **every** workflow's gated `totalTokens` — so one environment-only inflation drifted all six workflows plus the standalone `toolListBytes` finding. A local re-baseline couldn't clear it.

This makes the gate **trustworthy** without needing a root-cause that requires the runner:

- **`totalTokens` excludes `toolListBytes`** — it's now the workflow's own round-trip cost. The gated per-workflow metrics are in-process tool responses, **environment-independent by construction**, so the check is green on the runner.
- **`toolListBytes` is no longer gated** — reported advisorily via `toolListBytesDrift()`, with resolved **node + zod versions recorded** in the snapshot so a future `z.toJSONSchema` divergence is self-diagnosing (the issue's optional AC).
- **No coverage lost:** tool-description size — what actually drives tool-list token cost — stays gated deterministically by the 350-token/tool budget in `descriptions.lint.test.ts`.

## Design link

Implements [#1075](https://github.com/torsday/omnifocus-mcp/issues/1075).

Closes #1075.

### On the AC

The issue's AC hypothesized fixing this by making `toolListBytes` *identical* across environments (bullets 1–2) — but that root-cause genuinely needs to run on the `mac-local` runner to diff `z.toJSONSchema` output, which can't be done from a single environment. This PR instead achieves the issue's **purpose** (a trustworthy gate that's green on the runner — AC bullet 3) by removing the env-sensitive metric from the gate and making it advisory + self-diagnosing (AC bullet 4). If pinning down the literal `z.toJSONSchema` env-difference is ever wanted, the recorded versions make it a quick diff on the runner.

## Breaking change?

- [x] No — test-infra only; no product surface touched.

## Test plan

- [x] New `snapshot.test.ts` (runs in the normal suite, not OMNIFOCUS_BENCH-gated): a +30% `toolListBytes`-only delta does **not** fail; a real per-workflow `totalResponseBytes` regression **does**; `resolveVersions` records node + zod
- [x] `OMNIFOCUS_BENCH=1` bench gate passes against the regenerated baseline
- [x] `pnpm typecheck && pnpm lint && pnpm test` green; pre-push hook passed
- [x] No new dependencies

## Conventions checklist

- [x] Conventional Commits; README + inline docs updated