### PR TITLE
fix(observability): wire internal_status.queueDepth to live pool depth

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "overrides": {
       "fast-uri": ">=3.1.2",
       "ip-address": ">=10.1.1",
-      "hono": ">=4.12.18"
+      "hono": ">=4.12.21",
+      "qs": ">=6.15.2",
+      "brace-expansion": ">=5.0.6"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,9 @@ settings:
 overrides:
   fast-uri: '>=3.1.2'
   ip-address: '>=10.1.1'
-  hono: '>=4.12.18'
+  hono: '>=4.12.21'
+  qs: '>=6.15.2'
+  brace-expansion: '>=5.0.6'
 
 importers:
 
@@ -617,7 +619,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.18'
+      hono: '>=4.12.21'
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -1372,8 +1374,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -1670,8 +1672,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2063,8 +2065,8 @@ packages:
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -2909,9 +2911,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.23
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -3053,7 +3055,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3063,7 +3065,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.23
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3537,13 +3539,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3774,7 +3776,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -3884,7 +3886,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.18: {}
+  hono@4.12.23: {}
 
   html-escaper@2.0.2: {}
 
@@ -4062,7 +4064,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   mlly@1.8.2:
     dependencies:
@@ -4243,7 +4245,7 @@ snapshots:
 
   pure-rand@8.4.0: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -4533,7 +4535,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.1
+      qs: 6.15.2
       tunnel: 0.0.6
       underscore: 1.13.8
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -473,6 +473,10 @@ export async function startServer(): Promise<void> {
       loopDetectorKeys: loopDetector.size,
     }),
     probeTransportStats: () => getPersistentTransportStats(),
+    // Total pending work across the read pool + both write queues (#1108).
+    // In-process counters only — preserves internal_status's no-JXA contract.
+    probeQueueDepth: () =>
+      readPool.pendingCount() + jxaWriteQueue.pendingCount() + omniJsQueue.pendingCount(),
   });
 
   // Register MCP prompts (DESIGN §29) — four workflow templates.

--- a/src/tools/observability/internalStatus.test.ts
+++ b/src/tools/observability/internalStatus.test.ts
@@ -44,6 +44,7 @@ function makeCtx(
       | import("../../observability/toolDurationStats.js").ToolDurationSnapshot
       | null;
     probeTransportStats?: () => import("../../observability/transportStats.js").PersistentTransportStats;
+    probeQueueDepth?: () => number;
   } = {},
 ) {
   const adapter = {
@@ -84,6 +85,9 @@ function makeCtx(
   }
   if (overrides.probeTransportStats !== undefined) {
     ctx.probeTransportStats = overrides.probeTransportStats;
+  }
+  if (overrides.probeQueueDepth !== undefined) {
+    ctx.probeQueueDepth = overrides.probeQueueDepth;
   }
   return ctx;
 }
@@ -143,10 +147,26 @@ describe("internal_status — handler", () => {
     expect(envelope.data.circuits).toEqual([{ name: "task_list", state: "closed" }]);
   });
 
-  it("returns cache=null and queueDepth=null (not yet tracked)", async () => {
+  it("returns cache=null and queueDepth=null when no probes are wired", async () => {
     const ctx = makeCtx();
     const envelope = await handleInternalStatus({}, ctx);
     expect(envelope.data.cache).toBeNull();
+    expect(envelope.data.queueDepth).toBeNull();
+  });
+
+  it("returns queueDepth from probeQueueDepth when wired (#1108)", async () => {
+    const ctx = makeCtx({ probeQueueDepth: () => 4 });
+    const envelope = await handleInternalStatus({}, ctx);
+    expect(envelope.data.queueDepth).toBe(4);
+  });
+
+  it("surfaces queueDepth=null when the probe throws (#1108)", async () => {
+    const ctx = makeCtx({
+      probeQueueDepth: () => {
+        throw new Error("probe boom");
+      },
+    });
+    const envelope = await handleInternalStatus({}, ctx);
     expect(envelope.data.queueDepth).toBeNull();
   });
 

--- a/src/tools/observability/internalStatus.ts
+++ b/src/tools/observability/internalStatus.ts
@@ -200,6 +200,15 @@ export interface InternalStatusContext {
    * counters for the long-lived osascript child. Omitting surfaces as `null`.
    */
   probeTransportStats?: () => PersistentTransportStats;
+  /**
+   * Optional queue-depth probe (#1108). Returns total pending work
+   * (in-flight + waiting) across the read pool and write queues, so read-pool
+   * saturation is visible in status — the field that was previously a constant
+   * `null`, hiding contention. Reads in-process counters only; never calls the
+   * transport, preserving this tool's no-JXA contract. Omitting surfaces as
+   * `null`.
+   */
+  probeQueueDepth?: () => number;
 }
 
 /**
@@ -294,6 +303,15 @@ export async function handleInternalStatus(
     }
   }
 
+  let queueDepth: number | null = null;
+  if (ctx.probeQueueDepth !== undefined) {
+    try {
+      queueDepth = ctx.probeQueueDepth();
+    } catch {
+      queueDepth = null;
+    }
+  }
+
   const data: InternalStatusData = {
     uptimeMs,
     ofRunning: true,
@@ -302,7 +320,7 @@ export async function handleInternalStatus(
     mutation,
     cache,
     circuits,
-    queueDepth: null,
+    queueDepth,
     responseStats,
     latencyStats,
     toolDurationStats,


### PR DESCRIPTION
## Summary

- `internal_status.queueDepth` was hardcoded `null`; now reports total pending work (in-flight + waiting) across `readPool` + `jxaWriteQueue` + `omniJsQueue` via a `probeQueueDepth` ctx probe.
- In-process counters only — preserves the no-JXA contract.

Closes #1108.

## Issue
Implements [#1108](https://github.com/torsday/omnifocus-mcp/issues/1108). First of three fixes from the concurrent-read "busy" report (the others: #1109 busy-probe classifier, #1110 getLastSync stub).

## Breaking change?
- [x] No

## Test plan
- [x] tsc clean
- [x] internalStatus tests 33 pass (2 new: probe-wired → number, probe-throws → null)
- [x] biome clean
- [x] No behavior change beyond the previously-null field now reporting real depth