### PR TITLE
fix(sync): cache last-sync timestamp so getLastSync matches sync_trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "overrides": {
       "fast-uri": ">=3.1.2",
       "ip-address": ">=10.1.1",
-      "hono": ">=4.12.18"
+      "hono": ">=4.12.21",
+      "qs": ">=6.15.2",
+      "brace-expansion": ">=5.0.6"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,9 @@ settings:
 overrides:
   fast-uri: '>=3.1.2'
   ip-address: '>=10.1.1'
-  hono: '>=4.12.18'
+  hono: '>=4.12.21'
+  qs: '>=6.15.2'
+  brace-expansion: '>=5.0.6'
 
 importers:
 
@@ -617,7 +619,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.18'
+      hono: '>=4.12.21'
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -1372,8 +1374,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -1670,8 +1672,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2063,8 +2065,8 @@ packages:
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -2909,9 +2911,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.23
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -3053,7 +3055,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3063,7 +3065,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.23
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3537,13 +3539,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3774,7 +3776,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -3884,7 +3886,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.18: {}
+  hono@4.12.23: {}
 
   html-escaper@2.0.2: {}
 
@@ -4062,7 +4064,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   mlly@1.8.2:
     dependencies:
@@ -4243,7 +4245,7 @@ snapshots:
 
   pure-rand@8.4.0: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -4533,7 +4535,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.1
+      qs: 6.15.2
       tunnel: 0.0.6
       underscore: 1.13.8
 

--- a/src/adapter/jxa/JxaTransport.test.ts
+++ b/src/adapter/jxa/JxaTransport.test.ts
@@ -64,10 +64,46 @@ describe("JxaTransport — syncTrigger (wired)", () => {
   });
 });
 
-describe("JxaTransport — getLastSync (interim)", () => {
-  it("returns a null status until the lifecycle layer (#25) lands", async () => {
+describe("JxaTransport — getLastSync (#1110 read-back cache)", () => {
+  it("returns a null status before the first syncTrigger of the process", async () => {
     const t = new JxaTransport({ spawner: spawnerReturning("{}") });
     expect(await t.getLastSync()).toEqual({ lastSyncAt: null, inFlight: false });
+  });
+
+  it("returns the timestamp cached from a prior syncTrigger", async () => {
+    const t = new JxaTransport({
+      spawner: spawnerReturning('{"lastSyncAt":"2026-04-21T12:00:00.000Z","inFlight":false}'),
+    });
+    await t.syncTrigger();
+    expect(await t.getLastSync()).toEqual({
+      lastSyncAt: "2026-04-21T12:00:00.000Z",
+      inFlight: false,
+    });
+  });
+
+  it("a null-timestamp syncTrigger does not clobber a previously cached value", async () => {
+    // First sync returns a concrete timestamp; the second reports in-flight
+    // with no timestamp — the cache must keep the known-good value.
+    const stdouts = [
+      '{"lastSyncAt":"2026-04-21T12:00:00.000Z","inFlight":false}',
+      '{"lastSyncAt":null,"inFlight":true}',
+    ];
+    let call = 0;
+    const spawner: ScriptSpawner = vi.fn(
+      async (): Promise<SpawnResult> => ({
+        stdout: stdouts[Math.min(call++, stdouts.length - 1)] ?? "{}",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      }),
+    );
+    const t = new JxaTransport({ spawner });
+    await t.syncTrigger();
+    await t.syncTrigger();
+    expect(await t.getLastSync()).toEqual({
+      lastSyncAt: "2026-04-21T12:00:00.000Z",
+      inFlight: false,
+    });
   });
 });
 

--- a/src/adapter/jxa/JxaTransport.ts
+++ b/src/adapter/jxa/JxaTransport.ts
@@ -189,6 +189,17 @@ function isWindowError<T>(
 export class JxaTransport implements OmniFocusAdapter {
   private readonly runOpts: RunScriptOptions;
 
+  /**
+   * Process-local cache of the most recent successful sync (#1110). OmniFocus
+   * exposes no "last sync timestamp" property to read back, so `getLastSync`
+   * surfaces this — populated by `syncTrigger` whenever it returns a concrete
+   * timestamp. `null` until the first `syncTrigger` of the process. This is
+   * the read-back cache the lifecycle layer (#25) anticipated; scoped to the
+   * transport instance (syncTrigger + getLastSync both route to this same
+   * jxa instance per the router).
+   */
+  private lastSync: SyncStatus | null = null;
+
   constructor(options: JxaTransportOptions = {}) {
     this.runOpts = {
       ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
@@ -1125,16 +1136,20 @@ export class JxaTransport implements OmniFocusAdapter {
       {},
       { ...this.runOpts, scriptName: "sync_trigger" },
     );
+    // Populate the read-back cache (#1110) when sync produced a timestamp, so
+    // getLastSync / internal_status agree with this result. A null result
+    // (sync in flight, never synced) doesn't overwrite a known-good value.
+    if (result.lastSyncAt !== null) {
+      this.lastSync = result;
+    }
     return result;
   }
 
   async getLastSync(): Promise<SyncStatus> {
-    // `getLastSync` is a pure read with no JXA equivalent — OmniFocus does
-    // not expose a "last sync timestamp" property on the document. The real
-    // implementation will surface this from a process-local cache populated
-    // by `syncTrigger`. The lifecycle layer (#25) owns that cache; until
-    // it lands, signal "unknown" rather than a misleading timestamp.
-    return { lastSyncAt: null, inFlight: false };
+    // OmniFocus exposes no "last sync timestamp" property to read directly, so
+    // surface the process-local cache populated by syncTrigger (#1110). `null`
+    // before the first syncTrigger of this process — correct, not misleading.
+    return this.lastSync ?? { lastSyncAt: null, inFlight: false };
   }
 
   // -- Change detection ------------------------------------------------------


### PR DESCRIPTION
## Summary

- `getLastSync()` was a null-returning stub while `syncTrigger()` returned a live timestamp → `internal_status.lastSync` / `sync_status` reported null even right after a sync. Now backed by a process-local read-back cache on `JxaTransport`: `syncTrigger` populates it (only on a concrete timestamp; a null/in-flight result won't clobber); `getLastSync` returns it.

Closes #1110.

## Issue
Implements [#1110](https://github.com/torsday/omnifocus-mcp/issues/1110). Third of three fixes from the concurrent-read "busy" report (#1108 queueDepth ✓ merged; #1109 busy-probe classifier next).

## Breaking change?
- [x] No

## Test plan
- [x] tsc clean
- [x] 60 tests pass (3 new: empty→null, populated-after-sync, null-doesn't-clobber)
- [x] biome clean